### PR TITLE
fix(findings): let autofix-implementer run after mechanical-lintfix exhausts; run reviews on mechanical-only failures

### DIFF
--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -415,12 +415,15 @@ export async function decideStageAction(
   }
 
   // Mechanical-only failure: if rectification exhausted but all unfixed findings are from
-  // mechanical sources (lint/typecheck), LLM review passed — proceed rather than escalating.
+  // mechanical sources (lint/typecheck), and any configured LLM reviews ran and passed
+  // (the resume block in the orchestrator runs reviews even when mechanical findings are
+  // unfixed — see story-orchestrator.ts mechanicalOnlyExhausted), proceed rather than
+  // escalating. Reviews absent from phaseOutputs means they were not configured (OK).
   if (planResult.rectificationExhausted && planResult.unfixedFindings && planResult.unfixedFindings.length > 0) {
     const sources = new Set(planResult.unfixedFindings.map((f) => (f as { source?: string }).source));
     const allMechanical = [...sources].every((s) => s === "lint" || s === "typecheck");
     if (allMechanical) {
-      logger.warn("execution", "Mechanical-only failure unfixable — proceeding (LLM review passed)", {
+      logger.warn("execution", "Mechanical-only failure unfixable — proceeding (style-only errors remain)", {
         storyId: ctx.story.id,
       });
       return { action: "continue" };

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -1175,6 +1175,42 @@ export class ExecutionPlan {
       }
     }
 
+    // Mechanical-only resume: when rectification exhausted with only lint/typecheck
+    // findings, phases that never executed (e.g. semantic-review, adversarial-review)
+    // still need to run. Lint-style errors (E501 line-too-long in docstrings) do not
+    // invalidate LLM analysis — skipping reviews would mean the story passes without
+    // semantic/adversarial judgment, which is unsound. Unlike the normal resume above,
+    // this loop skips phases already in phaseOutputs (pass or fail) rather than
+    // re-running failed phases — the gate will not green since the style error remains.
+    if (this.state.rectification && rectResult.rectificationExhausted) {
+      const mechanicalOnly =
+        !!rectResult.unfixedFindings?.length &&
+        rectResult.unfixedFindings.every((f) => f.source === "lint" || f.source === "typecheck");
+      if (mechanicalOnly) {
+        for (const phase of collectOrderedPhases(this.state)) {
+          const name = phase.slot.op.name;
+          if (name in phaseOutputs) continue; // already ran (passed or failed)
+          try {
+            await runPhase(this.ctx, phase.slot, phaseCosts, phaseOutputs, this.isThreeSession);
+          } catch (error) {
+            logger?.error("story-orchestrator", "Phase threw unexpected error (mechanical-only resume)", {
+              storyId: this.ctx.storyId,
+              phase: name,
+              error: errorMessage(error),
+            });
+            throw error;
+          }
+          if (!phasePassed(name, phaseOutputs[name], this.ctx.storyId)) {
+            logger?.warn("story-orchestrator", "Phase failed in mechanical-only resume", {
+              storyId: this.ctx.storyId,
+              phase: name,
+            });
+            break;
+          }
+        }
+      }
+    }
+
     // ADR-024 — non-blocking best-effort fix over advisory adversarial findings.
     // Only when the story is currently green (adversarial passed, nothing pending).
     const advCfg = this.state.adversarialReview ? this.state.nonBlockingFix : undefined;

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -182,27 +182,27 @@ export async function runFixCycle<F extends Finding>(
       };
     }
 
-    // ── Per-strategy attempt cap ──────────────────────────────────────────────
-    for (const strategy of active) {
-      const attempts = countStrategyAttempts(cycle.iterations, strategy.name);
-      if (attempts >= strategy.maxAttempts) {
-        logger?.info("findings.cycle", "cycle exited — strategy attempt cap reached", {
-          storyId,
-          packageDir,
-          cycleName,
-          reason: "max-attempts-per-strategy",
-          exhaustedStrategy: strategy.name,
-          attempts,
-          maxAttempts: strategy.maxAttempts,
-        });
-        return {
-          iterations: cycle.iterations,
-          finalFindings: cycle.findings,
-          exitReason: "max-attempts-per-strategy",
-          exhaustedStrategy: strategy.name,
-          costUsd: totalCostUsd,
-        };
-      }
+    // ── Filter exhausted strategies ───────────────────────────────────────────
+    // An exclusive strategy that exhausts its cap should not block uncapped
+    // companions from running in subsequent iterations. Only exit when ALL
+    // active strategies are exhausted (no uncapped companion can take over).
+    const uncappedActive = active.filter((s) => countStrategyAttempts(cycle.iterations, s.name) < s.maxAttempts);
+    if (uncappedActive.length === 0) {
+      const exhaustedStrategy = active.find((s) => countStrategyAttempts(cycle.iterations, s.name) >= s.maxAttempts);
+      logger?.info("findings.cycle", "cycle exited — all active strategies exhausted", {
+        storyId,
+        packageDir,
+        cycleName,
+        reason: "max-attempts-per-strategy",
+        exhaustedStrategy: exhaustedStrategy?.name,
+      });
+      return {
+        iterations: cycle.iterations,
+        finalFindings: cycle.findings,
+        exitReason: "max-attempts-per-strategy",
+        exhaustedStrategy: exhaustedStrategy?.name,
+        costUsd: totalCostUsd,
+      };
     }
 
     // ── Total attempt cap ─────────────────────────────────────────────────────
@@ -225,7 +225,7 @@ export async function runFixCycle<F extends Finding>(
     }
 
     // ── bailWhen predicates ───────────────────────────────────────────────────
-    for (const strategy of active) {
+    for (const strategy of uncappedActive) {
       const bailReason = strategy.bailWhen?.(cycle.iterations) ?? null;
       if (bailReason !== null) {
         logger?.info("findings.cycle", "cycle exited — bail predicate fired", {
@@ -247,7 +247,7 @@ export async function runFixCycle<F extends Finding>(
     }
 
     // ── Execute strategies ────────────────────────────────────────────────────
-    const group = selectExecutionGroup(active);
+    const group = selectExecutionGroup(uncappedActive);
     const startedAt = now();
     const findingsBefore = [...cycle.findings];
     const fixesApplied: FixApplied[] = [];
@@ -371,6 +371,23 @@ export async function runFixCycle<F extends Finding>(
       }
 
       if (liteShortCircuited) {
+        // If uncapped companion strategies exist outside this group, let them
+        // run in the next iteration rather than exiting. The exclusive strategy
+        // exhausted but a co-run companion (e.g. autofix-implementer after
+        // mechanical-lintfix) may still be able to resolve the findings.
+        const companions = uncappedActive.filter((s) => !group.includes(s));
+        if (companions.length > 0) {
+          const iterCostUsd = fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
+          totalCostUsd += iterCostUsd;
+          logger?.info("findings.cycle", "exclusive strategy exhausted — continuing to companion strategies", {
+            storyId,
+            packageDir,
+            cycleName,
+            exhaustedStrategies: group.map((s) => s.name),
+            remainingStrategies: companions.map((s) => s.name),
+          });
+          continue;
+        }
         logger?.info("findings.cycle", "cycle exited — validate short-circuited", {
           storyId,
           packageDir,

--- a/test/unit/execution/story-orchestrator-resume-guard.test.ts
+++ b/test/unit/execution/story-orchestrator-resume-guard.test.ts
@@ -333,3 +333,131 @@ describe("AC6: liteScopeIncomplete: true → resume IS entered", () => {
     }
   });
 });
+
+// ============================================================================
+// AC7: rectificationExhausted=true + mechanical-only unfixedFindings → resume IS entered
+// ============================================================================
+
+describe("AC7: mechanical-only rectificationExhausted → resume IS entered for review phases", () => {
+  test("AC7: verifier dispatched in resume block when rectificationExhausted=true and unfixedFindings are all lint/typecheck", async () => {
+    // Reproduces the E501 scenario: lint-check fails, ruff --fix can't fix it,
+    // rectification exhausts with lint-only findings. semantic/adversarial reviews
+    // should still run — skipping them means the story passes without LLM review.
+    const config = makeNaxConfig();
+    runtime = makeTestRuntime({ config });
+
+    const LINT_FINDING: Finding = {
+      source: "lint",
+      category: "style",
+      severity: "error",
+      message: "E501 Line too long",
+      rule: "E501",
+      file: "tests/unit/test_foo.py",
+    };
+
+    const opRunCount: Record<string, number> = {};
+    const gateOp = makeDeterministicOp("full-suite-gate", {
+      success: false,
+      findings: [LINT_FINDING],
+    });
+    const verOp = makeDeterministicOp("verifier", { success: true });
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      opRunCount[op.name] = (opRunCount[op.name] ?? 0) + 1;
+      if (op.name === "full-suite-gate") {
+        // Gate stays failing — lint error is unfixable.
+        return { success: false, findings: [LINT_FINDING], estimatedCostUsd: 0 };
+      }
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+    // rectificationExhausted=true with mechanical-only unfixedFindings
+    _storyOrchestratorDeps.runFixCycle = async () => ({
+      iterations: [{ iterationNum: 1, findingsBefore: [LINT_FINDING], fixesApplied: [{ strategyName: "mechanical-lintfix", op: "mechanical-lintfix", targetFiles: [], summary: "" }], findingsAfter: [LINT_FINDING], outcome: "unchanged" as const, startedAt: "", finishedAt: "" }],
+      finalFindings: [LINT_FINDING],
+      exitReason: "validate-short-circuit" as const,
+      costUsd: 0,
+    });
+
+    try {
+      const ctx: any = {
+        runtime: runtime!,
+        packageView: runtime!.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-ac7",
+      };
+
+      const semOp = makeDeterministicOp("semantic-review", { success: true });
+      const advOp = makeDeterministicOp("adversarial-review", { success: true });
+
+      await new StoryOrchestratorBuilder()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-ac7" } as any, workdir: "/tmp" } })
+        .addVerifier({ op: verOp, input: { code: "" } })
+        .addSemanticReview({ op: semOp, input: {} as any })
+        .addAdversarialReview({ op: advOp, input: {} as any })
+        .addRectification({ maxAttempts: 3, strategies: [], abortOnIncreasingFailures: false })
+        .build(ctx)
+        .run();
+
+      // AC7: resume block IS entered because unfixedFindings are all lint.
+      // Verifier and reviews run even though the lint gate stays failing.
+      expect(opRunCount["verifier"] ?? 0).toBeGreaterThan(0);
+      expect(opRunCount["semantic-review"] ?? 0).toBeGreaterThan(0);
+      expect(opRunCount["adversarial-review"] ?? 0).toBeGreaterThan(0);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+
+  test("AC7b: resume NOT entered when rectificationExhausted=true with non-mechanical unfixedFindings (AC5 unchanged)", async () => {
+    // Existing AC5 contract: test-runner findings are not mechanical → no resume.
+    const config = makeNaxConfig();
+    runtime = makeTestRuntime({ config });
+
+    const opRunCount: Record<string, number> = {};
+    const gateOp = makeDeterministicOp("full-suite-gate", { success: false, findings: [GATE_FINDING] });
+    const verOp = makeDeterministicOp("verifier", { success: true });
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      opRunCount[op.name] = (opRunCount[op.name] ?? 0) + 1;
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+    _storyOrchestratorDeps.runFixCycle = async () => ({
+      iterations: [],
+      finalFindings: [GATE_FINDING],
+      exitReason: "validate-short-circuit" as const,
+      costUsd: 0,
+    });
+
+    try {
+      const ctx: any = {
+        runtime: runtime!,
+        packageView: runtime!.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-ac7b",
+      };
+
+      await new StoryOrchestratorBuilder()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-ac7b" } as any, workdir: "/tmp" } })
+        .addVerifier({ op: verOp, input: { code: "" } })
+        .addRectification({ maxAttempts: 3, strategies: [], abortOnIncreasingFailures: false })
+        .build(ctx)
+        .run();
+
+      expect(opRunCount["verifier"] ?? 0).toBe(0);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+});

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -545,6 +545,75 @@ callOp: callOpMock as unknown as CallOpFn, logger: mockLogger as unknown as impo
   });
 });
 
+// ─── runFixCycle — exclusive exhausted, co-run companion continues ───────────
+
+describe("runFixCycle — exclusive strategy exhausted with uncapped companion", () => {
+  test("co-run companion runs after exclusive strategy exhausts and validate short-circuits", async () => {
+    // Reproduces the mechanical-lintfix (exclusive, maxAttempts=1) +
+    // autofix-implementer (co-run-sequential) scenario: exclusive exhausts and
+    // can't fix E501, but the companion LLM strategy should still get a turn.
+    // Give each strategy a distinct fixOp name so callOrder can tell them apart.
+    const exclusiveStrategy = makeStrategy({
+      name: "mechanical-fix",
+      coRun: "exclusive",
+      maxAttempts: 1,
+      fixOp: { ...noopOp, name: "mechanical-fix-op" } as typeof noopOp,
+      appliesTo: (f) => f.source === "lint",
+    });
+    const companionStrategy = makeStrategy({
+      name: "llm-fix",
+      coRun: "co-run-sequential",
+      maxAttempts: 2,
+      fixOp: { ...noopOp, name: "llm-fix-op" } as typeof noopOp,
+      appliesTo: (f) => f.source === "lint",
+    });
+
+    const callOrder: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const callOpMock = (async (_ctx: any, op: any) => {
+      callOrder.push(op.name as string);
+      return {};
+    }) as unknown as CallOpFn;
+
+    let validateCall = 0;
+    const cycle = makeCycle(
+      [lintA],
+      [exclusiveStrategy, companionStrategy],
+      async () => {
+        validateCall++;
+        // Short-circuit on first lite-validate (mechanical fix ran but couldn't fix);
+        // resolve on second full-validate (LLM fix succeeded).
+        if (validateCall === 1) return { findings: [lintA], shortCircuited: true } as unknown as Finding[];
+        return [];
+      },
+    );
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: callOpMock });
+
+    expect(result.exitReason).toBe("resolved");
+    // Distinct op names prove: mechanical-fix ran first (exclusive), then llm-fix (companion).
+    expect(callOrder).toEqual(["mechanical-fix-op", "llm-fix-op"]);
+    expect(result.finalFindings).toHaveLength(0);
+  });
+
+  test("validate-short-circuit exits when exclusive exhausts AND no uncapped companions exist", async () => {
+    const exclusiveOnly = makeStrategy({
+      name: "mechanical-fix",
+      coRun: "exclusive",
+      maxAttempts: 1,
+      appliesTo: (f) => f.source === "lint",
+    });
+    const validateResult: ValidateResult<Finding> = { findings: [lintA], shortCircuited: true };
+    const cycle = makeCycle([lintA], [exclusiveOnly], async () => validateResult as unknown as Finding[]);
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: makeCallOpMock() as unknown as CallOpFn });
+
+    expect(result.exitReason).toBe("validate-short-circuit");
+    expect(result.finalFindings).toEqual([lintA]);
+  });
+});
+
 // ─── runFixCycle — AC3/AC4: ValidateResult short-circuit flag ────────────────
 
 describe("runFixCycle — ValidateResult short-circuit flag", () => {


### PR DESCRIPTION
## Summary

- **Bug 1 — `src/findings/cycle.ts`**: `mechanical-lintfix` (exclusive, `maxAttempts=1`) was blocking `autofix-implementer` (co-run-sequential companion) from running. When ruff couldn't auto-fix E501 on its single attempt, the cycle exited immediately via the per-strategy cap check, giving the LLM companion zero turns. Fixed by computing `uncappedActive` (strategies still under their cap) and only exiting when *all* active strategies are exhausted — if uncapped companions remain after an exclusive short-circuit, the loop continues.

- **Bug 2 — `src/execution/story-orchestrator.ts`**: When `rectificationExhausted=true` the normal resume block was skipped entirely, so `semantic-review` and `adversarial-review` never ran, yet the story was marked passed. Added a separate mechanical-only resume block that runs never-executed phases (skipping phases already in `phaseOutputs` whether passed or failed) when all unfixed findings have `source === "lint"` or `source === "typecheck"`. Style errors (E501 line-too-long in docstrings) don't invalidate LLM analysis, so reviews must still run.

- **`src/execution/post-run.ts`**: Corrected misleading log message from `"Mechanical-only failure unfixable — proceeding (LLM review passed)"` to `"style-only errors remain"` (reviews hadn't run yet at that point).

## Root cause

Triggered by commit `fc07bcb5` which correctly routed `fixTarget == null` lint findings to `autofix-implementer`. Before that fix, E501 findings were silently dropped. After it, `mechanical-lintfix` claimed them exclusively, exhausted in 1 attempt, and the cycle exited — stranding the LLM strategy. Simultaneously, the exhausted rectification suppressed the resume block, preventing semantic/adversarial reviews from running.

## Full repair path after this fix

1. **Iteration 1**: `mechanical-lintfix` runs (`ruff check . --fix`) — fixes auto-fixable errors, E501 remains
2. Validate short-circuits (unfixable mechanically) → `mechanical-lintfix` exhausted (1/1)
3. `uncappedActive = [autofix-implementer]` → loop continues
4. **Iteration 2**: `autofix-implementer` (LLM) attempts to reformat the long lines
5. If resolved → done. If not → `rectificationExhausted=true` with lint-only `unfixedFindings`
6. Mechanical-only resume block runs: `typecheck-check`, `semantic-review`, `adversarial-review` execute

## Test plan

- [ ] `test/unit/findings/cycle.test.ts` — new describe block "runFixCycle — exclusive strategy exhausted with uncapped companion": verifies companion runs after exclusive exhausts (using distinct op names to prove order), and that no-companion case still exits `validate-short-circuit`
- [ ] `test/unit/execution/story-orchestrator-resume-guard.test.ts` — AC7: `rectificationExhausted=true` with lint-only `unfixedFindings` → verifier, semantic-review, and adversarial-review all dispatched; AC7b: non-mechanical findings still skip resume (AC5 contract unchanged)
- [ ] `bun run lint` ✓
- [ ] `bun run typecheck` ✓
- [ ] `bun run test` — 1094 tests pass ✓