### PR TITLE
fix(acceptance): detect language per package in polyglot monorepos

### DIFF
--- a/src/acceptance/index.ts
+++ b/src/acceptance/index.ts
@@ -33,6 +33,7 @@ export type { AcceptanceEntry } from "./content-loader";
 export { loadAcceptanceTestContent } from "./content-loader";
 export { loadSemanticVerdicts } from "./semantic-verdict";
 export {
+  _groupDeps,
   findExistingAcceptanceTestPath,
   groupStoriesByPackage,
   resolveAcceptanceFeatureTestPath,

--- a/src/acceptance/test-path.ts
+++ b/src/acceptance/test-path.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
 import type { PRD, UserStory } from "../prd/types";
+import { detectLanguage as _detectLanguage } from "../project/detector";
+
+export const _groupDeps = {
+  detectLanguage: _detectLanguage as (dir: string) => Promise<string | undefined>,
+};
 
 export interface AcceptanceTestPathEntry {
   testPath: string;
@@ -103,13 +108,13 @@ export interface AcceptanceTestGroup {
  * @param testPathConfig - Optional override filename from config.acceptance.testPath
  * @param language    - Optional language from config.project.language
  */
-export function groupStoriesByPackage(
+export async function groupStoriesByPackage(
   prd: PRD,
   workdir: string,
   featureName: string,
   testPathConfig?: string,
   language?: string,
-): AcceptanceTestGroup[] {
+): Promise<AcceptanceTestGroup[]> {
   const nonFixStories = prd.userStories.filter((s) => !s.id.startsWith("US-FIX-") && s.status !== "decomposed");
 
   const groupMap = new Map<string, { stories: UserStory[]; criteria: string[] }>();
@@ -130,13 +135,18 @@ export function groupStoriesByPackage(
     groupMap.set("", { stories: [], criteria: [] });
   }
 
-  const groups: AcceptanceTestGroup[] = [];
-  for (const [wd, { stories, criteria }] of groupMap) {
-    const packageDir = wd ? path.join(workdir, wd) : workdir;
-    const testPath = resolveAcceptancePackageFeatureTestPath(packageDir, featureName, testPathConfig, language);
-    groups.push({ testPath, packageDir, stories, criteria });
-  }
-  return groups;
+  // Detect language per package in parallel so polyglot monorepos (e.g. Python API + TS web)
+  // get the correct test file extension. Falls back to the global language when detection
+  // returns undefined (e.g. no package markers, temp dirs in tests).
+  return Promise.all(
+    Array.from(groupMap.entries()).map(async ([wd, { stories, criteria }]) => {
+      const packageDir = wd ? path.join(workdir, wd) : workdir;
+      const detectedLang = await _groupDeps.detectLanguage(packageDir);
+      const resolvedLang = detectedLang ?? language;
+      const testPath = resolveAcceptancePackageFeatureTestPath(packageDir, featureName, testPathConfig, resolvedLang);
+      return { testPath, packageDir, stories, criteria };
+    }),
+  );
 }
 
 // ─── Suggested test path helpers (hardening pass) ───────────────────────────

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -135,12 +135,14 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
       // complete at run start (re-run). groupStoriesByPackage is the SSOT.
       const acceptanceTestPaths = options.featureDir
         ? await Promise.all(
-            groupStoriesByPackage(
-              options.prd,
-              options.workdir,
-              options.feature,
-              options.config.acceptance.testPath,
-              options.config.project?.language,
+            (
+              await groupStoriesByPackage(
+                options.prd,
+                options.workdir,
+                options.feature,
+                options.config.acceptance.testPath,
+                options.config.project?.language,
+              )
             ).map(async (g) => {
               const relativeWorkdir = path.relative(options.workdir, g.packageDir);
               let groupConfig = options.config;

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -201,7 +201,7 @@ export const acceptanceSetupStage: PipelineStage = {
     // US-001: Group non-fix, non-decomposed stories by story.workdir — one test file per package.
     // groupStoriesByPackage handles workdir grouping, path computation, and root fallback.
     const featureName = ctx.prd.feature ?? (ctx.prd as unknown as Record<string, string>).featureName;
-    const groups = groupStoriesByPackage(ctx.prd, ctx.workdir, featureName, testPathConfig, language);
+    const groups = await groupStoriesByPackage(ctx.prd, ctx.workdir, featureName, testPathConfig, language);
     const nonFixStories = groups.flatMap((g) => g.stories);
 
     let totalCriteria = 0;

--- a/test/unit/acceptance/test-path.test.ts
+++ b/test/unit/acceptance/test-path.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  _groupDeps,
   groupStoriesByPackage,
   resolveSuggestedPackageFeatureTestPath,
   resolveSuggestedTestFile,
@@ -41,76 +42,109 @@ const WORKDIR = "/repo";
 // ─── groupStoriesByPackage ───────────────────────────────────────────────────
 
 describe("groupStoriesByPackage()", () => {
-  test("single workdir — one group with correct testPath", () => {
+  test("single workdir — one group with correct testPath", async () => {
     const prd = makePRD([makeStory("US-001", "apps/api"), makeStory("US-002", "apps/api")]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature");
     expect(groups).toHaveLength(1);
     expect(groups[0].packageDir).toBe("/repo/apps/api");
     expect(groups[0].testPath).toBe("/repo/apps/api/.nax/features/my-feature/.nax-acceptance.test.ts");
     expect(groups[0].stories.map((s) => s.id)).toEqual(["US-001", "US-002"]);
   });
 
-  test("multiple workdirs (monorepo) — one group per unique workdir", () => {
+  test("multiple workdirs (monorepo) — one group per unique workdir", async () => {
     const prd = makePRD([
       makeStory("US-001", "apps/api"),
       makeStory("US-002", "apps/cli"),
       makeStory("US-003", "apps/api"),
     ]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature");
     expect(groups).toHaveLength(2);
     const dirs = groups.map((g) => g.packageDir).sort();
     expect(dirs).toEqual(["/repo/apps/api", "/repo/apps/cli"]);
   });
 
-  test("stories with no workdir are grouped at repo root", () => {
+  test("stories with no workdir are grouped at repo root", async () => {
     const prd = makePRD([makeStory("US-001"), makeStory("US-002")]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature");
     expect(groups).toHaveLength(1);
     expect(groups[0].packageDir).toBe(WORKDIR);
     expect(groups[0].testPath).toBe("/repo/.nax/features/my-feature/.nax-acceptance.test.ts");
   });
 
-  test("empty PRD — fallback to one root group", () => {
+  test("empty PRD — fallback to one root group", async () => {
     const prd = makePRD([]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature");
     expect(groups).toHaveLength(1);
     expect(groups[0].packageDir).toBe(WORKDIR);
     expect(groups[0].stories).toHaveLength(0);
   });
 
-  test("fix stories (US-FIX-*) are excluded", () => {
+  test("fix stories (US-FIX-*) are excluded", async () => {
     const prd = makePRD([makeStory("US-001", "apps/api"), makeStory("US-FIX-001", "apps/api")]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature");
     expect(groups).toHaveLength(1);
     expect(groups[0].stories.map((s) => s.id)).toEqual(["US-001"]);
   });
 
-  test("decomposed stories are excluded", () => {
+  test("decomposed stories are excluded", async () => {
     const prd = makePRD([
       makeStory("US-001", "apps/api"),
       makeStory("US-002", "apps/api", "decomposed" as UserStory["status"]),
     ]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature");
     expect(groups).toHaveLength(1);
     expect(groups[0].stories.map((s) => s.id)).toEqual(["US-001"]);
   });
 
-  test("respects language for file extension", () => {
+  test("respects language for file extension", async () => {
     const prd = makePRD([makeStory("US-001", "apps/api")]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature", undefined, "go");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature", undefined, "go");
     expect(groups[0].testPath).toBe("/repo/apps/api/.nax/features/my-feature/.nax-acceptance_test.go");
   });
 
-  test("respects testPathConfig override", () => {
+  test("respects testPathConfig override", async () => {
     const prd = makePRD([makeStory("US-001", "apps/api")]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature", "custom.test.ts");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature", "custom.test.ts");
     expect(groups[0].testPath).toBe("/repo/apps/api/.nax/features/my-feature/custom.test.ts");
   });
 
-  test("criteria are collected per group", () => {
+  test("criteria are collected per group", async () => {
     const prd = makePRD([makeStory("US-001", "apps/api"), makeStory("US-002", "apps/api")]);
-    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature");
     expect(groups[0].criteria).toEqual(["AC-1 for US-001", "AC-1 for US-002"]);
+  });
+
+  describe("per-package language detection", () => {
+    let origDetect: typeof _groupDeps.detectLanguage;
+
+    beforeEach(() => {
+      origDetect = _groupDeps.detectLanguage;
+    });
+
+    afterEach(() => {
+      _groupDeps.detectLanguage = origDetect;
+    });
+
+    test("polyglot monorepo — detected language per package overrides global language", async () => {
+      _groupDeps.detectLanguage = async (dir: string) => {
+        if (dir.endsWith("apps/web")) return "typescript";
+        if (dir.endsWith("apps/api")) return "python";
+        return undefined;
+      };
+      const prd = makePRD([makeStory("US-001", "apps/api"), makeStory("US-002", "apps/web")]);
+      const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature", undefined, "python");
+      const api = groups.find((g) => g.packageDir.endsWith("apps/api"))!;
+      const web = groups.find((g) => g.packageDir.endsWith("apps/web"))!;
+      expect(api.testPath).toBe("/repo/apps/api/.nax/features/my-feature/_nax_acceptance_test.py");
+      expect(web.testPath).toBe("/repo/apps/web/.nax/features/my-feature/.nax-acceptance.test.ts");
+    });
+
+    test("falls back to global language when detection returns undefined", async () => {
+      _groupDeps.detectLanguage = async () => undefined;
+      const prd = makePRD([makeStory("US-001", "apps/api")]);
+      const groups = await groupStoriesByPackage(prd, WORKDIR, "my-feature", undefined, "go");
+      expect(groups[0].testPath).toBe("/repo/apps/api/.nax/features/my-feature/.nax-acceptance_test.go");
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- `groupStoriesByPackage` previously applied a single `config.project.language` (detected from the repo root) to all story groups. In a polyglot monorepo — e.g. a Python FastAPI backend at `apps/api` and a TypeScript Next.js frontend at `apps/web` — the root detects as Python, so `apps/web` stories incorrectly got `_nax_acceptance_test.py` instead of `.nax-acceptance.test.ts`.
- Fix: `groupStoriesByPackage` now calls `detectLanguage(packageDir)` per group in parallel via `Promise.all`, falling back to the global `language` param only when detection returns `undefined` (no package markers found, e.g. temp dirs in tests).
- Added `_groupDeps` injectable so the detection call is mockable in unit tests without filesystem setup.
- Added two new unit tests: polyglot per-package detection overrides global language; undefined detection falls back to global language.

## Test plan

- [ ] `bun run lint` — clean
- [ ] `bun run typecheck` — clean
- [ ] `bun run test` — 1077 tests, 0 fail
- [ ] New tests cover the polyglot detection path (`apps/api` → python, `apps/web` → typescript) and the fallback path (detection returns `undefined` → global language wins)