### PR TITLE
fix(logger): exclude plural metric keys from TOKEN redaction

### DIFF
--- a/src/logger/redact.ts
+++ b/src/logger/redact.ts
@@ -8,7 +8,10 @@
  *     are scanned for token-shaped substrings (API keys, PATs, etc.).
  */
 
-const SECRET_KEY_PATTERN = /(SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)/i;
+// TOKEN(?!s\b) prevents matching plural metric keys like "tokens", "inputTokens",
+// "totalTokens" (which are counts, not credentials) while still matching "token",
+// "GITHUB_TOKEN", "accessToken", etc.
+const SECRET_KEY_PATTERN = /(SECRET|TOKEN(?!s\b)|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)/i;
 
 /**
  * Patterns are reset via `re.lastIndex = 0` before every call because they carry

--- a/test/unit/logger/redact.test.ts
+++ b/test/unit/logger/redact.test.ts
@@ -32,4 +32,18 @@ describe("redactSecrets", () => {
     expect(out.message).toBe("hello world");
     expect(out.count).toBe(42);
   });
+
+  test("does not redact plural metric keys: tokens, inputTokens, totalTokens", () => {
+    const out = redactSecrets({ tokens: 1234, inputTokens: 500, totalTokens: 1000 }) as any;
+    expect(out.tokens).toBe(1234);
+    expect(out.inputTokens).toBe(500);
+    expect(out.totalTokens).toBe(1000);
+  });
+
+  test("still redacts singular token credential keys: token, GITHUB_TOKEN, accessToken", () => {
+    const out = redactSecrets({ token: "abc123", GITHUB_TOKEN: "ghp_xxxx", accessToken: "bearer_xyz" }) as any;
+    expect(out.token).toBe("[REDACTED]");
+    expect(out.GITHUB_TOKEN).toBe("[REDACTED]");
+    expect(out.accessToken).toBe("[REDACTED]");
+  });
 });


### PR DESCRIPTION
## Summary

- `TOKEN` in `SECRET_KEY_PATTERN` was matching any key containing the substring "token" (case-insensitive), including metric fields like `tokens`, `inputTokens`, and `totalTokens`
- Added negative lookahead `TOKEN(?!s\b)` so the plural form is excluded — these are LLM token counts, not credentials
- Singular/credential forms (`token`, `GITHUB_TOKEN`, `accessToken`, `ACCESS_TOKEN`) are still correctly redacted

## Test plan

- [ ] `tokens`, `inputTokens`, `totalTokens` keys log their numeric values unredacted
- [ ] `token`, `GITHUB_TOKEN`, `accessToken` keys are still redacted to `[REDACTED]`
- [ ] `bun test test/unit/logger/redact.test.ts` passes all 7 tests