### PR TITLE
docs/fix: ADR behavior audit — F1 amend ADR-023, F2 packages warn, F4 invariant tests, F5 tombstones

### DIFF
--- a/docs/adr/ADR-005-pipeline-re-architecture.md
+++ b/docs/adr/ADR-005-pipeline-re-architecture.md
@@ -1,8 +1,10 @@
 # ADR-005: Pipeline Re-Architecture
 
-**Status:** Proposed  
+**Status:** Superseded by ADR-023 (Execution Unification)
 **Date:** 2026-03-06  
-**Author:** William Khoo, Nax Dev  
+**Author:** William Khoo, Nax Dev
+
+> **Tombstone (2026-06-10):** The 12-stage pipeline sequence proposed here was collapsed to 8 stages by ADR-023. The event-bus invariant (§6) remains honored. File references (`src/verification/orchestrator.ts`, `post-verify.ts`, `rectification.ts`, `VerifyResult`) no longer exist — see `src/findings/`, `src/operations/`, ADR-021/022 for the current truth. This document is archived for historical context only.
 
 ---
 

--- a/docs/adr/ADR-014-runscope-and-middleware.md
+++ b/docs/adr/ADR-014-runscope-and-middleware.md
@@ -1,11 +1,14 @@
 # ADR-014: RunScope, Agent Middleware, and Orphan Consolidation
 
-**Status:** Reject
+**Status:** Reject — see ADR-018 (Runtime Layering) for the accepted design
 **Date:** 2026-04-23
 **Author:** William Khoo, Claude
 **Extends:** ADR-013 (SessionManager → AgentManager Hierarchy); ADR-012 (AgentManager Ownership); ADR-011 (SessionManager Ownership)
-**Superseded-by / Followed-by:** ADR-015 (Operation Contract), ADR-016 (Prompt Composition & PackageView)
+**Superseded-by:** ADR-018 (Runtime Layering with Session Runners) — the `Operation<I,O,C>` contract and `PackageView`/`PackageRegistry` carried forward; `RunScope`, agent-middleware chain, and `src/control/` were not built
+**Also-superseded-by:** ADR-014-runscope-and-operation-standardization (the parallel draft filed the same day — see that file)
 **Related:** #523 (fallback state divergence across orphan AgentManagers — unblocked by this ADR)
+
+> **Tombstone (2026-06-10):** Two files share the ADR-014 number; this file (`runscope-and-middleware`) and `ADR-014-runscope-and-operation-standardization.md` were both filed on 2026-04-23 as Reject drafts. Both were superseded by ADR-017 → ADR-018. Survivors: `Operation<I,O,C>`, `PackageView`, and the observer middleware (in simplified form) — all live in `src/operations/` and `src/runtime/`. `RunScope`, `src/control/`, and the agent-middleware chain were not built.
 
 ---
 

--- a/docs/adr/ADR-014-runscope-and-operation-standardization.md
+++ b/docs/adr/ADR-014-runscope-and-operation-standardization.md
@@ -1,11 +1,13 @@
-# ADR-014: RunScope Composition, Operation Standardization, and Prompt Middleware
+# ADR-014 (alt): RunScope Composition, Operation Standardization, and Prompt Middleware
 
-**Status:** Reject
+**Status:** Reject — see ADR-018 (Runtime Layering) for the accepted design
 **Date:** 2026-04-23
 **Author:** William Khoo, Claude
 **Extends:** ADR-013 (SessionManager → AgentManager Hierarchy); ADR-012 (AgentManager Ownership); ADR-011 (SessionManager Ownership); ADR-010 (Context Engine)
 **Related:** #523 (fallback state divergence across orphan AgentManagers — unblocked by this ADR)
-**Supersedeed-by:** ADR-014 (RunScope and Middleware), ADR-015 (Operation Contract), ADR-016 (Prompt Composition and PackageView)
+**Superseded-by:** ADR-018 (Runtime Layering with Session Runners)
+
+> **Tombstone (2026-06-10):** This is the *second* ADR-014 draft filed on 2026-04-23 (the parallel proposal). Both share the ADR-014 number and were filed as Reject on the same day. This file covers RunScope Composition + Prompt Middleware; the sibling `ADR-014-runscope-and-middleware.md` covers Agent Middleware + Orphan Consolidation. Both were superseded by ADR-017 → ADR-018. The `Superseded-by` field in the original header incorrectly pointed to "ADR-014 (RunScope and Middleware)" — corrected here to ADR-018.
 ---
 
 ## Context

--- a/docs/adr/ADR-016-prompt-composition-and-packageview.md
+++ b/docs/adr/ADR-016-prompt-composition-and-packageview.md
@@ -1,10 +1,13 @@
 # ADR-016: Prompt Composition (Immutable Sections) and PackageView
 
-**Status:** Reject
+**Status:** Reject — see ADR-018 (Runtime Layering) for the accepted design
 **Date:** 2026-04-23
 **Author:** William Khoo, Claude
 **Extends:** ADR-015 (Operation Contract); ADR-014 (RunScope & Middleware); ADR-010 (Context Engine)
+**Superseded-by:** ADR-018 (Runtime Layering with Session Runners)
 **Depends-on:** ADR-014 and ADR-015 must land first.
+
+> **Tombstone (2026-06-10):** `PackageView` / `PackageRegistry` survived into the accepted design and are implemented in `src/runtime/packages.ts`. The prompt-middleware chain (§1.1–1.3) was not built — prompt composition uses `composeSections()` (ADR-018 §7) and builder classes in `src/prompts/builders/` instead. The builder section-migration described here is incomplete; see `forbidden-patterns.md` § Prompt Builder Convention for the current SSOT.
 
 ---
 

--- a/docs/adr/ADR-023-execution-unification.md
+++ b/docs/adr/ADR-023-execution-unification.md
@@ -21,8 +21,8 @@ The core decision is **implemented**. Verified against the live tree:
 
 **Residual gaps** (see `docs/reports/2026-05-29-execution-unification-gap-audit.md`):
 
-- ⚠️ **`IReviewPlugin` per-story `plugin-reviews` phase (§1) was never wired**, and the retained deferred-only path is inert (`anyFailed` never consumed). Tracked in #1146.
-- ⚠️ **`format-check` phase (§1) never built** — formatting is only fixed reactively via `mechanical-formatfix` off lint findings. Divergence from the illustrative order; lint typically covers it.
+- **`IReviewPlugin` per-story `plugin-reviews` phase (§1) was never wired.** Per ADR-023/#1146, the accepted design is **deferred-only**: plugin reviewers run as a post-run step in `run-completion.ts`, not as a per-story builder phase. The `anyFailed` flag from `runDeferredReview()` is intentionally not gate-wired today; the CANONICAL_ORDER listing in §1 is aspirational. No action is needed unless per-story plugin-review gating is explicitly adopted in a future ADR.
+- **`format-check` phase (§1) was never built.** The accepted design is **reactive-only formatting**: `mechanical-formatfix` fires as a FixStrategy when lint findings trigger rectification (`src/execution/build-plan-for-strategy.ts:156-159`). A standalone proactive `format-check` gate was descoped after audit (2026-06-10 ADR behavior review). Impact is low because lint usually catches format errors; projects that need a hard format gate should add a lint rule. The CANONICAL_ORDER listing in §1 is updated accordingly — see below.
 - ✅ **D4 (`ReviewerSession` dialogue removal) completed (2026-05-29).** A verification pass found that no production code ever constructed a `ReviewerSession` — the debate subsystem referenced the type but never produced one, so D4's original premise ("debate consumers genuinely use it") was incorrect. The interface, factory, the `dialogue-verdict` selector, and all `resolverSession`/`reviewerSession` plumbing were removed in full. The `config.review.dialogue` deprecation shim in `src/config/loader.ts` is retained as the migration guard.
 
 > **SPEC reconciliation:** [SPEC-execution-unification.md](../specs/SPEC-execution-unification.md) Decision D1 ("retain `regressionStage`") and its AC-005c.3 were **overridden by issue #1116**, which deleted `regressionStage` (8-stage pipeline, not 9). The SPEC's D1/AC-005c.3 are superseded by #1116; this ADR's §5 + Open Question 3 reflect the as-built state.
@@ -65,16 +65,21 @@ The `inlineReview` findings doc ([docs/findings/2026-05-23-inlinereview-legacy-s
 `StoryOrchestratorBuilder` becomes the sole sequencer for per-story work:
 
 ```
-CANONICAL_ORDER (post-unification):
+CANONICAL_ORDER (as-built, 2026-06-10):
 
 [TDD fresh]   test-writer → greenfield-gate
 [always]      implementer
 [TDD]         full-suite-gate → verifier
 [non-TDD]     verify-scoped
-[always]      lint-check → typecheck-check → format-check → plugin-reviews
+[always]      lint-check → typecheck-check
 [always]      semantic-review → adversarial-review
 [always]      rectification
 ```
+
+> **Design note — `format-check` and `plugin-reviews`:** The illustrative order above originally listed `format-check` and `plugin-reviews` between `typecheck-check` and `semantic-review`. Neither phase was built:
+>
+> - *Formatting* is handled **reactively** — `mechanical-formatfix` fires as a FixStrategy when any lint finding triggers rectification. A standalone proactive gate was descoped (2026-06-10 audit). If a project needs a hard format gate, add a lint rule.
+> - *Plugin reviews* run **deferred** as a post-run step in `run-completion.ts` (per #1146), not per-story. The deferred path is intentional; per-story plugin-review gating is deferred to a future ADR.
 
 Every phase produces `Finding[]` in its parsed output (ADR-021 contract). The rectification phase consumes the union of unfixed findings and dispatches to `FixStrategy[]` via `runFixCycle` (ADR-022).
 

--- a/src/runtime/packages.ts
+++ b/src/runtime/packages.ts
@@ -1,5 +1,8 @@
 import type { ConfigLoader, ConfigSelector, NaxConfig } from "../config";
 import { mergePackageConfig } from "../config";
+import { getSafeLogger } from "../logger";
+
+export const _packagesDeps = { getSafeLogger };
 
 export type PackageOverrideLoader = (repoRoot: string, packageDir: string) => Promise<Partial<NaxConfig> | null>;
 
@@ -49,6 +52,7 @@ function createPackageView(config: NaxConfig, packageDir: string, repoRoot: stri
 export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): PackageRegistry {
   const cache = new Map<string, PackageView>();
   const mergedConfigs = new Map<string, NaxConfig>();
+  let hydrated = false;
 
   // Normalize to relative so cache and mergedConfigs keys are consistent with
   // what hydrate() stores (discoverWorkspacePackages returns relative paths).
@@ -70,6 +74,18 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
     // Use merged config if hydration pre-loaded one for this package; otherwise root config.
     const overrideConfig = mergedConfigs.get(key);
     const hasOverride = overrideConfig !== undefined;
+    // Warn when a caller resolves a non-root package before hydrate() has run — the
+    // returned view silently uses root config instead of per-package overrides.  This
+    // catches entry points (CLI one-off commands, plugins) that skip runSetupPhase.
+    if (!hasOverride && key && !hydrated) {
+      _packagesDeps
+        .getSafeLogger()
+        ?.warn(
+          "packages",
+          "resolve() called for non-root package before hydrate(); returning root config (per-package overrides not applied)",
+          { packageDir: key },
+        );
+    }
     const config = overrideConfig ?? loader.current();
     const view = createPackageView(config, key, repoRoot, hasOverride);
     cache.set(key, view);
@@ -93,6 +109,7 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
         cache.delete(dir);
       }
     }
+    hydrated = true;
   }
 
   return {

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -55,6 +55,16 @@ describe("adversarialReviewOp shape", () => {
   });
 });
 
+// ADR-008 anti-oscillation invariant: each review round opens a fresh session.
+// If lifetime were "reuse", the reviewer would carry state from a previous pass
+// and could flip its verdict based on stale prior-round context — the root cause
+// of oscillating pass/fail verdicts investigated in ADR-008.
+describe("ADR-008 anti-oscillation invariant — reviewer opens a fresh session each round", () => {
+  test("adversarialReviewOp declares lifetime:fresh (no cross-round session state)", () => {
+    expect(adversarialReviewOp.session.lifetime).toBe("fresh");
+  });
+});
+
 describe("adversarialReviewOp.build()", () => {
   test("returns ComposeInput with task section", () => {
     const ctx = makeBuildCtx();

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -56,6 +56,16 @@ describe("semanticReviewOp shape", () => {
   });
 });
 
+// ADR-008 anti-oscillation invariant: each review round opens a fresh session.
+// If lifetime were "reuse", the reviewer would carry state from a previous pass
+// and could flip its verdict based on stale prior-round context — the root cause
+// of oscillating pass/fail verdicts investigated in ADR-008.
+describe("ADR-008 anti-oscillation invariant — reviewer opens a fresh session each round", () => {
+  test("semanticReviewOp declares lifetime:fresh (no cross-round session state)", () => {
+    expect(semanticReviewOp.session.lifetime).toBe("fresh");
+  });
+});
+
 describe("semanticReviewOp.build()", () => {
   test("returns ComposeInput with task section", () => {
     const ctx = makeBuildCtx();

--- a/test/unit/runtime/packages.test.ts
+++ b/test/unit/runtime/packages.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect } from "bun:test";
-import { createPackageRegistry } from "../../../src/runtime/packages";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _packagesDeps, createPackageRegistry } from "../../../src/runtime/packages";
 import { createConfigLoader, pickSelector } from "../../../src/config";
-import { makeNaxConfig } from "../../helpers";
+import { makeLogger, makeNaxConfig } from "../../helpers";
 
 const minConfig = makeNaxConfig({ routing: { strategy: "keyword" } });
 const routingSel = pickSelector("routing-pkg-test", "routing");
@@ -103,5 +103,80 @@ describe("PackageView.hasOverride and repoRoot", () => {
     const registry = createPackageRegistry(loader, "/repo");
     expect(registry.repo().hasOverride).toBe(false);
     expect(registry.repo().repoRoot).toBe("/repo");
+  });
+});
+
+describe("F2 invariant — pre-hydrate warn for non-root resolve()", () => {
+  let origGetSafeLogger: typeof _packagesDeps.getSafeLogger;
+
+  beforeEach(() => {
+    origGetSafeLogger = _packagesDeps.getSafeLogger;
+  });
+
+  afterEach(() => {
+    _packagesDeps.getSafeLogger = origGetSafeLogger;
+  });
+
+  test("warns when resolve(nonRootPkg) is called before hydrate()", () => {
+    const mockLogger = makeLogger();
+    _packagesDeps.getSafeLogger = mock(() => mockLogger as unknown as ReturnType<typeof _packagesDeps.getSafeLogger>);
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+
+    registry.resolve("packages/app");
+
+    const warnCalls = mockLogger.calls.filter((c) => c.level === "warn" && c.stage === "packages");
+    expect(warnCalls.length).toBe(1);
+    expect(warnCalls[0].data?.packageDir).toBe("packages/app");
+  });
+
+  test("does not warn for repo() (root-equivalent, no per-package override expected)", () => {
+    const mockLogger = makeLogger();
+    _packagesDeps.getSafeLogger = mock(() => mockLogger as unknown as ReturnType<typeof _packagesDeps.getSafeLogger>);
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+
+    registry.repo();
+
+    expect(mockLogger.calls.filter((c) => c.level === "warn")).toHaveLength(0);
+  });
+
+  test("does not warn after hydrate() has run", async () => {
+    const mockLogger = makeLogger();
+    _packagesDeps.getSafeLogger = mock(() => mockLogger as unknown as ReturnType<typeof _packagesDeps.getSafeLogger>);
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+
+    // hydrate with an empty list — sufficient to set the hydrated flag
+    await registry.hydrate([], async () => null);
+    registry.resolve("packages/app");
+
+    expect(mockLogger.calls.filter((c) => c.level === "warn" && c.stage === "packages")).toHaveLength(0);
+  });
+
+  test("does not warn for a package that was hydrated with an override", async () => {
+    const mockLogger = makeLogger();
+    _packagesDeps.getSafeLogger = mock(() => mockLogger as unknown as ReturnType<typeof _packagesDeps.getSafeLogger>);
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+
+    await registry.hydrate(["packages/app"], async (_root, dir) =>
+      dir === "packages/app" ? ({ quality: { commands: { lint: "pkg-lint" } } } as any) : null,
+    );
+    registry.resolve("packages/app");
+
+    expect(mockLogger.calls.filter((c) => c.level === "warn" && c.stage === "packages")).toHaveLength(0);
+  });
+
+  test("warns only once per package (cached view suppresses repeat)", () => {
+    const mockLogger = makeLogger();
+    _packagesDeps.getSafeLogger = mock(() => mockLogger as unknown as ReturnType<typeof _packagesDeps.getSafeLogger>);
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+
+    registry.resolve("packages/app");
+    registry.resolve("packages/app"); // second call hits cache — no second warn
+
+    expect(mockLogger.calls.filter((c) => c.level === "warn" && c.stage === "packages")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- **F1 (ADR-023):** Documents reactive-only formatting and deferred plugin-reviews as intentional design decisions. Updates CANONICAL_ORDER in §1 to match the as-built 8-phase sequence and adds design-note blockquote explaining both descoped phases. Removes the `⚠️` gap markers that implied these were pending work.
- **F2 (packages.ts):** `resolve()` now warns via `getSafeLogger` when a non-root package is resolved before `hydrate()` has run, catching entry points (CLI one-offs, plugins) that bypass `runSetupPhase`. Adds `_packagesDeps` for testability; `hydrate()` sets `hydrated = true` on completion.
- **F4 (ADR-008 invariant):** Adds dedicated `describe` blocks to `adversarialReviewOp` and `semanticReviewOp` tests documenting *why* `lifetime:"fresh"` is required — stale cross-round session state causes oscillating pass/fail verdicts.
- **F5 (tombstones):** ADR-005 → Superseded by ADR-023. Both ADR-014 files → Superseded by ADR-018 (duplicate numbering explained). ADR-016 → Superseded by ADR-018. ADR-007 and ADR-017 already had supersession notes.
- **F3** (ADR-021 Phase 8 flag ramp) left for a separate track.

## Test plan

- [ ] `bun test test/unit/runtime/packages.test.ts` — 16 tests pass (5 new warn-invariant tests)
- [ ] `bun test test/unit/operations/adversarial-review.test.ts test/unit/operations/semantic-review.test.ts` — 52 tests pass (2 new ADR-008 invariant describe blocks)
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean