### PR TITLE
fix(acceptance): use packageDir for hardening suggested test path in monorepos

### DIFF
--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -5,13 +5,15 @@
  * Passing criteria are promoted from suggestedCriteria → acceptanceCriteria.
  */
 
+import path from "node:path";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { getSafeLogger } from "../logger";
 import { callOp as _callOp, acceptanceGenerateOp, acceptanceRefineOp } from "../operations";
 import type { CallContext } from "../operations/types";
 import { savePRD } from "../prd";
-import type { PRD } from "../prd/types";
+import type { PRD, UserStory } from "../prd/types";
+import { detectLanguage as _detectLanguage } from "../project/detector";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { parseTestFailures } from "../test-runners/ac-parser";
 import { buildAcceptanceRunCommand, generateSkeletonTests } from "./generator";
@@ -45,15 +47,159 @@ export const _hardeningDeps = {
   writeFile: async (p: string, c: string) => {
     await Bun.write(p, c);
   },
+  detectLanguage: _detectLanguage as (dir: string) => Promise<string | undefined>,
 };
 
-// ─── Main runner ────────────────────────────────────────────────────────────
+// ─── Private helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Process one package group: refine criteria, generate test file, run it,
+ * then promote passing criteria and discard failing ones.
+ * Mutates groupStories' acceptanceCriteria/suggestedCriteria in place and
+ * accumulates results into the shared HardeningResult.
+ */
+async function processPackageGroup(
+  ctx: HardeningContext,
+  packageDir: string,
+  groupStories: UserStory[],
+  language: string | undefined,
+  result: HardeningResult,
+): Promise<void> {
+  const logger = getSafeLogger();
+
+  // Refine suggested criteria for this group
+  const groupRefined: RefinedCriterion[] = [];
+  for (const story of groupStories) {
+    const callCtx: CallContext = {
+      runtime: ctx.runtime,
+      packageView: ctx.runtime.packages.resolve(packageDir),
+      packageDir,
+      storyId: story.id,
+      featureName: ctx.prd.feature,
+      agentName: ctx.agentManager.getDefault(),
+    };
+    const refined = await _hardeningDeps.callOp(callCtx, acceptanceRefineOp, {
+      criteria: story.suggestedCriteria ?? [],
+      codebaseContext: "",
+      storyId: story.id,
+      testStrategy: ctx.config.acceptance?.testStrategy,
+      testFramework: ctx.config.acceptance?.testFramework,
+      storyTitle: story.title,
+      storyDescription: story.description,
+    });
+    groupRefined.push(...refined);
+  }
+
+  // Resolve suggested test path using packageDir (not workdir)
+  const suggestedTestPath = resolveSuggestedPackageFeatureTestPath(
+    packageDir,
+    ctx.prd.feature,
+    ctx.config.acceptance?.suggestedTestPath,
+    language,
+  );
+
+  // Generate test file via acceptanceGenerateOp
+  const criteriaList = groupRefined.map((c, i) => `AC-${i + 1}: ${c.refined}`).join("\n");
+  const frameworkOverrideLine = ctx.config.acceptance?.testFramework
+    ? `\n[FRAMEWORK OVERRIDE: Use ${ctx.config.acceptance.testFramework} as the test framework regardless of what you detect.]`
+    : "";
+
+  const genCallCtx: CallContext = {
+    runtime: ctx.runtime,
+    packageView: ctx.runtime.packages.resolve(packageDir),
+    packageDir,
+    storyId: groupStories[0]?.id,
+    featureName: ctx.prd.feature,
+    agentName: ctx.agentManager.getDefault(),
+  };
+  const genResult = await _hardeningDeps.callOp(genCallCtx, acceptanceGenerateOp, {
+    featureName: ctx.prd.feature,
+    criteriaList,
+    frameworkOverrideLine,
+    targetTestFilePath: suggestedTestPath,
+  });
+
+  // Write test file; fall back to skeleton when op returns no code (ACP writes directly)
+  let testCode = genResult.testCode;
+  if (!testCode) {
+    const skeletonCriteria: AcceptanceCriterion[] = groupRefined.map((c, i) => ({
+      id: `AC-${i + 1}`,
+      text: c.refined,
+      lineNumber: i + 1,
+    }));
+    testCode = generateSkeletonTests(
+      ctx.prd.feature,
+      skeletonCriteria,
+      ctx.config.acceptance?.testFramework,
+      language,
+    );
+    logger?.warn("acceptance", "Hardening generate op returned no test code — using skeleton", {
+      storyIds: groupStories.map((s) => s.id),
+      storiesProcessed: groupStories.length,
+    });
+  }
+  await _hardeningDeps.writeFile(suggestedTestPath, testCode);
+
+  // Run tests scoped to the package dir
+  const testCmd = buildAcceptanceRunCommand(
+    suggestedTestPath,
+    ctx.config.project?.testFramework,
+    ctx.config.acceptance?.command,
+    packageDir,
+  );
+  const proc = _hardeningDeps.spawn(testCmd, { cwd: packageDir, stdout: "pipe", stderr: "pipe" });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const output = `${stdout}\n${stderr}`;
+
+  // Parse results and promote/discard for this group
+  const failedACs = parseTestFailures(output);
+  const failedSet = new Set(failedACs.map((ac) => ac.toUpperCase()));
+
+  // Group refined by storyId to prevent AC index drift (#336 gap 4)
+  const refinedByStory = new Map<string, RefinedCriterion[]>();
+  for (const r of groupRefined) {
+    const list = refinedByStory.get(r.storyId) ?? [];
+    list.push(r);
+    refinedByStory.set(r.storyId, list);
+  }
+
+  let acIndex = 0;
+  for (const story of groupStories) {
+    const storyRefined = refinedByStory.get(story.id) ?? [];
+    const toPromote: string[] = [];
+    const toDiscard: string[] = [];
+
+    for (const refined of storyRefined) {
+      acIndex++;
+      const acId = `AC-${acIndex}`;
+      if (refined.testable === false || failedSet.has(acId) || (exitCode !== 0 && failedACs.length === 0)) {
+        toDiscard.push(refined.original);
+      } else {
+        toPromote.push(refined.original);
+      }
+    }
+
+    if (toPromote.length > 0) {
+      const existingACs = new Set(story.acceptanceCriteria);
+      story.acceptanceCriteria = [...story.acceptanceCriteria, ...toPromote.filter((ac) => !existingACs.has(ac))];
+      result.promoted.push(...toPromote);
+    }
+    result.discarded.push(...toDiscard);
+    story.suggestedCriteria = toDiscard.length > 0 ? toDiscard : undefined;
+  }
+}
+
+// ─── Main runner ─────────────────────────────────────────────────────────────
 
 export async function runHardeningPass(ctx: HardeningContext): Promise<HardeningResult> {
   const logger = getSafeLogger();
   const result: HardeningResult = { promoted: [], discarded: [] };
 
-  // 1. Collect stories with suggestedCriteria
   const storiesWithSuggested = ctx.prd.userStories.filter((s) => s.suggestedCriteria && s.suggestedCriteria.length > 0);
   if (storiesWithSuggested.length === 0) return result;
 
@@ -64,147 +210,21 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
   });
 
   try {
-    // 2. Refine suggested criteria via acceptanceRefineOp
-    const allRefined: RefinedCriterion[] = [];
+    // Group stories by package so each package gets its own suggested test file
+    // placed under <packageDir>/.nax/features/… rather than at the repo root.
+    const packageGroups = new Map<string, typeof storiesWithSuggested>();
     for (const story of storiesWithSuggested) {
-      const criteria = story.suggestedCriteria ?? [];
-      const callCtx: CallContext = {
-        runtime: ctx.runtime,
-        packageView: ctx.runtime.packages.resolve(ctx.workdir),
-        packageDir: ctx.workdir,
-        storyId: story.id,
-        featureName: ctx.prd.feature,
-        agentName: ctx.agentManager.getDefault(),
-      };
-      const refined = await _hardeningDeps.callOp(callCtx, acceptanceRefineOp, {
-        criteria,
-        codebaseContext: "",
-        storyId: story.id,
-        testStrategy: ctx.config.acceptance?.testStrategy,
-        testFramework: ctx.config.acceptance?.testFramework,
-        storyTitle: story.title,
-        storyDescription: story.description,
-      });
-      allRefined.push(...refined);
+      const wd = story.workdir ?? "";
+      if (!packageGroups.has(wd)) packageGroups.set(wd, []);
+      packageGroups.get(wd)!.push(story);
     }
 
-    // 3. Resolve test path
-    const language = ctx.config.project?.language;
-    const suggestedTestPath = resolveSuggestedPackageFeatureTestPath(
-      ctx.workdir,
-      ctx.prd.feature,
-      ctx.config.acceptance?.suggestedTestPath,
-      language,
-    );
-
-    // 4. Generate test file via acceptanceGenerateOp
-    const criteriaList = allRefined.map((c, i) => `AC-${i + 1}: ${c.refined}`).join("\n");
-    const frameworkOverrideLine = ctx.config.acceptance?.testFramework
-      ? `\n[FRAMEWORK OVERRIDE: Use ${ctx.config.acceptance.testFramework} as the test framework regardless of what you detect.]`
-      : "";
-
-    const genCallCtx: CallContext = {
-      runtime: ctx.runtime,
-      packageView: ctx.runtime.packages.resolve(ctx.workdir),
-      packageDir: ctx.workdir,
-      storyId: storiesWithSuggested[0]?.id,
-      featureName: ctx.prd.feature,
-      agentName: ctx.agentManager.getDefault(),
-    };
-    const genResult = await _hardeningDeps.callOp(genCallCtx, acceptanceGenerateOp, {
-      featureName: ctx.prd.feature,
-      criteriaList,
-      frameworkOverrideLine,
-      targetTestFilePath: suggestedTestPath,
-    });
-
-    // 5. Write test file if returned as code (ACP writes directly)
-    let testCode = genResult.testCode;
-    if (!testCode) {
-      // Fall back to skeleton tests when the op returns no code
-      const skeletonCriteria: AcceptanceCriterion[] = allRefined.map((c, i) => ({
-        id: `AC-${i + 1}`,
-        text: c.refined,
-        lineNumber: i + 1,
-      }));
-      testCode = generateSkeletonTests(
-        ctx.prd.feature,
-        skeletonCriteria,
-        ctx.config.acceptance?.testFramework,
-        language,
-      );
-      logger?.warn("acceptance", "Hardening generate op returned no test code — using skeleton", {
-        storyIds: storiesWithSuggested.map((s) => s.id),
-        storiesProcessed: storiesWithSuggested.length,
-      });
-    }
-    await _hardeningDeps.writeFile(suggestedTestPath, testCode);
-
-    // 6. Run tests
-    const testCmd = buildAcceptanceRunCommand(
-      suggestedTestPath,
-      ctx.config.project?.testFramework,
-      ctx.config.acceptance?.command,
-      ctx.workdir,
-    );
-    const proc = _hardeningDeps.spawn(testCmd, {
-      cwd: ctx.workdir,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [exitCode, stdout, stderr] = await Promise.all([
-      proc.exited,
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
-    const output = `${stdout}\n${stderr}`;
-
-    // 7. Parse results and promote/discard
-    const failedACs = parseTestFailures(output);
-    const failedSet = new Set(failedACs.map((ac) => ac.toUpperCase()));
-
-    // Group allRefined by storyId so the mapping loop is driven by the refined
-    // criteria (not the original suggestedCriteria). This prevents AC index drift
-    // if acceptanceRefineOp ever changes the criterion count (#336 gap 4).
-    const refinedByStory = new Map<string, RefinedCriterion[]>();
-    for (const r of allRefined) {
-      const list = refinedByStory.get(r.storyId) ?? [];
-      list.push(r);
-      refinedByStory.set(r.storyId, list);
+    for (const [wd, groupStories] of packageGroups.entries()) {
+      const packageDir = wd ? path.join(ctx.workdir, wd) : ctx.workdir;
+      const detectedLang = await _hardeningDeps.detectLanguage(packageDir);
+      await processPackageGroup(ctx, packageDir, groupStories, detectedLang ?? ctx.config.project?.language, result);
     }
 
-    let acIndex = 0;
-    for (const story of storiesWithSuggested) {
-      const storyRefined = refinedByStory.get(story.id) ?? [];
-      const toPromote: string[] = [];
-      const toDiscard: string[] = [];
-
-      for (const refinedCriterion of storyRefined) {
-        acIndex++;
-        const acId = `AC-${acIndex}`;
-        const nonTestable = refinedCriterion.testable === false;
-        if (nonTestable || failedSet.has(acId) || (exitCode !== 0 && failedACs.length === 0)) {
-          // Discard: non-testable implementation detail, failed, or test crashed
-          toDiscard.push(refinedCriterion.original);
-        } else {
-          toPromote.push(refinedCriterion.original);
-        }
-      }
-
-      // Promote passing criteria — deduplicate against existing ACs (#336 gap 5)
-      if (toPromote.length > 0) {
-        const existingACs = new Set(story.acceptanceCriteria);
-        story.acceptanceCriteria = [...story.acceptanceCriteria, ...toPromote.filter((ac) => !existingACs.has(ac))];
-        result.promoted.push(...toPromote);
-      }
-      result.discarded.push(...toDiscard);
-
-      // Clean up suggestedCriteria
-      story.suggestedCriteria = toDiscard.length > 0 ? toDiscard : undefined;
-    }
-
-    // 8. Save PRD with promotions
     if (result.promoted.length > 0) {
       await _hardeningDeps.savePRD(ctx.prd, ctx.prdPath);
     }

--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -127,12 +127,7 @@ async function processPackageGroup(
       text: c.refined,
       lineNumber: i + 1,
     }));
-    testCode = generateSkeletonTests(
-      ctx.prd.feature,
-      skeletonCriteria,
-      ctx.config.acceptance?.testFramework,
-      language,
-    );
+    testCode = generateSkeletonTests(ctx.prd.feature, skeletonCriteria, ctx.config.acceptance?.testFramework, language);
     logger?.warn("acceptance", "Hardening generate op returned no test code — using skeleton", {
       storyIds: groupStories.map((s) => s.id),
       storiesProcessed: groupStories.length,
@@ -216,7 +211,7 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
     for (const story of storiesWithSuggested) {
       const wd = story.workdir ?? "";
       if (!packageGroups.has(wd)) packageGroups.set(wd, []);
-      packageGroups.get(wd)!.push(story);
+      packageGroups.get(wd)?.push(story);
     }
 
     for (const [wd, groupStories] of packageGroups.entries()) {

--- a/test/unit/acceptance/hardening.test.ts
+++ b/test/unit/acceptance/hardening.test.ts
@@ -1,22 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { type HardeningContext, _hardeningDeps, runHardeningPass } from "../../../src/acceptance/hardening";
 import type { NaxConfig } from "../../../src/config";
-import type { PRD } from "../../../src/prd/types";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makePRD, makeStory } from "../../helpers";
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
-
-function makePRD(overrides: Partial<PRD> = {}): PRD {
-  return {
-    project: "test",
-    feature: "test-feature",
-    branchName: "feat/test",
-    createdAt: "2026-01-01T00:00:00Z",
-    updatedAt: "2026-01-01T00:00:00Z",
-    userStories: [],
-    ...overrides,
-  };
-}
 
 const TEST_CONFIG = {
   autoMode: { defaultAgent: "claude" },
@@ -49,9 +36,7 @@ function makeCtx(overrides: Partial<HardeningContext> = {}): HardeningContext {
     runtime: {
       configLoader: { current: () => TEST_CONFIG },
       packages: {
-        resolve: () => ({
-          select: () => TEST_CONFIG,
-        }),
+        resolve: () => ({ select: () => TEST_CONFIG }),
         repo: () => ({ select: () => TEST_CONFIG }),
       },
       agentManager: runtimeAgentManager,
@@ -74,12 +59,16 @@ let origCallOp: typeof _hardeningDeps.callOp;
 let origSavePRD: typeof _hardeningDeps.savePRD;
 let origSpawn: typeof _hardeningDeps.spawn;
 let origWriteFile: typeof _hardeningDeps.writeFile;
+let origDetectLanguage: typeof _hardeningDeps.detectLanguage;
 
 beforeEach(() => {
   origCallOp = _hardeningDeps.callOp;
   origSavePRD = _hardeningDeps.savePRD;
   origSpawn = _hardeningDeps.spawn;
   origWriteFile = _hardeningDeps.writeFile;
+  origDetectLanguage = _hardeningDeps.detectLanguage;
+  // Stub out language detection so tests don't hit the filesystem
+  _hardeningDeps.detectLanguage = mock(async () => undefined);
 });
 
 afterEach(() => {
@@ -87,29 +76,46 @@ afterEach(() => {
   _hardeningDeps.savePRD = origSavePRD;
   _hardeningDeps.spawn = origSpawn;
   _hardeningDeps.writeFile = origWriteFile;
+  _hardeningDeps.detectLanguage = origDetectLanguage;
 });
+
+// ─── Spawn helpers ───────────────────────────────────────────────────────────
+
+function passingSpawn() {
+  return mock(() => ({
+    exited: Promise.resolve(0),
+    stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+    stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+  } as ReturnType<typeof Bun.spawn>));
+}
+
+function failingSpawn(output: string) {
+  return mock(() => ({
+    exited: Promise.resolve(1),
+    stdout: new ReadableStream({
+      start(ctrl) {
+        ctrl.enqueue(new TextEncoder().encode(output));
+        ctrl.close();
+      },
+    }),
+    stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+  } as ReturnType<typeof Bun.spawn>));
+}
+
+function mockCallOp(refineReturn: object[], generateReturn: object) {
+  return mock(async (_ctx: any, op: any, _input: any) => {
+    if (op.name === "acceptance-refine") return refineReturn;
+    if (op.name === "acceptance-generate") return generateReturn;
+    throw new Error(`Unexpected op: ${op.name}`);
+  });
+}
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("runHardeningPass()", () => {
   test("returns empty result when no stories have suggestedCriteria", async () => {
     const ctx = makeCtx({
-      prd: makePRD({
-        userStories: [
-          {
-            id: "US-001",
-            title: "Story",
-            description: "Desc",
-            acceptanceCriteria: ["AC-1"],
-            tags: [],
-            dependencies: [],
-            status: "passed",
-            passes: true,
-            escalations: [],
-            attempts: 1,
-          },
-        ],
-      }),
+      prd: makePRD({ userStories: [makeStory({ status: "passed", passes: true, attempts: 1 })] }),
     });
 
     const result = await runHardeningPass(ctx);
@@ -119,45 +125,31 @@ describe("runHardeningPass()", () => {
   });
 
   test("promotes passing suggested criteria to acceptanceCriteria", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC"],
       suggestedCriteria: ["suggested edge case"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
-
-    _hardeningDeps.callOp = mock(async (_ctx, op, _input) => {
-      if (op.name === "acceptance-refine") {
-        return [{ original: "suggested edge case", refined: "suggested edge case", testable: true, storyId: "US-001" }];
-      }
-      if (op.name === "acceptance-generate") {
-        return { testCode: 'test("AC-1", () => {})' };
-      }
-      throw new Error(`Unexpected op: ${op.name}`);
     });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.callOp = mockCallOp(
+      [{ original: "suggested edge case", refined: "suggested edge case", testable: true, storyId: "US-001" }],
+      { testCode: 'test("AC-1", () => {})' },
+    );
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => {
-      return {
-        exited: Promise.resolve(0),
-        stdout: new ReadableStream({
-          start(ctrl) {
-            ctrl.enqueue(new TextEncoder().encode("(pass) AC-1: suggested edge case\n"));
-            ctrl.close();
-          },
-        }),
-        stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      } as ReturnType<typeof Bun.spawn>;
-    });
+    _hardeningDeps.spawn = mock(() => ({
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream({
+        start(ctrl) {
+          ctrl.enqueue(new TextEncoder().encode("(pass) AC-1: suggested edge case\n"));
+          ctrl.close();
+        },
+      }),
+      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+    } as ReturnType<typeof Bun.spawn>));
 
     const result = await runHardeningPass(ctx);
 
@@ -169,45 +161,22 @@ describe("runHardeningPass()", () => {
   });
 
   test("discards failing suggested criteria", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC"],
       suggestedCriteria: ["failing edge case"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
-
-    _hardeningDeps.callOp = mock(async (_ctx, op, _input) => {
-      if (op.name === "acceptance-refine") {
-        return [{ original: "failing edge case", refined: "failing edge case", testable: true, storyId: "US-001" }];
-      }
-      if (op.name === "acceptance-generate") {
-        return { testCode: 'test("AC-1", () => {})' };
-      }
-      throw new Error(`Unexpected op: ${op.name}`);
     });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.callOp = mockCallOp(
+      [{ original: "failing edge case", refined: "failing edge case", testable: true, storyId: "US-001" }],
+      { testCode: 'test("AC-1", () => {})' },
+    );
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => {
-      return {
-        exited: Promise.resolve(1),
-        stdout: new ReadableStream({
-          start(ctrl) {
-            ctrl.enqueue(new TextEncoder().encode("(fail) AC-1: failing edge case\n"));
-            ctrl.close();
-          },
-        }),
-        stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      } as ReturnType<typeof Bun.spawn>;
-    });
+    _hardeningDeps.spawn = failingSpawn("(fail) AC-1: failing edge case\n");
 
     const result = await runHardeningPass(ctx);
 
@@ -219,40 +188,22 @@ describe("runHardeningPass()", () => {
   });
 
   test("discards testable:false criteria even when the stub test passes", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC"],
       suggestedCriteria: ["cli.ts contains an import of writeFileSync"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
-
-    _hardeningDeps.callOp = mock(async (_ctx, op, _input) => {
-      if (op.name === "acceptance-refine") {
-        return [{ original: "cli.ts contains an import of writeFileSync", refined: "cli.ts contains an import of writeFileSync", testable: false, storyId: "US-001" }];
-      }
-      if (op.name === "acceptance-generate") {
-        return { testCode: 'test("AC-1", () => { expect(true).toBe(true); })' };
-      }
-      throw new Error(`Unexpected op: ${op.name}`);
     });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.callOp = mockCallOp(
+      [{ original: "cli.ts contains an import of writeFileSync", refined: "cli.ts contains an import of writeFileSync", testable: false, storyId: "US-001" }],
+      { testCode: 'test("AC-1", () => { expect(true).toBe(true); })' },
+    );
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => {
-      return {
-        exited: Promise.resolve(0),
-        stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-        stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      } as ReturnType<typeof Bun.spawn>;
-    });
+    _hardeningDeps.spawn = passingSpawn();
 
     const result = await runHardeningPass(ctx);
 
@@ -264,43 +215,25 @@ describe("runHardeningPass()", () => {
   });
 
   test("promotes testable:true criterion while discarding testable:false in same story", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC"],
       suggestedCriteria: ["behavioral edge case", "cli.ts contains an import"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
-
-    _hardeningDeps.callOp = mock(async (_ctx, op, _input) => {
-      if (op.name === "acceptance-refine") {
-        return [
-          { original: "behavioral edge case", refined: "behavioral edge case", testable: true, storyId: "US-001" },
-          { original: "cli.ts contains an import", refined: "cli.ts contains an import", testable: false, storyId: "US-001" },
-        ];
-      }
-      if (op.name === "acceptance-generate") {
-        return { testCode: 'test("AC-1", () => {})\ntest("AC-2", () => { expect(true).toBe(true); })' };
-      }
-      throw new Error(`Unexpected op: ${op.name}`);
     });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.callOp = mockCallOp(
+      [
+        { original: "behavioral edge case", refined: "behavioral edge case", testable: true, storyId: "US-001" },
+        { original: "cli.ts contains an import", refined: "cli.ts contains an import", testable: false, storyId: "US-001" },
+      ],
+      { testCode: 'test("AC-1", () => {})\ntest("AC-2", () => { expect(true).toBe(true); })' },
+    );
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => {
-      return {
-        exited: Promise.resolve(0),
-        stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-        stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      } as ReturnType<typeof Bun.spawn>;
-    });
+    _hardeningDeps.spawn = passingSpawn();
 
     const result = await runHardeningPass(ctx);
 
@@ -312,19 +245,13 @@ describe("runHardeningPass()", () => {
   });
 
   test("does not throw on error — returns partial result", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC"],
       suggestedCriteria: ["edge case"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
+    });
     const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
 
     _hardeningDeps.callOp = mock(async () => {
@@ -339,42 +266,26 @@ describe("runHardeningPass()", () => {
   });
 
   test("mapping loop driven from allRefined prevents AC index drift when refine count changes (#336 gap 4)", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC"],
       // 3 suggested criteria, but refine deduplicates to 2
       suggestedCriteria: ["dup criterion A", "dup criterion A", "passing criterion"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
-
-    _hardeningDeps.callOp = mock(async (_ctx, op, _input) => {
-      if (op.name === "acceptance-refine") {
-        return [
-          { original: "dup criterion A", refined: "dup criterion A", testable: true, storyId: "US-001" },
-          { original: "passing criterion", refined: "passing criterion", testable: true, storyId: "US-001" },
-        ];
-      }
-      if (op.name === "acceptance-generate") {
-        return { testCode: 'test("AC-1", () => {})\ntest("AC-2", () => {})' };
-      }
-      throw new Error(`Unexpected op: ${op.name}`);
     });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.callOp = mockCallOp(
+      [
+        { original: "dup criterion A", refined: "dup criterion A", testable: true, storyId: "US-001" },
+        { original: "passing criterion", refined: "passing criterion", testable: true, storyId: "US-001" },
+      ],
+      { testCode: 'test("AC-1", () => {})\ntest("AC-2", () => {})' },
+    );
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => ({
-      exited: Promise.resolve(0),
-      stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-    } as ReturnType<typeof Bun.spawn>));
+    _hardeningDeps.spawn = passingSpawn();
 
     const result = await runHardeningPass(ctx);
 
@@ -384,41 +295,25 @@ describe("runHardeningPass()", () => {
   });
 
   test("deduplicates against existing acceptanceCriteria when promoting (#336 gap 5)", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC", "already promoted criterion"],
       suggestedCriteria: ["already promoted criterion", "new criterion"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
-
-    _hardeningDeps.callOp = mock(async (_ctx, op, _input) => {
-      if (op.name === "acceptance-refine") {
-        return [
-          { original: "already promoted criterion", refined: "already promoted criterion", testable: true, storyId: "US-001" },
-          { original: "new criterion", refined: "new criterion", testable: true, storyId: "US-001" },
-        ];
-      }
-      if (op.name === "acceptance-generate") {
-        return { testCode: 'test("AC-1", () => {})\ntest("AC-2", () => {})' };
-      }
-      throw new Error(`Unexpected op: ${op.name}`);
     });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.callOp = mockCallOp(
+      [
+        { original: "already promoted criterion", refined: "already promoted criterion", testable: true, storyId: "US-001" },
+        { original: "new criterion", refined: "new criterion", testable: true, storyId: "US-001" },
+      ],
+      { testCode: 'test("AC-1", () => {})\ntest("AC-2", () => {})' },
+    );
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => ({
-      exited: Promise.resolve(0),
-      stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-    } as ReturnType<typeof Bun.spawn>));
+    _hardeningDeps.spawn = passingSpawn();
 
     await runHardeningPass(ctx);
 
@@ -429,38 +324,22 @@ describe("runHardeningPass()", () => {
   });
 
   test("falls back to skeleton tests when acceptanceGenerateOp returns null testCode", async () => {
-    const story = {
-      id: "US-001",
-      title: "Story",
-      description: "Desc",
+    const story = makeStory({
       acceptanceCriteria: ["spec AC"],
       suggestedCriteria: ["edge case"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
-
-    _hardeningDeps.callOp = mock(async (_ctx, op, _input) => {
-      if (op.name === "acceptance-refine") {
-        return [{ original: "edge case", refined: "edge case", testable: true, storyId: "US-001" }];
-      }
-      if (op.name === "acceptance-generate") {
-        return { testCode: null };
-      }
-      throw new Error(`Unexpected op: ${op.name}`);
     });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.callOp = mockCallOp(
+      [{ original: "edge case", refined: "edge case", testable: true, storyId: "US-001" }],
+      { testCode: null },
+    );
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => ({
-      exited: Promise.resolve(0),
-      stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-    } as ReturnType<typeof Bun.spawn>));
+    _hardeningDeps.spawn = passingSpawn();
 
     const result = await runHardeningPass(ctx);
 
@@ -472,24 +351,19 @@ describe("runHardeningPass()", () => {
   });
 
   test("calls acceptanceRefineOp with story context fields", async () => {
-    const story = {
-      id: "US-001",
+    const story = makeStory({
       title: "Story Title",
       description: "Story Description",
       acceptanceCriteria: ["spec AC"],
       suggestedCriteria: ["edge case"],
-      tags: [],
-      dependencies: [],
-      status: "passed" as const,
+      status: "passed",
       passes: true,
-      escalations: [],
       attempts: 1,
-    };
-    const prd = makePRD({ userStories: [story] });
-    const ctx = makeCtx({ prd });
+    });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
 
     let capturedRefineInput: unknown;
-    _hardeningDeps.callOp = mock(async (_ctx, op, input) => {
+    _hardeningDeps.callOp = mock(async (_ctx: any, op: any, input: any) => {
       if (op.name === "acceptance-refine") {
         capturedRefineInput = input;
         return [{ original: "edge case", refined: "edge case", testable: true, storyId: "US-001" }];
@@ -501,11 +375,7 @@ describe("runHardeningPass()", () => {
     });
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
-    _hardeningDeps.spawn = mock(() => ({
-      exited: Promise.resolve(0),
-      stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
-    } as ReturnType<typeof Bun.spawn>));
+    _hardeningDeps.spawn = passingSpawn();
 
     await runHardeningPass(ctx);
 
@@ -514,5 +384,33 @@ describe("runHardeningPass()", () => {
     expect(refineInput.storyId).toBe("US-001");
     expect(refineInput.storyTitle).toBe("Story Title");
     expect(refineInput.storyDescription).toBe("Story Description");
+  });
+
+  test("uses packageDir (not workdir) for suggested test path in monorepo", async () => {
+    const story = makeStory({
+      acceptanceCriteria: ["spec AC"],
+      suggestedCriteria: ["edge case"],
+      workdir: "packages/api",
+      status: "passed",
+      passes: true,
+      attempts: 1,
+    });
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    const writtenPaths: string[] = [];
+    _hardeningDeps.callOp = mockCallOp(
+      [{ original: "edge case", refined: "edge case", testable: true, storyId: "US-001" }],
+      { testCode: 'test("AC-1", () => {})' },
+    );
+    _hardeningDeps.writeFile = mock(async (p: string) => { writtenPaths.push(p); });
+    _hardeningDeps.savePRD = mock(async () => {});
+    _hardeningDeps.spawn = passingSpawn();
+
+    await runHardeningPass(ctx);
+
+    expect(writtenPaths).toHaveLength(1);
+    // Must be under <packageDir>/.nax, not <workdir>/.nax
+    expect(writtenPaths[0]).toContain("/tmp/workdir/packages/api/.nax/");
+    expect(writtenPaths[0]).not.toMatch(/^\/tmp\/workdir\/\.nax\//);
   });
 });


### PR DESCRIPTION
## Summary

- **Bug**: `runHardeningPass` called `resolveSuggestedPackageFeatureTestPath(ctx.workdir, …)` where `ctx.workdir` is the repo root, so suggested test files were always written to `<repoRoot>/.nax/features/…` instead of `<packageDir>/.nax/features/…` in monorepos
- **Fix**: Group `suggestedCriteria` stories by `story.workdir` and process each package group independently — same pattern as `groupStoriesByPackage` in `test-path.ts` for normal acceptance
- **Refactor**: Extract `processPackageGroup()` private helper; brings `runHardeningPass` to ~40 lines and max nesting depth to 3 (was 5 after the grouping loop was added inline)
- **Tests**: Migrate test fixtures to shared `makeStory()`/`makePRD()` helpers per ADR-013; add `detectLanguage` dep stub; add regression test asserting path placement under `packages/api/.nax/` not `workdir/.nax/`

## Test plan

- [ ] `timeout 30 bun test test/unit/acceptance/hardening.test.ts --timeout=5000` — 11 pass, 0 fail
- [ ] `bun run typecheck` — clean (no errors in source files)
- [ ] Manual: run a feature with `suggestedCriteria` in a monorepo package and confirm the `.nax-suggested.test.ts` is created under the package dir, not the repo root