### PR TITLE
fix(verification): scoped test selection self-maps Python sources; no fix dispatched on zero-finding failures

### DIFF
--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -1,6 +1,6 @@
 import { qualityConfigSelector } from "../config";
 import type { QualityConfig } from "../config/selectors";
-import { testSummaryToFindings } from "../findings";
+import { executionFailureToFinding, testSummaryToFindings } from "../findings";
 import type { Finding } from "../findings/types";
 import { getLogger } from "../logger";
 import { _scopedSelectionDeps, parseTestOutput, selectScopedTests } from "../test-runners";
@@ -150,33 +150,57 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       timeoutSeconds: scopedTimeout,
       isFullSuite: selection.isFullSuite,
     });
+    const runTests = async (command: string) => {
+      const result = await deps.regression({
+        workdir: cmdWorkdir,
+        command,
+        // regressionGate.timeoutSeconds lives in execution; QualityConfig includes execution.
+        timeoutSeconds: scopedTimeout,
+        // acceptOnTimeout is not consumed by runVerificationCore — the runner returns status="TIMEOUT"
+        // and the caller (this op) decides accept-on-timeout policy. The op currently does not accept
+        // scoped-test timeouts as pass; full-suite gate is the only place that does.
+        forceExit: quality.quality?.forceExit,
+        detectOpenHandles: quality.quality?.detectOpenHandles,
+        detectOpenHandlesRetries: quality.quality?.detectOpenHandlesRetries,
+        gracePeriodMs: quality.quality?.gracePeriodMs,
+        drainTimeoutMs: quality.quality?.drainTimeoutMs,
+        shell: quality.quality?.shell,
+        stripEnvVars: quality.quality?.stripEnvVars,
+      });
+      const parsed = result.output ? deps.parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };
+      return { result, parsed };
+    };
+
     const start = Date.now();
-    const result = await deps.regression({
-      workdir: cmdWorkdir,
-      command: selection.effectiveCommand,
-      // regressionGate.timeoutSeconds lives in execution; QualityConfig includes execution.
-      timeoutSeconds: quality.execution?.regressionGate?.timeoutSeconds ?? 600,
-      // acceptOnTimeout is not consumed by runVerificationCore — the runner returns status="TIMEOUT"
-      // and the caller (this op) decides accept-on-timeout policy. The op currently does not accept
-      // scoped-test timeouts as pass; full-suite gate is the only place that does.
-      forceExit: quality.quality?.forceExit,
-      detectOpenHandles: quality.quality?.detectOpenHandles,
-      detectOpenHandlesRetries: quality.quality?.detectOpenHandlesRetries,
-      gracePeriodMs: quality.quality?.gracePeriodMs,
-      drainTimeoutMs: quality.quality?.drainTimeoutMs,
-      shell: quality.quality?.shell,
-      stripEnvVars: quality.quality?.stripEnvVars,
-    });
+    let effectiveCommand = selection.effectiveCommand;
+    let isFullSuite = selection.isFullSuite;
+    let scopeTestFallback = selection.scopeTestFallback;
+    let { result, parsed } = await runTests(effectiveCommand);
+
+    // Scoped run failed without executing a single test (e.g. pytest exit 5
+    // "no tests collected" when the scope probed a non-test file, or a
+    // collection error confined to the scoped file). The scope is unusable as
+    // a verdict — rerun the full suite, which is the actual arbiter (#1207).
+    if (!result.success && result.status !== "TIMEOUT" && !isFullSuite && parsed.passed === 0 && parsed.failed === 0) {
+      logger.warn("verify[scoped]", "Scoped run executed no tests — falling back to full suite", {
+        storyId: input.storyId,
+        command: effectiveCommand,
+        exitCode: result.exitCode,
+      });
+      effectiveCommand = baseCommand;
+      isFullSuite = true;
+      scopeTestFallback = true;
+      ({ result, parsed } = await runTests(effectiveCommand));
+    }
     const durationMs = Date.now() - start;
-    const parsed = result.output ? deps.parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };
 
     if (result.success) {
       logger.info("verify[scoped]", "Scoped tests passed", {
         storyId: input.storyId,
         passCount: parsed.passed,
         durationMs,
-        scopeTestFallback: selection.scopeTestFallback ?? false,
-        isFullSuite: selection.isFullSuite,
+        scopeTestFallback: scopeTestFallback ?? false,
+        isFullSuite,
       });
       return {
         success: true,
@@ -184,8 +208,8 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
         findings: [],
         durationMs,
         passCount: parsed.passed,
-        isFullSuite: selection.isFullSuite,
-        scopeTestFallback: selection.scopeTestFallback,
+        isFullSuite,
+        scopeTestFallback,
       };
     }
 
@@ -193,8 +217,8 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       logger.warn("verify[scoped]", "Scoped tests timed out", {
         storyId: input.storyId,
         durationMs,
-        scopeTestFallback: selection.scopeTestFallback ?? false,
-        isFullSuite: selection.isFullSuite,
+        scopeTestFallback: scopeTestFallback ?? false,
+        isFullSuite,
       });
       return {
         success: false,
@@ -202,8 +226,8 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
         findings: [],
         durationMs,
         passCount: parsed.passed,
-        isFullSuite: selection.isFullSuite,
-        scopeTestFallback: selection.scopeTestFallback,
+        isFullSuite,
+        scopeTestFallback,
       };
     }
 
@@ -212,17 +236,40 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       passCount: parsed.passed,
       failCount: parsed.failed,
       durationMs,
-      scopeTestFallback: selection.scopeTestFallback ?? false,
-      isFullSuite: selection.isFullSuite,
+      scopeTestFallback: scopeTestFallback ?? false,
+      isFullSuite,
     });
+    let findings = deps.testSummaryToFindings(parsed);
+    if (findings.length === 0) {
+      // Runner exited non-zero but the parser found 0 structured failures
+      // (environmental failure: config crash, missing dep, import error).
+      // Without a finding, rectification no-ops on 0 findings and the story
+      // fails terminally without ever dispatching a fix — mirror the
+      // full-suite gate's synth finding (#1207, see full-suite-gate.ts).
+      logger.warn("verify[scoped]", "Scoped verify execution-failed — emitting synth finding", {
+        storyId: input.storyId,
+        command: effectiveCommand,
+        exitCode: result.exitCode,
+        cwd: cmdWorkdir,
+      });
+      findings = [
+        executionFailureToFinding({
+          command: effectiveCommand,
+          exitCode: result.exitCode,
+          output: result.output ?? "",
+          packageDir: input.packagePrefix,
+          cwd: cmdWorkdir,
+        }),
+      ];
+    }
     return {
       success: false,
       status: "failed",
-      findings: deps.testSummaryToFindings(parsed),
+      findings,
       durationMs,
       passCount: parsed.passed,
-      isFullSuite: selection.isFullSuite,
-      scopeTestFallback: selection.scopeTestFallback,
+      isFullSuite,
+      scopeTestFallback,
     };
   },
 };

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -181,7 +181,11 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     // "no tests collected" when the scope probed a non-test file, or a
     // collection error confined to the scoped file). The scope is unusable as
     // a verdict — rerun the full suite, which is the actual arbiter (#1207).
-    if (!result.success && result.status !== "TIMEOUT" && !isFullSuite && parsed.passed === 0 && parsed.failed === 0) {
+    // TIMEOUT is excluded: a hung scoped run must not escalate into a second
+    // long run. Cost note: the rerun pays regression()'s 2s cleanup sleep a
+    // second time — accepted, the story genuinely needs the full-suite verdict.
+    const ranNoTests = parsed.passed === 0 && parsed.failed === 0 && parsed.failures.length === 0;
+    if (!result.success && result.status !== "TIMEOUT" && !isFullSuite && ranNoTests) {
       logger.warn("verify[scoped]", "Scoped run executed no tests — falling back to full suite", {
         storyId: input.storyId,
         command: effectiveCommand,
@@ -254,7 +258,9 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       });
       findings = [
         executionFailureToFinding({
-          command: effectiveCommand,
+          // Prefer the post-wrap shell command actually executed (parity with
+          // full-suite-gate.ts) — falls back to the pre-wrap effective command.
+          command: result.command ?? effectiveCommand,
           exitCode: result.exitCode,
           output: result.output ?? "",
           packageDir: input.packagePrefix,

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -85,6 +85,10 @@ interface BasenamePattern {
  * Looks only at the basename segment (after the last `/`) and requires exactly
  * one `*` wildcard in it, splitting into prefix + suffix.
  *
+ * @remarks Only single-wildcard basenames are representable — patterns like
+ * `*spec*.ts` return null and contribute no Pass-1 candidate (Pass 2
+ * import-grep still covers files matching them).
+ *
  * @example
  * extractBasenamePattern("test/**\/*.test.ts")   // { prefix: "",      suffix: ".test.ts" }
  * extractBasenamePattern("tests/**\/test_*.py")  // { prefix: "test_", suffix: ".py" }

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -12,7 +12,7 @@
  */
 import { join, relative } from "node:path";
 import { getSafeLogger } from "../logger";
-import { DEFAULT_SEPARATED_TEST_DIRS, DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
+import { DEFAULT_SEPARATED_TEST_DIRS, DEFAULT_TEST_FILE_PATTERNS, extractTestDirs } from "../test-runners/conventions";
 import { getGitRoot, gitWithTimeout } from "../utils/git";
 import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 
@@ -100,24 +100,40 @@ async function getGitRootMemo(workdir: string): Promise<string | null> {
  * ```
  */
 /**
- * Extract the test-file suffix implied by a glob pattern.
+ * Test-file basename shape implied by a glob pattern: `<prefix>*<suffix>`.
  *
- * The suffix is everything that follows the last `*` wildcard, making this
- * language-agnostic: the caller's `testFilePatterns` configuration drives which
- * suffixes are probed rather than hardcoding TypeScript-specific extensions.
- *
- * @example
- * extractPatternSuffix("test/**\/*.test.ts")  // ".test.ts"
- * extractPatternSuffix("src/**\/*.spec.ts")   // ".spec.ts"
- * extractPatternSuffix("**\/*_test.go")       // "_test.go"
+ * Derived from the glob's basename segment so both suffix conventions
+ * (`*.test.ts`, `*_test.go`) and prefix conventions (pytest's `test_*.py`)
+ * are representable. Language-agnostic: the caller's `testFilePatterns`
+ * configuration drives which shapes are probed.
  *
  * @internal
  */
-function extractPatternSuffix(pattern: string): string | null {
-  const lastStar = pattern.lastIndexOf("*");
-  if (lastStar === -1) return null;
-  const suffix = pattern.slice(lastStar + 1);
-  return suffix.length > 0 ? suffix : null;
+interface BasenamePattern {
+  prefix: string;
+  suffix: string;
+}
+
+/**
+ * Extract the test-file basename shape implied by a glob pattern.
+ *
+ * Looks only at the basename segment (after the last `/`) and requires exactly
+ * one `*` wildcard in it, splitting into prefix + suffix.
+ *
+ * @example
+ * extractBasenamePattern("test/**\/*.test.ts")   // { prefix: "",      suffix: ".test.ts" }
+ * extractBasenamePattern("tests/**\/test_*.py")  // { prefix: "test_", suffix: ".py" }
+ * extractBasenamePattern("**\/*_test.go")        // { prefix: "",      suffix: "_test.go" }
+ *
+ * @internal
+ */
+function extractBasenamePattern(pattern: string): BasenamePattern | null {
+  const basename = pattern.slice(pattern.lastIndexOf("/") + 1);
+  const parts = basename.split("*");
+  if (parts.length !== 2) return null;
+  const [prefix, suffix] = parts;
+  if (!prefix && !suffix) return null;
+  return { prefix, suffix };
 }
 
 /**
@@ -193,45 +209,18 @@ export async function mapSourceToTests(
   packagePrefix?: string,
   testFilePatterns: string[] = [...DEFAULT_TEST_FILE_PATTERNS],
 ): Promise<string[]> {
-  // Derive unique test-file suffixes from configured patterns — language-agnostic.
-  // e.g. ["test/**/*.test.ts", "src/**/*.spec.ts"] → [".test.ts", ".spec.ts"]
-  // e.g. ["**/*_test.go"] → ["_test.go"]
-  const testSuffixes = [...new Set(testFilePatterns.map(extractPatternSuffix).filter((s): s is string => s !== null))];
+  // Derive unique basename shapes from configured patterns — language-agnostic.
+  // e.g. ["test/**/*.test.ts"] → [{prefix:"", suffix:".test.ts"}]
+  // e.g. ["tests/**/test_*.py"] → [{prefix:"test_", suffix:".py"}]
+  const shapes = dedupeBasenamePatterns(testFilePatterns);
+  // Probe separated dirs from the SSOT default PLUS any static leading dir the
+  // patterns themselves declare (e.g. "tests/**/*.py" → "tests").
+  const testDirs = [...new Set([...DEFAULT_SEPARATED_TEST_DIRS, ...extractTestDirs(testFilePatterns)])];
 
   const result: string[] = [];
 
   for (const sourceFile of sourceFiles) {
-    // Strip source extension for co-located candidate generation
-    const sourceWithoutExt = sourceFile.replace(/\.[^.]+$/, "");
-
-    let innerRelative: string;
-    let testBase: string;
-
-    if (packagePrefix) {
-      // Monorepo: source path is "<prefix>/src/foo.ts" — strip "<prefix>/src/" to get "foo"
-      const srcRoot = `${packagePrefix}/src/`;
-      const inner = sourceFile.startsWith(srcRoot)
-        ? sourceFile.slice(srcRoot.length)
-        : sourceFile.replace(/^.*\/src\//, "");
-      innerRelative = inner.replace(/\.[^.]+$/, "");
-      testBase = `${workdir}/${packagePrefix}`;
-    } else {
-      // Single-package: source path is "src/foo.ts" — strip "src/" and extension
-      innerRelative = sourceFile.replace(/^src\//, "").replace(/\.[^.]+$/, "");
-      testBase = workdir;
-    }
-
-    const candidates: string[] = [];
-
-    for (const suffix of testSuffixes) {
-      // Separated test directories (driven by SSOT — see conventions.ts)
-      for (const testDir of DEFAULT_SEPARATED_TEST_DIRS) {
-        candidates.push(`${testBase}/${testDir}/${innerRelative}${suffix}`);
-      }
-      // Co-located: next to the source file (e.g. NestJS .spec.ts, Vitest .test.ts, Go _test.go)
-      candidates.push(`${workdir}/${sourceWithoutExt}${suffix}`);
-    }
-
+    const candidates = buildTestCandidates(sourceFile, workdir, packagePrefix, shapes, testDirs);
     const existsFlags = await Promise.all(candidates.map((c) => _bunDeps.file(c).exists()));
     candidates.forEach((c, i) => {
       if (existsFlags[i]) result.push(c);
@@ -239,6 +228,93 @@ export async function mapSourceToTests(
   }
 
   return result;
+}
+
+/** @internal Dedupe basename shapes by prefix+suffix identity. */
+function dedupeBasenamePatterns(testFilePatterns: readonly string[]): BasenamePattern[] {
+  const seen = new Set<string>();
+  const shapes: BasenamePattern[] = [];
+  for (const pattern of testFilePatterns) {
+    const shape = extractBasenamePattern(pattern);
+    if (!shape) continue;
+    const key = `${shape.prefix} ${shape.suffix}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    shapes.push(shape);
+  }
+  return shapes;
+}
+
+/**
+ * Build candidate test-file paths for one source file.
+ *
+ * Suffix shapes (prefix === "") probe the historical layout: mirrored under
+ * each test dir + co-located next to the source. Prefix shapes (pytest's
+ * `test_*.py`) probe mirrored, flat, and co-located with the prefixed basename.
+ *
+ * Identity guard (#1207): a suffix shape whose suffix equals the source
+ * extension (e.g. ".py" from "tests/**\/*.py") reconstructs the source file
+ * itself as its co-located candidate — pytest would then "run" a non-test
+ * source file. The source path is always excluded.
+ *
+ * @internal
+ */
+function buildTestCandidates(
+  sourceFile: string,
+  workdir: string,
+  packagePrefix: string | undefined,
+  shapes: readonly BasenamePattern[],
+  testDirs: readonly string[],
+): string[] {
+  // Strip source extension for co-located candidate generation
+  const sourceWithoutExt = sourceFile.replace(/\.[^.]+$/, "");
+
+  let innerRelative: string;
+  let testBase: string;
+
+  if (packagePrefix) {
+    // Monorepo: source path is "<prefix>/src/foo.ts" — strip "<prefix>/src/" to get "foo"
+    const srcRoot = `${packagePrefix}/src/`;
+    const inner = sourceFile.startsWith(srcRoot)
+      ? sourceFile.slice(srcRoot.length)
+      : sourceFile.replace(/^.*\/src\//, "");
+    innerRelative = inner.replace(/\.[^.]+$/, "");
+    testBase = `${workdir}/${packagePrefix}`;
+  } else {
+    // Single-package: source path is "src/foo.ts" — strip "src/" and extension
+    innerRelative = sourceFile.replace(/^src\//, "").replace(/\.[^.]+$/, "");
+    testBase = workdir;
+  }
+
+  const lastSlash = innerRelative.lastIndexOf("/");
+  const innerDir = lastSlash === -1 ? "" : innerRelative.slice(0, lastSlash);
+  const baseName = lastSlash === -1 ? innerRelative : innerRelative.slice(lastSlash + 1);
+  const sourceDirAbs = sourceWithoutExt.includes("/")
+    ? `${workdir}/${sourceWithoutExt.slice(0, sourceWithoutExt.lastIndexOf("/"))}`
+    : workdir;
+
+  const candidates: string[] = [];
+  for (const { prefix, suffix } of shapes) {
+    if (prefix === "") {
+      // Suffix convention — mirrored under each test dir (driven by SSOT — see conventions.ts)
+      for (const testDir of testDirs) {
+        candidates.push(`${testBase}/${testDir}/${innerRelative}${suffix}`);
+      }
+      // Co-located: next to the source file (e.g. NestJS .spec.ts, Vitest .test.ts, Go _test.go)
+      candidates.push(`${workdir}/${sourceWithoutExt}${suffix}`);
+    } else {
+      // Prefix convention (pytest test_*.py) — prefixed basename, mirrored + flat + co-located
+      const named = `${prefix}${baseName}${suffix}`;
+      for (const testDir of testDirs) {
+        candidates.push(`${testBase}/${testDir}/${innerDir ? `${innerDir}/` : ""}${named}`);
+        if (innerDir) candidates.push(`${testBase}/${testDir}/${named}`);
+      }
+      candidates.push(`${sourceDirAbs}/${named}`);
+    }
+  }
+
+  const sourceAbs = `${workdir}/${sourceFile}`;
+  return [...new Set(candidates)].filter((c) => c !== sourceAbs);
 }
 
 /**

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -65,41 +65,6 @@ async function getGitRootMemo(workdir: string): Promise<string | null> {
 }
 
 /**
- * Map source files to their corresponding test files.
- *
- * Checks four candidate locations per source file (in order):
- *
- * 1. Separated test directory — `<testBase>/test/unit/<relative>.test.ts`
- * 2. Separated test directory — `<testBase>/test/integration/<relative>.test.ts`
- * 3. Co-located spec file    — `<workdir>/<sourceFile>.spec.ts`  (NestJS convention)
- * 4. Co-located test file    — `<workdir>/<sourceFile>.test.ts`  (Vitest/Jest convention)
- *
- * `<testBase>` is `workdir` for single-package repos and `workdir/<packagePrefix>`
- * for monorepo packages. Co-located candidates always resolve relative to the git root.
- *
- * Only returns paths that actually exist on disk.
- *
- * @param sourceFiles   - Source file paths relative to the git root (e.g. `["src/foo/bar.ts"]`)
- * @param workdir       - Absolute path to the repository root
- * @param packagePrefix - Monorepo package directory relative to repo root (e.g. `"apps/api"`)
- * @returns Existing test file paths (absolute)
- *
- * @example
- * ```typescript
- * // Single-package, separated
- * await mapSourceToTests(["src/foo/bar.ts"], "/repo");
- * // => ["/repo/test/unit/foo/bar.test.ts"]
- *
- * // Monorepo, separated
- * await mapSourceToTests(["apps/api/src/foo/bar.ts"], "/repo", "apps/api");
- * // => ["/repo/apps/api/test/unit/foo/bar.test.ts"]
- *
- * // Monorepo, co-located .spec.ts (NestJS)
- * await mapSourceToTests(["apps/api/src/agents/agents.service.ts"], "/repo", "apps/api");
- * // => ["/repo/apps/api/src/agents/agents.service.spec.ts"]
- * ```
- */
-/**
  * Test-file basename shape implied by a glob pattern: `<prefix>*<suffix>`.
  *
  * Derived from the glob's basename segment so both suffix conventions
@@ -203,6 +168,39 @@ export async function importGrepFallback(
   return results.filter((p): p is string => p !== null);
 }
 
+/**
+ * Map source files to their corresponding test files (Pass 1 — path convention).
+ *
+ * Per source file, probes candidates built from the configured patterns'
+ * basename shapes (see {@link buildTestCandidates}): mirrored under separated
+ * test dirs (SSOT defaults + dirs declared by the patterns), flat for prefix
+ * shapes, and co-located next to the source. The source file itself is never
+ * a candidate. Only returns paths that actually exist on disk.
+ *
+ * `<testBase>` is `workdir` for single-package repos and `workdir/<packagePrefix>`
+ * for monorepo packages. Co-located candidates always resolve relative to the git root.
+ *
+ * @param sourceFiles      - Source file paths relative to the git root (e.g. `["src/foo/bar.ts"]`)
+ * @param workdir          - Absolute path to the repository root
+ * @param packagePrefix    - Monorepo package directory relative to repo root (e.g. `"apps/api"`)
+ * @param testFilePatterns - Glob patterns classifying test files (config-driven)
+ * @returns Existing test file paths (absolute)
+ *
+ * @example
+ * ```typescript
+ * // Single-package, separated (suffix convention)
+ * await mapSourceToTests(["src/foo/bar.ts"], "/repo");
+ * // => ["/repo/test/unit/foo/bar.test.ts"]
+ *
+ * // Monorepo, co-located .spec.ts (NestJS)
+ * await mapSourceToTests(["apps/api/src/agents/agents.service.ts"], "/repo", "apps/api");
+ * // => ["/repo/apps/api/src/agents/agents.service.spec.ts"]
+ *
+ * // Monorepo, pytest prefix convention
+ * await mapSourceToTests(["apps/api/src/pkg/sizing.py"], "/repo", "apps/api", ["tests/**\/test_*.py"]);
+ * // => ["/repo/apps/api/tests/pkg/test_sizing.py"]
+ * ```
+ */
 export async function mapSourceToTests(
   sourceFiles: string[],
   workdir: string,

--- a/test/unit/operations/verify-scoped.test.ts
+++ b/test/unit/operations/verify-scoped.test.ts
@@ -310,6 +310,148 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
     expect(seen?.resolvedTestPatterns).toBe(resolvedTestPatterns);
   });
 
+  test("scoped failure with zero executed tests → falls back to full suite (#1207)", async () => {
+    const commands: string[] = [];
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "uv run pytest 'src/stock_api/_agent.py'",
+        isFullSuite: false,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: false,
+      }),
+      regression: async (opts) => {
+        commands.push(opts.command);
+        // First (scoped) run: pytest collected no tests → exit 5, 0/0.
+        if (commands.length === 1) {
+          return {
+            status: "TEST_FAILURE" as const,
+            success: false,
+            countsTowardEscalation: true,
+            output: "collected 0 items",
+            exitCode: 5,
+          };
+        }
+        // Full-suite rerun passes.
+        return { status: "SUCCESS" as const, success: true, countsTowardEscalation: true, output: "8 passed" };
+      },
+      parseTestOutput: (output) =>
+        output === "8 passed" ? { passed: 8, failed: 0, failures: [] } : { passed: 0, failed: 0, failures: [] },
+    });
+    const ctx = ctxWithQuality({ commands: { test: "uv run pytest" } });
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", storyGitRef: "abc", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(commands).toEqual(["uv run pytest 'src/stock_api/_agent.py'", "uv run pytest"]);
+    expect(result.success).toBe(true);
+    expect(result.status).toBe("passed");
+    expect(result.isFullSuite).toBe(true);
+    expect(result.scopeTestFallback).toBe(true);
+    expect(result.passCount).toBe(8);
+  });
+
+  test("scoped failure with real test failures → no full-suite rerun", async () => {
+    let regressionCalls = 0;
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "bun test test/a.test.ts",
+        isFullSuite: false,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: false,
+      }),
+      regression: async () => {
+        regressionCalls++;
+        return { status: "TEST_FAILURE" as const, success: false, countsTowardEscalation: true, output: "1 fail" };
+      },
+      parseTestOutput: () => ({
+        passed: 3,
+        failed: 1,
+        failures: [{ testName: "t1", file: "a.test.ts", error: "boom", stackTrace: [] }],
+      }),
+      testSummaryToFindings: () => [mockFinding],
+    });
+    const ctx = ctxWithQuality({ commands: { test: "bun test" } });
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", storyGitRef: "abc", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(regressionCalls).toBe(1);
+    expect(result.status).toBe("failed");
+    expect(result.isFullSuite).toBe(false);
+  });
+
+  test("failure with zero parsed findings → emits synth execution-failed finding (#1207)", async () => {
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "uv run pytest",
+        isFullSuite: true,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: false,
+      }),
+      regression: async () => ({
+        status: "TEST_FAILURE" as const,
+        success: false,
+        countsTowardEscalation: true,
+        output: "ImportError: cannot import name 'foo'",
+        exitCode: 2,
+      }),
+      parseTestOutput: () => ({ passed: 0, failed: 0, failures: [] }),
+      testSummaryToFindings: () => [],
+    });
+    const ctx = ctxWithQuality({ commands: { test: "uv run pytest" } });
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.status).toBe("failed");
+    expect(result.findings.length).toBe(1);
+    expect(result.findings[0].source).toBe("test-runner");
+    expect(result.findings[0].category).toBe("execution-failed");
+    expect(result.findings[0].message).toContain("uv run pytest");
+    expect(result.findings[0].message).toContain("ImportError");
+  });
+
+  test("scoped 0/0 failure → full-suite rerun also 0/0 → synth finding for the full-suite command", async () => {
+    let regressionCalls = 0;
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "uv run pytest 'src/_agent.py'",
+        isFullSuite: false,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: false,
+      }),
+      regression: async () => {
+        regressionCalls++;
+        return {
+          status: "TEST_FAILURE" as const,
+          success: false,
+          countsTowardEscalation: true,
+          output: "conftest.py crash",
+          exitCode: 4,
+        };
+      },
+      parseTestOutput: () => ({ passed: 0, failed: 0, failures: [] }),
+      testSummaryToFindings: () => [],
+    });
+    const ctx = ctxWithQuality({ commands: { test: "uv run pytest" } });
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", storyGitRef: "abc", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(regressionCalls).toBe(2);
+    expect(result.status).toBe("failed");
+    expect(result.isFullSuite).toBe(true);
+    expect(result.scopeTestFallback).toBe(true);
+    expect(result.findings.length).toBe(1);
+    expect(result.findings[0].category).toBe("execution-failed");
+    expect(result.findings[0].message).toContain("uv run pytest");
+  });
+
   test("timeout → status=timeout, success=false", async () => {
     const deps = fakeDeps({
       regression: async () => ({

--- a/test/unit/operations/verify-scoped.test.ts
+++ b/test/unit/operations/verify-scoped.test.ts
@@ -452,6 +452,33 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
     expect(result.findings[0].message).toContain("uv run pytest");
   });
 
+  test("scoped TIMEOUT with zero executed tests → no full-suite rerun, status=timeout", async () => {
+    let regressionCalls = 0;
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "uv run pytest 'src/_agent.py'",
+        isFullSuite: false,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: false,
+      }),
+      regression: async () => {
+        regressionCalls++;
+        return { status: "TIMEOUT" as const, success: false, countsTowardEscalation: false, output: "" };
+      },
+      parseTestOutput: () => ({ passed: 0, failed: 0, failures: [] }),
+    });
+    const ctx = ctxWithQuality({ commands: { test: "uv run pytest" } });
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", storyGitRef: "abc", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(regressionCalls).toBe(1);
+    expect(result.status).toBe("timeout");
+    expect(result.success).toBe(false);
+    expect(result.isFullSuite).toBe(false);
+  });
+
   test("timeout → status=timeout, success=false", async () => {
     const deps = fakeDeps({
       regression: async () => ({

--- a/test/unit/verification/smart-runner-discovery.test.ts
+++ b/test/unit/verification/smart-runner-discovery.test.ts
@@ -54,6 +54,61 @@ describe("Pass 1: mapSourceToTests (path convention)", () => {
     const result = await mapSourceToTests([], "/repo");
     expect(result).toEqual([]);
   });
+
+  // ── Identity guard (#1207): a suffix-only pattern like "tests/**/*.py"
+  // degrades to suffix ".py", whose co-located candidate reconstructs the
+  // source file itself. The source file must never be returned as its own test.
+  test("never maps a source file to itself (Python suffix degeneration)", async () => {
+    mockFileExists(["/repo/src/stock_api/_agent.py"]);
+    const result = await mapSourceToTests(["src/stock_api/_agent.py"], "/repo", undefined, ["tests/**/*.py"]);
+    expect(result).toEqual([]);
+  });
+
+  test("never maps a source file to itself with packagePrefix (monorepo)", async () => {
+    mockFileExists(["/repo/apps/api/src/stock_api/_agent.py"]);
+    const result = await mapSourceToTests(["apps/api/src/stock_api/_agent.py"], "/repo", "apps/api", [
+      "tests/**/*.py",
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  // ── Prefix patterns (#1207): pytest's test_*.py convention is prefix-based;
+  // candidates must carry the basename prefix, not just a suffix.
+  test("prefix pattern maps to mirrored test under derived test dir", async () => {
+    mockFileExists(["/repo/tests/stock_api/_tools/test_sizing.py"]);
+    const result = await mapSourceToTests(["src/stock_api/_tools/sizing.py"], "/repo", undefined, [
+      "tests/**/test_*.py",
+    ]);
+    expect(result).toEqual(["/repo/tests/stock_api/_tools/test_sizing.py"]);
+  });
+
+  test("prefix pattern maps to flat test under derived test dir", async () => {
+    mockFileExists(["/repo/tests/test_sizing.py"]);
+    const result = await mapSourceToTests(["src/stock_api/_tools/sizing.py"], "/repo", undefined, [
+      "tests/**/test_*.py",
+    ]);
+    expect(result).toEqual(["/repo/tests/test_sizing.py"]);
+  });
+
+  test("prefix pattern maps to co-located test next to the source", async () => {
+    mockFileExists(["/repo/src/stock_api/_tools/test_sizing.py"]);
+    const result = await mapSourceToTests(["src/stock_api/_tools/sizing.py"], "/repo", undefined, ["test_*.py"]);
+    expect(result).toEqual(["/repo/src/stock_api/_tools/test_sizing.py"]);
+  });
+
+  test("prefix pattern maps under packagePrefix (monorepo)", async () => {
+    mockFileExists(["/repo/apps/api/tests/stock_api/_tools/test_sizing.py"]);
+    const result = await mapSourceToTests(["apps/api/src/stock_api/_tools/sizing.py"], "/repo", "apps/api", [
+      "tests/**/test_*.py",
+    ]);
+    expect(result).toEqual(["/repo/apps/api/tests/stock_api/_tools/test_sizing.py"]);
+  });
+
+  test("suffix pattern also probes test dirs derived from the glob (tests/ mirror)", async () => {
+    mockFileExists(["/repo/tests/foo/bar_test.py"]);
+    const result = await mapSourceToTests(["src/foo/bar.py"], "/repo", undefined, ["tests/**/*_test.py"]);
+    expect(result).toEqual(["/repo/tests/foo/bar_test.py"]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A Python monorepo run (pytest, `tests/**/*.py` patterns) exposed a failure chain in scoped verification:

1. **`mapSourceToTests` mapped a changed source file to itself.** Test candidates were derived from the suffix after the last `*` in each glob — every Python pattern (`tests/**/*.py`, `test_*.py`) reduces to suffix `.py`, so the co-located candidate reconstructed the source file itself. The scoped command became `uv run pytest .../src/stock_api/_agent.py`.
2. **pytest collected 0 tests (exit 5) → phase failed with `passCount: 0, failCount: 0`.**
3. **Rectification silently no-oped.** Zero parsed failures → zero findings → `runRectification` returned `{}` without dispatching a fix → post-rectification resume re-ran the same deterministic failure → terminal story failure, no agent ever invoked.

## Changes

**`src/verification/smart-runner.ts`**
- Identity guard: a candidate equal to the changed source file is never returned.
- Basename shapes: globs parse to `<prefix>*<suffix>` (was suffix-only), so pytest's prefix convention (`test_*.py`) generates mirrored / flat / co-located candidates.
- Probe dirs now include static leading dirs declared by the patterns themselves (e.g. `tests/`) in addition to `DEFAULT_SEPARATED_TEST_DIRS`.

**`src/operations/verify-scoped.ts`**
- A failed scoped run that executed zero tests (pytest exit 5 "no tests collected", collection error confined to the scoped file) reruns the full suite instead of failing the story on an unusable scope (`isFullSuite: true, scopeTestFallback: true`). Runs with real failures are unaffected.
- A failed run whose output parses to zero structured failures now emits the `execution-failed` synth finding (reusing `executionFailureToFinding`, mirroring `full-suite-gate.ts`) carrying command + exit code + output tail — so rectification dispatches the implementer instead of no-oping on 0 findings.

## Test plan

- [x] 7 new `mapSourceToTests` cases: self-map guard (single-package + monorepo), prefix mirrored/flat/co-located, monorepo prefix, derived-dir suffix mirror
- [x] 4 new `verifyScopedOp` cases: 0/0 scoped failure → full-suite fallback (pass + fail paths), synth finding shape/content, real failures → no rerun
- [x] All pre-existing tests pass unchanged (`bun run test:bail` — unit + integration + ui green)
- [x] `bun run typecheck`, `bun run lint` clean