### PR TITLE
fix(greenfield): route detection + isolation through resolveTestFilePatterns SSOT

### DIFF
--- a/docs/findings/2026-06-10-greenfield-detection-bug.md
+++ b/docs/findings/2026-06-10-greenfield-detection-bug.md
@@ -1,0 +1,129 @@
+# Greenfield Detection Bug — 2026-06-10
+
+## Summary
+
+The greenfield gate reported "no pre-existing tests" even after the TDD test-writer
+had created test files, causing the orchestrator to short-circuit with a terminal
+phase failure. The first pass (Root Causes 1–3) fixed the path-matching and Bun-native
+violations. A follow-up pass (Root Cause 4, **revised**) standardised *which test-file
+patterns* greenfield detection uses, so the routing pre-check, the orchestrator
+greenfield gate, and test-writer isolation all classify test files identically through
+the ADR-009 SSOT (`resolveTestFilePatterns`).
+
+---
+
+## Root Cause 1 — `scanForTestFiles` tested filename, not relative path
+
+**File:** `src/context/greenfield.ts`
+
+`scanForTestFiles` matched regex patterns against `entry.name` (just the filename, e.g.
+`"foo.test.ts"`) but `globsToTestRegex` produces path-aware regexes anchored with
+`(?:^|/)`. Patterns with a directory component (e.g. `test/**/*.test.ts`) never matched
+a bare filename.
+
+**Effect:** Any project using the default `test/**/*.test.ts` pattern saw the greenfield
+gate fail to find tests under `test/`.
+
+**Fix:** Classify against the **relative path** (`git ls-files` output / `Bun.Glob`
+relative paths), not `entry.name`.
+
+---
+
+## Root Cause 2 — Bun-native + scan-logic duplication in `greenfield.ts`
+
+**File:** `src/context/greenfield.ts`
+
+`scanForTestFiles` used `readdir` from `node:fs/promises` (forbidden) and duplicated
+directory-scanning logic.
+
+**Fix:** Replaced with `git ls-files` → `isTestFileByPatterns` (the established pattern
+used by `auto-detect.ts` and `isolation.ts`), with a `Bun.Glob` fallback for non-git
+workdirs.
+
+---
+
+## Root Cause 3 — `IGNORE_DIRS` was TypeScript-centric
+
+**File:** `src/context/greenfield.ts`
+
+The ignored-directory set (used only by the non-git `Bun.Glob` fallback) was missing
+output/dependency dirs for Go, Python, Rust, and Java. `build/` was removed from the
+ignore list because it is a legitimate source package name in Go and Rust.
+
+**Fix:** Expanded `IGNORE_DIRS` to cover JS/TS, Go (`vendor`), Python
+(`__pycache__`, `.venv`, …), Rust/Java/Gradle (`target`, `.gradle`, `out`), and universal
+(`tmp`, `temp`, `.git`).
+
+---
+
+## Root Cause 4 — Three test-detection sites used divergent pattern sources (REVISED)
+
+**Files:** `src/pipeline/stages/routing.ts`, `src/operations/write-test.ts`,
+`src/execution/plan-inputs.ts`, `src/context/greenfield.ts`,
+`src/test-runners/conventions.ts`, `src/test-runners/index.ts`, `src/utils/paths.ts`
+
+The original pass introduced a **fourth competing pattern constant**,
+`GREENFIELD_FALLBACK_PATTERNS` (broad polyglot), and had the routing pre-check and
+test-writer isolation each hand-roll a read of `execution.smartTestRunner.testFilePatterns`
+with **different fallbacks**. The result: three sites that could disagree.
+
+| Site | Pattern source (before) | Fallback (before) |
+|:-----|:------------------------|:------------------|
+| Routing greenfield pre-check (`routing.ts`) | inline config read | `GREENFIELD_FALLBACK_PATTERNS` (broad) |
+| `greenfieldGateOp` (orchestrator) | ✅ `resolveTestFilePatterns()` → `.globs` | `DEFAULT_TEST_FILE_PATTERNS` |
+| Test-writer isolation (`write-test.ts`) | inline config read | `DEFAULT_TEST_FILE_PATTERNS` |
+
+This violates `monorepo-awareness.md` §C ("one source of truth per concept") and ADR-009.
+The orchestrator gate already did the right thing; the other two bypassed the SSOT.
+
+**Revised fix — collapse all three onto `resolveTestFilePatterns()`:**
+
+1. **Routing pre-check** now resolves patterns via the SSOT (same call shape the gate
+   uses) and passes `.globs` to `isGreenfieldStory`. Its detection tier
+   (`detectTestFilePatterns`) discovers pre-existing tests across languages from
+   `git ls-files`.
+2. **`plan-inputs.ts`** threads its already-resolved `resolvedTestPatterns` (the SAME
+   object the greenfield gate receives) into `testWriterInput`. Isolation consumes
+   `.globs`, so isolation and the gate classify test files identically.
+3. **`isGreenfieldStory`** now defaults to `DEFAULT_TEST_FILE_PATTERNS` (signature parity
+   with `verifyTestWriterIsolation`); `GREENFIELD_FALLBACK_PATTERNS` is **deleted**.
+4. The duplicated `packageDirRelative(projectDir, workdir)` computation is extracted into
+   one helper in `src/utils/paths.ts`, shared by routing and plan-inputs so both resolve
+   patterns against an identical package anchor.
+
+**Behavioural note:** In production (git repo) the detection tier finds pre-existing tests
+anywhere, so behaviour is preserved. The only change is the *no-config* fallback, which
+narrows from broad polyglot to `DEFAULT_TEST_FILE_PATTERNS` — intentional, for parity with
+isolation. Detection (not a hardcoded broad constant) is the SSOT for polyglot coverage.
+
+---
+
+## Log Signature
+
+```
+{"stage":"tdd","message":"Session complete: test-writer", ...}
+{"stage":"tdd","message":"Isolation maintained", ...}
+{"stage":"story-orchestrator","message":"Greenfield-gate: no pre-existing tests — greenfield run, pausing TDD test-writer", ...}
+{"stage":"story-orchestrator","message":"Short-circuiting on phase failure", ...}
+{"stage":"story-orchestrator","message":"Terminal phase failure (post-rectification resume — bypasses rectification)", ...}
+```
+
+"Isolation maintained" means the test-writer correctly limited itself to test files only
+(role isolation check) — unrelated to whether the files were written to disk.
+
+---
+
+## Files Changed
+
+| File | Change |
+|:-----|:-------|
+| `src/context/greenfield.ts` | `git ls-files` + `isTestFileByPatterns`, Bun.Glob fallback, expanded `IGNORE_DIRS`; default patterns → `DEFAULT_TEST_FILE_PATTERNS` (parity with isolation) |
+| `src/pipeline/stages/routing.ts` | Greenfield pre-check resolves via `resolveTestFilePatterns()` SSOT and passes `.globs` |
+| `src/execution/plan-inputs.ts` | Use shared `packageDirRelative`; thread `resolvedTestPatterns` into `testWriterInput` |
+| `src/operations/write-test.ts` | `TestWriterInput.resolvedTestPatterns`; isolation `verify` consumes `.globs` (drops inline config read) |
+| `src/utils/paths.ts` | New `packageDirRelative(projectDir, workdir)` helper — SSOT for the resolver's package anchor |
+| `src/test-runners/conventions.ts` | **Removed** `GREENFIELD_FALLBACK_PATTERNS` (competing SSOT) |
+| `src/test-runners/index.ts` | Removed barrel export for `GREENFIELD_FALLBACK_PATTERNS` |
+| `test/unit/pipeline/greenfield.test.ts` | Co-located-src cases pass resolved globs; added DEFAULT-fallback parity test |
+| `test/unit/pipeline/stages/routing-greenfield-monorepo.test.ts` | Stub `resolveTestFilePatterns` to broad globs (isolates fs-scoping under test) |
+| `test/integration/routing/routing-stage-greenfield.test.ts`, `routing-stage-final-state.test.ts` | Configure co-located `testFilePatterns` (resolver tier-2) |

--- a/src/context/greenfield.ts
+++ b/src/context/greenfield.ts
@@ -6,95 +6,93 @@
  * from producing empty test files (BUG-010).
  */
 
-import { readdir } from "node:fs/promises";
-import { join } from "node:path";
 import type { UserStory } from "../prd/types";
-import { globsToTestRegex } from "../test-runners/conventions";
+import { DEFAULT_TEST_FILE_PATTERNS, isTestFileByPatterns } from "../test-runners";
 
-/**
- * Broad fallback patterns for the greenfield scan — covers any test file
- * across all common languages without restricting to a single directory.
- * Patterns are expanded (no brace alternatives) so globsToTestRegex can build
- * correct suffix regexes. Used when the caller doesn't supply resolved patterns.
- */
-const GREENFIELD_FALLBACK_PATTERNS: readonly string[] = Object.freeze([
-  "**/*.test.ts",
-  "**/*.test.js",
-  "**/*.test.tsx",
-  "**/*.test.jsx",
-  "**/*.spec.ts",
-  "**/*.spec.js",
-  "**/*.spec.tsx",
-  "**/*.spec.jsx",
-  "**/*_test.go",
-  "test_*.py",
-  "*_test.py",
+/** Injectable deps for testability. */
+export const _greenfieldDeps = {
+  spawn: Bun.spawn as typeof Bun.spawn,
+};
+
+/** Directories excluded from the Bun.Glob fallback scan (non-git workdirs only). */
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  "dist",
+  ".next",
+  ".nuxt",
+  ".cache",
+  "coverage",
+  "vendor",
+  "__pycache__",
+  ".venv",
+  "venv",
+  ".eggs",
+  "target",
+  ".gradle",
+  "out",
+  "tmp",
+  "temp",
+  ".git",
 ]);
 
 /**
- * Recursively scan directory for test files.
- * Ignores node_modules, dist, build, .next directories.
- * Throws error if root directory is unreadable.
+ * List files in workdir via `git ls-files`.
+ * Returns null when git is unavailable or the directory is not a repo.
  */
-async function scanForTestFiles(dir: string, testPatterns: RegExp[], isRootCall = true): Promise<string[]> {
-  const results: string[] = [];
-  const ignoreDirs = new Set(["node_modules", "dist", "build", ".next", ".git"]);
-
+async function gitLsFiles(workdir: string): Promise<string[] | null> {
   try {
-    const entries = await readdir(dir, { withFileTypes: true });
+    const proc = _greenfieldDeps.spawn(["git", "ls-files"], {
+      cwd: workdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const output = await new Response(proc.stdout).text();
+    return output.split("\n").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
 
-    for (const entry of entries) {
-      const fullPath = join(dir, entry.name);
+/**
+ * Return true if at least one test file exists in `workdir` matching `patterns`.
+ * Uses `git ls-files` as primary; falls back to Bun.Glob for non-git workdirs.
+ */
+async function hasTestFiles(workdir: string, patterns: readonly string[]): Promise<boolean> {
+  const files = await gitLsFiles(workdir);
 
-      if (entry.isDirectory()) {
-        // Skip ignored directories
-        if (ignoreDirs.has(entry.name)) continue;
-
-        // Recursively scan subdirectories (not root call)
-        const subResults = await scanForTestFiles(fullPath, testPatterns, false);
-        results.push(...subResults);
-      } else if (entry.isFile()) {
-        // Check if file matches any test pattern
-        if (testPatterns.some((re) => re.test(entry.name))) {
-          results.push(fullPath);
-        }
-      }
-    }
-  } catch (error) {
-    // If this is the root call and we can't read it, propagate the error
-    if (isRootCall) {
-      throw error;
-    }
-    // Otherwise, ignore errors from unreadable subdirectories
+  if (files !== null) {
+    return files.some((f) => isTestFileByPatterns(f, patterns));
   }
 
-  return results;
+  // Fallback: Bun.Glob scan for non-git workdirs (e.g. temp fixtures in tests).
+  for (const pattern of patterns) {
+    const g = new Bun.Glob(pattern);
+    for await (const path of g.scan({ cwd: workdir, onlyFiles: true })) {
+      if (!path.split("/").some((seg) => IGNORE_DIRS.has(seg))) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**
  * Detect if a story is greenfield based on test file presence in workdir.
  *
- * A story is greenfield if:
- * - No test files exist matching any of the given patterns in the working directory
+ * A story is greenfield if no test files matching the given patterns exist
+ * in the working directory.
  *
- * This prevents the TDD test-writer from struggling to create tests when there are
- * no existing test examples to follow.
+ * Production callers (the routing pre-check and `greenfieldGateOp`) always pass
+ * patterns resolved through `resolveTestFilePatterns()` — the ADR-009 SSOT,
+ * whose detection tier finds pre-existing tests across languages. The `patterns`
+ * argument is therefore the single source of truth. When omitted (ad-hoc / test
+ * callers only), it falls back to `DEFAULT_TEST_FILE_PATTERNS` — the SAME default
+ * `verifyTestWriterIsolation` uses, so greenfield detection and test-writer
+ * isolation classify test files identically.
  *
- * @param story - User story to check
- * @param workdir - Working directory to scan for test files
- * @param patterns - Glob patterns for test files (default: DEFAULT_TEST_FILE_PATTERNS)
  * @returns true if no test files exist (greenfield), false otherwise
- *
- * @example
- * ```ts
- * // Empty project with no tests
- * const isGreenfield = await isGreenfieldStory(story, "/path/to/project");
- * // => true
- *
- * // Project with existing test files
- * const isGreenfield = await isGreenfieldStory(story, "/path/to/project");
- * // => false
- * ```
  */
 export async function isGreenfieldStory(
   _story: UserStory,
@@ -102,12 +100,9 @@ export async function isGreenfieldStory(
   patterns?: readonly string[],
 ): Promise<boolean> {
   try {
-    const regexes = globsToTestRegex(patterns ?? GREENFIELD_FALLBACK_PATTERNS);
-    const testFiles = await scanForTestFiles(workdir, regexes);
-    return testFiles.length === 0;
-  } catch (error) {
-    // If scan fails completely (e.g., workdir doesn't exist), assume not greenfield (safe fallback)
-    // This prevents skipping TDD when we can't determine the actual state
+    return !(await hasTestFiles(workdir, patterns ?? DEFAULT_TEST_FILE_PATTERNS));
+  } catch {
+    // Scan failed (e.g. workdir doesn't exist) — assume not greenfield so TDD is not skipped.
     return false;
   }
 }

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -6,7 +6,6 @@
  * plan construction.
  */
 
-import { relative, sep } from "node:path";
 import { isThreeSessionStrategy } from "../config";
 import type { NaxConfig } from "../config/schema";
 import { filterContextByRole } from "../context";
@@ -28,6 +27,7 @@ import { TddPromptBuilder } from "../prompts";
 import { prepareAdversarialReviewInput, prepareSemanticReviewInput } from "../review";
 import type { ResolvedTestPatterns } from "../test-runners";
 import { resolveTestFilePatterns } from "../test-runners/resolver";
+import { packageDirRelative } from "../utils/paths";
 import type { RectificationPhaseOptions } from "./story-orchestrator";
 
 /**
@@ -210,14 +210,9 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
 
   // AC#4 (#1120) + ADR-009: resolve once per plan — shared by TDD gates AND review helpers.
   // Always resolves (not gated on _isTdd) so review helpers get patterns even on non-TDD plans.
-  // Using projectDir as root (with packageDirRelative for monorepos) is the SSOT per ADR-009.
-  const packageDirRelative = (() => {
-    if (ctx.workdir === ctx.projectDir) return undefined;
-    const rel = relative(ctx.projectDir, ctx.workdir);
-    if (rel === ".." || rel.startsWith(`..${sep}`)) return undefined;
-    return rel && rel !== "." ? rel : undefined;
-  })();
-  const resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.projectDir, packageDirRelative);
+  // Using projectDir as root (with packageDirRel for monorepos) is the SSOT per ADR-009.
+  const packageDirRel = packageDirRelative(ctx.projectDir, ctx.workdir);
+  const resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.projectDir, packageDirRel);
   const [testWriterPrompt, implementerPrompt, verifierPrompt] = _isTdd
     ? await Promise.all([
         _isFreshRun ? buildThreeSessionPrompt("test-writer", ctx, isLite) : Promise.resolve(""),
@@ -234,6 +229,9 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           featureContextMarkdown: ctx.featureContextMarkdown,
           constitution: ctx.constitution?.content,
           lite: isLite,
+          // Same resolved object the greenfield gate receives — so test-writer
+          // isolation classifies test files identically to the gate (ADR-009 SSOT).
+          resolvedTestPatterns,
         }
       : undefined;
 
@@ -280,7 +278,7 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
         // undefined for single-package — see PipelineContext.workdir invariant); resolvedTestPatterns
         // is the ADR-009 SSOT. Use the same anchor as resolveTestFilePatterns above for consistency.
         repoRoot: ctx.projectDir,
-        packagePrefix: packageDirRelative,
+        packagePrefix: packageDirRel,
         resolvedTestPatterns,
       }
     : undefined;

--- a/src/operations/write-test.ts
+++ b/src/operations/write-test.ts
@@ -3,6 +3,7 @@ import type { TddConfig } from "../config/selectors";
 import type { UserStory } from "../prd";
 import { _isolationDeps, verifyTestWriterIsolation } from "../tdd/isolation";
 import type { IsolationCheck } from "../tdd/types";
+import type { ResolvedTestPatterns } from "../test-runners";
 import { parseSessionJsonOutput } from "./_session-output";
 import { shouldKeepSessionOpen } from "./execution-gates";
 import type { RunOperation } from "./types";
@@ -28,6 +29,14 @@ export interface TestWriterInput {
    * src/ write outside `tdd.testWriterAllowedPaths`.
    */
   readonly lite?: boolean;
+  /**
+   * Test-file patterns resolved once per plan via the ADR-009 SSOT
+   * (`resolveTestFilePatterns`). The `verify` hook passes `.globs` to
+   * `verifyTestWriterIsolation` so isolation classifies test files identically
+   * to `greenfieldGateOp` (which receives the SAME resolved object). Absent in
+   * legacy / ad-hoc callers — isolation then falls back to DEFAULT_TEST_FILE_PATTERNS.
+   */
+  readonly resolvedTestPatterns?: ResolvedTestPatterns;
 }
 
 export interface TestWriterOutput {
@@ -93,11 +102,11 @@ export const testWriterOp: RunOperation<TestWriterInput, TestWriterOutput, TddCo
   async verify(parsed, input, ctx): Promise<TestWriterOutput | null> {
     if (!input.beforeRef) return parsed;
     const allowedPaths = ctx.config.tdd?.testWriterAllowedPaths ?? ["src/index.ts", "src/**/index.ts"];
-    const testFilePatterns =
-      typeof ctx.packageView.config.execution?.smartTestRunner === "object" &&
-      ctx.packageView.config.execution.smartTestRunner !== null
-        ? ctx.packageView.config.execution.smartTestRunner.testFilePatterns
-        : undefined;
+    // ADR-009 SSOT: use the patterns resolved once at plan-build time (the SAME
+    // object the greenfield gate received) so isolation and greenfield detection
+    // classify test files identically. Falls back to verifyTestWriterIsolation's
+    // own DEFAULT_TEST_FILE_PATTERNS default when absent (legacy / ad-hoc callers).
+    const testFilePatterns = input.resolvedTestPatterns?.globs;
     const isolation = await verifyTestWriterIsolation(
       ctx.packageView.packageDir,
       input.beforeRef,

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -11,11 +11,14 @@
  * - `continue`: Routing determined, proceed to next stage
  */
 
+import { resolveTestFilePatterns } from "@/test-runners";
+import { packageDirRelative } from "@/utils/paths";
 import { isGreenfieldStory } from "../../context/greenfield";
 import { getLogger } from "../../logger";
 import { savePRD } from "../../prd";
 import { complexityToModelTier, resolveRouting } from "../../routing";
 import { clearCache } from "../../routing/strategies/llm";
+import { errorMessage } from "../../utils/errors";
 import type { PipelineContext, PipelineStage, RoutingResult, StageResult } from "../types";
 
 export const routingStage: PipelineStage = {
@@ -78,7 +81,25 @@ export const routingStage: PipelineStage = {
     const greenfieldDetectionEnabled = ctx.config.tdd.greenfieldDetection ?? true;
     if (greenfieldDetectionEnabled && routing.testStrategy.startsWith("three-session-tdd")) {
       const greenfieldScanDir = ctx.workdir;
-      const isGreenfield = await _routingDeps.isGreenfieldStory(ctx.story, greenfieldScanDir);
+      // Resolve test-file patterns through the ADR-009 SSOT — the SAME resolver
+      // greenfieldGateOp and test-writer isolation use — so the routing pre-check,
+      // the orchestrator gate, and isolation all classify test files identically.
+      // Its detection tier discovers pre-existing tests across languages; falls
+      // back to DEFAULT_TEST_FILE_PATTERNS only when nothing is found/configured.
+      const root = ctx.projectDir ?? ctx.workdir;
+      const packageDir = packageDirRelative(root, ctx.workdir);
+      const resolved = await _routingDeps
+        .resolveTestFilePatterns(ctx.config, root, packageDir, { storyId: ctx.story.id })
+        .catch((err) => {
+          // Misconfigured per-package config etc. — degrade to the DEFAULT greenfield
+          // patterns (isGreenfieldStory handles undefined), but leave a diagnostic trail.
+          logger.debug("routing", "Test-pattern resolution failed; using default greenfield patterns", {
+            storyId: ctx.story.id,
+            error: errorMessage(err),
+          });
+          return undefined;
+        });
+      const isGreenfield = await _routingDeps.isGreenfieldStory(ctx.story, greenfieldScanDir, resolved?.globs);
       if (isGreenfield) {
         logger.info("routing", "Greenfield detected — forcing test-after strategy", {
           storyId: ctx.story.id,
@@ -114,6 +135,7 @@ export const _routingDeps = {
   resolveRouting,
   complexityToModelTier,
   isGreenfieldStory,
+  resolveTestFilePatterns,
   clearCache,
   savePRD,
 };

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -2,8 +2,28 @@
  * Shared path utilities
  */
 
-import { join } from "node:path";
+import { join, relative, sep } from "node:path";
 import { globalConfigDir } from "../config/paths";
+
+/**
+ * Compute the monorepo package directory **relative** to the repo root, as
+ * `resolveTestFilePatterns()` expects it (third argument).
+ *
+ * Returns `undefined` for single-package repos (workdir === projectDir) and for
+ * any case where `workdir` is not contained within `projectDir` (e.g. worktree
+ * mode where `workdir` points outside the repo root) — callers then resolve
+ * patterns against the repo root with no package scoping.
+ *
+ * SSOT: both the routing stage (greenfield pre-check) and plan-inputs (gate +
+ * isolation inputs) call this so they resolve test-file patterns against an
+ * identical package anchor. See `.claude/rules/monorepo-awareness.md` §C.
+ */
+export function packageDirRelative(projectDir: string, workdir: string): string | undefined {
+  if (!projectDir || !workdir || workdir === projectDir) return undefined;
+  const rel = relative(projectDir, workdir);
+  if (rel === ".." || rel.startsWith(`..${sep}`)) return undefined;
+  return rel && rel !== "." ? rel : undefined;
+}
 
 /**
  * Get the central runs directory, respecting NAX_RUNS_DIR env var override.

--- a/test/integration/routing/routing-stage-final-state.test.ts
+++ b/test/integration/routing/routing-stage-final-state.test.ts
@@ -86,6 +86,23 @@ function createTestContext(workdir: string, overrides?: Partial<PipelineContext>
         abortOnIncreasingFailures: true,
       },
       contextProviderTokenBudget: 2000,
+      // Explicit co-located test patterns (resolver tier-2, ADR-009 SSOT) so
+      // greenfield detection matches src-co-located tests without needing a git
+      // fixture for the detection tier. Mirrors a project using co-located tests.
+      smartTestRunner: {
+        enabled: true,
+        fallback: "import-grep",
+        testFilePatterns: [
+          "**/*.test.ts",
+          "**/*.test.tsx",
+          "**/*.test.js",
+          "**/*.test.jsx",
+          "**/*.spec.ts",
+          "**/*.spec.js",
+          "**/*.spec.tsx",
+          "**/*.spec.jsx",
+        ],
+      },
     },
     quality: {
       requireTypecheck: false,

--- a/test/integration/routing/routing-stage-greenfield.test.ts
+++ b/test/integration/routing/routing-stage-greenfield.test.ts
@@ -99,6 +99,23 @@ function createTestContext(
         abortOnIncreasingFailures: true,
       },
       contextProviderTokenBudget: 2000,
+      // Explicit co-located test patterns (resolver tier-2, ADR-009 SSOT) so
+      // greenfield detection matches src-co-located tests without needing a git
+      // fixture for the detection tier. Mirrors a project using co-located tests.
+      smartTestRunner: {
+        enabled: true,
+        fallback: "import-grep",
+        testFilePatterns: [
+          "**/*.test.ts",
+          "**/*.test.tsx",
+          "**/*.test.js",
+          "**/*.test.jsx",
+          "**/*.spec.ts",
+          "**/*.spec.js",
+          "**/*.spec.tsx",
+          "**/*.spec.jsx",
+        ],
+      },
     },
     quality: {
       requireTypecheck: false,

--- a/test/unit/pipeline/greenfield.test.ts
+++ b/test/unit/pipeline/greenfield.test.ts
@@ -32,9 +32,28 @@ const createMockStory = (id = "US-001"): UserStory => ({
 
 async function createTestFile(workdir: string, filepath: string, content = ""): Promise<void> {
   const fullPath = join(workdir, filepath);
-  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
   await Bun.write(fullPath, content);
 }
+
+/**
+ * Broad polyglot globs equivalent to what the ADR-009 SSOT resolver's detection
+ * tier yields for a repo with co-located tests. Production callers (routing
+ * pre-check, greenfieldGateOp) always pass patterns resolved via
+ * `resolveTestFilePatterns()`; these exercise the classifier + IGNORE_DIRS logic
+ * for co-located-test layouts. With NO patterns, `isGreenfieldStory` falls back
+ * to DEFAULT_TEST_FILE_PATTERNS ("test/**\/*.test.ts") — parity with
+ * `verifyTestWriterIsolation`.
+ */
+const BROAD_PATTERNS = [
+  "**/*.test.ts",
+  "**/*.test.tsx",
+  "**/*.test.js",
+  "**/*.test.jsx",
+  "**/*.spec.ts",
+  "**/*.spec.js",
+  "**/*.spec.tsx",
+  "**/*.spec.jsx",
+] as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // isGreenfieldStory
@@ -57,67 +76,82 @@ describe("isGreenfieldStory", () => {
     expect(result).toBe(true);
   });
 
-  it("returns false when .test.ts files exist", async () => {
+  // Co-located-src layouts: production resolves broad globs via the SSOT detection
+  // tier, so these pass BROAD_PATTERNS to exercise the classifier. (With the
+  // DEFAULT_TEST_FILE_PATTERNS fallback, src-co-located tests do not match — that
+  // is the intended parity with verifyTestWriterIsolation; see default-fallback
+  // test below.)
+  it("returns false when .test.ts files exist (resolved globs)", async () => {
     await createTestFile(workdir, "src/foo.test.ts", "test('foo', () => {})");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(result).toBe(false);
   });
 
-  it("returns false when .spec.ts files exist", async () => {
+  it("returns false when .spec.ts files exist (resolved globs)", async () => {
     await createTestFile(workdir, "src/foo.spec.ts", "describe('foo', () => {})");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(result).toBe(false);
   });
 
-  it("returns false when .test.js files exist", async () => {
+  it("returns false when .test.js files exist (resolved globs)", async () => {
     await createTestFile(workdir, "src/foo.test.js", "test('foo', () => {})");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(result).toBe(false);
   });
 
-  it("returns false when .test.tsx files exist", async () => {
+  it("returns false when .test.tsx files exist (resolved globs)", async () => {
     await createTestFile(workdir, "src/Component.test.tsx", "test('renders', () => {})");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(result).toBe(false);
   });
 
-  it("returns false when test files exist in test/ directory", async () => {
+  it("returns false when test files exist in test/ directory (DEFAULT fallback)", async () => {
+    // test/**/*.test.ts is the DEFAULT_TEST_FILE_PATTERNS fallback — no patterns needed.
     await createTestFile(workdir, "test/unit/foo.test.ts", "test('foo', () => {})");
     const story = createMockStory();
     const result = await isGreenfieldStory(story, workdir);
     expect(result).toBe(false);
   });
 
+  it("falls back to DEFAULT_TEST_FILE_PATTERNS when no patterns supplied (parity with isolation)", async () => {
+    // src-co-located test does NOT match the narrow DEFAULT (test/**/*.test.ts).
+    // verifyTestWriterIsolation uses the same default, so both agree.
+    await createTestFile(workdir, "src/foo.test.ts", "test('foo', () => {})");
+    const story = createMockStory();
+    const result = await isGreenfieldStory(story, workdir);
+    expect(result).toBe(true);
+  });
+
   it("ignores test files in node_modules", async () => {
     await createTestFile(workdir, "node_modules/lib/foo.test.ts", "test('foo', () => {})");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(result).toBe(true);
   });
 
   it("ignores test files in dist", async () => {
     await createTestFile(workdir, "dist/foo.test.ts", "test('foo', () => {})");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(result).toBe(true);
   });
 
-  it("ignores test files in build", async () => {
+  it("does not ignore test files in build (build/ is a valid source dir in Go/Rust)", async () => {
     await createTestFile(workdir, "build/foo.test.ts", "test('foo', () => {})");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
-    expect(result).toBe(true);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
+    expect(result).toBe(false);
   });
 
   it("returns true when only source files exist", async () => {
     await createTestFile(workdir, "src/index.ts", "export const foo = 42;");
     await createTestFile(workdir, "src/utils.ts", "export const bar = 'baz';");
     const story = createMockStory();
-    const result = await isGreenfieldStory(story, workdir);
+    const result = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(result).toBe(true);
   });
 
@@ -125,8 +159,8 @@ describe("isGreenfieldStory", () => {
     await createTestFile(workdir, "src/foo.custom.ts", "test('foo', () => {})");
     const story = createMockStory();
 
-    // Default pattern should not match
-    const resultDefault = await isGreenfieldStory(story, workdir);
+    // Default (and broad) patterns should not match a .custom.ts file
+    const resultDefault = await isGreenfieldStory(story, workdir, BROAD_PATTERNS);
     expect(resultDefault).toBe(true);
 
     // Custom pattern should match
@@ -181,6 +215,31 @@ describe("pre-existing test files prevent false greenfield detection", () => {
     const story = createMockStory("US-001");
     const result = await isGreenfieldStory(story, workdir);
 
+    expect(result).toBe(true);
+  });
+
+  it("detects tests with directory-prefixed pattern (e.g. test/**/*.test.ts)", async () => {
+    // Regression: scanForTestFiles previously tested entry.name ("foo.test.ts") against
+    // path-aware regexes from globsToTestRegex, so "test/**/*.test.ts" never matched
+    // because the regex requires the "test/" prefix. With this fix it matches the
+    // relative path "test/unit/foo.test.ts" correctly.
+    await createTestFile(workdir, "test/unit/foo.test.ts", "test('foo', () => {})");
+
+    const story = createMockStory("US-001");
+    const result = await isGreenfieldStory(story, workdir, ["test/**/*.test.ts"]);
+
+    // NOT greenfield — test file exists and the directory-prefixed pattern must match
+    expect(result).toBe(false);
+  });
+
+  it("does not match test files outside the pattern-specified directory", async () => {
+    // A file at src/foo.test.ts should not match test/**/*.test.ts
+    await createTestFile(workdir, "src/foo.test.ts", "test('foo', () => {})");
+
+    const story = createMockStory("US-001");
+    const result = await isGreenfieldStory(story, workdir, ["test/**/*.test.ts"]);
+
+    // IS greenfield — the file is in src/, not test/, so pattern does not match
     expect(result).toBe(true);
   });
 });

--- a/test/unit/pipeline/stages/routing-greenfield-monorepo.test.ts
+++ b/test/unit/pipeline/stages/routing-greenfield-monorepo.test.ts
@@ -93,6 +93,16 @@ describe("MW-011: greenfield detection scopes to story package workdir", () => {
       reasoning: "mock classification",
     }));
     _routingDeps.complexityToModelTier = mock(() => "fast" as const);
+    // Stub the ADR-009 SSOT resolver to broad globs so this test exercises the
+    // greenfield filesystem SCOPING (which package dir is scanned) via the real
+    // isGreenfieldStory — independent of detection-tier fs/git behaviour.
+    _routingDeps.resolveTestFilePatterns = mock(async () => ({
+      globs: ["**/*.test.ts", "**/*.spec.ts"],
+      pathspec: [],
+      regex: [],
+      testDirs: [],
+      resolution: "detected" as const,
+    }));
     _routingDeps.savePRD = mock(async () => {});
     _routingDeps.computeStoryContentHash = mock(() => "hash1");
     _routingDeps.routeBatch = undefined /* routeBatch deleted ROUTE-001 */;


### PR DESCRIPTION
## Summary

Greenfield detection reported "no pre-existing tests" inconsistently because **three** test-file-classification sites used divergent pattern sources. Only `greenfieldGateOp` went through the ADR-009 SSOT (`resolveTestFilePatterns`); the routing pre-check and test-writer isolation each hand-rolled a read of `execution.smartTestRunner.testFilePatterns` with **different fallbacks**, and a fourth competing constant `GREENFIELD_FALLBACK_PATTERNS` (broad polyglot) made the routing pre-check disagree with the gate and isolation.

| Site | Pattern source (before) | Fallback (before) |
|:-----|:------------------------|:------------------|
| Routing greenfield pre-check | inline config read | `GREENFIELD_FALLBACK_PATTERNS` (broad) |
| `greenfieldGateOp` (orchestrator) | ✅ `resolveTestFilePatterns()` → `.globs` | `DEFAULT_TEST_FILE_PATTERNS` |
| Test-writer isolation | inline config read | `DEFAULT_TEST_FILE_PATTERNS` |

This violates `monorepo-awareness.md` §C ("one source of truth per concept") and ADR-009.

## What changed

All three sites now resolve through the single SSOT, so the routing pre-check, the orchestrator gate, and `verifyTestWriterIsolation` classify test files **identically** (the gate and isolation literally share the same resolved object):

- **`routing.ts`** — resolves via `resolveTestFilePatterns()` and passes `.globs` to `isGreenfieldStory` (same call shape as the gate); logs `storyId`-first on resolver failure.
- **`plan-inputs.ts`** — threads the already-resolved `ResolvedTestPatterns` (the SAME object the gate receives) into `testWriterInput`.
- **`write-test.ts`** — isolation `verify` consumes `input.resolvedTestPatterns.globs`, dropping the inline `packageView` config read.
- **`greenfield.ts`** — `isGreenfieldStory` defaults to `DEFAULT_TEST_FILE_PATTERNS` (signature parity with `verifyTestWriterIsolation`); **deletes** `GREENFIELD_FALLBACK_PATTERNS`.
- **`utils/paths.ts`** — extracts `packageDirRelative(projectDir, workdir)` helper shared by routing + plan-inputs so both resolve against an identical package anchor.

Keeps the prior Bun-native rewrite of `greenfield.ts` (`git ls-files` + `Bun.Glob` fallback, expanded `IGNORE_DIRS`, relative-path classification — the original Root Cause 1–3 fixes).

## Behavioural note

In production (git repo) the resolver's detection tier finds pre-existing tests across languages via `git ls-files`, so behaviour is preserved. The only change is the *no-config* fallback, which narrows from a hand-kept broad constant to `DEFAULT_TEST_FILE_PATTERNS` — intentional, for parity with isolation. Polyglot coverage now comes from detection, not a constant that silently disagreed with every other subsystem.

## Test plan

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run lint` (all gate scripts incl. deep-relatives, alias-internals, logger-storyId)
- [x] Targeted sweep: **2422 tests pass / 0 fail** across `pipeline/`, `routing/`, `operations/`, `execution/`, `tdd/`, isolation, `test-runners/`
- [x] Pre-commit hooks green
- [x] code-reviewer agent: APPROVE, no CRITICAL/HIGH

### Test changes
- `greenfield.test.ts`: co-located-src cases pass resolved globs; added an explicit DEFAULT-fallback parity test (`src/foo.test.ts` IS greenfield under the narrow default, matching isolation).
- `routing-greenfield-monorepo.test.ts`: stubs `resolveTestFilePatterns` to broad globs to isolate the fs-scoping behaviour under test.
- `routing-stage-greenfield.test.ts` / `routing-stage-final-state.test.ts`: configure co-located `testFilePatterns` (resolver tier-2), representing a project with co-located tests.

## Known follow-up (not in scope)

`greenfield.ts`'s `git ls-files` (tracked files) is intentionally consistent with the detection tier's `file-scan.ts`. Switching to `--others --exclude-standard` to also catch untracked-but-present test files would make the greenfield gate use working-tree state — worth considering, but would diverge from the detection-tier SSOT this PR aligns to.