### PR TITLE
chore: release v0.69.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.69.7",
+  "version": "0.69.8",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.69.8

Bumps version: 0.69.7 → 0.69.8

After merging, run:
```bash
git checkout main && git pull origin main
bun run release tag
```