### PR TITLE
feat(routing): agent routing amendment v1 — cross-agent escalation fix + plan-time agent selection

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -53,6 +53,7 @@ import {
   pluginsListCommand,
   promptsCommand,
   promptsInitCommand,
+  resolveRunProfileOverride,
   rulesExportCommand,
   rulesLintCommand,
   rulesMigrateCommand,
@@ -418,8 +419,18 @@ program
 
     const naxDir = findProjectDir(workdir);
     const cliOverrides: Record<string, unknown> = {};
-    if (options.profile) {
-      cliOverrides.profile = options.profile;
+    // Delta C4: nax run defaults to the profile the PRD was planned with,
+    // unless --profile or NAX_PROFILE overrides it.
+    const profileOverride = naxDir
+      ? await resolveRunProfileOverride({
+          prdPath: join(naxDir, "features", options.feature, "prd.json"),
+          projectRoot: workdir,
+          cliProfile: options.profile,
+          envProfile: process.env.NAX_PROFILE,
+        })
+      : options.profile;
+    if (profileOverride) {
+      cliOverrides.profile = profileOverride;
     }
     const config = await loadConfig(naxDir ?? undefined, cliOverrides);
 

--- a/docs/adr/ADR-025-agent-routing-and-cross-agent-escalation.md
+++ b/docs/adr/ADR-025-agent-routing-and-cross-agent-escalation.md
@@ -1,0 +1,256 @@
+# ADR-025: Agent Routing via Plan-Time Selection and Cross-Agent Escalation
+
+**Status:** Accepted
+**Date:** 2026-06-12
+**Author:** William Khoo, Claude
+**Branch:** `worktree-feat+agent-routing-amendment`
+**Supersedes:** `docs/plans/2026-06-11-agent-routing-design.md` §2, §4, §6, Goal 2's "wrong agent is non-recoverable" premise, and its Open Questions 1 & 2
+**Source plans:**
+- `docs/plans/2026-06-11-agent-routing-amendment.md` (design — the SSOT)
+- `docs/plans/2026-06-11-agent-routing-amendment-fixes.md` (first review pass)
+- `docs/plans/2026-06-12-agent-routing-review-fixes.md` (consolidated review fixes)
+
+---
+
+## Context
+
+nax orchestrates multiple coding agents (Claude Code, opencode, etc.), each with
+different strengths and cost. A story should run on the agent best suited to it,
+and a poor initial choice should be recoverable rather than fatal.
+
+The original routing design (`2026-06-11-agent-routing-design.md`) proposed:
+
+1. A new structured `classification` block emitted at decompose time (§2).
+2. A new dedicated one-shot op, `assignAgentsOp`, with its own session role (§4).
+3. Escalation framed as **tier-only within a single agent** (§6).
+4. A core premise (Goal 2): *agent choice must be LLM-driven, never rules-based,
+   because a wrong agent is non-recoverable — unlike a wrong tier, which
+   escalation can fix.*
+
+Review surfaced three findings that collapse most of that machinery:
+
+1. **The expensive work already exists.** The LLM tier classifier
+   (`classifyRouteOp` / `classifyRouteBatchOp`) already runs a cost-configurable
+   model with a rubric-shaped prompt and persists structured, reasoned,
+   content-hash-cached output to the PRD. A separate router would reinvent it.
+
+2. **Cross-agent escalation is already coded but dead at the config boundary.**
+   The execution layer (`escalateTier`, `tier-escalation.ts`) already reads
+   `next.agent` from each `tierOrder` rung and writes the next agent onto the
+   story. The `TierConfig` **type** carries `agent?: string`. But the Zod
+   **schema** (`schemas-model.ts`) parsed only `{ tier, attempts }`, so Zod's
+   `.strip()` silently deleted any `agent` written in config — making `next.agent`
+   always `undefined`. The feature was fully implemented and unreachable.
+
+3. **The "wrong agent is non-recoverable" premise is therefore false.** Once the
+   schema permits `(agent, tier)` rungs, a wrong *initial* agent is recoverable:
+   the story climbs the ladder to a stronger agent. The initial route stops being
+   a high-stakes, irreversible decision and collapses to "pick a starting rung."
+
+The driving cost constraint — *the router is itself an LLM call and must run on a
+cheap model, which can't be trusted with open-ended judgment* — is dissolved, not
+solved: selection folds into the **existing decompose call** at plan time, costing
+only a few extra output tokens. The cheap model still adjudicates, but guided by a
+structured rubric carried in the prompt (prompt scaffolding for an LLM, not
+deterministic `if/else` rules).
+
+## Decision
+
+**`autoMode.escalation.tierOrder` is the unified agent+model ranking. Each rung is
+an `(agent, tier)` pair. Agent selection happens at `nax plan` (folded into
+decompose), is written to the PRD as a reviewable artifact, and is replayed
+deterministically at `nax run`. Escalation advances along the same ladder,
+crossing agents where the ladder does.**
+
+v1 ships a **single global ladder**; per-domain ladders are deferred.
+
+### 1. One ladder, three behaviors
+
+`tierOrder` is the ranking SSOT. The same capability-ordered ladder serves:
+
+| Behavior | Mechanism on the ladder |
+|:---|:---|
+| **Initial route** | plan-time selection picks the starting rung |
+| **Escalation** (quality failure) | advance the rung index — crosses agents where the ladder does |
+| **Fallback** (availability failure) | sidestep an unreachable rung to the next reachable one, without consuming an escalation step |
+
+Escalation and fallback remain **distinct triggers** keyed off different failure
+outcomes; they share the ladder structure but are not merged.
+
+### 2. Part B — light up cross-agent escalation (ship first, independently valuable)
+
+- **`TierConfigSchema` gains `agent?: string`** (`schemas-model.ts`) — the field
+  was on the type, missing from the schema. This alone makes the already-coded
+  cross-agent escalation reachable.
+- **`escalateTier` matches by `(tier, agent)` tuple** (`escalation.ts`). A
+  cross-agent ladder repeats tier names (`opencode@balanced`, `claude@balanced`),
+  so matching on tier name alone always resolved to the first match — a latent
+  bug the feature exposes. The signature now takes the current `{ tier, agent }`
+  and `findIndex`es on both fields, falling back to tier-name-only matching when
+  `agent` is absent (single-agent ladders). `getTierConfig` matches the same way.
+- **Origin tracking** (`StoryRouting.initialAgent` / `initialProfileId`) — written
+  once at first route, never overwritten by escalation (sibling to
+  `initialComplexity`), so metrics and replay know where a story started.
+
+Part B is a no-op for single-agent ladders and fixes a real dead-config bug, so it
+ships first with no dependency on Part C.
+
+### 3. Part C — plan-time selection via config profiles (the v1 selection path)
+
+- **Config shape.** `routing.agents` carries `enabled` (boolean, default `true` —
+  disable plan-time selection without deleting profiles), `strategy`
+  (`"off"` = plan-time only / v1 default; `"llm"` = run-time routing, deferred
+  Part A), `default` (fallback profile id), and `profiles`.
+- **Override unit is the existing config-profile mechanism.** `nax plan --profile
+  <name>` overlays `.nax/profiles/<name>.json` via `loadProfile` +
+  `deepMergeConfig` — a full overlay that can bundle **both** the
+  `routing.agents.profiles` registry **and** the `autoMode.escalation.tierOrder`
+  ladder. No new flag, no new override mechanism.
+- **Selection folds into decompose.** Capability cards (`OneShotPromptBuilder`)
+  are injected into the decompose prompt only when profiles exist. The plan agent
+  emits a per-story `agentProfileId`; decompose resolves it to `routing.agent` +
+  the profile's `target.model` as the starting tier, and writes it to the PRD.
+- **PRD is the reviewable, replayable artifact.** `nax run` honors the PRD's
+  `routing.agent` (precedence level 1 — already worked), and defaults to the PRD's
+  `routingProfile` (the resolved config-profile name) when `--profile` /
+  `NAX_PROFILE` are absent, warning on mismatch so ladder drift is visible.
+
+### 4. Profiles ↔ ladder unification (the binding invariant)
+
+`routing.agents.profiles` and `tierOrder` are two views of the same `(agent, tier)`
+pairs: profiles say *what each is good at* (for the start pick); the ladder says
+*what order to climb*. They must not drift:
+
+- **`tierOrder` is the ranking SSOT.**
+- A profile binds to a rung by its `target` `(agent, tier)`.
+- **Validation** (`NaxConfigSchema.superRefine`): every profile's `target` must
+  correspond to a rung in `tierOrder` (else escalation from it has no defined
+  next step), and every `target.agent` / `tierOrder[].agent` must exist in
+  `config.models` with a defined tier. The binding error names the remedy
+  (agent-qualify the ladder).
+
+### 5. Selection rules (decided)
+
+- **Profile tier fully overrides the complexity-derived tier (Interpretation A).**
+  A selected profile sets the starting rung *unconditionally*, even below what
+  complexity suggests; escalation climbs back up if needed. A complex story
+  assigned a cheap profile starts at `fast` and escalates upward — this is the
+  intended, designed behavior, locked by an explicit test.
+- **PRD agent wins; `decision.agent` (future Part A) applies only when the PRD
+  leaves agent unset** — never clobbered unconditionally.
+- **Never invent an agent.** Unknown/missing `agentProfileId` → default profile →
+  `agent` stays `undefined` → precedence falls to `agentManager.getDefault()`,
+  with a warn. Degradation is in code, not prose.
+- **`strategy: "llm"` requires ≥1 profile** (config error otherwise).
+
+### 6. Availability seam
+
+A planned-but-unavailable agent degrades to the default agent with a warning
+instead of failing the story (`resolveExecutionAgent`, unit-testable without
+booting the pipeline). Run-setup additionally warns per story when
+`routing.agent` is absent from `config.models` (hand-edited PRD / removed model).
+
+### 7. Part A — run-time routing (DEFERRED)
+
+Run-time routing folds into `classifyRouteOp` (not a new op), filling
+`routing.agent` only when the PRD leaves it unset, behind
+`routing.agents.strategy: "llm"`. It composes with Part C (PRD wins) and Part B
+(escalation) unchanged. Out of v1; retained as the documented future feature.
+
+## Consequences
+
+### Positive
+
+- **No new op, no new session role, no separate router.** Selection reuses the
+  decompose call; the cheap-model cost concern dissolves to a few output tokens.
+- **Fixes a real dead-config bug.** Cross-agent escalation was implemented and
+  unreachable; Part B lights it up with a one-field schema change plus the
+  rung-index fix.
+- **Initial route is low-stakes.** A wrong/cheap start is recoverable via
+  cross-agent escalation — which is what makes plan-time (and future structural)
+  selection safe.
+- **Determinism + review for free.** The decision is a PRD field, editable in the
+  plan→run gap and replayed at run (the cleanest realization of original Goal 5).
+- **No behavior change until opt-in.** Every path is a no-op until a user defines
+  a profile and plans with it; single-agent ladders are unaffected.
+
+### Negative
+
+- **Re-plan to apply changes.** New/edited profiles need a re-plan to take effect;
+  a story edited after plan can carry a stale assignment. v1 accepts this as the
+  trade for determinism + review. The content hash can flag staleness at run setup.
+- **`TIER_RANK` is a hardcoded three-name map.** Custom tier names are unrankable;
+  the escalation-record fallback preserves genuinely-escalated custom tiers, but a
+  config-derived ranking is the proper long-term fix (tracked follow-up).
+- **`initialProfileId` is forward-looking.** Escalation today never rewrites
+  `agentProfileId`, so `initialProfileId` currently always equals the live value;
+  it becomes meaningful only when escalation starts reassigning profiles.
+
+### Neutral
+
+- **Original `classification` block** is dropped as a routing prerequisite — the
+  classifier already emits complexity/risks that cards match against. Keep §2 only
+  if `analyze`/metrics want it independently.
+- **Fallback stays a separate trigger** from escalation; they share the ladder but
+  are not merged.
+
+## Alternatives Considered
+
+### A. Separate `assignAgentsOp` + `agent-route` session role (original §4)
+Reinvents the classifier's persisted, cached, reasoned output and adds a new
+session role and a second LLM call. Rejected — selection folds into decompose
+(v1) or `classifyRouteOp` (deferred Part A).
+
+### B. Keep escalation tier-only within one agent (original §6)
+Factually wrong: cross-agent escalation was already coded. Keeping the premise
+would leave the dead config in place and preserve the false "non-recoverable
+agent" asymmetry. Rejected.
+
+### C. Code-rules / keyword agent selection
+Brittle on unusual stories and loses recoverability framing. The rubric-in-prompt
+keeps an LLM adjudicating, guided — handles the unusual story and preserves
+recoverability. Rejected as the *sole* mechanism (though escalation now makes
+deterministic initial routing a legitimate *future* option, since the ladder
+self-corrects upward).
+
+### D. Per-domain / per-language ladders
+Key `tierOrder` by domain and select the ladder from `story.classification` /
+`detectLanguage`. Deferred — a single global capability order is sufficient
+because escalation is a blunt "throw more capability at it" instrument. Revisit if
+the global order proves too coarse.
+
+## Open Questions
+
+1. **Custom-tier ranking.** `TIER_RANK` should become config-derived if custom
+   tier names are formally supported; today they rely on escalation-record
+   evidence to survive a routing pass.
+2. **Origin-agent metrics.** `initialAgent` / `initialProfileId` are persisted to
+   the PRD only; whether to surface them in `metrics/tracker.ts` (alongside
+   `initialComplexity`) is deferred.
+3. **Staleness handling at run.** The content hash can flag a story edited after
+   plan; whether run warns, ignores, or (future Part A) re-routes is open.
+4. **Part A activation.** When/whether to ship run-time routing behind
+   `routing.agents.strategy: "llm"`.
+
+## Implementation
+
+Phasing (v1 = Phases 0–2):
+
+| Phase | Scope |
+|:---|:---|
+| **0** | Part B: `TierConfigSchema.agent`, `escalateTier` rung-index traversal, `initialAgent`/`initialProfileId`, cross-section validation |
+| **1** | Part C config + plumbing: `routing.agents.profiles` schema, both superRefines, `routingProfile` on the PRD root, `--profile` on `nax plan` |
+| **2** | Part C selection: capability cards in the decompose prompt, decompose output schema + parse + resolution + PRD write; run-side honor + mismatch warn; availability seam |
+| **3** (deferred) | Part A: run-time routing folded into `classifyRouteOp` behind `routing.agents.strategy: "llm"` |
+
+Consolidated review fixes (`2026-06-12-agent-routing-review-fixes.md`) closed:
+profile tier seeding at the mapper (HIGH), `routingProfile` recording the resolved
+config-profile name + run-side adoption (Delta C4), capability cards rendering
+`weaknesses`/`affinity` + the ordered rubric, the availability seam
+(`resolveExecutionAgent`), unknown-`agentProfileId` warn, `decision.agent`
+precedence + `initialAgent` origin gating, custom-tier escalation preservation,
+and schema hardening (`strategy:"llm"` needs profiles; binding error names the
+remedy).
+
+See the source plans for per-delta detail, file-level edits, and acceptance
+criteria.

--- a/src/agents/shared/decompose-prompt.ts
+++ b/src/agents/shared/decompose-prompt.ts
@@ -30,6 +30,8 @@ const DECOMPOSE_SPEC_SCHEMA: SchemaDescriptor = {
       estimatedLOC: 150,
       risks: ["Risk 1"],
       testStrategy: "test-after",
+      // Optional: set to a profile id from the Agent Profiles table above, or omit if no profiles are listed
+      agentProfileId: "",
     },
   ],
 };
@@ -51,6 +53,8 @@ const DECOMPOSE_PLAN_SCHEMA: SchemaDescriptor = {
       estimatedLOC: 0,
       risks: [],
       testStrategy: "no-test | tdd-simple | three-session-tdd-lite | three-session-tdd | test-after",
+      // Optional: set to a profile id from the Agent Profiles table above, or omit if no profiles are listed
+      agentProfileId: "",
     },
   ],
 };
@@ -71,6 +75,7 @@ For each story, provide:
 11. risks: Array of implementation risks
 12. testStrategy: "no-test" | "test-after" | "tdd-simple" | "three-session-tdd" | "three-session-tdd-lite"
 13. noTestJustification: string (REQUIRED when testStrategy is "no-test" — explain why tests are unnecessary)
+14. agentProfileId: (optional) profile id from the Agent Profiles table — assign the best-matching profile for each story; omit if no profiles are listed or none fits well
 
 ${COMPLEXITY_GUIDE}
 

--- a/src/agents/shared/decompose-prompt.ts
+++ b/src/agents/shared/decompose-prompt.ts
@@ -157,7 +157,10 @@ function buildPlanModePromptSync(input: DecomposePromptInput): string {
     builder = builder.inputData("Sibling Stories", siblingsSummary);
   }
 
-  return builder.agentProfiles(input.profiles ?? []).jsonSchema(DECOMPOSE_PLAN_SCHEMA).build();
+  return builder
+    .agentProfiles(input.profiles ?? [])
+    .jsonSchema(DECOMPOSE_PLAN_SCHEMA)
+    .build();
 }
 
 function buildSpecModePromptSync(input: DecomposePromptInput): string {
@@ -189,7 +192,10 @@ async function buildPlanModePrompt(options: DecomposeOptions): Promise<string> {
     builder = builder.inputData("Sibling Stories", siblingsSummary);
   }
 
-  return builder.agentProfiles(options.profiles ?? []).jsonSchema(DECOMPOSE_PLAN_SCHEMA).build();
+  return builder
+    .agentProfiles(options.profiles ?? [])
+    .jsonSchema(DECOMPOSE_PLAN_SCHEMA)
+    .build();
 }
 
 async function buildSpecModePrompt(options: DecomposeOptions): Promise<string> {

--- a/src/agents/shared/decompose-prompt.ts
+++ b/src/agents/shared/decompose-prompt.ts
@@ -9,6 +9,7 @@
  *   - plan mode: splits a single targetStory into sub-stories
  */
 
+import type { AgentRoutingProfile } from "@/config";
 import { COMPLEXITY_GUIDE, GROUPING_RULES, TEST_STRATEGY_GUIDE } from "../../config/test-strategy";
 import { OneShotPromptBuilder, type SchemaDescriptor } from "../../prompts";
 import type { DecomposeOptions } from "../types";
@@ -111,6 +112,8 @@ export interface DecomposePromptInput {
   targetStory?: import("../../prd/types").UserStory;
   siblings?: import("../../prd/types").UserStory[];
   maxAcCount?: number | null;
+  /** Agent routing profiles to inject as capability cards. Empty array = no cards. */
+  profiles?: AgentRoutingProfile[];
 }
 
 /**
@@ -154,7 +157,7 @@ function buildPlanModePromptSync(input: DecomposePromptInput): string {
     builder = builder.inputData("Sibling Stories", siblingsSummary);
   }
 
-  return builder.jsonSchema(DECOMPOSE_PLAN_SCHEMA).build();
+  return builder.agentProfiles(input.profiles ?? []).jsonSchema(DECOMPOSE_PLAN_SCHEMA).build();
 }
 
 function buildSpecModePromptSync(input: DecomposePromptInput): string {
@@ -162,6 +165,7 @@ function buildSpecModePromptSync(input: DecomposePromptInput): string {
     .instructions(SPEC_DECOMPOSE_INSTRUCTIONS)
     .inputData("Codebase Context", input.codebaseContext)
     .inputData("Feature Specification", input.specContent)
+    .agentProfiles(input.profiles ?? [])
     .jsonSchema(DECOMPOSE_SPEC_SCHEMA)
     .build();
 }
@@ -185,7 +189,7 @@ async function buildPlanModePrompt(options: DecomposeOptions): Promise<string> {
     builder = builder.inputData("Sibling Stories", siblingsSummary);
   }
 
-  return builder.jsonSchema(DECOMPOSE_PLAN_SCHEMA).build();
+  return builder.agentProfiles(options.profiles ?? []).jsonSchema(DECOMPOSE_PLAN_SCHEMA).build();
 }
 
 async function buildSpecModePrompt(options: DecomposeOptions): Promise<string> {
@@ -193,6 +197,7 @@ async function buildSpecModePrompt(options: DecomposeOptions): Promise<string> {
     .instructions(SPEC_DECOMPOSE_INSTRUCTIONS)
     .inputData("Codebase Context", options.codebaseContext)
     .inputData("Feature Specification", options.specContent)
+    .agentProfiles(options.profiles ?? [])
     .jsonSchema(DECOMPOSE_SPEC_SCHEMA)
     .build();
 }

--- a/src/agents/shared/decompose.ts
+++ b/src/agents/shared/decompose.ts
@@ -77,9 +77,10 @@ export function parseDecomposeOutput(output: string): DecomposedStory[] {
       estimatedLOC: Number(record.estimatedLOC) || 0,
       risks: Array.isArray(record.risks) ? record.risks : [],
       testStrategy: resolveTestStrategy(typeof record.testStrategy === "string" ? record.testStrategy : undefined),
-      agentProfileId: typeof record.agentProfileId === "string" && record.agentProfileId.length > 0
-        ? record.agentProfileId
-        : undefined,
+      agentProfileId:
+        typeof record.agentProfileId === "string" && record.agentProfileId.length > 0
+          ? record.agentProfileId
+          : undefined,
     };
   });
 

--- a/src/agents/shared/decompose.ts
+++ b/src/agents/shared/decompose.ts
@@ -5,9 +5,9 @@
  * parseDecomposeOutput(), validateComplexity()
  */
 
-import { NaxError } from "../../errors";
-import { parseLLMJson } from "../../utils/llm-json";
-import { resolveTestStrategy } from "../../config/test-strategy";
+import { resolveTestStrategy } from "@/config";
+import { NaxError } from "@/errors";
+import { parseLLMJson } from "@/utils/llm-json";
 import type { DecomposedStory } from "../types";
 
 /**

--- a/src/agents/shared/decompose.ts
+++ b/src/agents/shared/decompose.ts
@@ -5,55 +5,54 @@
  * parseDecomposeOutput(), validateComplexity()
  */
 
+import { NaxError } from "../../errors";
+import { parseLLMJson } from "../../utils/llm-json";
 import { resolveTestStrategy } from "../../config/test-strategy";
 import type { DecomposedStory } from "../types";
 
 /**
  * Parse decompose output from agent stdout.
  *
- * Extracts JSON array from output, handles markdown code fences,
- * and validates structure.
+ * Extracts JSON array from output via parseLLMJson (handles markdown fences,
+ * preamble, trailing commas) and validates structure.
  */
 export function parseDecomposeOutput(output: string): DecomposedStory[] {
-  // Extract JSON from output (handles markdown code fences)
-  const jsonMatch = output.match(/```(?:json)?\s*(\[[\s\S]*?\])\s*```/);
-  let jsonText = jsonMatch ? jsonMatch[1] : output;
-
-  // Try to find JSON array directly if no code fence
-  if (!jsonMatch) {
-    const arrayMatch = output.match(/\[[\s\S]*\]/);
-    if (arrayMatch) {
-      jsonText = arrayMatch[0];
-    }
-  }
-
-  // Parse JSON
   let parsed: unknown;
   try {
-    parsed = JSON.parse(jsonText.trim());
+    parsed = parseLLMJson<unknown>(output);
   } catch (error) {
-    throw new Error(
-      `Failed to parse decompose output as JSON: ${(error as Error).message}\n\nOutput:\n${output.slice(0, 500)}`,
-    );
+    throw new NaxError("Failed to parse decompose output as JSON", "DECOMPOSE_PARSE_FAILED", {
+      stage: "decompose",
+      outputSnippet: output.slice(0, 500),
+      cause: error,
+    });
   }
 
-  // Validate structure
   if (!Array.isArray(parsed)) {
-    throw new Error("Decompose output is not an array");
+    throw new NaxError("Decompose output is not an array", "DECOMPOSE_PARSE_FAILED", {
+      stage: "decompose",
+    });
   }
 
-  // Map to DecomposedStory[] with validation
   const stories: DecomposedStory[] = parsed.map((item: unknown, index: number) => {
-    // Type guard: ensure item is an object
     if (typeof item !== "object" || item === null) {
-      throw new Error(`Story at index ${index} is not an object`);
+      throw new NaxError(`Story at index ${index} is not an object`, "DECOMPOSE_PARSE_FAILED", {
+        stage: "decompose",
+        index,
+      });
     }
     const record = item as Record<string, unknown>;
     if (!record.id || typeof record.id !== "string") {
-      throw new Error(`Story at index ${index} missing valid 'id' field`);
+      throw new NaxError(`Story at index ${index} missing valid 'id' field`, "DECOMPOSE_PARSE_FAILED", {
+        stage: "decompose",
+        index,
+      });
     }
     if (!record.title || typeof record.title !== "string") {
-      throw new Error(`Story ${record.id} missing valid 'title' field`);
+      throw new NaxError(`Story ${record.id} missing valid 'title' field`, "DECOMPOSE_PARSE_FAILED", {
+        stage: "decompose",
+        storyId: record.id,
+      });
     }
 
     return {
@@ -85,7 +84,9 @@ export function parseDecomposeOutput(output: string): DecomposedStory[] {
   });
 
   if (stories.length === 0) {
-    throw new Error("Decompose returned empty story array");
+    throw new NaxError("Decompose returned empty story array", "DECOMPOSE_PARSE_FAILED", {
+      stage: "decompose",
+    });
   }
 
   return stories;

--- a/src/agents/shared/decompose.ts
+++ b/src/agents/shared/decompose.ts
@@ -77,6 +77,9 @@ export function parseDecomposeOutput(output: string): DecomposedStory[] {
       estimatedLOC: Number(record.estimatedLOC) || 0,
       risks: Array.isArray(record.risks) ? record.risks : [],
       testStrategy: resolveTestStrategy(typeof record.testStrategy === "string" ? record.testStrategy : undefined),
+      agentProfileId: typeof record.agentProfileId === "string" && record.agentProfileId.length > 0
+        ? record.agentProfileId
+        : undefined,
     };
   });
 

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -107,6 +107,8 @@ export interface DecomposeOptions {
   targetStory?: import("@/prd").UserStory;
   /** Sibling stories for context (plan-mode decompose) */
   siblings?: import("@/prd").UserStory[];
+  /** Agent routing profiles to inject as capability cards. Empty array = no cards. */
+  profiles?: import("@/config").AgentRoutingProfile[];
 }
 
 /** A single classified user story from decompose result. */

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -5,8 +5,8 @@
  * Separated from core types to keep each file under 400 lines.
  */
 
-import type { ResolvedPermissions } from "../../config/permissions";
-import type { ModelDef, ModelTier, NaxConfig } from "../../config/schema";
+import type { ResolvedPermissions } from "@/config/permissions";
+import type { ModelDef, ModelTier, NaxConfig } from "@/config/schema";
 
 /**
  * Configuration options for running an agent in plan mode.
@@ -104,9 +104,9 @@ export interface DecomposeOptions {
   /** Session role for TDD isolation (e.g. "decompose") */
   sessionRole?: string;
   /** Target story to decompose (plan-mode decompose) */
-  targetStory?: import("../../prd/types").UserStory;
+  targetStory?: import("@/prd").UserStory;
   /** Sibling stories for context (plan-mode decompose) */
-  siblings?: import("../../prd/types").UserStory[];
+  siblings?: import("@/prd").UserStory[];
 }
 
 /** A single classified user story from decompose result. */

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -135,6 +135,18 @@ export interface DecomposedStory {
   risks: string[];
   /** Test strategy recommendation from LLM */
   testStrategy?: import("../../config/test-strategy").TestStrategy;
+  /**
+   * Agent profile ID selected by the plan LLM from the capability cards.
+   * Present only when routing.agents.enabled === true and the LLM emitted a
+   * valid profile id in the decompose JSON. Resolved to routing.agent in
+   * decomposeOp.parse().
+   */
+  agentProfileId?: string;
+  /**
+   * Routing metadata resolved from agentProfileId during decomposeOp.parse().
+   * Populated only when a matching profile is found in config.routing.agents.profiles.
+   */
+  routing?: Pick<import("../../prd/types").StoryRouting, "agent" | "agentProfileId">;
 }
 
 /**

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -146,7 +146,7 @@ export interface DecomposedStory {
    * Routing metadata resolved from agentProfileId during decomposeOp.parse().
    * Populated only when a matching profile is found in config.routing.agents.profiles.
    */
-  routing?: Pick<import("../../prd/types").StoryRouting, "agent" | "agentProfileId">;
+  routing?: Pick<import("../../prd/types").StoryRouting, "agent" | "agentProfileId" | "profileModelTier">;
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -53,3 +53,4 @@ export {
   type RulesLintOptions,
   type RulesMigrateOptions,
 } from "./rules";
+export { resolveRunProfileOverride } from "./resolve-run-profile";

--- a/src/cli/plan-command.ts
+++ b/src/cli/plan-command.ts
@@ -198,7 +198,14 @@ export async function runPlanPipeline(
     });
 
     if (verdict.outcome === "passed") {
-      await _planDeps.writeFile(outputPath, JSON.stringify({ ...verdict.prd, project: projectName }, null, 2));
+      const routingProfile =
+        config.routing?.agents?.enabled === true ? (config.routing.agents.default ?? undefined) : undefined;
+      const prdToWrite = {
+        ...verdict.prd,
+        project: projectName,
+        ...(routingProfile !== undefined && { routingProfile }),
+      };
+      await _planDeps.writeFile(outputPath, JSON.stringify(prdToWrite, null, 2));
       logger?.info("plan", "[OK] PRD written via pipeline", { outputPath });
       return outputPath;
     }

--- a/src/cli/plan-command.ts
+++ b/src/cli/plan-command.ts
@@ -198,12 +198,12 @@ export async function runPlanPipeline(
     });
 
     if (verdict.outcome === "passed") {
-      const routingProfile =
-        config.routing?.agents?.enabled === true ? (config.routing.agents.default ?? undefined) : undefined;
+      // Delta C4: record the loader-resolved config profile name (AC 6 sets
+      // config.profile after all merges) so nax run can detect ladder drift.
       const prdToWrite = {
         ...verdict.prd,
         project: projectName,
-        ...(routingProfile !== undefined && { routingProfile }),
+        routingProfile: config.profile ?? "default",
       };
       await _planDeps.writeFile(outputPath, JSON.stringify(prdToWrite, null, 2));
       logger?.info("plan", "[OK] PRD written via pipeline", { outputPath });

--- a/src/cli/plan-decompose.ts
+++ b/src/cli/plan-decompose.ts
@@ -208,12 +208,12 @@ export async function planDecomposeCommand(
     ...updatedStories.slice(originalIndex + 1),
   ];
 
-  const routingProfile =
-    config.routing?.agents?.enabled === true ? (config.routing?.agents?.default ?? undefined) : undefined;
+  // Delta C4: record the loader-resolved config profile name (AC 6 sets
+  // config.profile after all merges) so nax run can detect ladder drift.
   const updatedPrd: PRD = {
     ...prd,
     userStories: finalStories,
-    ...(routingProfile !== undefined && { routingProfile }),
+    routingProfile: config.profile ?? "default",
   };
   await _planDeps.writeFile(prdPath, JSON.stringify(updatedPrd, null, 2));
   return () => {};

--- a/src/cli/plan-decompose.ts
+++ b/src/cli/plan-decompose.ts
@@ -93,8 +93,7 @@ export async function planDecomposeCommand(
       if (attempt === 0 && debateDecompEnabled) {
         const decomposeStageConfig = debateStages.decompose as DebateStageConfig;
         const agentRoutingForDebate = config.routing?.agents;
-        const profilesForDebate =
-          agentRoutingForDebate?.enabled === true ? (agentRoutingForDebate.profiles ?? []) : [];
+        const profilesForDebate = agentRoutingForDebate?.enabled === true ? (agentRoutingForDebate.profiles ?? []) : [];
         const prompt = await buildDecomposePromptAsync({
           specContent: "",
           codebaseContext,

--- a/src/cli/plan-decompose.ts
+++ b/src/cli/plan-decompose.ts
@@ -71,7 +71,12 @@ export async function planDecomposeCommand(
   const rt = createPlanRuntime(config, workdir, options.feature);
   const agentManager = rt.agentManager;
   const adapterForCapCheck = agentManager.getAgent(agentName);
-  if (!adapterForCapCheck) throw new Error(`[decompose] No agent adapter found for '${agentName}'`);
+  if (!adapterForCapCheck) {
+    throw new NaxError(`No agent adapter found for '${agentName}'`, "AGENT_NOT_FOUND", {
+      stage: "decompose",
+      agentName,
+    });
+  }
 
   const timeoutSeconds = config?.plan?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
   const maxAcCount = config?.precheck?.storySizeGate?.maxAcCount ?? Number.POSITIVE_INFINITY;
@@ -87,6 +92,9 @@ export async function planDecomposeCommand(
     for (let attempt = 0; attempt < maxReplanAttempts; attempt++) {
       if (attempt === 0 && debateDecompEnabled) {
         const decomposeStageConfig = debateStages.decompose as DebateStageConfig;
+        const agentRoutingForDebate = config.routing?.agents;
+        const profilesForDebate =
+          agentRoutingForDebate?.enabled === true ? (agentRoutingForDebate.profiles ?? []) : [];
         const prompt = await buildDecomposePromptAsync({
           specContent: "",
           codebaseContext,
@@ -96,6 +104,7 @@ export async function planDecomposeCommand(
           featureName: options.feature,
           storyId: options.storyId,
           maxAcCount: config?.precheck?.storySizeGate?.maxAcCount,
+          profiles: profilesForDebate,
         });
         const decompCallCtx = {
           runtime: rt,

--- a/src/cli/plan-decompose.ts
+++ b/src/cli/plan-decompose.ts
@@ -200,7 +200,13 @@ export async function planDecomposeCommand(
     ...updatedStories.slice(originalIndex + 1),
   ];
 
-  const updatedPrd: PRD = { ...prd, userStories: finalStories };
+  const routingProfile =
+    config.routing?.agents?.enabled === true ? (config.routing?.agents?.default ?? undefined) : undefined;
+  const updatedPrd: PRD = {
+    ...prd,
+    userStories: finalStories,
+    ...(routingProfile !== undefined && { routingProfile }),
+  };
   await _planDeps.writeFile(prdPath, JSON.stringify(updatedPrd, null, 2));
   return () => {};
 }

--- a/src/cli/resolve-run-profile.ts
+++ b/src/cli/resolve-run-profile.ts
@@ -1,0 +1,57 @@
+import { listProfiles } from "../config";
+import { getSafeLogger } from "../logger";
+
+/**
+ * Delta C4 run-side: resolve the config-profile override for `nax run`.
+ *
+ * Precedence: CLI --profile > NAX_PROFILE env (handled inside loadConfig — we
+ * return undefined so it applies) > PRD routingProfile > loadConfig defaults.
+ *
+ * GUARD: loadProfile THROWS on a missing profile file, so a PRD profile is
+ * adopted only when it actually resolves (or is "default", which the loader
+ * treats as no-overlay). Stale/legacy values warn and are skipped.
+ *
+ * Returns the profile name to pass as a CLI override into loadConfig, or
+ * undefined to let loadConfig's own resolution run.
+ */
+export async function resolveRunProfileOverride(opts: {
+  prdPath: string;
+  projectRoot: string;
+  cliProfile: string | undefined;
+  envProfile: string | undefined;
+  /** Test seam — defaults to reading prdPath via Bun.file */
+  _readJson?: (path: string) => Promise<unknown>;
+  /** Test seam — defaults to listProfiles(projectRoot) name extraction */
+  _listProfileNames?: () => Promise<string[]>;
+}): Promise<string | undefined> {
+  if (opts.cliProfile) return opts.cliProfile;
+  if (opts.envProfile) return undefined;
+
+  const readJson =
+    opts._readJson ??
+    (async (path: string) => {
+      const file = Bun.file(path);
+      if (!(await file.exists())) return undefined;
+      return file.json();
+    });
+
+  try {
+    const prd = (await readJson(opts.prdPath)) as { routingProfile?: unknown } | undefined;
+    if (prd && typeof prd.routingProfile === "string" && prd.routingProfile.length > 0) {
+      const name = prd.routingProfile;
+      if (name === "default") return name;
+      const listNames =
+        opts._listProfileNames ?? (async () => (await listProfiles(opts.projectRoot)).map((p) => p.name));
+      const available = await listNames();
+      if (available.includes(name)) return name;
+      getSafeLogger()?.warn(
+        "run",
+        `PRD was planned with config profile "${name}" but no such profile exists — continuing with current config resolution`,
+        { storyId: "prd", plannedProfile: name },
+      );
+    }
+  } catch {
+    // Corrupt/unreadable PRD — let the run's own PRD load surface the real error.
+  }
+  return undefined;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -43,7 +43,7 @@ export {
   AcceptanceConfigSchema,
   PlanConfigSchema,
 } from "./schema";
-export { ConfiguredModelSchema, ModelTierSchema } from "./schemas-model";
+export { ConfiguredModelSchema, ModelTierSchema, TierConfigSchema } from "./schemas-model";
 export { DebateConfigSchema } from "./schemas-debate";
 export { TddConfigSchema } from "./schemas-execution";
 export { loadConfig, loadConfigForWorkdir, loadPackageOverride, findProjectDir, globalConfigPath } from "./loader";

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -44,8 +44,8 @@ export {
   PlanConfigSchema,
 } from "./schema";
 export { ConfiguredModelSchema, ModelTierSchema, TierConfigSchema } from "./schemas-model";
-export type { AgentProfile } from "./schemas-infra";
-export { AgentProfileSchema, AgentRoutingConfigSchema } from "./schemas-infra";
+export type { AgentRoutingProfile, AgentRoutingConfig } from "./schemas-infra";
+export { AgentRoutingProfileSchema, AgentRoutingConfigSchema } from "./schemas-infra";
 export { DebateConfigSchema } from "./schemas-debate";
 export { TddConfigSchema } from "./schemas-execution";
 export { loadConfig, loadConfigForWorkdir, loadPackageOverride, findProjectDir, globalConfigPath } from "./loader";

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -44,6 +44,8 @@ export {
   PlanConfigSchema,
 } from "./schema";
 export { ConfiguredModelSchema, ModelTierSchema, TierConfigSchema } from "./schemas-model";
+export type { AgentProfile } from "./schemas-infra";
+export { AgentProfileSchema, AgentRoutingConfigSchema } from "./schemas-infra";
 export { DebateConfigSchema } from "./schemas-debate";
 export { TddConfigSchema } from "./schemas-execution";
 export { loadConfig, loadConfigForWorkdir, loadPackageOverride, findProjectDir, globalConfigPath } from "./loader";

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -18,6 +18,7 @@ import type {
   RoutingStrategyName,
   TddStrategy,
 } from "./schema-types";
+import type { AgentRoutingConfig } from "./schemas-infra";
 
 export interface EscalationEntry {
   from: string;
@@ -472,6 +473,8 @@ export interface RoutingConfig {
   adaptive?: AdaptiveRoutingConfig;
   /** LLM routing settings (used when strategy = "llm") */
   llm?: LlmRoutingConfig;
+  /** Agent routing settings (plan-time agent selection) */
+  agents?: AgentRoutingConfig;
 }
 
 /** Prompt overrides config (PB-003) */

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -74,9 +74,61 @@ const LlmRoutingConfigSchema = z.object({
   retryDelayMs: z.number().int().min(0, { message: "llm.retryDelayMs must be >= 0" }).optional(),
 });
 
+export const AgentProfileSchema = z.object({
+  id: z.string().min(1),
+  target: z.object({
+    agent: z.string().min(1),
+    model: ModelTierSchema,
+  }),
+  strengths: z.array(z.string().min(1)).min(1),
+  weaknesses: z.array(z.string().min(1)).optional(),
+  costTier: z.enum(["low", "medium", "high"]).optional(),
+  affinity: z
+    .object({
+      taskTypes: z.array(z.string().min(1)).optional(),
+      domains: z.array(z.string().min(1)).optional(),
+    })
+    .optional(),
+});
+
+export type AgentProfile = z.infer<typeof AgentProfileSchema>;
+
+export const AgentRoutingConfigSchema = z
+  .object({
+    /** Explicit toggle — set false to disable plan-time agent selection without removing profiles */
+    enabled: z.boolean().default(true),
+    /** "off" = plan-time only (v1 default). "llm" = run-time routing (Part A, deferred). */
+    strategy: z.enum(["off", "llm"]).default("off"),
+    /** Default profile id used when the plan agent emits an unknown or missing agentProfileId */
+    default: z.string().optional(),
+    profiles: z.array(AgentProfileSchema).default([]),
+  })
+  .superRefine((cfg, ctx) => {
+    const ids = cfg.profiles.map((p) => p.id);
+    const seen = new Set<string>();
+    for (const [i, id] of ids.entries()) {
+      if (seen.has(id)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["profiles", i, "id"],
+          message: `Duplicate profile id "${id}"`,
+        });
+      }
+      seen.add(id);
+    }
+    if (cfg.default !== undefined && !ids.includes(cfg.default)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["default"],
+        message: `Default profile "${cfg.default}" is not in the profiles list`,
+      });
+    }
+  });
+
 export const RoutingConfigSchema = z.object({
   strategy: z.enum(["keyword", "llm"]),
   llm: LlmRoutingConfigSchema.optional(),
+  agents: AgentRoutingConfigSchema.optional().default({ enabled: true, strategy: "off", profiles: [] }),
 });
 
 export const OptimizerConfigSchema = z.object({

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -123,6 +123,13 @@ export const AgentRoutingConfigSchema = z
         message: `Default profile "${cfg.default}" is not in the profiles list`,
       });
     }
+    if (cfg.strategy === "llm" && cfg.profiles.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["strategy"],
+        message: 'strategy "llm" requires at least one profile in routing.agents.profiles',
+      });
+    }
   });
 
 export type AgentRoutingConfig = z.infer<typeof AgentRoutingConfigSchema>;

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -74,7 +74,7 @@ const LlmRoutingConfigSchema = z.object({
   retryDelayMs: z.number().int().min(0, { message: "llm.retryDelayMs must be >= 0" }).optional(),
 });
 
-export const AgentProfileSchema = z.object({
+export const AgentRoutingProfileSchema = z.object({
   id: z.string().min(1),
   target: z.object({
     agent: z.string().min(1),
@@ -91,7 +91,7 @@ export const AgentProfileSchema = z.object({
     .optional(),
 });
 
-export type AgentProfile = z.infer<typeof AgentProfileSchema>;
+export type AgentRoutingProfile = z.infer<typeof AgentRoutingProfileSchema>;
 
 export const AgentRoutingConfigSchema = z
   .object({
@@ -101,7 +101,7 @@ export const AgentRoutingConfigSchema = z
     strategy: z.enum(["off", "llm"]).default("off"),
     /** Default profile id used when the plan agent emits an unknown or missing agentProfileId */
     default: z.string().optional(),
-    profiles: z.array(AgentProfileSchema).default([]),
+    profiles: z.array(AgentRoutingProfileSchema).default([]),
   })
   .superRefine((cfg, ctx) => {
     const ids = cfg.profiles.map((p) => p.id);
@@ -125,10 +125,12 @@ export const AgentRoutingConfigSchema = z
     }
   });
 
+export type AgentRoutingConfig = z.infer<typeof AgentRoutingConfigSchema>;
+
 export const RoutingConfigSchema = z.object({
   strategy: z.enum(["keyword", "llm"]),
   llm: LlmRoutingConfigSchema.optional(),
-  agents: AgentRoutingConfigSchema.optional().default({ enabled: true, strategy: "off", profiles: [] }),
+  agents: AgentRoutingConfigSchema.default({ enabled: true, strategy: "off", profiles: [] }),
 });
 
 export const OptimizerConfigSchema = z.object({

--- a/src/config/schemas-model.ts
+++ b/src/config/schemas-model.ts
@@ -50,5 +50,5 @@ export const ConfiguredModelSchema = z.union([ModelTierSchema, ConfiguredModelOb
 export const TierConfigSchema = z.object({
   tier: z.string().min(1, "Tier name must be non-empty"),
   attempts: z.number().int().min(1).max(20, { message: "attempts must be 1-20" }),
-  agent: z.string().min(1).optional(),
+  agent: z.string().min(1, { message: "agent must be non-empty" }).optional(),
 });

--- a/src/config/schemas-model.ts
+++ b/src/config/schemas-model.ts
@@ -50,4 +50,5 @@ export const ConfiguredModelSchema = z.union([ModelTierSchema, ConfiguredModelOb
 export const TierConfigSchema = z.object({
   tier: z.string().min(1, "Tier name must be non-empty"),
   attempts: z.number().int().min(1).max(20, { message: "attempts must be 1-20" }),
+  agent: z.string().min(1).optional(),
 });

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -98,6 +98,7 @@ export const NaxConfigSchema = z
         mode: "hybrid",
         timeoutMs: 30000,
       },
+      agents: { enabled: true, strategy: "off", profiles: [] },
     }),
     execution: ExecutionConfigSchema.default({
       maxIterations: 10,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -432,12 +432,10 @@ export const NaxConfigSchema = z
     // Profile↔ladder binding: every profile's target must map to a rung in tierOrder
     type AgentConfig = z.infer<typeof AgentRoutingConfigSchema>;
     type AgentProfile = AgentConfig["profiles"][number];
-    const profiles = (data.routing as { agents?: AgentConfig })?.agents?.profiles ?? [] as AgentProfile[];
+    const profiles = (data.routing as { agents?: AgentConfig })?.agents?.profiles ?? ([] as AgentProfile[]);
     for (const [pi, profile] of profiles.entries()) {
       const { agent: pAgent, model: pModel } = profile.target;
-      const hasMatchingRung = tierOrder.some(
-        (r) => r.tier === pModel && r.agent === pAgent,
-      );
+      const hasMatchingRung = tierOrder.some((r) => r.tier === pModel && r.agent === pAgent);
       if (!hasMatchingRung) {
         ctx.addIssue({
           code: "custom",

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -437,7 +437,10 @@ export const NaxConfigSchema = z
         ctx.addIssue({
           code: "custom",
           path: ["routing", "agents", "profiles", pi, "target"],
-          message: `Profile "${profile.id}" target (${pAgent}@${pModel}) has no matching rung in autoMode.escalation.tierOrder — escalation from this profile has no defined path`,
+          message:
+            `Profile "${profile.id}" target (${pAgent}@${pModel}) has no matching rung in autoMode.escalation.tierOrder — ` +
+            `escalation from this profile has no defined path. To fix: agent-qualify the ladder by adding a rung ` +
+            `{ "tier": "${pModel}", "agent": "${pAgent}", "attempts": <n> } (and an agent on every other rung) to autoMode.escalation.tierOrder.`,
         });
       }
       // Cross-section: profile target agent must exist in config.models

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -437,10 +437,7 @@ export const NaxConfigSchema = z
         ctx.addIssue({
           code: "custom",
           path: ["routing", "agents", "profiles", pi, "target"],
-          message:
-            `Profile "${profile.id}" target (${pAgent}@${pModel}) has no matching rung in autoMode.escalation.tierOrder — ` +
-            `escalation from this profile has no defined path. To fix: agent-qualify the ladder by adding a rung ` +
-            `{ "tier": "${pModel}", "agent": "${pAgent}", "attempts": <n> } (and an agent on every other rung) to autoMode.escalation.tierOrder.`,
+          message: `Profile "${profile.id}" target (${pAgent}@${pModel}) has no matching rung in autoMode.escalation.tierOrder — escalation from this profile has no defined path. To fix: agent-qualify the ladder by adding a rung { "tier": "${pModel}", "agent": "${pAgent}", "attempts": <n> } (and an agent on every other rung) to autoMode.escalation.tierOrder.`,
         });
       }
       // Cross-section: profile target agent must exist in config.models

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -409,14 +409,14 @@ export const NaxConfigSchema = z
     const tierOrder = data.autoMode?.escalation?.tierOrder ?? [];
     const knownAgents = Object.keys(data.models ?? {});
     for (const [i, rung] of tierOrder.entries()) {
-      if (rung.agent !== undefined && !knownAgents.includes(rung.agent)) {
+      if (rung.agent === undefined) continue;
+      if (!knownAgents.includes(rung.agent)) {
         ctx.addIssue({
           code: "custom",
           path: ["autoMode", "escalation", "tierOrder", i, "agent"],
           message: `Agent "${rung.agent}" is not defined in config.models (known: ${knownAgents.join(", ")})`,
         });
-      }
-      if (rung.agent !== undefined) {
+      } else {
         const agentTiers = data.models?.[rung.agent] ?? {};
         if (!(rung.tier in agentTiers)) {
           ctx.addIssue({

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -18,7 +18,6 @@ import {
 import {
   AcceptanceConfigSchema,
   AgentConfigSchema,
-  type AgentRoutingConfigSchema,
   CuratorConfigSchema,
   DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG,
   GenerateConfigSchema,
@@ -430,9 +429,7 @@ export const NaxConfigSchema = z
       }
     }
     // Profile↔ladder binding: every profile's target must map to a rung in tierOrder
-    type AgentConfig = z.infer<typeof AgentRoutingConfigSchema>;
-    type AgentProfile = AgentConfig["profiles"][number];
-    const profiles = (data.routing as { agents?: AgentConfig })?.agents?.profiles ?? ([] as AgentProfile[]);
+    const profiles = data.routing.agents?.profiles ?? [];
     for (const [pi, profile] of profiles.entries()) {
       const { agent: pAgent, model: pModel } = profile.target;
       const hasMatchingRung = tierOrder.some((r) => r.tier === pModel && r.agent === pAgent);

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -428,4 +428,27 @@ export const NaxConfigSchema = z
         }
       }
     }
+    // Profile↔ladder binding: every profile's target must map to a rung in tierOrder
+    const profiles = (data.routing as { agents?: { profiles?: Array<{ id: string; target: { agent: string; model: string } }> } })?.agents?.profiles ?? [];
+    for (const [pi, profile] of profiles.entries()) {
+      const { agent: pAgent, model: pModel } = profile.target;
+      const hasMatchingRung = tierOrder.some(
+        (r) => r.tier === pModel && r.agent === pAgent,
+      );
+      if (!hasMatchingRung) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["routing", "agents", "profiles", pi, "target"],
+          message: `Profile "${profile.id}" target (${pAgent}@${pModel}) has no matching rung in autoMode.escalation.tierOrder — escalation from this profile has no defined path`,
+        });
+      }
+      // Cross-section: profile target agent must exist in config.models
+      if (!knownAgents.includes(pAgent)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["routing", "agents", "profiles", pi, "target", "agent"],
+          message: `Profile "${profile.id}" target agent "${pAgent}" is not defined in config.models`,
+        });
+      }
+    }
   });

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -403,4 +403,28 @@ export const NaxConfigSchema = z
   .refine((data) => data.version === 1, {
     message: "Invalid version: expected 1",
     path: ["version"],
+  })
+  .superRefine((data, ctx) => {
+    // Cross-section: each tierOrder rung's agent (when set) must exist in config.models
+    const tierOrder = data.autoMode?.escalation?.tierOrder ?? [];
+    const knownAgents = Object.keys(data.models ?? {});
+    for (const [i, rung] of tierOrder.entries()) {
+      if (rung.agent !== undefined && !knownAgents.includes(rung.agent)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["autoMode", "escalation", "tierOrder", i, "agent"],
+          message: `Agent "${rung.agent}" is not defined in config.models (known: ${knownAgents.join(", ")})`,
+        });
+      }
+      if (rung.agent !== undefined) {
+        const agentTiers = data.models?.[rung.agent] ?? {};
+        if (!(rung.tier in agentTiers)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["autoMode", "escalation", "tierOrder", i, "tier"],
+            message: `Tier "${rung.tier}" is not defined for agent "${rung.agent}" in config.models`,
+          });
+        }
+      }
+    }
   });

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -18,6 +18,7 @@ import {
 import {
   AcceptanceConfigSchema,
   AgentConfigSchema,
+  type AgentRoutingConfigSchema,
   CuratorConfigSchema,
   DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG,
   GenerateConfigSchema,
@@ -429,7 +430,9 @@ export const NaxConfigSchema = z
       }
     }
     // Profile↔ladder binding: every profile's target must map to a rung in tierOrder
-    const profiles = (data.routing as { agents?: { profiles?: Array<{ id: string; target: { agent: string; model: string } }> } })?.agents?.profiles ?? [];
+    type AgentConfig = z.infer<typeof AgentRoutingConfigSchema>;
+    type AgentProfile = AgentConfig["profiles"][number];
+    const profiles = (data.routing as { agents?: AgentConfig })?.agents?.profiles ?? [] as AgentProfile[];
     for (const [pi, profile] of profiles.entries()) {
       const { agent: pAgent, model: pModel } = profile.target;
       const hasMatchingRung = tierOrder.some(

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -24,7 +24,7 @@ export const reviewConfigSelector = pickSelector(
   "agent",
 );
 export const planConfigSelector = pickSelector("plan", "plan", "debate", "agent", "project");
-export const decomposeConfigSelector = pickSelector("decompose", "plan", "agent");
+export const decomposeConfigSelector = pickSelector("decompose", "plan", "agent", "routing");
 export const rectifyConfigSelector = pickSelector("rectify", "execution");
 export const acceptanceConfigSelector = pickSelector("acceptance", "acceptance");
 // acceptance fix take more time to fix the code, so we use a separate config selector to use execution.sessionTimeoutSeconds instead of acceptance.timeoutMs

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -44,3 +44,5 @@ export {
 } from "./test-scanner";
 
 export { autoDetectContextFiles, extractKeywords, type AutoDetectOptions } from "./auto-detect";
+
+export { isGreenfieldStory } from "./greenfield";

--- a/src/execution/escalation/escalation.ts
+++ b/src/execution/escalation/escalation.ts
@@ -48,10 +48,19 @@ export function escalateTier(
 }
 
 /**
- * Get the tier config for a given tier name.
+ * Get the tier config for a given rung.
+ *
+ * When agent is provided, matches by (tier, agent) tuple so cross-agent ladders
+ * with repeated tier names return the correct rung's attempt budget.
+ * When agent is omitted, falls back to tier-name-only matching (first match).
  */
-export function getTierConfig(tierName: string, tierOrder: TierConfig[]): TierConfig | undefined {
-  return tierOrder.find((t) => t.tier === tierName);
+export function getTierConfig(
+  rung: { tier: string; agent?: string },
+  tierOrder: TierConfig[],
+): TierConfig | undefined {
+  return rung.agent !== undefined
+    ? tierOrder.find((t) => t.tier === rung.tier && t.agent === rung.agent)
+    : tierOrder.find((t) => t.tier === rung.tier);
 }
 
 /**

--- a/src/execution/escalation/escalation.ts
+++ b/src/execution/escalation/escalation.ts
@@ -54,10 +54,7 @@ export function escalateTier(
  * with repeated tier names return the correct rung's attempt budget.
  * When agent is omitted, falls back to tier-name-only matching (first match).
  */
-export function getTierConfig(
-  rung: { tier: string; agent?: string },
-  tierOrder: TierConfig[],
-): TierConfig | undefined {
+export function getTierConfig(rung: { tier: string; agent?: string }, tierOrder: TierConfig[]): TierConfig | undefined {
   return rung.agent !== undefined
     ? tierOrder.find((t) => t.tier === rung.tier && t.agent === rung.agent)
     : tierOrder.find((t) => t.tier === rung.tier);

--- a/src/execution/escalation/escalation.ts
+++ b/src/execution/escalation/escalation.ts
@@ -16,35 +16,44 @@ export interface EscalateTierResult {
 /**
  * Escalate to the next tier in the configured order.
  *
- * @param currentTier - Current tier name
+ * Matches the current rung by (tier, agent) tuple so that cross-agent ladders
+ * with repeated tier names (e.g. opencode@balanced → claude@balanced → claude@powerful)
+ * advance correctly instead of always anchoring on the first matching tier name.
+ *
+ * @param currentRung - Current rung as { tier, agent? }
  * @param tierOrder - Ordered tier config array from config (e.g., [{tier:"fast",attempts:5}, ...])
  * @returns Next tier and agent, or null if at max tier
  *
  * @example
  * ```typescript
  * const tiers = [{tier:"fast",agent:"claude",attempts:3}, {tier:"balanced",agent:"claude",attempts:2}];
- * escalateTier("fast", tiers);    // => { tier: "balanced", agent: "claude" }
- * escalateTier("balanced", tiers); // => null
+ * escalateTier({ tier: "fast", agent: "claude" }, tiers);    // => { tier: "balanced", agent: "claude" }
+ * escalateTier({ tier: "balanced", agent: "claude" }, tiers); // => null
  * ```
  */
-export function escalateTier(currentTier: string, tierOrder: TierConfig[]): EscalateTierResult | null {
-  const getName = (t: TierConfig) => t.tier ?? (t as unknown as { name?: string }).name ?? null;
-  const currentIndex = tierOrder.findIndex((t) => getName(t) === currentTier);
-  if (currentIndex === -1 || currentIndex === tierOrder.length - 1) {
-    return null;
-  }
-  const next = tierOrder[currentIndex + 1];
-  const nextName = getName(next);
-  if (!nextName) return null;
-  return { tier: nextName, agent: next.agent };
+export function escalateTier(
+  currentRung: { tier: string; agent?: string },
+  tierOrder: TierConfig[],
+): EscalateTierResult | null {
+  // When agent is specified, match by (tier, agent) tuple to correctly navigate
+  // cross-agent ladders where the same tier name appears for multiple agents.
+  // When agent is omitted, fall back to tier-name-only matching (first match).
+  const i =
+    currentRung.agent !== undefined
+      ? tierOrder.findIndex(
+          (t) => t.tier === currentRung.tier && (t.agent ?? undefined) === currentRung.agent,
+        )
+      : tierOrder.findIndex((t) => t.tier === currentRung.tier);
+  if (i === -1 || i === tierOrder.length - 1) return null;
+  const next = tierOrder[i + 1];
+  return { tier: next.tier, agent: next.agent };
 }
 
 /**
  * Get the tier config for a given tier name.
  */
 export function getTierConfig(tierName: string, tierOrder: TierConfig[]): TierConfig | undefined {
-  const getName = (t: TierConfig) => t.tier ?? (t as unknown as { name?: string }).name ?? null;
-  return tierOrder.find((t) => getName(t) === tierName);
+  return tierOrder.find((t) => t.tier === tierName);
 }
 
 /**

--- a/src/execution/escalation/escalation.ts
+++ b/src/execution/escalation/escalation.ts
@@ -41,7 +41,7 @@ export function escalateTier(
   const i =
     currentRung.agent !== undefined
       ? tierOrder.findIndex(
-          (t) => t.tier === currentRung.tier && (t.agent ?? undefined) === currentRung.agent,
+          (t) => t.tier === currentRung.tier && t.agent === currentRung.agent,
         )
       : tierOrder.findIndex((t) => t.tier === currentRung.tier);
   if (i === -1 || i === tierOrder.length - 1) return null;

--- a/src/execution/escalation/escalation.ts
+++ b/src/execution/escalation/escalation.ts
@@ -40,9 +40,7 @@ export function escalateTier(
   // When agent is omitted, fall back to tier-name-only matching (first match).
   const i =
     currentRung.agent !== undefined
-      ? tierOrder.findIndex(
-          (t) => t.tier === currentRung.tier && t.agent === currentRung.agent,
-        )
+      ? tierOrder.findIndex((t) => t.tier === currentRung.tier && t.agent === currentRung.agent)
       : tierOrder.findIndex((t) => t.tier === currentRung.tier);
   if (i === -1 || i === tierOrder.length - 1) return null;
   const next = tierOrder[i + 1];

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -136,9 +136,16 @@ export async function preIterationTierCheck(
     return { shouldSkipIteration: false, prdDirty: false, prd };
   }
 
-  // Exceeded current tier budget — try to escalate
-  const currentAgent = story.routing?.agent;
-  const escalationResult = escalateTier({ tier: currentTier, agent: currentAgent }, tierOrder);
+  // Exceeded current tier budget — try to escalate.
+  // Only match by (tier, agent) tuple when the tierOrder actually contains
+  // agent-qualified rungs (cross-agent ladder). For standard tier orders with
+  // no agent fields, fall back to tier-name-only matching so escalation still
+  // works for stories that carry a routing.agent (Task 9 agent-profile routing).
+  const hasAgentRungs = tierOrder.some((r) => r.agent !== undefined);
+  const currentRung = hasAgentRungs
+    ? { tier: currentTier, agent: story.routing?.agent }
+    : { tier: currentTier };
+  const escalationResult = escalateTier(currentRung, tierOrder);
   const nextAgent = escalationResult?.agent;
   const routingMode = config.routing.llm?.mode ?? "hybrid";
 
@@ -311,10 +318,16 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
     return { outcome: "retry-same", prdDirty: false, prd: ctx.prd };
   }
 
-  const escalationResult = escalateTier(
-    { tier: ctx.routing.modelTier, agent: ctx.story.routing?.agent },
-    ctx.config.autoMode.escalation.tierOrder,
-  );
+  // Only match by (tier, agent) tuple when the tierOrder contains agent-qualified
+  // rungs (cross-agent ladder). Standard tier orders with no agent fields fall back
+  // to tier-name-only matching so escalation still works for stories that carry a
+  // routing.agent (Task 9 agent-profile routing).
+  const escalationTierOrder = ctx.config.autoMode.escalation.tierOrder;
+  const hasAgentRungs = escalationTierOrder.some((r) => r.agent !== undefined);
+  const currentRung = hasAgentRungs
+    ? { tier: ctx.routing.modelTier, agent: ctx.story.routing?.agent }
+    : { tier: ctx.routing.modelTier };
+  const escalationResult = escalateTier(currentRung, escalationTierOrder);
   const nextAgent = escalationResult?.agent;
   const escalateWholeBatch = ctx.config.autoMode.escalation.escalateEntireBatch ?? true;
   const storiesToEscalate = ctx.isBatchExecution && escalateWholeBatch ? ctx.storiesToExecute : [ctx.story];

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -135,6 +135,15 @@ export async function preIterationTierCheck(
     : { tier: currentTier };
   const tierCfg = tierOrder.length > 0 ? getTierConfig(currentRungForBudget, tierOrder) : undefined;
 
+  if (tierOrder.length > 0 && !tierCfg) {
+    logger?.warn("escalation", "Current rung not found in tierOrder — escalation budget is unbounded for this story", {
+      storyId: story.id,
+      currentTier,
+      agent: story.routing?.agent,
+      hasAgentRungs,
+    });
+  }
+
   if (!tierCfg || (story.attempts ?? 0) < tierCfg.attempts) {
     // Story still has budget in current tier
     return { shouldSkipIteration: false, prdDirty: false, prd };

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -126,7 +126,7 @@ export async function preIterationTierCheck(
   totalCost: number,
   workdir: string,
 ): Promise<PreIterationCheckResult> {
-  const logger = getSafeLogger();
+  const logger = _tierEscalationDeps.getSafeLogger();
   const currentTier = story.routing?.modelTier ?? routing.modelTier;
   const tierOrder = config.autoMode.escalation?.tierOrder || [];
   const hasAgentRungs = tierOrder.some((r) => r.agent !== undefined);
@@ -306,6 +306,7 @@ export function shouldRetrySameTier(runtimeCrashResult: { status: string; succes
  */
 export const _tierEscalationDeps = {
   savePRD,
+  getSafeLogger,
 };
 
 /**

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -129,7 +129,11 @@ export async function preIterationTierCheck(
   const logger = getSafeLogger();
   const currentTier = story.routing?.modelTier ?? routing.modelTier;
   const tierOrder = config.autoMode.escalation?.tierOrder || [];
-  const tierCfg = tierOrder.length > 0 ? getTierConfig(currentTier, tierOrder) : undefined;
+  const hasAgentRungs = tierOrder.some((r) => r.agent !== undefined);
+  const currentRungForBudget = hasAgentRungs
+    ? { tier: currentTier, agent: story.routing?.agent }
+    : { tier: currentTier };
+  const tierCfg = tierOrder.length > 0 ? getTierConfig(currentRungForBudget, tierOrder) : undefined;
 
   if (!tierCfg || (story.attempts ?? 0) < tierCfg.attempts) {
     // Story still has budget in current tier
@@ -137,11 +141,6 @@ export async function preIterationTierCheck(
   }
 
   // Exceeded current tier budget — try to escalate.
-  // Only match by (tier, agent) tuple when the tierOrder actually contains
-  // agent-qualified rungs (cross-agent ladder). For standard tier orders with
-  // no agent fields, fall back to tier-name-only matching so escalation still
-  // works for stories that carry a routing.agent (Task 9 agent-profile routing).
-  const hasAgentRungs = tierOrder.some((r) => r.agent !== undefined);
   const currentRung = hasAgentRungs ? { tier: currentTier, agent: story.routing?.agent } : { tier: currentTier };
   const escalationResult = escalateTier(currentRung, tierOrder);
   const nextAgent = escalationResult?.agent;

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -142,9 +142,7 @@ export async function preIterationTierCheck(
   // no agent fields, fall back to tier-name-only matching so escalation still
   // works for stories that carry a routing.agent (Task 9 agent-profile routing).
   const hasAgentRungs = tierOrder.some((r) => r.agent !== undefined);
-  const currentRung = hasAgentRungs
-    ? { tier: currentTier, agent: story.routing?.agent }
-    : { tier: currentTier };
+  const currentRung = hasAgentRungs ? { tier: currentTier, agent: story.routing?.agent } : { tier: currentTier };
   const escalationResult = escalateTier(currentRung, tierOrder);
   const nextAgent = escalationResult?.agent;
   const routingMode = config.routing.llm?.mode ?? "hybrid";

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -137,7 +137,8 @@ export async function preIterationTierCheck(
   }
 
   // Exceeded current tier budget — try to escalate
-  const escalationResult = escalateTier(currentTier, tierOrder);
+  const currentAgent = story.routing?.agent;
+  const escalationResult = escalateTier({ tier: currentTier, agent: currentAgent }, tierOrder);
   const nextAgent = escalationResult?.agent;
   const routingMode = config.routing.llm?.mode ?? "hybrid";
 
@@ -310,7 +311,10 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
     return { outcome: "retry-same", prdDirty: false, prd: ctx.prd };
   }
 
-  const escalationResult = escalateTier(ctx.routing.modelTier, ctx.config.autoMode.escalation.tierOrder);
+  const escalationResult = escalateTier(
+    { tier: ctx.routing.modelTier, agent: ctx.story.routing?.agent },
+    ctx.config.autoMode.escalation.tierOrder,
+  );
   const nextAgent = escalationResult?.agent;
   const escalateWholeBatch = ctx.config.autoMode.escalation.escalateEntireBatch ?? true;
   const storiesToEscalate = ctx.isBatchExecution && escalateWholeBatch ? ctx.storiesToExecute : [ctx.story];

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -72,14 +72,23 @@ export function warnProfileMismatch(
     }
   }
 
+  const knownAgents = new Set(Object.keys(config.models ?? {}));
+
   for (const story of prd.userStories) {
     const profileId = story.routing?.agentProfileId;
-    if (!profileId) continue;
-    if (!profileIds.has(profileId)) {
+    if (profileId && !profileIds.has(profileId)) {
       logger?.warn(
         "setup",
         `Story ${story.id} was planned with profile ${profileId} which no longer exists in config — routing.agent assignment retained`,
         { storyId: story.id, agentProfileId: profileId },
+      );
+    }
+    const storyAgent = story.routing?.agent;
+    if (storyAgent && !knownAgents.has(storyAgent)) {
+      logger?.warn(
+        "setup",
+        `Story ${story.id} routes to agent "${storyAgent}" which is not defined in config.models — execution will degrade to the default agent`,
+        { storyId: story.id, agent: storyAgent },
       );
     }
   }

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -116,6 +116,7 @@ export function warnFallbackMisconfiguration(
       if (warned.has(candidate)) continue;
       if (!agentGetFn(candidate)) {
         logger?.warn("fallback", "Fallback candidate not available — will be skipped if triggered", {
+          storyId: "_setup",
           primaryAgent,
           candidate,
         });

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -58,15 +58,16 @@ export function warnProfileMismatch(
   const profiles = config.routing?.agents?.profiles ?? [];
   const profileIds = new Set(profiles.map((p) => p.id));
 
-  // PRD-level check: warn if the overall routing profile config changed since plan time.
+  // PRD-level check (Delta C4): warn when the run resolves a different config
+  // profile than the one the PRD was planned with — the escalation ladder and
+  // agent-profile registry may differ from what plan assumed.
   if (prd.routingProfile !== undefined) {
-    const current = config.routing?.agents?.default;
+    const current = config.profile ?? "default";
     if (prd.routingProfile !== current) {
-      const currentDisplay = current ?? "(none)";
       logger?.warn(
         "prd",
-        `PRD was planned with default routing profile "${prd.routingProfile}" but current config.routing.agents.default is "${currentDisplay}" — per-story agent assignments may not reflect current profile config`,
-        { storyId: "prd", routingProfile: prd.routingProfile, currentDefault: currentDisplay },
+        `PRD was planned with config profile "${prd.routingProfile}" but this run resolved profile "${current}" — the escalation ladder and agent profiles may differ from what plan assumed. Re-run with --profile ${prd.routingProfile} to match.`,
+        { storyId: "prd", plannedProfile: prd.routingProfile, currentProfile: current },
       );
     }
   }

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -62,10 +62,11 @@ export function warnProfileMismatch(
   if (prd.routingProfile !== undefined) {
     const current = config.routing?.agents?.default;
     if (prd.routingProfile !== current) {
+      const currentDisplay = current ?? "(none)";
       logger?.warn(
         "prd",
-        `PRD was planned with default routing profile "${prd.routingProfile}" but current config.routing.agents.default is "${current}" — per-story agent assignments may not reflect current profile config`,
-        { storyId: "prd", routingProfile: prd.routingProfile, currentDefault: current },
+        `PRD was planned with default routing profile "${prd.routingProfile}" but current config.routing.agents.default is "${currentDisplay}" — per-story agent assignments may not reflect current profile config`,
+        { storyId: "prd", routingProfile: prd.routingProfile, currentDefault: currentDisplay },
       );
     }
   }

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -12,7 +12,6 @@
  * - Run initialization
  */
 
-import * as os from "node:os";
 import path from "node:path";
 import { pipelineEventBus } from "@/pipeline";
 import { discoverWorkspacePackages, resolveTestFilePatterns } from "@/test-runners";

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -44,6 +44,35 @@ export const _runSetupDeps = {
 };
 
 /**
+ * Emit a warning for each story whose agentProfileId no longer exists in
+ * config.routing.agents.profiles (Task 10 Part B — profile-mismatch check).
+ *
+ * This handles the case where a user runs an old PRD after removing a profile
+ * from config. The existing routing.agent assignment is retained — warn only,
+ * no throw.
+ */
+export function warnProfileMismatch(
+  prd: import("../../prd").PRD,
+  config: NaxConfig,
+  logger: ReturnType<typeof getSafeLogger>,
+): void {
+  const profiles = config.routing?.agents?.profiles ?? [];
+  const profileIds = new Set(profiles.map((p) => p.id));
+
+  for (const story of prd.userStories) {
+    const profileId = story.routing?.agentProfileId;
+    if (!profileId) continue;
+    if (!profileIds.has(profileId)) {
+      logger?.warn(
+        "setup",
+        `Story ${story.id} was planned with profile ${profileId} which no longer exists in config — routing.agent assignment retained`,
+        { storyId: story.id, agentProfileId: profileId },
+      );
+    }
+  }
+}
+
+/**
  * Emit a warning for each fallback candidate in config.agent.fallback.map
  * that cannot be resolved by agentGetFn (AC-35 pre-flight check).
  *
@@ -402,6 +431,10 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     // initializeRun calls loadPRD() internally, producing a new object.
     // Re-prime statusWriter so crash handlers during the prompt window see current state (#356).
     statusWriter.setPrd(prd);
+
+    // Warn when any story was planned with an agent profile that has since been removed.
+    warnProfileMismatch(prd, config, logger);
+
     let counts = initResult.storyCounts;
 
     // Prompt user for each paused story — skip in headless mode

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -58,6 +58,18 @@ export function warnProfileMismatch(
   const profiles = config.routing?.agents?.profiles ?? [];
   const profileIds = new Set(profiles.map((p) => p.id));
 
+  // PRD-level check: warn if the overall routing profile config changed since plan time.
+  if (prd.routingProfile !== undefined) {
+    const current = config.routing?.agents?.default;
+    if (prd.routingProfile !== current) {
+      logger?.warn(
+        "prd",
+        `PRD was planned with default routing profile "${prd.routingProfile}" but current config.routing.agents.default is "${current}" — per-story agent assignments may not reflect current profile config`,
+        { storyId: "prd", routingProfile: prd.routingProfile, currentDefault: current },
+      );
+    }
+  }
+
   for (const story of prd.userStories) {
     const profileId = story.routing?.agentProfileId;
     if (!profileId) continue;

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -39,7 +39,7 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
       const profiles = agentRouting.profiles ?? [];
       const cards = OneShotPromptBuilder.agentCapabilityCards(profiles);
       if (cards.length > 0) {
-        prompt = `${prompt}\n\n${cards}`;
+        prompt = `${prompt}\n\n${cards}\n\n${OneShotPromptBuilder.agentProfileInstruction()}`;
       }
     }
 
@@ -61,23 +61,39 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
       return stories;
     }
 
+    const defaultProfile = agentRouting.default
+      ? profiles.find((p) => p.id === agentRouting.default)
+      : undefined;
+
     return stories.map((story) => {
-      if (!story.agentProfileId) {
-        return story;
+      if (story.agentProfileId) {
+        const profile = profiles.find((p) => p.id === story.agentProfileId);
+        if (profile) {
+          return {
+            ...story,
+            routing: {
+              ...story.routing,
+              agent: profile.target.agent,
+              agentProfileId: profile.id,
+            },
+          };
+        }
+        // LLM emitted an unknown/hallucinated profile id — fall through to default
       }
-      const profile = profiles.find((p) => p.id === story.agentProfileId);
-      if (!profile) {
-        // LLM hallucinated an unknown profile id — leave routing unchanged
-        return story;
+
+      // No valid per-story selection — apply default profile if configured
+      if (defaultProfile) {
+        return {
+          ...story,
+          routing: {
+            ...story.routing,
+            agent: defaultProfile.target.agent,
+            agentProfileId: defaultProfile.id,
+          },
+        };
       }
-      return {
-        ...story,
-        routing: {
-          ...story.routing,
-          agent: profile.target.agent,
-          agentProfileId: profile.id,
-        },
-      };
+
+      return story;
     });
   },
 };

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -75,6 +75,7 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
               ...story.routing,
               agent: profile.target.agent,
               agentProfileId: profile.id,
+              profileModelTier: profile.target.model,
             },
           };
         }
@@ -89,6 +90,7 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
             ...story.routing,
             agent: defaultProfile.target.agent,
             agentProfileId: defaultProfile.id,
+            profileModelTier: defaultProfile.target.model,
           },
         };
       }

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -4,6 +4,7 @@ import type { DecomposedStory } from "../agents/shared/types-extended";
 import { decomposeConfigSelector } from "../config";
 import type { DecomposeConfig } from "../config/selectors";
 import type { UserStory } from "../prd";
+import { OneShotPromptBuilder } from "../prompts";
 import type { CompleteOperation } from "./types";
 
 export interface DecomposeOpInput {
@@ -24,14 +25,24 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
   config: decomposeConfigSelector,
   model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.decomposeTimeoutSeconds ?? ctx.config.plan.timeoutSeconds ?? 600) * 1000,
-  build(input, _ctx) {
-    const prompt = buildDecomposePromptSync({
+  build(input, ctx) {
+    let prompt = buildDecomposePromptSync({
       specContent: input.specContent,
       codebaseContext: input.codebaseContext,
       targetStory: input.targetStory,
       siblings: input.siblings,
       maxAcCount: input.maxAcCount,
     });
+
+    const agentRouting = ctx.config.routing?.agents;
+    if (agentRouting?.enabled === true) {
+      const profiles = agentRouting.profiles ?? [];
+      const cards = OneShotPromptBuilder.agentCapabilityCards(profiles);
+      if (cards.length > 0) {
+        prompt = `${prompt}\n\n${cards}`;
+      }
+    }
+
     return {
       role: { id: "role", content: "", overridable: false },
       task: { id: "task", content: prompt, overridable: false },

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -4,7 +4,6 @@ import type { DecomposedStory } from "../agents/shared/types-extended";
 import { decomposeConfigSelector } from "../config";
 import type { DecomposeConfig } from "../config/selectors";
 import type { UserStory } from "../prd";
-import { OneShotPromptBuilder } from "../prompts";
 import type { CompleteOperation } from "./types";
 
 export interface DecomposeOpInput {
@@ -26,22 +25,16 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
   model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.decomposeTimeoutSeconds ?? ctx.config.plan.timeoutSeconds ?? 600) * 1000,
   build(input, ctx) {
-    let prompt = buildDecomposePromptSync({
+    const agentRouting = ctx.config.routing?.agents;
+    const profiles = agentRouting?.enabled === true ? (agentRouting.profiles ?? []) : [];
+    const prompt = buildDecomposePromptSync({
       specContent: input.specContent,
       codebaseContext: input.codebaseContext,
       targetStory: input.targetStory,
       siblings: input.siblings,
       maxAcCount: input.maxAcCount,
+      profiles,
     });
-
-    const agentRouting = ctx.config.routing?.agents;
-    if (agentRouting?.enabled === true) {
-      const profiles = agentRouting.profiles ?? [];
-      const cards = OneShotPromptBuilder.agentCapabilityCards(profiles);
-      if (cards.length > 0) {
-        prompt = `${prompt}\n\n${cards}\n\n${OneShotPromptBuilder.agentProfileInstruction()}`;
-      }
-    }
 
     return {
       role: { id: "role", content: "", overridable: false },

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -3,8 +3,16 @@ import { buildDecomposePromptSync } from "../agents/shared/decompose-prompt";
 import type { DecomposedStory } from "../agents/shared/types-extended";
 import { decomposeConfigSelector } from "../config";
 import type { DecomposeConfig } from "../config/selectors";
+import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import type { CompleteOperation } from "./types";
+
+/**
+ * Swappable dependencies for testing (avoids mock.module() which leaks in Bun 1.x).
+ */
+export const _decomposeOpDeps = {
+  getSafeLogger,
+};
 
 export interface DecomposeOpInput {
   specContent: string;
@@ -70,7 +78,14 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
             },
           };
         }
-        // LLM emitted an unknown/hallucinated profile id — fall through to default
+        // Delta C3: never invent an agent — warn and fall through to the default profile.
+        _decomposeOpDeps
+          .getSafeLogger()
+          ?.warn(
+            "decompose",
+            `Story ${story.id} selected unknown agent profile "${story.agentProfileId}" — falling back to ${defaultProfile ? `default profile "${defaultProfile.id}"` : "no profile"}`,
+            { storyId: story.id, agentProfileId: story.agentProfileId },
+          );
       }
 
       // No valid per-story selection — apply default profile if configured

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -48,7 +48,36 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
       task: { id: "task", content: prompt, overridable: false },
     };
   },
-  parse(output, _input, _ctx) {
-    return parseDecomposeOutput(output);
+  parse(output, _input, ctx) {
+    const stories = parseDecomposeOutput(output);
+
+    const agentRouting = ctx.config.routing?.agents;
+    if (agentRouting?.enabled !== true) {
+      return stories;
+    }
+
+    const profiles = agentRouting.profiles ?? [];
+    if (profiles.length === 0) {
+      return stories;
+    }
+
+    return stories.map((story) => {
+      if (!story.agentProfileId) {
+        return story;
+      }
+      const profile = profiles.find((p) => p.id === story.agentProfileId);
+      if (!profile) {
+        // LLM hallucinated an unknown profile id — leave routing unchanged
+        return story;
+      }
+      return {
+        ...story,
+        routing: {
+          ...story.routing,
+          agent: profile.target.agent,
+          agentProfileId: profile.id,
+        },
+      };
+    });
   },
 };

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -61,9 +61,7 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
       return stories;
     }
 
-    const defaultProfile = agentRouting.default
-      ? profiles.find((p) => p.id === agentRouting.default)
-      : undefined;
+    const defaultProfile = agentRouting.default ? profiles.find((p) => p.id === agentRouting.default) : undefined;
 
     return stories.map((story) => {
       if (story.agentProfileId) {

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -18,6 +18,8 @@ export type { PipelineRunResult } from "./runner";
 export { PipelineEventEmitter } from "./events";
 export type { PipelineEvents, RunSummary } from "./events";
 export { executionStage, _executionDeps } from "./stages";
+export { resolveExecutionAgent } from "./stages/execution-helpers";
+export type { ResolvedExecutionAgent } from "./stages/execution-helpers";
 
 export { pipelineEventBus } from "./event-bus";
 export type {

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -5,10 +5,10 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { NaxError } from "../../errors";
-import type { FailureCategory } from "../../tdd";
-import type { PipelineContext, StageResult } from "../types";
-import type { AgentAdapter } from "../../agents/types";
+import type { AgentAdapter } from "@/agents/types";
+import { NaxError } from "@/errors";
+import type { PipelineContext, StageResult } from "@/pipeline/types";
+import type { FailureCategory } from "@/tdd";
 
 export interface ResolvedExecutionAgent {
   agentName: string;

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -8,6 +8,32 @@ import { join } from "node:path";
 import { NaxError } from "../../errors";
 import type { FailureCategory } from "../../tdd";
 import type { PipelineContext, StageResult } from "../types";
+import type { AgentAdapter } from "../../agents/types";
+
+export interface ResolvedExecutionAgent {
+  agentName: string;
+  agent: AgentAdapter | undefined;
+  /** True when the routed agent could not be resolved and we fell back to the default. */
+  degraded: boolean;
+}
+
+/**
+ * Availability seam: a planned-but-unavailable agent degrades to the default
+ * agent instead of failing the story. Caller logs when `degraded` is true.
+ */
+export function resolveExecutionAgent(opts: {
+  routedAgent: string | undefined;
+  defaultAgent: string;
+  getAgent: (name: string) => AgentAdapter | undefined;
+}): ResolvedExecutionAgent {
+  const { routedAgent, defaultAgent, getAgent } = opts;
+  if (routedAgent !== undefined) {
+    const routed = getAgent(routedAgent);
+    if (routed) return { agentName: routedAgent, agent: routed, degraded: false };
+    return { agentName: defaultAgent, agent: getAgent(defaultAgent), degraded: true };
+  }
+  return { agentName: defaultAgent, agent: getAgent(defaultAgent), degraded: false };
+}
 
 /**
  * Resolve the effective working directory for a story.

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -26,6 +26,7 @@ import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 // Re-export helpers so existing importers continue to work.
 export { resolveStoryWorkdir, routeTddFailure } from "./execution-helpers";
+import { resolveExecutionAgent } from "./execution-helpers";
 
 /**
  * NaxError codes that indicate agent/infrastructure failure rather than user intent.
@@ -41,10 +42,23 @@ export const executionStage: PipelineStage = {
   async execute(ctx: PipelineContext): Promise<StageResult> {
     const logger = getLogger();
 
-    // HARD FAILURE: No agent available — cannot proceed without an agent
+    // Resolve the ROUTED agent's adapter (availability seam): a planned agent
+    // that cannot be resolved degrades to the default agent with a warning.
     const defaultAgent = ctx.agentManager?.getDefault() ?? "claude";
-    const agent = (ctx.agentGetFn ?? _executionDeps.getAgent)(defaultAgent);
-    if (!agent) return { action: "fail", reason: `Agent "${defaultAgent}" not found` };
+    const resolved = resolveExecutionAgent({
+      routedAgent: ctx.routing.agent,
+      defaultAgent,
+      getAgent: ctx.agentGetFn ?? _executionDeps.getAgent,
+    });
+    if (resolved.degraded) {
+      logger.warn("execution", "Routed agent unavailable — degrading to default agent", {
+        storyId: ctx.story.id,
+        routedAgent: ctx.routing.agent,
+        defaultAgent,
+      });
+    }
+    const agent = resolved.agent;
+    if (!agent) return { action: "fail", reason: `Agent "${resolved.agentName}" not found` };
 
     // Prompt presence is validated inside assemblePlanInputsFromCtx — it knows
     // which strategies depend on ctx.prompt vs. build per-role prompts internally.
@@ -76,7 +90,7 @@ export const executionStage: PipelineStage = {
       runtime: ctx.runtime,
       packageView,
       packageDir: ctx.workdir,
-      agentName: ctx.routing.agent ?? defaultAgent,
+      agentName: resolved.agentName,
       storyId: ctx.story.id,
       featureName: ctx.prd.feature,
       story: ctx.story,

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -68,13 +68,19 @@ export const routingStage: PipelineStage = {
       (previousRank !== undefined && candidateRank !== undefined ? previousRank > candidateRank : hasEscalationRecords);
     const modelTier = isEscalated ? previousTier : candidateTier;
 
-    const routing = { ...decision, modelTier, agent: ctx.story.routing?.agent };
+    // PRD-assigned agent wins (plan-time selection, Delta C3). decision.agent is
+    // the Part A run-time classifier's choice and applies only when the PRD
+    // leaves agent unset — do NOT clobber it unconditionally.
+    const routing = { ...decision, modelTier, agent: ctx.story.routing?.agent ?? decision.agent };
 
     // Write routing back to story (for escalation tracking).
-    // initialAgent / initialProfileId use the first-write idiom: captured once and
-    // never overwritten by subsequent routing passes or escalation.
-    const initialAgent = ctx.story.routing?.initialAgent ?? routing.agent;
-    const initialProfileId = ctx.story.routing?.initialProfileId ?? ctx.story.routing?.agentProfileId;
+    // initialAgent / initialProfileId use the first-write idiom AND require that
+    // no escalation has happened yet: an agent first assigned by cross-agent
+    // escalation is not the story's origin (origin was "no agent").
+    const neverEscalated = !hasEscalationRecords;
+    const initialAgent = ctx.story.routing?.initialAgent ?? (neverEscalated ? routing.agent : undefined);
+    const initialProfileId =
+      ctx.story.routing?.initialProfileId ?? (neverEscalated ? ctx.story.routing?.agentProfileId : undefined);
 
     ctx.story.routing = {
       ...(ctx.story.routing ?? {}),
@@ -83,6 +89,8 @@ export const routingStage: PipelineStage = {
       testStrategy: routing.testStrategy,
       reasoning: routing.reasoning ?? "",
       modelTier: routing.modelTier,
+      // Persist the resolved agent (PRD agent wins; decision.agent fills in when unset).
+      ...(routing.agent !== undefined && { agent: routing.agent }),
       ...(initialAgent !== undefined && { initialAgent }),
       ...(initialProfileId !== undefined && { initialProfileId }),
     };

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -37,31 +37,44 @@ export const routingStage: PipelineStage = {
     const decision = await _routingDeps.resolveRouting(ctx.story, ctx.config, ctx.plugins, ctx);
 
     // @design: BUG-032: Only preserve a previously-stored modelTier when it represents an escalation
-    // (i.e., a higher tier than what routing freshly derives). This prevents stale tiers
+    // (i.e., a higher tier than the candidate baseline). This prevents stale tiers
     // from sticking when complexity changes between runs, while still honoring explicit
     // escalations set by handleTierEscalation.
     const TIER_RANK: Record<string, number> = { fast: 0, balanced: 1, powerful: 2 };
     const derivedTier = decision.modelTier;
+
+    // Open Item B: a selected profile's target tier seeds the STARTING rung and
+    // overrides the complexity-derived tier. Genuine escalation still wins below.
+    const profileTier = ctx.story.routing?.profileModelTier;
+    const candidateTier = profileTier ?? derivedTier;
+    const candidateRank = TIER_RANK[candidateTier];
+
     const previousTier = ctx.story.routing?.modelTier;
     const previousRank = previousTier !== undefined ? TIER_RANK[previousTier] : undefined;
-    const derivedRank = TIER_RANK[derivedTier];
     if (previousTier !== undefined && previousRank === undefined) {
       logger?.warn("routing", "Ignoring unknown previousTier — not escalating", {
         storyId: ctx.story.id,
         previousTier,
-        derivedTier,
+        candidateTier,
       });
     }
+    // Preserve a previously-stored tier only when it is a strictly higher escalation
+    // than the candidate (profile-or-derived) baseline.
     const isEscalated =
       previousTier !== undefined &&
       previousRank !== undefined &&
-      derivedRank !== undefined &&
-      previousRank > derivedRank;
-    const modelTier = isEscalated ? previousTier : derivedTier;
+      candidateRank !== undefined &&
+      previousRank > candidateRank;
+    const modelTier = isEscalated ? previousTier : candidateTier;
 
     const routing = { ...decision, modelTier, agent: ctx.story.routing?.agent };
 
-    // Write routing back to story (for escalation tracking)
+    // Write routing back to story (for escalation tracking).
+    // initialAgent / initialProfileId use the first-write idiom: captured once and
+    // never overwritten by subsequent routing passes or escalation.
+    const initialAgent = ctx.story.routing?.initialAgent ?? routing.agent;
+    const initialProfileId = ctx.story.routing?.initialProfileId ?? ctx.story.routing?.agentProfileId;
+
     ctx.story.routing = {
       ...(ctx.story.routing ?? {}),
       complexity: routing.complexity,
@@ -69,6 +82,8 @@ export const routingStage: PipelineStage = {
       testStrategy: routing.testStrategy,
       reasoning: routing.reasoning ?? "",
       modelTier: routing.modelTier,
+      ...(initialAgent !== undefined && { initialAgent }),
+      ...(initialProfileId !== undefined && { initialProfileId }),
     };
     if (ctx.prdPath) {
       await _routingDeps.savePRD(ctx.prd, ctx.prdPath);
@@ -113,14 +128,14 @@ export const routingStage: PipelineStage = {
     ctx.routing = routing as RoutingResult;
 
     logger.debug("routing", "Task classified", {
+      storyId: ctx.story.id,
       complexity: ctx.routing.complexity,
       modelTier: ctx.routing.modelTier,
       testStrategy: ctx.routing.testStrategy,
-      storyId: ctx.story.id,
     });
 
     if (ctx.stories.length === 1) {
-      logger.debug("routing", "Routing reasoning", { reasoning: ctx.routing.reasoning, storyId: ctx.story.id });
+      logger.debug("routing", "Routing reasoning", { storyId: ctx.story.id, reasoning: ctx.routing.reasoning });
     }
 
     return { action: "continue" };

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -65,9 +65,7 @@ export const routingStage: PipelineStage = {
     //   since rank comparison is meaningless for names outside TIER_RANK
     const isEscalated =
       previousTier !== undefined &&
-      (previousRank !== undefined && candidateRank !== undefined
-        ? previousRank > candidateRank
-        : hasEscalationRecords);
+      (previousRank !== undefined && candidateRank !== undefined ? previousRank > candidateRank : hasEscalationRecords);
     const modelTier = isEscalated ? previousTier : candidateTier;
 
     const routing = { ...decision, modelTier, agent: ctx.story.routing?.agent };

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -11,14 +11,13 @@
  * - `continue`: Routing determined, proceed to next stage
  */
 
+import { isGreenfieldStory } from "@/context";
+import { getLogger } from "@/logger";
+import { savePRD } from "@/prd";
+import { clearCache, complexityToModelTier, resolveRouting } from "@/routing";
 import { resolveTestFilePatterns } from "@/test-runners";
+import { errorMessage } from "@/utils/errors";
 import { packageDirRelative } from "@/utils/paths";
-import { isGreenfieldStory } from "../../context/greenfield";
-import { getLogger } from "../../logger";
-import { savePRD } from "../../prd";
-import { complexityToModelTier, resolveRouting } from "../../routing";
-import { clearCache } from "../../routing/strategies/llm";
-import { errorMessage } from "../../utils/errors";
 import type { PipelineContext, PipelineStage, RoutingResult, StageResult } from "../types";
 
 export const routingStage: PipelineStage = {

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -51,20 +51,23 @@ export const routingStage: PipelineStage = {
 
     const previousTier = ctx.story.routing?.modelTier;
     const previousRank = previousTier !== undefined ? TIER_RANK[previousTier] : undefined;
-    if (previousTier !== undefined && previousRank === undefined) {
+    const hasEscalationRecords = (ctx.story.escalations?.length ?? 0) > 0;
+    if (previousTier !== undefined && previousRank === undefined && !hasEscalationRecords) {
       logger?.warn("routing", "Ignoring unknown previousTier — not escalating", {
         storyId: ctx.story.id,
         previousTier,
         candidateTier,
       });
     }
-    // Preserve a previously-stored tier only when it is a strictly higher escalation
-    // than the candidate (profile-or-derived) baseline.
+    // Preserve a previously-stored tier only when it is a genuine escalation:
+    // - both tiers rankable -> strictly-higher rank wins (canonical behavior)
+    // - either tier custom/unrankable -> fall back to escalation-record evidence,
+    //   since rank comparison is meaningless for names outside TIER_RANK
     const isEscalated =
       previousTier !== undefined &&
-      previousRank !== undefined &&
-      candidateRank !== undefined &&
-      previousRank > candidateRank;
+      (previousRank !== undefined && candidateRank !== undefined
+        ? previousRank > candidateRank
+        : hasEscalationRecords);
     const modelTier = isEscalated ? previousTier : candidateTier;
 
     const routing = { ...decision, modelTier, agent: ctx.story.routing?.agent };

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -67,6 +67,7 @@ export function mapDecomposedStoriesToUserStories(
         modelTier: "balanced" as const,
         ...(story.routing?.agent !== undefined && { agent: story.routing.agent }),
         ...(story.routing?.agentProfileId !== undefined && { agentProfileId: story.routing.agentProfileId }),
+        ...(story.routing?.profileModelTier !== undefined && { profileModelTier: story.routing.profileModelTier }),
       },
     };
   });

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -7,6 +7,7 @@
 
 import type { DecomposedStory } from "../agents/shared/types-extended";
 import { NaxError } from "../errors";
+import { getSafeLogger } from "../logger";
 import type { UserStory } from "./types";
 
 /**
@@ -14,7 +15,7 @@ import type { UserStory } from "./types";
  *
  * - Moves complexity, testStrategy, and reasoning into routing sub-object
  * - Sets lifecycle defaults: status='pending', passes=false, escalations=[], attempts=0
- * - Validates required fields (id, contextFiles) and throws with entry index on failure
+ * - Validates required field id and throws on failure; warns (does not throw) for empty contextFiles
  * - Inherits workdir from parent story so per-package config is applied to sub-stories
  *
  * @param stories - Flat decompose output from adapter
@@ -38,10 +39,9 @@ export function mapDecomposedStoriesToUserStories(
     }
 
     if (!story.contextFiles || story.contextFiles.length === 0) {
-      throw new NaxError(`Entry ${entryIndex} (${story.id}) has empty contextFiles`, "DECOMPOSE_VALIDATION_FAILED", {
-        stage: "decompose-mapper",
-        entryIndex,
+      getSafeLogger()?.warn("decompose-mapper", `Entry ${entryIndex} (${story.id}) has empty contextFiles — continuing`, {
         storyId: story.id,
+        entryIndex,
         parentStoryId,
       });
     }

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -65,6 +65,8 @@ export function mapDecomposedStoriesToUserStories(
         testStrategy: story.testStrategy ?? ("test-after" as const),
         reasoning: story.reasoning,
         modelTier: "balanced" as const,
+        ...(story.routing?.agent !== undefined && { agent: story.routing.agent }),
+        ...(story.routing?.agentProfileId !== undefined && { agentProfileId: story.routing.agentProfileId }),
       },
     };
   });

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -68,7 +68,7 @@ export function mapDecomposedStoriesToUserStories(
         complexity: story.complexity,
         testStrategy: story.testStrategy ?? ("test-after" as const),
         reasoning: story.reasoning,
-        modelTier: "balanced" as const,
+        modelTier: story.routing?.profileModelTier ?? ("balanced" as const),
         ...(story.routing?.agent !== undefined && { agent: story.routing.agent }),
         ...(story.routing?.agentProfileId !== undefined && { agentProfileId: story.routing.agentProfileId }),
         ...(story.routing?.profileModelTier !== undefined && { profileModelTier: story.routing.profileModelTier }),

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -39,11 +39,15 @@ export function mapDecomposedStoriesToUserStories(
     }
 
     if (!story.contextFiles || story.contextFiles.length === 0) {
-      getSafeLogger()?.warn("decompose-mapper", `Entry ${entryIndex} (${story.id}) has empty contextFiles — continuing`, {
-        storyId: story.id,
-        entryIndex,
-        parentStoryId,
-      });
+      getSafeLogger()?.warn(
+        "decompose-mapper",
+        `Entry ${entryIndex} (${story.id}) has empty contextFiles — continuing`,
+        {
+          storyId: story.id,
+          entryIndex,
+          parentStoryId,
+        },
+      );
     }
 
     return {

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -85,6 +85,10 @@ export interface StoryRouting {
   llmModel?: string;
   /** Agent to use for this story (overrides default agent from config) */
   agent?: string;
+  /** Profile ID that produced the starting rung — written once, not overwritten by escalation */
+  initialProfileId?: string;
+  /** Agent at first route — written once, not overwritten by escalation */
+  initialAgent?: string;
 }
 
 /** Escalation attempt tracking */

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -89,6 +89,8 @@ export interface StoryRouting {
   initialProfileId?: string;
   /** Agent at first route — written once, not overwritten by escalation */
   initialAgent?: string;
+  /** Profile id that produced the current agent assignment */
+  agentProfileId?: string;
 }
 
 /** Escalation attempt tracking */
@@ -319,4 +321,6 @@ export interface PRD {
   };
   /** Acceptance test overrides (AC-N → reason for accepting despite test failure) */
   acceptanceOverrides?: Record<string, string>;
+  /** Config profile resolved at plan time — used to warn when nax run uses a different profile */
+  routingProfile?: string;
 }

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -323,6 +323,6 @@ export interface PRD {
   };
   /** Acceptance test overrides (AC-N → reason for accepting despite test failure) */
   acceptanceOverrides?: Record<string, string>;
-  /** Config profile resolved at plan time — used to warn when nax run uses a different profile */
+  /** Config profile name resolved at plan time (loader AC 6) — nax run adopts it by default and warns on mismatch */
   routingProfile?: string;
 }

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -91,6 +91,8 @@ export interface StoryRouting {
   initialAgent?: string;
   /** Profile id that produced the current agent assignment */
   agentProfileId?: string;
+  /** Model tier from the matched agent profile's target — set at plan time, used to bias routing tier selection */
+  profileModelTier?: ModelTier;
 }
 
 /** Escalation attempt tracking */

--- a/src/prompts/builders/one-shot-builder.ts
+++ b/src/prompts/builders/one-shot-builder.ts
@@ -98,11 +98,19 @@ export class OneShotPromptBuilder {
   }
 
   /**
-   * Returns the instruction telling the LLM to assign `agentProfileId` per story.
-   * Used internally by agentProfiles().
+   * Returns the ordered selection rubric telling the LLM how to assign
+   * `agentProfileId` per story. The procedure (not free-form judgment) is
+   * load-bearing: decompose may run on a cheap model that cannot be trusted
+   * with open-ended "pick the best agent" questions.
    */
   static agentProfileInstruction(): string {
-    return "When agent profiles are listed above, assign the best-matching profile id to the `agentProfileId` field for each story. If no profile fits well or profiles are not listed, omit `agentProfileId`.";
+    return [
+      "When agent profiles are listed above, pick exactly ONE profile id per story and set it on the `agentProfileId` field. Apply these steps in order:",
+      "1. Eliminate any profile whose weaknesses conflict with the story.",
+      "2. Keep profiles whose strengths or affinity cover the story's main job (task type + primary domain).",
+      "3. If more than one remains, choose the LOWEST cost profile.",
+      "4. If none clearly fit, omit `agentProfileId` entirely — never invent a profile id.",
+    ].join("\n");
   }
 
   /**
@@ -112,15 +120,24 @@ export class OneShotPromptBuilder {
   static agentCapabilityCards(profiles: AgentRoutingProfile[]): string {
     if (profiles.length === 0) return "";
 
-    const header = ["## Agent Profiles", "", "| ID | Agent | Tier | Strengths | Cost |", "|---|---|---|---|---|"];
+    const header = [
+      "## Agent Profiles",
+      "",
+      "| ID | Agent | Tier | Strengths | Weaknesses | Affinity | Cost |",
+      "|---|---|---|---|---|---|---|",
+    ];
 
     const rows = profiles.map((p) => {
-      const id = OneShotPromptBuilder.escapeCell(p.id);
-      const agent = OneShotPromptBuilder.escapeCell(p.target.agent);
-      const model = OneShotPromptBuilder.escapeCell(p.target.model);
-      const strengths = p.strengths.map((s) => OneShotPromptBuilder.escapeCell(s)).join(", ");
-      const cost = OneShotPromptBuilder.escapeCell(p.costTier ?? "—");
-      return `| ${id} | ${agent} | ${model} | ${strengths} | ${cost} |`;
+      const esc = OneShotPromptBuilder.escapeCell;
+      const id = esc(p.id);
+      const agent = esc(p.target.agent);
+      const model = esc(p.target.model);
+      const strengths = p.strengths.map(esc).join(", ");
+      const weaknesses = p.weaknesses?.length ? p.weaknesses.map(esc).join("; ") : "—";
+      const affinityParts = [...(p.affinity?.taskTypes ?? []), ...(p.affinity?.domains ?? [])];
+      const affinity = affinityParts.length ? affinityParts.map(esc).join(", ") : "—";
+      const cost = esc(p.costTier ?? "—");
+      return `| ${id} | ${agent} | ${model} | ${strengths} | ${weaknesses} | ${affinity} | ${cost} |`;
     });
 
     return [...header, ...rows].join("\n");

--- a/src/prompts/builders/one-shot-builder.ts
+++ b/src/prompts/builders/one-shot-builder.ts
@@ -9,6 +9,7 @@
  * here, promote the prompt to its own dedicated builder instead.
  */
 
+import type { AgentRoutingProfile } from "@/config";
 import {
   SectionAccumulator,
   instructionsSection,
@@ -78,5 +79,27 @@ export class OneShotPromptBuilder {
 
   build(): string {
     return this.acc.join();
+  }
+
+  /**
+   * Formats agent routing profiles as a markdown capability card table for LLM consumption.
+   * Returns an empty string when profiles is empty — caller decides whether to include the section.
+   */
+  static agentCapabilityCards(profiles: AgentRoutingProfile[]): string {
+    if (profiles.length === 0) return "";
+
+    const header = [
+      "## Agent Profiles",
+      "",
+      "| ID | Agent | Tier | Strengths | Cost |",
+      "|---|---|---|---|---|",
+    ];
+
+    const rows = profiles.map(
+      (p) =>
+        `| ${p.id} | ${p.target.agent} | ${p.target.model} | ${p.strengths.join(", ")} | ${p.costTier ?? "—"} |`,
+    );
+
+    return [...header, ...rows].join("\n");
   }
 }

--- a/src/prompts/builders/one-shot-builder.ts
+++ b/src/prompts/builders/one-shot-builder.ts
@@ -77,13 +77,29 @@ export class OneShotPromptBuilder {
     return this;
   }
 
+  /**
+   * Injects agent capability cards + selection instruction into the prompt.
+   * No-op when profiles is empty — safe to call unconditionally.
+   * Must be called before jsonSchema() so cards appear before the output schema.
+   */
+  agentProfiles(profiles: AgentRoutingProfile[]): this {
+    const cards = OneShotPromptBuilder.agentCapabilityCards(profiles);
+    if (cards.length === 0) return this;
+    this.acc.add({
+      id: "agent-profiles",
+      overridable: false,
+      content: `${cards}\n\n${OneShotPromptBuilder.agentProfileInstruction()}`,
+    });
+    return this;
+  }
+
   build(): string {
     return this.acc.join();
   }
 
   /**
    * Returns the instruction telling the LLM to assign `agentProfileId` per story.
-   * Append to the decompose prompt when agent profiles are listed and routing is enabled.
+   * Used internally by agentProfiles().
    */
   static agentProfileInstruction(): string {
     return "When agent profiles are listed above, assign the best-matching profile id to the `agentProfileId` field for each story. If no profile fits well or profiles are not listed, omit `agentProfileId`.";

--- a/src/prompts/builders/one-shot-builder.ts
+++ b/src/prompts/builders/one-shot-builder.ts
@@ -96,12 +96,7 @@ export class OneShotPromptBuilder {
   static agentCapabilityCards(profiles: AgentRoutingProfile[]): string {
     if (profiles.length === 0) return "";
 
-    const header = [
-      "## Agent Profiles",
-      "",
-      "| ID | Agent | Tier | Strengths | Cost |",
-      "|---|---|---|---|---|",
-    ];
+    const header = ["## Agent Profiles", "", "| ID | Agent | Tier | Strengths | Cost |", "|---|---|---|---|---|"];
 
     const rows = profiles.map((p) => {
       const id = OneShotPromptBuilder.escapeCell(p.id);

--- a/src/prompts/builders/one-shot-builder.ts
+++ b/src/prompts/builders/one-shot-builder.ts
@@ -82,6 +82,14 @@ export class OneShotPromptBuilder {
   }
 
   /**
+   * Returns the instruction telling the LLM to assign `agentProfileId` per story.
+   * Append to the decompose prompt when agent profiles are listed and routing is enabled.
+   */
+  static agentProfileInstruction(): string {
+    return "When agent profiles are listed above, assign the best-matching profile id to the `agentProfileId` field for each story. If no profile fits well or profiles are not listed, omit `agentProfileId`.";
+  }
+
+  /**
    * Formats agent routing profiles as a markdown capability card table for LLM consumption.
    * Returns an empty string when profiles is empty — caller decides whether to include the section.
    */

--- a/src/prompts/builders/one-shot-builder.ts
+++ b/src/prompts/builders/one-shot-builder.ts
@@ -127,6 +127,6 @@ export class OneShotPromptBuilder {
   }
 
   private static escapeCell(value: string): string {
-    return value.replace(/\|/g, "\\|");
+    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
   }
 }

--- a/src/prompts/builders/one-shot-builder.ts
+++ b/src/prompts/builders/one-shot-builder.ts
@@ -103,11 +103,19 @@ export class OneShotPromptBuilder {
       "|---|---|---|---|---|",
     ];
 
-    const rows = profiles.map(
-      (p) =>
-        `| ${p.id} | ${p.target.agent} | ${p.target.model} | ${p.strengths.join(", ")} | ${p.costTier ?? "—"} |`,
-    );
+    const rows = profiles.map((p) => {
+      const id = OneShotPromptBuilder.escapeCell(p.id);
+      const agent = OneShotPromptBuilder.escapeCell(p.target.agent);
+      const model = OneShotPromptBuilder.escapeCell(p.target.model);
+      const strengths = p.strengths.map((s) => OneShotPromptBuilder.escapeCell(s)).join(", ");
+      const cost = OneShotPromptBuilder.escapeCell(p.costTier ?? "—");
+      return `| ${id} | ${agent} | ${model} | ${strengths} | ${cost} |`;
+    });
 
     return [...header, ...rows].join("\n");
+  }
+
+  private static escapeCell(value: string): string {
+    return value.replace(/\|/g, "\\|");
   }
 }

--- a/src/routing/decision.ts
+++ b/src/routing/decision.ts
@@ -6,4 +6,8 @@ export interface RoutingDecision {
   modelTier: ModelTier;
   testStrategy: TestStrategy;
   reasoning: string;
+  /** Resolved agent name from the chosen profile — undefined when no profile selected */
+  agent?: string;
+  /** Profile id that produced the agent choice — for audit and metrics */
+  agentProfileId?: string;
 }

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -1,8 +1,8 @@
 // Core types
 export type { RoutingDecision, RoutingStrategy, RoutingContext } from "./router";
 
-// Shared prompt constants used by classifyRoute op and llm strategy
-export { ROUTING_INSTRUCTIONS } from "./strategies/llm";
+// Shared prompt constants and cache management used by classifyRoute op and llm strategy
+export { ROUTING_INSTRUCTIONS, clearCache } from "./strategies/llm";
 
 // Shared validator used by classifyRoute op and llm parsing — single SSOT for
 // LLM routing-decision validation (config-aware tier check + testStrategy derivation).

--- a/test/integration/execution/runner-escalation.test.ts
+++ b/test/integration/execution/runner-escalation.test.ts
@@ -82,7 +82,7 @@ describe("Batch Failure Escalation Strategy", () => {
       { tier: "balanced", attempts: 3 },
       { tier: "powerful", attempts: 2 },
     ];
-    const nextTier = escalateTier(currentTier!, tierOrder);
+    const nextTier = escalateTier({ tier: currentTier! }, tierOrder);
 
     expect(currentTier).toBe("fast");
     expect(nextTier?.tier).toBe("balanced");
@@ -111,11 +111,11 @@ describe("Batch Failure Escalation Strategy", () => {
     const expectedNext = ["balanced", "powerful", null];
 
     for (let i = 0; i < tiers.length; i++) {
-      const nextTier = escalateTier(tiers[i], tierOrder);
+      const nextTier = escalateTier({ tier: tiers[i] }, tierOrder);
       expect(nextTier?.tier ?? null).toBe(expectedNext[i]);
     }
 
-    const powerfulTier = escalateTier("powerful", tierOrder);
+    const powerfulTier = escalateTier({ tier: "powerful" }, tierOrder);
     expect(powerfulTier).toBeNull();
   });
 
@@ -160,9 +160,9 @@ describe("Configurable Escalation Chain (ADR-003)", () => {
   ];
 
   test("escalateTier with standard chain (fast→balanced→powerful→null)", () => {
-    expect(escalateTier("fast", defaultTiers)?.tier).toBe("balanced");
-    expect(escalateTier("balanced", defaultTiers)?.tier).toBe("powerful");
-    expect(escalateTier("powerful", defaultTiers)).toBeNull();
+    expect(escalateTier({ tier: "fast" }, defaultTiers)?.tier).toBe("balanced");
+    expect(escalateTier({ tier: "balanced" }, defaultTiers)?.tier).toBe("powerful");
+    expect(escalateTier({ tier: "powerful" }, defaultTiers)).toBeNull();
   });
 
   test("escalateTier with custom tierOrder (skip balanced)", () => {
@@ -170,14 +170,14 @@ describe("Configurable Escalation Chain (ADR-003)", () => {
       { tier: "fast", attempts: 5 },
       { tier: "powerful", attempts: 2 },
     ];
-    expect(escalateTier("fast", customOrder)?.tier).toBe("powerful");
-    expect(escalateTier("powerful", customOrder)).toBeNull();
-    expect(escalateTier("balanced", customOrder)).toBeNull();
+    expect(escalateTier({ tier: "fast" }, customOrder)?.tier).toBe("powerful");
+    expect(escalateTier({ tier: "powerful" }, customOrder)).toBeNull();
+    expect(escalateTier({ tier: "balanced" }, customOrder)).toBeNull();
   });
 
   test("escalateTier with single-tier order", () => {
     const singleTier = [{ tier: "fast", attempts: 10 }];
-    expect(escalateTier("fast", singleTier)).toBeNull();
+    expect(escalateTier({ tier: "fast" }, singleTier)).toBeNull();
   });
 
   test("escalateTier with reversed order", () => {
@@ -186,16 +186,16 @@ describe("Configurable Escalation Chain (ADR-003)", () => {
       { tier: "balanced", attempts: 3 },
       { tier: "fast", attempts: 5 },
     ];
-    expect(escalateTier("powerful", reversed)?.tier).toBe("balanced");
-    expect(escalateTier("balanced", reversed)?.tier).toBe("fast");
-    expect(escalateTier("fast", reversed)).toBeNull();
+    expect(escalateTier({ tier: "powerful" }, reversed)?.tier).toBe("balanced");
+    expect(escalateTier({ tier: "balanced" }, reversed)?.tier).toBe("fast");
+    expect(escalateTier({ tier: "fast" }, reversed)).toBeNull();
   });
 
   test("escalateTier returns null for empty tierOrder, unknown tier, and idempotent at max", () => {
-    expect(escalateTier("fast", [])).toBeNull();
-    expect(escalateTier("unknown", defaultTiers)).toBeNull();
-    expect(escalateTier("powerful", defaultTiers)).toBeNull();
-    expect(escalateTier("powerful", defaultTiers)).toBeNull();
+    expect(escalateTier({ tier: "fast" }, [])).toBeNull();
+    expect(escalateTier({ tier: "unknown" }, defaultTiers)).toBeNull();
+    expect(escalateTier({ tier: "powerful" }, defaultTiers)).toBeNull();
+    expect(escalateTier({ tier: "powerful" }, defaultTiers)).toBeNull();
   });
 
   test("calculateMaxIterations sums all tier attempts", () => {
@@ -238,7 +238,7 @@ describe("Pre-Iteration Escalation: tier budget exhaustion triggers escalation b
     expect(story.attempts).toBeGreaterThanOrEqual(tierCfg!.attempts);
 
     // Should escalate to next tier
-    const nextTier = escalateTier(currentTier!, defaultTiers);
+    const nextTier = escalateTier({ tier: currentTier! }, defaultTiers);
     expect(nextTier?.tier).toBe("balanced");
   });
 
@@ -263,7 +263,7 @@ describe("Pre-Iteration Escalation: tier budget exhaustion triggers escalation b
     expect(tierCfg).toBeDefined();
     expect(story.attempts).toBeGreaterThanOrEqual(tierCfg!.attempts);
 
-    const nextTier = escalateTier(currentTier!, defaultTiers);
+    const nextTier = escalateTier({ tier: currentTier! }, defaultTiers);
     expect(nextTier?.tier).toBe("powerful");
   });
 
@@ -289,7 +289,7 @@ describe("Pre-Iteration Escalation: tier budget exhaustion triggers escalation b
     expect(story.attempts).toBeGreaterThanOrEqual(tierCfg!.attempts);
 
     // No next tier available
-    const nextTier = escalateTier(currentTier!, defaultTiers);
+    const nextTier = escalateTier({ tier: currentTier! }, defaultTiers);
     expect(nextTier).toBeNull();
 
     // Story should be marked as FAILED (not retried)
@@ -322,7 +322,7 @@ describe("Pre-Iteration Escalation: tier budget exhaustion triggers escalation b
     expect(story.attempts).toBeGreaterThanOrEqual(tierCfg!.attempts);
 
     // Should escalate instead of retrying at same tier
-    const nextTier = escalateTier(currentTier!, defaultTiers);
+    const nextTier = escalateTier({ tier: currentTier! }, defaultTiers);
     expect(nextTier?.tier).toBe("balanced");
   });
 
@@ -355,7 +355,7 @@ describe("Pre-Iteration Escalation: tier budget exhaustion triggers escalation b
     const tierCfg = defaultTiers.find((t) => t.tier === "fast");
     expect(updatedStory.attempts).toBeGreaterThanOrEqual(tierCfg!.attempts);
 
-    const nextTier = escalateTier("fast", defaultTiers);
+    const nextTier = escalateTier({ tier: "fast" }, defaultTiers);
     expect(nextTier?.tier).toBe("balanced");
   });
 

--- a/test/unit/cli/plan-decompose-guards.test.ts
+++ b/test/unit/cli/plan-decompose-guards.test.ts
@@ -275,22 +275,22 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
     expect(capturedDecomposeOpts[0]).toMatchObject({ workdir: tmpDir, storyId: "US-001" });
   });
 
-  test("AC-6: throws DECOMPOSE_VALIDATION_FAILED when sub-story has empty contextFiles array", async () => {
+  test("AC-6: succeeds when sub-story has empty contextFiles array (warns, does not throw)", async () => {
     const prd = makePrd();
     setupDeps(prd, [makeSubStory("US-001-A", { contextFiles: [] }), makeSubStory("US-001-B")]);
     await expect(
       planDecomposeCommand(tmpDir, makeConfig(), { feature: FEATURE, storyId: "US-001" }),
-    ).rejects.toMatchObject({ code: "DECOMPOSE_VALIDATION_FAILED" });
+    ).resolves.not.toThrow();
   });
 
-  test("AC-6: throws DECOMPOSE_VALIDATION_FAILED when sub-story has no contextFiles field", async () => {
+  test("AC-6: succeeds when sub-story has no contextFiles field (warns, does not throw)", async () => {
     const prd = makePrd();
     const noCtxStory = makeSubStory("US-001-A");
     delete (noCtxStory as Partial<UserStory>).contextFiles;
     setupDeps(prd, [noCtxStory, makeSubStory("US-001-B")]);
     await expect(
       planDecomposeCommand(tmpDir, makeConfig(), { feature: FEATURE, storyId: "US-001" }),
-    ).rejects.toMatchObject({ code: "DECOMPOSE_VALIDATION_FAILED" });
+    ).resolves.not.toThrow();
   });
 
   test("AC-7: missing routing.complexity in legacy input is tolerated (adapter coercion)", async () => {

--- a/test/unit/cli/plan-decompose-mapper.test.ts
+++ b/test/unit/cli/plan-decompose-mapper.test.ts
@@ -263,22 +263,16 @@ describe("planDecomposeCommand — mapper wiring (US-003 AC-5)", () => {
     ).rejects.toThrow(/index 1/);
   });
 
-  test("throws DECOMPOSE_VALIDATION_FAILED with entry index when DecomposedStory has empty contextFiles", async () => {
+  test("succeeds and writes PRD when DecomposedStory has empty contextFiles (warns, does not throw)", async () => {
     const prd = makePrd();
     const decomposed = [
-      makeDecomposedStory({ id: "US-001-A", contextFiles: [] }), // invalid — empty contextFiles
+      makeDecomposedStory({ id: "US-001-A", contextFiles: [] }), // empty contextFiles — warns and continues
     ];
     setupDepsWithDecompose(prd, decomposed);
 
-    let caught: unknown;
-    try {
-      await planDecomposeCommand(tmpDir, makeNaxConfig(), { feature: FEATURE, storyId: "US-001" });
-    } catch (err) {
-      caught = err;
-    }
-
-    expect(caught).toMatchObject({ code: "DECOMPOSE_VALIDATION_FAILED" });
-    // biome-ignore lint: test accesses dynamic property
-    expect((caught as any)?.context?.entryIndex).toBeDefined();
+    // Should complete without throwing
+    await expect(
+      planDecomposeCommand(tmpDir, makeNaxConfig(), { feature: FEATURE, storyId: "US-001" }),
+    ).resolves.not.toThrow();
   });
 });

--- a/test/unit/cli/resolve-run-profile.test.ts
+++ b/test/unit/cli/resolve-run-profile.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { resolveRunProfileOverride } from "@/cli";
+
+const readReturning = (value: unknown) => () => Promise.resolve(value);
+const profilesAvailable = (...names: string[]) => () => Promise.resolve(names);
+
+describe("resolveRunProfileOverride", () => {
+  test("CLI --profile wins over PRD routingProfile", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: "cli-prof",
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: "prd-prof" }),
+      _listProfileNames: profilesAvailable("prd-prof"),
+    });
+    expect(result).toBe("cli-prof");
+  });
+
+  test("NAX_PROFILE env defers to loadConfig (returns undefined, does not read PRD)", async () => {
+    let read = false;
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: "env-prof",
+      _readJson: () => {
+        read = true;
+        return Promise.resolve({ routingProfile: "prd-prof" });
+      },
+      _listProfileNames: profilesAvailable("prd-prof"),
+    });
+    expect(result).toBeUndefined();
+    expect(read).toBe(false);
+  });
+
+  test("adopts PRD routingProfile when neither CLI nor env is set and the profile exists", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: "aggressive" }),
+      _listProfileNames: profilesAvailable("aggressive", "cheap"),
+    });
+    expect(result).toBe("aggressive");
+  });
+
+  test('adopts "default" without consulting the profile list (loader applies no overlay)', async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: "default" }),
+      _listProfileNames: profilesAvailable(), // empty — must not matter
+    });
+    expect(result).toBe("default");
+  });
+
+  test("skips adoption (returns undefined) when the PRD profile has no profile file — stale/legacy value", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: "oc-balanced" }), // legacy agent-profile id
+      _listProfileNames: profilesAvailable("aggressive"),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test.each([
+    ["missing PRD", undefined],
+    ["PRD without routingProfile", {}],
+    ["non-string routingProfile", { routingProfile: 42 }],
+    ["empty-string routingProfile", { routingProfile: "" }],
+  ])("returns undefined for %s", async (_label, prdValue) => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning(prdValue),
+      _listProfileNames: profilesAvailable("aggressive"),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when the PRD read throws (corrupt JSON)", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: () => Promise.reject(new Error("bad json")),
+      _listProfileNames: profilesAvailable("aggressive"),
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/test/unit/config/schemas-infra.test.ts
+++ b/test/unit/config/schemas-infra.test.ts
@@ -92,7 +92,7 @@ describe("AgentRoutingConfigSchema", () => {
     const result = AgentRoutingConfigSchema.safeParse({ enabled: true, strategy: "llm", profiles: [] });
     expect(result.success).toBe(false);
     if (result.success) return;
-    expect(result.error.issues.some((i) => i.message.includes("requires at least one profile"))).toBe(true);
+    expect(result.error.issues.some((i: { message: string }) => i.message.includes("requires at least one profile"))).toBe(true);
   });
 
   test('strategy "off" with zero profiles still parses (v1 default)', () => {

--- a/test/unit/config/schemas-infra.test.ts
+++ b/test/unit/config/schemas-infra.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { AgentProfileSchema, AgentRoutingConfigSchema } from "@/config";
+import { AgentRoutingProfileSchema, AgentRoutingConfigSchema } from "@/config";
 
-describe("AgentProfileSchema", () => {
+describe("AgentRoutingProfileSchema", () => {
   test("parses a minimal valid profile", () => {
-    const result = AgentProfileSchema.parse({
+    const result = AgentRoutingProfileSchema.parse({
       id: "claude-powerful",
       target: { agent: "claude", model: "powerful" },
       strengths: ["architecture"],
@@ -14,7 +14,7 @@ describe("AgentProfileSchema", () => {
   });
 
   test("parses a full profile", () => {
-    const result = AgentProfileSchema.parse({
+    const result = AgentRoutingProfileSchema.parse({
       id: "opencode-balanced",
       target: { agent: "opencode", model: "balanced" },
       strengths: ["general implementation", "frontend"],
@@ -28,7 +28,7 @@ describe("AgentProfileSchema", () => {
 
   test("rejects empty id", () => {
     expect(() =>
-      AgentProfileSchema.parse({
+      AgentRoutingProfileSchema.parse({
         id: "",
         target: { agent: "claude", model: "balanced" },
         strengths: ["x"],
@@ -38,7 +38,7 @@ describe("AgentProfileSchema", () => {
 
   test("rejects empty strengths array", () => {
     expect(() =>
-      AgentProfileSchema.parse({
+      AgentRoutingProfileSchema.parse({
         id: "x",
         target: { agent: "claude", model: "balanced" },
         strengths: [],

--- a/test/unit/config/schemas-infra.test.ts
+++ b/test/unit/config/schemas-infra.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { AgentProfileSchema, AgentRoutingConfigSchema } from "@/config";
+
+describe("AgentProfileSchema", () => {
+  test("parses a minimal valid profile", () => {
+    const result = AgentProfileSchema.parse({
+      id: "claude-powerful",
+      target: { agent: "claude", model: "powerful" },
+      strengths: ["architecture"],
+    });
+    expect(result.id).toBe("claude-powerful");
+    expect(result.target.agent).toBe("claude");
+    expect(result.weaknesses).toBeUndefined();
+  });
+
+  test("parses a full profile", () => {
+    const result = AgentProfileSchema.parse({
+      id: "opencode-balanced",
+      target: { agent: "opencode", model: "balanced" },
+      strengths: ["general implementation", "frontend"],
+      weaknesses: ["complex refactors"],
+      costTier: "low",
+      affinity: { taskTypes: ["feature"], domains: ["react"] },
+    });
+    expect(result.costTier).toBe("low");
+    expect(result.affinity?.domains).toEqual(["react"]);
+  });
+
+  test("rejects empty id", () => {
+    expect(() =>
+      AgentProfileSchema.parse({
+        id: "",
+        target: { agent: "claude", model: "balanced" },
+        strengths: ["x"],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects empty strengths array", () => {
+    expect(() =>
+      AgentProfileSchema.parse({
+        id: "x",
+        target: { agent: "claude", model: "balanced" },
+        strengths: [],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("AgentRoutingConfigSchema", () => {
+  test("defaults to enabled=true, strategy=off, empty profiles", () => {
+    const result = AgentRoutingConfigSchema.parse({});
+    expect(result.enabled).toBe(true);
+    expect(result.strategy).toBe("off");
+    expect(result.profiles).toEqual([]);
+  });
+
+  test("accepts enabled=false to disable routing even with profiles", () => {
+    const result = AgentRoutingConfigSchema.parse({
+      enabled: false,
+      profiles: [
+        { id: "claude-powerful", target: { agent: "claude", model: "powerful" }, strengths: ["arch"] },
+      ],
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.profiles).toHaveLength(1);
+  });
+
+  test("rejects duplicate profile ids", () => {
+    expect(() =>
+      AgentRoutingConfigSchema.parse({
+        profiles: [
+          { id: "dup", target: { agent: "claude", model: "balanced" }, strengths: ["x"] },
+          { id: "dup", target: { agent: "opencode", model: "balanced" }, strengths: ["y"] },
+        ],
+      }),
+    ).toThrow(/duplicate/i);
+  });
+
+  test("rejects unknown default profile id", () => {
+    expect(() =>
+      AgentRoutingConfigSchema.parse({
+        default: "nonexistent",
+        profiles: [
+          { id: "real-profile", target: { agent: "claude", model: "balanced" }, strengths: ["x"] },
+        ],
+      }),
+    ).toThrow(/default/i);
+  });
+});

--- a/test/unit/config/schemas-infra.test.ts
+++ b/test/unit/config/schemas-infra.test.ts
@@ -87,4 +87,16 @@ describe("AgentRoutingConfigSchema", () => {
       }),
     ).toThrow(/default/i);
   });
+
+  test('strategy "llm" with zero profiles is rejected', () => {
+    const result = AgentRoutingConfigSchema.safeParse({ enabled: true, strategy: "llm", profiles: [] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.some((i) => i.message.includes("requires at least one profile"))).toBe(true);
+  });
+
+  test('strategy "off" with zero profiles still parses (v1 default)', () => {
+    const result = AgentRoutingConfigSchema.safeParse({ enabled: true, strategy: "off", profiles: [] });
+    expect(result.success).toBe(true);
+  });
 });

--- a/test/unit/config/schemas-model.test.ts
+++ b/test/unit/config/schemas-model.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { TierConfigSchema } from "@/config/schemas-model";
+
+describe("TierConfigSchema", () => {
+  test("parses valid tier without agent", () => {
+    const result = TierConfigSchema.parse({ tier: "balanced", attempts: 3 });
+    expect(result).toEqual({ tier: "balanced", attempts: 3 });
+    expect(result.agent).toBeUndefined();
+  });
+
+  test("parses valid tier with agent", () => {
+    const result = TierConfigSchema.parse({ tier: "balanced", attempts: 3, agent: "opencode" });
+    expect(result).toEqual({ tier: "balanced", attempts: 3, agent: "opencode" });
+  });
+
+  test("rejects empty agent string", () => {
+    expect(() => TierConfigSchema.parse({ tier: "balanced", attempts: 3, agent: "" })).toThrow();
+  });
+
+  test("strips unknown keys (default Zod behaviour)", () => {
+    const result = TierConfigSchema.parse({ tier: "fast", attempts: 5, agent: "claude", extra: "ignored" });
+    expect((result as Record<string, unknown>).extra).toBeUndefined();
+  });
+});

--- a/test/unit/config/schemas-model.test.ts
+++ b/test/unit/config/schemas-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { TierConfigSchema } from "@/config/schemas-model";
+import { TierConfigSchema } from "@/config";
 
 describe("TierConfigSchema", () => {
   test("parses valid tier without agent", () => {

--- a/test/unit/config/schemas.test.ts
+++ b/test/unit/config/schemas.test.ts
@@ -437,4 +437,28 @@ describe("NaxConfigSchema — superRefine: tierOrder agent cross-section validat
     ]);
     expect(result.success).toBe(true);
   });
+
+  test("profile with the default tier-only ladder fails with an actionable agent-qualify message", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...(DEFAULT_CONFIG as Record<string, unknown>),
+      models: MODELS,
+      routing: {
+        ...(DEFAULT_CONFIG.routing as Record<string, unknown>),
+        agents: {
+          enabled: true,
+          strategy: "off",
+          profiles: [
+            { id: "oc-bal", target: { agent: "opencode", model: "balanced" }, strengths: ["impl"] },
+          ],
+        },
+      },
+      // DEFAULT_CONFIG tierOrder is tier-only: fast/balanced/powerful with no agent fields
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => i.message.includes("no matching rung"));
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain("agent-qualify");
+    expect(issue?.message).toContain('"tier": "balanced", "agent": "opencode"');
+  });
 });

--- a/test/unit/config/schemas.test.ts
+++ b/test/unit/config/schemas.test.ts
@@ -366,3 +366,75 @@ describe("QualityConfigSchema — scopeTestThreshold (US-001)", () => {
     expect(result.quality.scopeTestThreshold).toBe(value);
   });
 });
+
+describe("NaxConfigSchema — superRefine: tierOrder agent cross-section validation", () => {
+  const MODELS = {
+    opencode: { balanced: "oc-model", fast: "oc-fast" },
+    claude: { balanced: "sonnet", powerful: "opus" },
+  };
+
+  function withTierOrder(
+    tierOrder: Array<{ tier: string; agent?: string; attempts: number }>,
+    models?: unknown,
+  ) {
+    return NaxConfigSchema.safeParse({
+      ...(DEFAULT_CONFIG as Record<string, unknown>),
+      ...(models !== undefined ? { models } : {}),
+      autoMode: {
+        ...(DEFAULT_CONFIG.autoMode as Record<string, unknown>),
+        escalation: {
+          ...((DEFAULT_CONFIG.autoMode as Record<string, unknown>).escalation as Record<string, unknown>),
+          tierOrder,
+        },
+      },
+    });
+  }
+
+  test("valid cross-agent ladder passes", () => {
+    const result = withTierOrder(
+      [
+        { tier: "balanced", agent: "opencode", attempts: 3 },
+        { tier: "balanced", agent: "claude", attempts: 2 },
+        { tier: "powerful", agent: "claude", attempts: 2 },
+      ],
+      MODELS,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test("unknown agent in tierOrder produces exactly one issue (not two)", () => {
+    const result = withTierOrder(
+      [{ tier: "balanced", agent: "nonexistent", attempts: 3 }],
+      MODELS,
+    );
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const agentIssues = result.error.issues.filter((e) =>
+      e.message.includes("nonexistent"),
+    );
+    expect(agentIssues).toHaveLength(1);
+    expect(agentIssues[0].message).toMatch(/not defined in config\.models/);
+  });
+
+  test("valid agent but unknown tier produces one issue on the tier path", () => {
+    const result = withTierOrder(
+      [{ tier: "powerful", agent: "opencode", attempts: 2 }],
+      MODELS,
+    );
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const tierIssues = result.error.issues.filter((e) =>
+      e.message.includes('"powerful"') && e.message.includes('"opencode"'),
+    );
+    expect(tierIssues).toHaveLength(1);
+    expect(tierIssues[0].message).toMatch(/not defined for agent/);
+  });
+
+  test("tier-only rungs (no agent field) are ignored by superRefine", () => {
+    const result = withTierOrder([
+      { tier: "fast", attempts: 3 },
+      { tier: "balanced", attempts: 2 },
+    ]);
+    expect(result.success).toBe(true);
+  });
+});

--- a/test/unit/execution/escalation/escalation.test.ts
+++ b/test/unit/execution/escalation/escalation.test.ts
@@ -5,7 +5,7 @@
  * Covers: escalateTier, getTierConfig, calculateMaxIterations
  */
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import type { TierConfig } from "../../../../src/config";
 import { calculateMaxIterations, escalateTier, getTierConfig } from "../../../../src/execution/escalation";
 
@@ -31,8 +31,8 @@ const customTierOrder: TierConfig[] = [
 
 describe("escalateTier", () => {
   it("returns next tier object when not at max", () => {
-    expect(escalateTier("fast", defaultTierOrder)).toEqual({ tier: "balanced", agent: undefined });
-    expect(escalateTier("balanced", defaultTierOrder)).toEqual({ tier: "powerful", agent: undefined });
+    expect(escalateTier({ tier: "fast" }, defaultTierOrder)).toEqual({ tier: "balanced", agent: undefined });
+    expect(escalateTier({ tier: "balanced" }, defaultTierOrder)).toEqual({ tier: "powerful", agent: undefined });
   });
 
   it.each([
@@ -40,18 +40,18 @@ describe("escalateTier", () => {
     ["tier not found in order", "unknown", defaultTierOrder],
     ["empty tier order", "fast", [] as TierConfig[]],
   ])("returns null when %s", (_label, tier, tierOrder) => {
-    expect(escalateTier(tier, tierOrder)).toBeNull();
+    expect(escalateTier({ tier }, tierOrder)).toBeNull();
   });
 
   it("handles single-tier order", () => {
     const singleTier: TierConfig[] = [{ tier: "only", attempts: 10 }];
-    expect(escalateTier("only", singleTier)).toBeNull();
+    expect(escalateTier({ tier: "only" }, singleTier)).toBeNull();
   });
 
   it("works with custom tier names", () => {
-    expect(escalateTier("haiku", customTierOrder)).toEqual({ tier: "sonnet", agent: undefined });
-    expect(escalateTier("sonnet", customTierOrder)).toEqual({ tier: "opus", agent: undefined });
-    expect(escalateTier("opus", customTierOrder)).toBeNull();
+    expect(escalateTier({ tier: "haiku" }, customTierOrder)).toEqual({ tier: "sonnet", agent: undefined });
+    expect(escalateTier({ tier: "sonnet" }, customTierOrder)).toEqual({ tier: "opus", agent: undefined });
+    expect(escalateTier({ tier: "opus" }, customTierOrder)).toBeNull();
   });
 
 
@@ -60,7 +60,7 @@ describe("escalateTier", () => {
       { tier: "fast", agent: "claude", attempts: 3 },
       { tier: "balanced", agent: "claude", attempts: 2 },
     ];
-    expect(escalateTier("fast", tierOrder)).toEqual({ tier: "balanced", agent: "claude" });
+    expect(escalateTier({ tier: "fast" }, tierOrder)).toEqual({ tier: "balanced", agent: "claude" });
   });
 
   it("returns codex agent when next entry is codex/fast (AC-2)", () => {
@@ -69,7 +69,7 @@ describe("escalateTier", () => {
       { tier: "balanced", agent: "claude", attempts: 2 },
       { tier: "fast", agent: "codex", attempts: 2 },
     ];
-    expect(escalateTier("balanced", tierOrder)).toEqual({ tier: "fast", agent: "codex" });
+    expect(escalateTier({ tier: "balanced" }, tierOrder)).toEqual({ tier: "fast", agent: "codex" });
   });
 
   it("returns null at last entry even with agent field (AC-3)", () => {
@@ -77,7 +77,7 @@ describe("escalateTier", () => {
       { tier: "fast", agent: "claude", attempts: 3 },
       { tier: "balanced", agent: "claude", attempts: 2 },
     ];
-    expect(escalateTier("balanced", tierOrder)).toBeNull();
+    expect(escalateTier({ tier: "balanced" }, tierOrder)).toBeNull();
   });
 
   it("returns undefined agent when tierOrder entry has no agent field (AC-4)", () => {
@@ -85,8 +85,55 @@ describe("escalateTier", () => {
       { tier: "fast", attempts: 5 },
       { tier: "balanced", attempts: 3 },
     ];
-    const result = escalateTier("fast", tierOrder);
+    const result = escalateTier({ tier: "fast" }, tierOrder);
     expect(result).toEqual({ tier: "balanced", agent: undefined });
+  });
+
+  test("finds next rung by (tier, agent) tuple on a cross-agent ladder", () => {
+    const tierOrder: TierConfig[] = [
+      { tier: "balanced", agent: "opencode", attempts: 3 },
+      { tier: "balanced", agent: "claude", attempts: 2 },
+      { tier: "powerful", agent: "claude", attempts: 2 },
+    ];
+    const result = escalateTier({ tier: "balanced", agent: "opencode" }, tierOrder);
+    expect(result).toEqual({ tier: "balanced", agent: "claude" });
+  });
+
+  test("escalates opencode@balanced -> claude@balanced -> claude@powerful in sequence", () => {
+    const tierOrder: TierConfig[] = [
+      { tier: "balanced", agent: "opencode", attempts: 3 },
+      { tier: "balanced", agent: "claude", attempts: 2 },
+      { tier: "powerful", agent: "claude", attempts: 2 },
+    ];
+    const step1 = escalateTier({ tier: "balanced", agent: "opencode" }, tierOrder);
+    expect(step1).toEqual({ tier: "balanced", agent: "claude" });
+
+    // biome-ignore lint/style/noNonNullAssertion: checked above
+    const step2 = escalateTier({ tier: step1!.tier, agent: step1!.agent }, tierOrder);
+    expect(step2).toEqual({ tier: "powerful", agent: "claude" });
+
+    // biome-ignore lint/style/noNonNullAssertion: checked above
+    const step3 = escalateTier({ tier: step2!.tier, agent: step2!.agent }, tierOrder);
+    expect(step3).toBeNull();
+  });
+
+  test("does not match the second balanced rung when first is requested", () => {
+    const tierOrder: TierConfig[] = [
+      { tier: "balanced", agent: "opencode", attempts: 3 },
+      { tier: "balanced", agent: "claude", attempts: 2 },
+      { tier: "powerful", agent: "claude", attempts: 2 },
+    ];
+    // Requesting the second balanced rung should escalate to powerful
+    const result = escalateTier({ tier: "balanced", agent: "claude" }, tierOrder);
+    expect(result).toEqual({ tier: "powerful", agent: "claude" });
+  });
+
+  test("returns null when rung not found in ladder", () => {
+    const tierOrder: TierConfig[] = [
+      { tier: "balanced", agent: "claude", attempts: 3 },
+    ];
+    const result = escalateTier({ tier: "fast", agent: "claude" }, tierOrder);
+    expect(result).toBeNull();
   });
 });
 

--- a/test/unit/execution/escalation/escalation.test.ts
+++ b/test/unit/execution/escalation/escalation.test.ts
@@ -135,6 +135,17 @@ describe("escalateTier", () => {
     const result = escalateTier({ tier: "fast", agent: "claude" }, tierOrder);
     expect(result).toBeNull();
   });
+
+  test("returns null when caller has agent set but ladder rungs have no agent (mixed config)", () => {
+    // Story has routing.agent = "claude" but tier-only ladder — tuple match finds no rung, escalation blocked.
+    // Intentional: user must add agent fields to tierOrder to use cross-agent escalation.
+    const tierOrder: TierConfig[] = [
+      { tier: "fast", attempts: 3 },
+      { tier: "balanced", attempts: 2 },
+    ];
+    const result = escalateTier({ tier: "fast", agent: "claude" }, tierOrder);
+    expect(result).toBeNull();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/execution/escalation/escalation.test.ts
+++ b/test/unit/execution/escalation/escalation.test.ts
@@ -153,27 +153,52 @@ describe("escalateTier", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("getTierConfig", () => {
-  it("returns tier config when tier exists", () => {
-    const config = getTierConfig("balanced", defaultTierOrder);
+  it("returns tier config when tier exists (tier-name-only)", () => {
+    const config = getTierConfig({ tier: "balanced" }, defaultTierOrder);
     expect(config).toEqual({ tier: "balanced", attempts: 3 });
   });
 
   it("returns undefined when tier not found", () => {
-    expect(getTierConfig("unknown", defaultTierOrder)).toBeUndefined();
+    expect(getTierConfig({ tier: "unknown" }, defaultTierOrder)).toBeUndefined();
   });
 
   it("handles first tier", () => {
-    const config = getTierConfig("fast", defaultTierOrder);
+    const config = getTierConfig({ tier: "fast" }, defaultTierOrder);
     expect(config).toEqual({ tier: "fast", attempts: 5 });
   });
 
   it("handles last tier", () => {
-    const config = getTierConfig("powerful", defaultTierOrder);
+    const config = getTierConfig({ tier: "powerful" }, defaultTierOrder);
     expect(config).toEqual({ tier: "powerful", attempts: 2 });
   });
 
   it("returns undefined for empty tier order", () => {
-    expect(getTierConfig("fast", [])).toBeUndefined();
+    expect(getTierConfig({ tier: "fast" }, [])).toBeUndefined();
+  });
+
+  it("matches by (tier, agent) tuple on cross-agent ladder", () => {
+    const crossAgentOrder: TierConfig[] = [
+      { tier: "balanced", agent: "opencode", attempts: 3 },
+      { tier: "balanced", agent: "claude", attempts: 2 },
+      { tier: "powerful", agent: "claude", attempts: 2 },
+    ];
+    expect(getTierConfig({ tier: "balanced", agent: "opencode" }, crossAgentOrder)).toEqual({
+      tier: "balanced",
+      agent: "opencode",
+      attempts: 3,
+    });
+    expect(getTierConfig({ tier: "balanced", agent: "claude" }, crossAgentOrder)).toEqual({
+      tier: "balanced",
+      agent: "claude",
+      attempts: 2,
+    });
+  });
+
+  it("returns undefined when (tier, agent) tuple not found", () => {
+    const crossAgentOrder: TierConfig[] = [
+      { tier: "balanced", agent: "opencode", attempts: 3 },
+    ];
+    expect(getTierConfig({ tier: "balanced", agent: "unknown" }, crossAgentOrder)).toBeUndefined();
   });
 });
 

--- a/test/unit/execution/escalation/tier-escalation.test.ts
+++ b/test/unit/execution/escalation/tier-escalation.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { makeLogger } from "@test/helpers";
 import { pipelineEventBus } from "../../../../src/pipeline/event-bus";
 
 // ---------------------------------------------------------------------------
@@ -668,7 +669,10 @@ describe("preIterationTierCheck — M2: unmatched rung on non-empty agent ladder
     const { preIterationTierCheck, _tierEscalationDeps } = mod;
 
     const origSavePRD = _tierEscalationDeps.savePRD;
+    const origGetSafeLogger = _tierEscalationDeps.getSafeLogger;
+    const mockLogger = makeLogger();
     _tierEscalationDeps.savePRD = () => Promise.resolve();
+    _tierEscalationDeps.getSafeLogger = () => mockLogger as unknown as ReturnType<typeof origGetSafeLogger>;
 
     try {
       // Story whose agent ("codex") is not in the tierOrder (which only has "claude" rungs)
@@ -723,11 +727,21 @@ describe("preIterationTierCheck — M2: unmatched rung on non-empty agent ladder
       );
 
       // Unmatched rung → budget is unbounded → iteration proceeds (not skipped).
-      // A warn is emitted by the implementation (observable in logs, not asserted
-      // here since preIterationTierCheck uses getSafeLogger() without _deps injection).
       expect(result.shouldSkipIteration).toBe(false);
+
+      // A warn must be emitted so the silent-unlimited-budget path is observable.
+      const warnCalls = mockLogger.calls.filter((c) => c.level === "warn");
+      expect(warnCalls.length).toBeGreaterThan(0);
+      const unmatchedWarn = warnCalls.find((c) =>
+        c.message.includes("Current rung not found in tierOrder"),
+      );
+      expect(unmatchedWarn).toBeDefined();
+      expect(unmatchedWarn?.data?.storyId).toBe("US-unmatched-001");
+      expect(unmatchedWarn?.data?.agent).toBe("codex");
+      expect(unmatchedWarn?.data?.hasAgentRungs).toBe(true);
     } finally {
       _tierEscalationDeps.savePRD = origSavePRD;
+      _tierEscalationDeps.getSafeLogger = origGetSafeLogger;
     }
   });
 });

--- a/test/unit/execution/escalation/tier-escalation.test.ts
+++ b/test/unit/execution/escalation/tier-escalation.test.ts
@@ -138,8 +138,8 @@ describe("handleTierEscalation — tier escalation regression guard", () => {
             escalation: {
               enabled: true,
               tierOrder: [
-                { name: "fast", attempts: 1 },
-                { name: "balanced", attempts: 2 },
+                { tier: "fast", attempts: 1 },
+                { tier: "balanced", attempts: 2 },
               ],
               escalateEntireBatch: false,
             },
@@ -458,8 +458,8 @@ describe("preIterationTierCheck — story:escalated event emission", () => {
           escalation: {
             enabled: true,
             tierOrder: [
-              { name: "fast", attempts: 1 },
-              { name: "balanced", attempts: 2 },
+              { tier: "fast", attempts: 1 },
+              { tier: "balanced", attempts: 2 },
             ],
           },
         },
@@ -530,8 +530,8 @@ describe("preIterationTierCheck — story:escalated event emission", () => {
           escalation: {
             enabled: true,
             tierOrder: [
-              { name: "fast", attempts: 1 },
-              { name: "balanced", attempts: 2 },
+              { tier: "fast", attempts: 1 },
+              { tier: "balanced", attempts: 2 },
             ],
           },
         },
@@ -613,8 +613,8 @@ describe("handleTierEscalation — story:escalated event emission", () => {
             escalation: {
               enabled: true,
               tierOrder: [
-                { name: "fast", attempts: 1 },
-                { name: "balanced", attempts: 2 },
+                { tier: "fast", attempts: 1 },
+                { tier: "balanced", attempts: 2 },
               ],
               escalateEntireBatch: false,
             },

--- a/test/unit/execution/escalation/tier-escalation.test.ts
+++ b/test/unit/execution/escalation/tier-escalation.test.ts
@@ -653,3 +653,81 @@ describe("handleTierEscalation — story:escalated event emission", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// preIterationTierCheck — M2: unmatched rung does not grant unlimited budget
+//
+// When tierOrder has agent-qualified rungs but the story's (tier, agent) pair
+// matches no rung, the function must NOT skip the iteration (budget is treated
+// as unbounded, which keeps the story running) and emits a warn.
+// ---------------------------------------------------------------------------
+
+describe("preIterationTierCheck — M2: unmatched rung on non-empty agent ladder", () => {
+  test("shouldSkipIteration is false when (tier, agent) pair is absent from agent-qualified tierOrder", async () => {
+    const mod = await import("../../../../src/execution/escalation/tier-escalation");
+    const { preIterationTierCheck, _tierEscalationDeps } = mod;
+
+    const origSavePRD = _tierEscalationDeps.savePRD;
+    _tierEscalationDeps.savePRD = () => Promise.resolve();
+
+    try {
+      // Story whose agent ("codex") is not in the tierOrder (which only has "claude" rungs)
+      const story = {
+        id: "US-unmatched-001",
+        title: "Story",
+        description: "Test",
+        acceptanceCriteria: [],
+        tags: [],
+        dependencies: [],
+        status: "in-progress" as const,
+        passes: false,
+        escalations: [],
+        attempts: 5, // well above any tier's attempt budget — would skip if rung were found
+        routing: { modelTier: "fast", testStrategy: "test-after", agent: "codex" },
+      };
+
+      const prd = {
+        project: "test",
+        feature: "f",
+        branchName: "b",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        userStories: [story],
+      };
+
+      const config = {
+        autoMode: {
+          escalation: {
+            enabled: true,
+            tierOrder: [
+              { tier: "fast", agent: "claude", attempts: 2 },
+              { tier: "balanced", agent: "claude", attempts: 2 },
+            ],
+          },
+        },
+        routing: { llm: { mode: "per-story" }, strategy: "keyword" },
+        models: {},
+      };
+
+      const result = await preIterationTierCheck(
+        story as unknown as Parameters<typeof preIterationTierCheck>[0],
+        { modelTier: "fast" },
+        config as unknown as Parameters<typeof preIterationTierCheck>[2],
+        prd as unknown as Parameters<typeof preIterationTierCheck>[3],
+        "/tmp/test-prd-unmatched.json",
+        undefined,
+        { hooks: {} } as unknown as Parameters<typeof preIterationTierCheck>[6],
+        "f",
+        0,
+        "/tmp",
+      );
+
+      // Unmatched rung → budget is unbounded → iteration proceeds (not skipped).
+      // A warn is emitted by the implementation (observable in logs, not asserted
+      // here since preIterationTierCheck uses getSafeLogger() without _deps injection).
+      expect(result.shouldSkipIteration).toBe(false);
+    } finally {
+      _tierEscalationDeps.savePRD = origSavePRD;
+    }
+  });
+});

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -205,6 +205,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
       routing: {
         agents: {
           enabled: true,
+          strategy: "off" as const,
           default: "default-profile",
           profiles: [
             {
@@ -248,6 +249,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
       routing: {
         agents: {
           enabled: true,
+          strategy: "off" as const,
           default: "existing-profile",
           profiles: [
             {
@@ -284,6 +286,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
       routing: {
         agents: {
           enabled: true,
+          strategy: "off" as const,
           default: "some-profile",
           profiles: [
             {

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -313,7 +313,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
   test("emits PRD-level warn when prd.routingProfile differs from the resolved config profile", () => {
     const { logger, warns } = makeLogger();
     const prd = makePRD({ userStories: [], routingProfile: "aggressive" });
-    const config = { ...makeNaxConfig(), profile: "cheap" };
+    const config = makeNaxConfig({ profile: "cheap" });
 
     warnProfileMismatch(
       prd,

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -194,7 +194,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
       id: "US-001",
       routing: {
         complexity: "medium",
-        testStrategy: "tdd",
+        testStrategy: "tdd-simple",
         reasoning: "test",
         agent: "opencode",
         agentProfileId: "removed-profile",
@@ -210,7 +210,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
             {
               id: "existing-profile",
               description: "Another profile",
-              target: { agent: "claude" },
+              target: { agent: "claude", model: "fast" },
             },
           ],
         },
@@ -237,7 +237,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
       id: "US-002",
       routing: {
         complexity: "simple",
-        testStrategy: "tdd",
+        testStrategy: "tdd-simple",
         reasoning: "test",
         agent: "claude",
         agentProfileId: "existing-profile",
@@ -253,7 +253,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
             {
               id: "existing-profile",
               description: "A profile",
-              target: { agent: "claude" },
+              target: { agent: "claude", model: "fast" },
             },
           ],
         },
@@ -275,7 +275,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
       id: "US-003",
       routing: {
         complexity: "simple",
-        testStrategy: "tdd",
+        testStrategy: "tdd-simple",
         reasoning: "test",
       },
     });
@@ -289,7 +289,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
             {
               id: "some-profile",
               description: "A profile",
-              target: { agent: "claude" },
+              target: { agent: "claude", model: "fast" },
             },
           ],
         },

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -308,19 +308,10 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
     expect(warns).toHaveLength(0);
   });
 
-  test("emits PRD-level warn when prd.routingProfile differs from config.routing.agents.default", () => {
+  test("emits PRD-level warn when prd.routingProfile differs from the resolved config profile", () => {
     const { logger, warns } = makeLogger();
-    const prd = makePRD({ userStories: [], routingProfile: "old-default" });
-    const config = makeNaxConfig({
-      routing: {
-        agents: {
-          enabled: true,
-          strategy: "off" as const,
-          default: "new-default",
-          profiles: [],
-        },
-      },
-    });
+    const prd = makePRD({ userStories: [], routingProfile: "aggressive" });
+    const config = { ...makeNaxConfig(), profile: "cheap" };
 
     warnProfileMismatch(
       prd,
@@ -331,26 +322,16 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
     expect(warns).toHaveLength(1);
     const [stage, msg, ctx] = warns[0]!;
     expect(stage).toBe("prd");
-    expect(msg).toContain("old-default");
-    expect(msg).toContain("new-default");
+    expect(msg).toContain('planned with config profile "aggressive"');
     expect(ctx.storyId).toBe("prd");
-    expect(ctx.routingProfile).toBe("old-default");
-    expect(ctx.currentDefault).toBe("new-default");
+    expect(ctx.plannedProfile).toBe("aggressive");
+    expect(ctx.currentProfile).toBe("cheap");
   });
 
-  test("does not emit PRD-level warn when prd.routingProfile matches config.routing.agents.default", () => {
+  test("does not emit PRD-level warn when prd.routingProfile matches the resolved config profile", () => {
     const { logger, warns } = makeLogger();
-    const prd = makePRD({ userStories: [], routingProfile: "shared-default" });
-    const config = makeNaxConfig({
-      routing: {
-        agents: {
-          enabled: true,
-          strategy: "off" as const,
-          default: "shared-default",
-          profiles: [],
-        },
-      },
-    });
+    const prd = makePRD({ userStories: [], routingProfile: "shared" });
+    const config = { ...makeNaxConfig(), profile: "shared" };
 
     warnProfileMismatch(
       prd,

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -8,8 +8,12 @@
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { rmSync } from "node:fs";
-import { _runSetupDeps, warnFallbackMisconfiguration } from "../../../../src/execution/lifecycle/run-setup";
-import { makeNaxConfig } from "../../../helpers";
+import {
+  _runSetupDeps,
+  warnFallbackMisconfiguration,
+  warnProfileMismatch,
+} from "../../../../src/execution/lifecycle/run-setup";
+import { makeNaxConfig, makePRD, makeStory } from "../../../helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -165,5 +169,139 @@ describe("warnFallbackMisconfiguration — #508-M4 AC-35 pre-flight warning", ()
 
     const geminiWarns = warns.filter((w) => (w[2] as Record<string, unknown>).candidate === "gemini");
     expect(geminiWarns).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 10 Part B: profile-mismatch warning
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("warnProfileMismatch — Task 10 Part B", () => {
+  function makeLogger() {
+    const warns: Array<[string, string, Record<string, unknown>]> = [];
+    const logger = {
+      warn: (stage: string, msg: string, ctx: Record<string, unknown>) => warns.push([stage, msg, ctx]),
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+    };
+    return { logger, warns };
+  }
+
+  test("emits warn when story has agentProfileId that no longer exists in config", () => {
+    const { logger, warns } = makeLogger();
+    const story = makeStory({
+      id: "US-001",
+      routing: {
+        complexity: "medium",
+        testStrategy: "tdd",
+        reasoning: "test",
+        agent: "opencode",
+        agentProfileId: "removed-profile",
+      },
+    });
+    const prd = makePRD({ userStories: [story] });
+    const config = makeNaxConfig({
+      routing: {
+        agents: {
+          enabled: true,
+          default: "default-profile",
+          profiles: [
+            {
+              id: "existing-profile",
+              description: "Another profile",
+              target: { agent: "claude" },
+            },
+          ],
+        },
+      },
+    });
+
+    warnProfileMismatch(
+      prd,
+      config,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(1);
+    const [stage, msg, ctx] = warns[0]!;
+    expect(stage).toBe("setup");
+    expect(msg).toContain("removed-profile");
+    expect(msg).toContain("no longer exists");
+    expect(ctx.storyId).toBe("US-001");
+  });
+
+  test("does not emit warn when story's agentProfileId still exists in config", () => {
+    const { logger, warns } = makeLogger();
+    const story = makeStory({
+      id: "US-002",
+      routing: {
+        complexity: "simple",
+        testStrategy: "tdd",
+        reasoning: "test",
+        agent: "claude",
+        agentProfileId: "existing-profile",
+      },
+    });
+    const prd = makePRD({ userStories: [story] });
+    const config = makeNaxConfig({
+      routing: {
+        agents: {
+          enabled: true,
+          default: "existing-profile",
+          profiles: [
+            {
+              id: "existing-profile",
+              description: "A profile",
+              target: { agent: "claude" },
+            },
+          ],
+        },
+      },
+    });
+
+    warnProfileMismatch(
+      prd,
+      config,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(0);
+  });
+
+  test("does not emit warn when story has no agentProfileId (control case)", () => {
+    const { logger, warns } = makeLogger();
+    const story = makeStory({
+      id: "US-003",
+      routing: {
+        complexity: "simple",
+        testStrategy: "tdd",
+        reasoning: "test",
+      },
+    });
+    const prd = makePRD({ userStories: [story] });
+    const config = makeNaxConfig({
+      routing: {
+        agents: {
+          enabled: true,
+          default: "some-profile",
+          profiles: [
+            {
+              id: "some-profile",
+              description: "A profile",
+              target: { agent: "claude" },
+            },
+          ],
+        },
+      },
+    });
+
+    warnProfileMismatch(
+      prd,
+      config,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(0);
   });
 });

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -307,4 +307,57 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
 
     expect(warns).toHaveLength(0);
   });
+
+  test("emits PRD-level warn when prd.routingProfile differs from config.routing.agents.default", () => {
+    const { logger, warns } = makeLogger();
+    const prd = makePRD({ userStories: [], routingProfile: "old-default" });
+    const config = makeNaxConfig({
+      routing: {
+        agents: {
+          enabled: true,
+          strategy: "off" as const,
+          default: "new-default",
+          profiles: [],
+        },
+      },
+    });
+
+    warnProfileMismatch(
+      prd,
+      config,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(1);
+    const [stage, msg, ctx] = warns[0]!;
+    expect(stage).toBe("prd");
+    expect(msg).toContain("old-default");
+    expect(msg).toContain("new-default");
+    expect(ctx.storyId).toBe("prd");
+    expect(ctx.routingProfile).toBe("old-default");
+    expect(ctx.currentDefault).toBe("new-default");
+  });
+
+  test("does not emit PRD-level warn when prd.routingProfile matches config.routing.agents.default", () => {
+    const { logger, warns } = makeLogger();
+    const prd = makePRD({ userStories: [], routingProfile: "shared-default" });
+    const config = makeNaxConfig({
+      routing: {
+        agents: {
+          enabled: true,
+          strategy: "off" as const,
+          default: "shared-default",
+          profiles: [],
+        },
+      },
+    });
+
+    warnProfileMismatch(
+      prd,
+      config,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(0);
+  });
 });

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -209,7 +209,6 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
           profiles: [
             {
               id: "existing-profile",
-              description: "Another profile",
               target: { agent: "claude", model: "fast" },
             },
           ],
@@ -252,7 +251,6 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
           profiles: [
             {
               id: "existing-profile",
-              description: "A profile",
               target: { agent: "claude", model: "fast" },
             },
           ],
@@ -288,7 +286,6 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
           profiles: [
             {
               id: "some-profile",
-              description: "A profile",
               target: { agent: "claude", model: "fast" },
             },
           ],

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -210,6 +210,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
             {
               id: "existing-profile",
               target: { agent: "claude", model: "fast" },
+              strengths: ["general"],
             },
           ],
         },
@@ -252,6 +253,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
             {
               id: "existing-profile",
               target: { agent: "claude", model: "fast" },
+              strengths: ["general"],
             },
           ],
         },
@@ -287,6 +289,7 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
             {
               id: "some-profile",
               target: { agent: "claude", model: "fast" },
+              strengths: ["general"],
             },
           ],
         },

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -202,6 +202,8 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
     });
     const prd = makePRD({ userStories: [story] });
     const config = makeNaxConfig({
+      // Include "opencode" in models so only the profile-mismatch warn fires, not the agent warn.
+      models: { claude: { fast: "haiku" }, opencode: { fast: "opencode-fast" } },
       routing: {
         agents: {
           enabled: true,
@@ -340,5 +342,36 @@ describe("warnProfileMismatch — Task 10 Part B", () => {
     );
 
     expect(warns).toHaveLength(0);
+  });
+
+  test("warns per story when routing.agent is not defined in config.models", () => {
+    const { logger, warns } = makeLogger();
+    const prd = makePRD({
+      userStories: [
+        makeStory({
+          id: "US-1",
+          routing: {
+            complexity: "simple",
+            testStrategy: "test-after",
+            reasoning: "",
+            modelTier: "fast",
+            agent: "ghost",
+          },
+        }),
+      ],
+    });
+    const config = makeNaxConfig({ models: { claude: { fast: "m" } } });
+
+    warnProfileMismatch(
+      prd,
+      config,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    const agentWarns = warns.filter(
+      ([, msg, ctx]) => /agent "ghost".*not defined in config\.models/i.test(msg) && ctx.storyId === "US-1",
+    );
+    expect(agentWarns).toHaveLength(1);
+    expect(agentWarns[0]?.[2]).toMatchObject({ storyId: "US-1", agent: "ghost" });
   });
 });

--- a/test/unit/operations/decompose.test.ts
+++ b/test/unit/operations/decompose.test.ts
@@ -192,7 +192,7 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-2: story with valid agentProfileId sets routing.agent and routing.agentProfileId", () => {
+  test("AC-T9-2: story with valid agentProfileId sets routing.agent, routing.agentProfileId, and routing.profileModelTier", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -206,6 +206,7 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result).toHaveLength(1);
     expect(result[0].routing?.agent).toBe("opencode");
     expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+    expect(result[0].routing?.profileModelTier).toBe("fast");
   });
 
   test("AC-T9-2b: routing.agent and routing.agentProfileId are set per-story independently", () => {
@@ -269,7 +270,7 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-4: agentProfileId missing + default set → routing resolved from default profile", () => {
+  test("AC-T9-4: agentProfileId missing + default set → routing resolved from default profile, including profileModelTier", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -287,9 +288,10 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result).toHaveLength(1);
     expect(result[0].routing?.agent).toBe("opencode");
     expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+    expect(result[0].routing?.profileModelTier).toBe("fast");
   });
 
-  test("AC-T9-5: agentProfileId unknown/hallucinated + default set → routing resolved from default profile", () => {
+  test("AC-T9-5: agentProfileId unknown/hallucinated + default set → routing resolved from default profile, including profileModelTier", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -307,6 +309,7 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result).toHaveLength(1);
     expect(result[0].routing?.agent).toBe("opencode");
     expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+    expect(result[0].routing?.profileModelTier).toBe("fast");
   });
 
   test("AC-T9-6: agentProfileId unknown + no default → routing unchanged (existing behavior preserved)", () => {

--- a/test/unit/operations/decompose.test.ts
+++ b/test/unit/operations/decompose.test.ts
@@ -5,6 +5,9 @@
  * - AC-T8-1: Capability cards are NOT injected when routing.agents.enabled === false
  * - AC-T8-2: Capability cards are NOT injected when profiles is empty (even if enabled)
  * - AC-T8-3: Capability cards ARE injected when enabled === true and profiles are non-empty
+ * - AC-T9-1: Story with unknown/hallucinated agentProfileId → routing unchanged, no error
+ * - AC-T9-2: Story with valid agentProfileId → routing.agent and routing.agentProfileId set
+ * - AC-T9-3: Story without agentProfileId → routing unchanged
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -37,6 +40,29 @@ function makeBuildCtx(configOverrides?: object) {
   createdRuntimes.push(runtime);
   const view = runtime.packages.repo();
   return { packageView: view, config: view.select(decomposeConfigSelector) };
+}
+
+/** Minimal LLM JSON for a single story with optional agentProfileId */
+function makeDecomposeOutput(stories: Array<{
+  id?: string;
+  title?: string;
+  agentProfileId?: string;
+}>): string {
+  const arr = stories.map((s) => ({
+    id: s.id ?? "US-001",
+    title: s.title ?? "Story One",
+    description: "desc",
+    acceptanceCriteria: ["AC-1"],
+    tags: [],
+    dependencies: [],
+    complexity: "simple",
+    contextFiles: [],
+    reasoning: "reason",
+    estimatedLOC: 10,
+    risks: [],
+    ...(s.agentProfileId !== undefined ? { agentProfileId: s.agentProfileId } : {}),
+  }));
+  return JSON.stringify(arr);
 }
 
 describe("decomposeOp — agent capability cards injection", () => {
@@ -113,5 +139,129 @@ describe("decomposeOp — agent capability cards injection", () => {
 
     expect(result.role.content).toBe("");
     expect(result.task.content.length).toBeGreaterThan(0);
+  });
+});
+
+describe("decomposeOp — parse: agentProfileId resolution", () => {
+  test("AC-T9-3: story without agentProfileId leaves routing unchanged (undefined)", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: { enabled: true, profiles: [SAMPLE_PROFILE] },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].routing).toBeUndefined();
+  });
+
+  test("AC-T9-1: story with unknown/hallucinated agentProfileId leaves routing unchanged, no error", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: { enabled: true, profiles: [SAMPLE_PROFILE] },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "nonexistent-profile" }]);
+    // Should not throw
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].routing).toBeUndefined();
+  });
+
+  test("AC-T9-1b: hallucinated agentProfileId with empty profiles list also leaves routing unchanged", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: { enabled: true, profiles: [] },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "some-id" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result[0].routing).toBeUndefined();
+  });
+
+  test("AC-T9-2: story with valid agentProfileId sets routing.agent and routing.agentProfileId", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: { enabled: true, profiles: [SAMPLE_PROFILE] },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "fast-coder" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].routing?.agent).toBe("opencode");
+    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+  });
+
+  test("AC-T9-2b: routing.agent and routing.agentProfileId are set per-story independently", () => {
+    const secondProfile = {
+      id: "quality-agent",
+      target: { agent: "claude", model: "balanced" as const },
+      strengths: ["review"],
+      costTier: "high" as const,
+    };
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: { enabled: true, profiles: [SAMPLE_PROFILE, secondProfile] },
+      },
+    });
+
+    const output = makeDecomposeOutput([
+      { id: "US-001", agentProfileId: "fast-coder" },
+      { id: "US-002", agentProfileId: "quality-agent" },
+      { id: "US-003" },
+    ]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].routing?.agent).toBe("opencode");
+    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+    expect(result[1].routing?.agent).toBe("claude");
+    expect(result[1].routing?.agentProfileId).toBe("quality-agent");
+    expect(result[2].routing).toBeUndefined();
+  });
+
+  test("AC-T9-2c: existing routing fields are preserved when profile is matched", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: { enabled: true, profiles: [SAMPLE_PROFILE] },
+      },
+    });
+
+    // The LLM may emit extra routing-adjacent fields; parse should not destroy them.
+    // The decomposed story doesn't carry a full routing object — it only carries agentProfileId.
+    // After resolution, routing.agent and routing.agentProfileId are set; others remain absent.
+    const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "fast-coder" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result[0].routing?.agent).toBe("opencode");
+    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+  });
+
+  test("AC-T9-1c: when agents.enabled === false, agentProfileId is ignored even if profile exists", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: { enabled: false, profiles: [SAMPLE_PROFILE] },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "fast-coder" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result[0].routing).toBeUndefined();
   });
 });

--- a/test/unit/operations/decompose.test.ts
+++ b/test/unit/operations/decompose.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for src/operations/decompose.ts
+ *
+ * Verifies:
+ * - AC-T8-1: Capability cards are NOT injected when routing.agents.enabled === false
+ * - AC-T8-2: Capability cards are NOT injected when profiles is empty (even if enabled)
+ * - AC-T8-3: Capability cards ARE injected when enabled === true and profiles are non-empty
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { decomposeConfigSelector } from "../../../src/config";
+import { decomposeOp } from "../../../src/operations/decompose";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
+import type { NaxRuntime } from "../../../src/runtime";
+
+const createdRuntimes: NaxRuntime[] = [];
+afterEach(async () => {
+  await Promise.allSettled(createdRuntimes.map((r) => r.close()));
+  createdRuntimes.length = 0;
+});
+
+const SAMPLE_INPUT = {
+  specContent: "A feature spec",
+  codebaseContext: "Some context",
+};
+
+const SAMPLE_PROFILE = {
+  id: "fast-coder",
+  target: { agent: "opencode", model: "fast" as const },
+  strengths: ["code-generation", "refactoring"],
+  costTier: "low" as const,
+};
+
+function makeBuildCtx(configOverrides?: object) {
+  const config = makeNaxConfig(configOverrides);
+  const runtime = makeTestRuntime({ config });
+  createdRuntimes.push(runtime);
+  const view = runtime.packages.repo();
+  return { packageView: view, config: view.select(decomposeConfigSelector) };
+}
+
+describe("decomposeOp — agent capability cards injection", () => {
+  test("AC-T8-1: capability cards are NOT injected when routing.agents.enabled === false", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: false,
+          profiles: [SAMPLE_PROFILE],
+        },
+      },
+    });
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+    const prompt = result.task.content;
+
+    expect(prompt).not.toContain("## Agent Profiles");
+    expect(prompt).not.toContain("fast-coder");
+  });
+
+  test("AC-T8-2: capability cards are NOT injected when profiles is empty (enabled === true)", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: true,
+          profiles: [],
+        },
+      },
+    });
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+    const prompt = result.task.content;
+
+    expect(prompt).not.toContain("## Agent Profiles");
+  });
+
+  test("AC-T8-3: capability cards ARE injected when enabled === true and profiles are non-empty", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: true,
+          profiles: [SAMPLE_PROFILE],
+        },
+      },
+    });
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+    const prompt = result.task.content;
+
+    expect(prompt).toContain("## Agent Profiles");
+    expect(prompt).toContain("fast-coder");
+    expect(prompt).toContain("opencode");
+    expect(prompt).toContain("code-generation");
+    expect(prompt).toContain("low");
+  });
+
+  test("AC-T8-4: default config (no routing.agents override) produces no capability cards", () => {
+    const ctx = makeBuildCtx();
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+    const prompt = result.task.content;
+
+    // Default has profiles = [] so no capability cards should appear
+    expect(prompt).not.toContain("## Agent Profiles");
+  });
+
+  test("AC-T8-5: prompt structure — role block is empty, task block contains the full prompt", () => {
+    const ctx = makeBuildCtx();
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+
+    expect(result.role.content).toBe("");
+    expect(result.task.content.length).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/operations/decompose.test.ts
+++ b/test/unit/operations/decompose.test.ts
@@ -16,7 +16,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { decomposeConfigSelector } from "../../../src/config";
-import { decomposeOp } from "../../../src/operations/decompose";
+import { _decomposeOpDeps, decomposeOp } from "../../../src/operations/decompose";
 import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 import type { NaxRuntime } from "../../../src/runtime";
 
@@ -328,6 +328,42 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].routing).toBeUndefined();
+  });
+
+  test("Delta C3: warns with storyId when the LLM emits an unknown agentProfileId", () => {
+    const orig = _decomposeOpDeps.getSafeLogger;
+    const warnings: Array<{ message: string; data?: Record<string, unknown> }> = [];
+    _decomposeOpDeps.getSafeLogger = () =>
+      ({
+        warn: (_stage: string, message: string, data?: Record<string, unknown>) => {
+          warnings.push({ message, data });
+        },
+        info: () => {},
+        debug: () => {},
+        error: () => {},
+      }) as never;
+    try {
+      const ctx = makeBuildCtx({
+        routing: {
+          strategy: "keyword",
+          agents: {
+            enabled: true,
+            profiles: [SAMPLE_PROFILE],
+          },
+        },
+      });
+
+      const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "hallucinated-id" }]);
+      const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+      const warn = warnings.find(
+        (w) => w.message.includes("hallucinated-id") || w.message.includes("unknown"),
+      );
+      expect(warn).toBeDefined();
+      expect(warn?.data?.storyId).toBe(result[0].id);
+    } finally {
+      _decomposeOpDeps.getSafeLogger = orig;
+    }
   });
 });
 

--- a/test/unit/operations/decompose.test.ts
+++ b/test/unit/operations/decompose.test.ts
@@ -5,9 +5,13 @@
  * - AC-T8-1: Capability cards are NOT injected when routing.agents.enabled === false
  * - AC-T8-2: Capability cards are NOT injected when profiles is empty (even if enabled)
  * - AC-T8-3: Capability cards ARE injected when enabled === true and profiles are non-empty
+ * - AC-T8-6: Agent profile selection instruction is injected alongside capability cards
  * - AC-T9-1: Story with unknown/hallucinated agentProfileId → routing unchanged, no error
  * - AC-T9-2: Story with valid agentProfileId → routing.agent and routing.agentProfileId set
  * - AC-T9-3: Story without agentProfileId → routing unchanged
+ * - AC-T9-4: agentProfileId missing + default set → routing resolved from default profile
+ * - AC-T9-5: agentProfileId unknown/hallucinated + default set → routing resolved from default profile
+ * - AC-T9-6: agentProfileId unknown + no default → routing unchanged
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -263,5 +267,118 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
 
     expect(result[0].routing).toBeUndefined();
+  });
+
+  test("AC-T9-4: agentProfileId missing + default set → routing resolved from default profile", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: true,
+          default: "fast-coder",
+          profiles: [SAMPLE_PROFILE],
+        },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].routing?.agent).toBe("opencode");
+    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+  });
+
+  test("AC-T9-5: agentProfileId unknown/hallucinated + default set → routing resolved from default profile", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: true,
+          default: "fast-coder",
+          profiles: [SAMPLE_PROFILE],
+        },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "nonexistent-profile" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].routing?.agent).toBe("opencode");
+    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+  });
+
+  test("AC-T9-6: agentProfileId unknown + no default → routing unchanged (existing behavior preserved)", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: true,
+          profiles: [SAMPLE_PROFILE],
+        },
+      },
+    });
+
+    const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "nonexistent-profile" }]);
+    const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].routing).toBeUndefined();
+  });
+});
+
+describe("decomposeOp — build: agent profile instruction injection", () => {
+  test("AC-T8-6: agent profile selection instruction is injected when enabled and profiles are non-empty", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: true,
+          profiles: [SAMPLE_PROFILE],
+        },
+      },
+    });
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+    const prompt = result.task.content;
+
+    expect(prompt).toContain("agentProfileId");
+  });
+
+  test("AC-T8-6b: agent profile selection instruction is NOT injected when routing.agents.enabled === false", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: false,
+          profiles: [SAMPLE_PROFILE],
+        },
+      },
+    });
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+    const prompt = result.task.content;
+
+    // The instruction appended by agentProfileInstruction() should not be present
+    // (Note: agentProfileId may appear from the schema example — check for the full instruction phrase)
+    expect(prompt).not.toContain("assign the best-matching profile id to the");
+  });
+
+  test("AC-T8-6c: agent profile selection instruction is NOT injected when profiles is empty", () => {
+    const ctx = makeBuildCtx({
+      routing: {
+        strategy: "keyword",
+        agents: {
+          enabled: true,
+          profiles: [],
+        },
+      },
+    });
+
+    const result = decomposeOp.build(SAMPLE_INPUT, ctx);
+    const prompt = result.task.content;
+
+    expect(prompt).not.toContain("assign the best-matching profile id to the");
   });
 });

--- a/test/unit/pipeline/stages/execution-agent-routing.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveExecutionAgent } from "@/pipeline/stages/execution-helpers";
+import { resolveExecutionAgent } from "@/pipeline";
 
 const fakeAdapter = (name: string) => ({ name }) as never;
 

--- a/test/unit/pipeline/stages/execution-agent-routing.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-routing.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { resolveExecutionAgent } from "@/pipeline/stages/execution-helpers";
+
+const fakeAdapter = (name: string) => ({ name }) as never;
+
+describe("resolveExecutionAgent", () => {
+  test("uses the routed agent when its adapter resolves", () => {
+    const result = resolveExecutionAgent({
+      routedAgent: "opencode",
+      defaultAgent: "claude",
+      getAgent: (n) => (n === "opencode" ? fakeAdapter("opencode") : undefined),
+    });
+    expect(result.agentName).toBe("opencode");
+    expect(result.degraded).toBe(false);
+    expect(result.agent).toBeDefined();
+  });
+
+  test("degrades to the default agent when the routed agent is unresolvable", () => {
+    const result = resolveExecutionAgent({
+      routedAgent: "ghost",
+      defaultAgent: "claude",
+      getAgent: (n) => (n === "claude" ? fakeAdapter("claude") : undefined),
+    });
+    expect(result.agentName).toBe("claude");
+    expect(result.degraded).toBe(true);
+    expect(result.agent).toBeDefined();
+  });
+
+  test("uses the default agent when no routed agent is set", () => {
+    const result = resolveExecutionAgent({
+      routedAgent: undefined,
+      defaultAgent: "claude",
+      getAgent: (n) => (n === "claude" ? fakeAdapter("claude") : undefined),
+    });
+    expect(result.agentName).toBe("claude");
+    expect(result.degraded).toBe(false);
+  });
+
+  test("returns undefined adapter (degraded) when neither resolves", () => {
+    const result = resolveExecutionAgent({
+      routedAgent: "ghost",
+      defaultAgent: "claude",
+      getAgent: () => undefined,
+    });
+    expect(result.agentName).toBe("claude");
+    expect(result.agent).toBeUndefined();
+    expect(result.degraded).toBe(true);
+  });
+});

--- a/test/unit/pipeline/stages/execution-agent-routing.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-routing.test.ts
@@ -8,7 +8,7 @@ describe("resolveExecutionAgent", () => {
     const result = resolveExecutionAgent({
       routedAgent: "opencode",
       defaultAgent: "claude",
-      getAgent: (n) => (n === "opencode" ? fakeAdapter("opencode") : undefined),
+      getAgent: (n: string) => (n === "opencode" ? fakeAdapter("opencode") : undefined),
     });
     expect(result.agentName).toBe("opencode");
     expect(result.degraded).toBe(false);
@@ -19,7 +19,7 @@ describe("resolveExecutionAgent", () => {
     const result = resolveExecutionAgent({
       routedAgent: "ghost",
       defaultAgent: "claude",
-      getAgent: (n) => (n === "claude" ? fakeAdapter("claude") : undefined),
+      getAgent: (n: string) => (n === "claude" ? fakeAdapter("claude") : undefined),
     });
     expect(result.agentName).toBe("claude");
     expect(result.degraded).toBe(true);
@@ -30,7 +30,7 @@ describe("resolveExecutionAgent", () => {
     const result = resolveExecutionAgent({
       routedAgent: undefined,
       defaultAgent: "claude",
-      getAgent: (n) => (n === "claude" ? fakeAdapter("claude") : undefined),
+      getAgent: (n: string) => (n === "claude" ? fakeAdapter("claude") : undefined),
     });
     expect(result.agentName).toBe("claude");
     expect(result.degraded).toBe(false);

--- a/test/unit/pipeline/stages/routing-profile-tier.test.ts
+++ b/test/unit/pipeline/stages/routing-profile-tier.test.ts
@@ -9,12 +9,12 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
-import type { PRD, UserStory } from "../../../../src/prd";
-import type { _routingDeps as RoutingDeps } from "../../../../src/pipeline/stages/routing";
-import type { PipelineContext } from "../../../../src/pipeline/types";
-import type { StoryRouting } from "../../../../src/prd/types";
-import { makeNaxConfig, makeStory } from "../../../helpers";
+import { DEFAULT_CONFIG } from "@/config";
+import type { PRD, UserStory } from "@/prd";
+import type { _routingDeps as RoutingDeps } from "@/pipeline/stages/routing";
+import type { PipelineContext } from "@/pipeline/types";
+import type { StoryRouting } from "@/prd/types";
+import { makeNaxConfig, makeStory } from "@test/helpers";
 
 const WORKDIR = `/tmp/nax-routing-profile-tier-test-${randomUUID()}`;
 

--- a/test/unit/pipeline/stages/routing-profile-tier.test.ts
+++ b/test/unit/pipeline/stages/routing-profile-tier.test.ts
@@ -223,6 +223,39 @@ describe("routingStage — H1: profileModelTier seeds starting tier", () => {
     expect(ctx.story.routing?.modelTier).toBe("fast");
   });
 
+  test("custom-named escalated tier (from a custom tierOrder rung) is preserved over a canonical candidate", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "medium" as const, modelTier: "balanced" as const, testStrategy: "test-after" as const, reasoning: "x" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    // TierConfigSchema.tier is free-form z.string() — a ladder may define a rung
+    // named "ultra". Escalation wrote it onto the story (with a record). The next
+    // routingStage pass must not drop it just because "ultra" has no TIER_RANK.
+    const story = makeStory({
+      escalations: [
+        { fromTier: "balanced", toTier: "ultra" as never, reason: "budget", timestamp: new Date().toISOString() },
+      ],
+      routing: {
+        complexity: "medium",
+        testStrategy: "test-after",
+        reasoning: "",
+        modelTier: "ultra" as never, // custom escalated tier — previousRank undefined
+      },
+    });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    // Escalation records prove "ultra" was a real escalation — preserve it.
+    expect(ctx.story.routing?.modelTier).toBe("ultra");
+  });
+
   test("idempotence — running routingStage twice on a profile-seeded story yields stable modelTier", async () => {
     const { routingStage, _routingDeps } = await import(
       "../../../../src/pipeline/stages/routing"

--- a/test/unit/pipeline/stages/routing-profile-tier.test.ts
+++ b/test/unit/pipeline/stages/routing-profile-tier.test.ts
@@ -380,4 +380,74 @@ describe("routingStage — H2: initialAgent / initialProfileId written once", ()
     expect("initialAgent" in (ctx.story.routing ?? {})).toBe(false);
     expect("initialProfileId" in (ctx.story.routing ?? {})).toBe(false);
   });
+
+  test("decision.agent applies when the PRD leaves agent unset (Part A forward-compat)", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({
+        complexity: "simple" as const,
+        modelTier: "fast" as const,
+        testStrategy: "test-after" as const,
+        reasoning: "llm",
+        agent: "opencode",
+      });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({ routing: { complexity: "simple", testStrategy: "test-after", reasoning: "" } });
+    const ctx = makeCtx(story);
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    expect(ctx.story.routing?.agent).toBe("opencode");
+  });
+
+  test("PRD agent still wins over decision.agent", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({
+        complexity: "simple" as const,
+        modelTier: "fast" as const,
+        testStrategy: "test-after" as const,
+        reasoning: "llm",
+        agent: "opencode",
+      });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({ routing: { complexity: "simple", testStrategy: "test-after", reasoning: "", agent: "claude" } });
+    const ctx = makeCtx(story);
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    expect(ctx.story.routing?.agent).toBe("claude");
+  });
+
+  test("initialAgent is NOT captured from an agent first assigned by escalation", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "k" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    // Story had NO plan-time agent; escalation later assigned one and left a record.
+    const story = makeStory({
+      escalations: [
+        { fromTier: "fast", toTier: "balanced", reason: "budget", timestamp: new Date().toISOString() },
+      ],
+      routing: { complexity: "simple", testStrategy: "test-after", reasoning: "", modelTier: "balanced", agent: "claude" },
+    });
+    const ctx = makeCtx(story);
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    // Origin was "no agent" — escalation's assignment must not be recorded as origin.
+    expect(ctx.story.routing?.initialAgent).toBeUndefined();
+  });
 });

--- a/test/unit/pipeline/stages/routing-profile-tier.test.ts
+++ b/test/unit/pipeline/stages/routing-profile-tier.test.ts
@@ -209,6 +209,8 @@ describe("routingStage — H1: profileModelTier seeds starting tier", () => {
           complexity: "medium" as const,
           testStrategy: "test-after" as const,
           reasoning: "r",
+          estimatedLOC: 50,
+          risks: [],
           routing: { agent: "opencode", agentProfileId: "oc-fast", profileModelTier: "fast" as const },
         },
       ],

--- a/test/unit/pipeline/stages/routing-profile-tier.test.ts
+++ b/test/unit/pipeline/stages/routing-profile-tier.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Routing Stage — H1: profileModelTier seeds the starting rung (Open Item B)
+ *                 H2: initialAgent / initialProfileId written once on first route
+ *
+ * Interpretation A (DECIDED 2026-06-11): a selected profile's target tier
+ * overrides the complexity-derived tier unconditionally. A cheap profile can
+ * start a complex story at "fast" — escalation recovers upward if needed.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
+import type { PRD, UserStory } from "../../../../src/prd";
+import type { _routingDeps as RoutingDeps } from "../../../../src/pipeline/stages/routing";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import type { StoryRouting } from "../../../../src/prd/types";
+import { makeNaxConfig, makeStory } from "../../../helpers";
+
+const WORKDIR = `/tmp/nax-routing-profile-tier-test-${randomUUID()}`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePRD(story: UserStory): PRD {
+  return {
+    project: "test-project",
+    feature: "test-feature",
+    branchName: "feat/test",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: [story],
+  };
+}
+
+function makeCtx(story: UserStory, overrides?: Partial<PipelineContext>): PipelineContext & { prdPath: string } {
+  const prd = makePRD(story);
+  return {
+    config: makeNaxConfig({ tdd: { greenfieldDetection: false } }),
+    prd,
+    story,
+    stories: [story],
+    routing: {
+      complexity: "simple",
+      modelTier: "fast",
+      testStrategy: "test-after",
+      reasoning: "test",
+    },
+    rootConfig: DEFAULT_CONFIG,
+    workdir: WORKDIR,
+    projectDir: WORKDIR,
+    hooks: { hooks: {} },
+    prdPath: `${WORKDIR}/nax/prd.json`,
+    ...overrides,
+  } as PipelineContext & { prdPath: string };
+}
+
+// ---------------------------------------------------------------------------
+// H1 — profileModelTier seeds the starting tier
+// ---------------------------------------------------------------------------
+
+describe("routingStage — H1: profileModelTier seeds starting tier", () => {
+  let origRoutingDeps: typeof RoutingDeps;
+
+  afterEach(() => {
+    if (origRoutingDeps) {
+      const { _routingDeps } = require("../../../../src/pipeline/stages/routing");
+      Object.assign(_routingDeps, origRoutingDeps);
+    }
+  });
+
+  test("upward override — profileModelTier=powerful beats complexity-derived fast", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({
+      routing: { complexity: "simple", testStrategy: "test-after", reasoning: "", profileModelTier: "powerful" as const },
+    });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    expect(ctx.story.routing?.modelTier).toBe("powerful");
+  });
+
+  test("downward override (Interpretation A) — a cheap profile starts a complex story at fast — escalation recovers", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "expert" as const, modelTier: "powerful" as const, testStrategy: "three-session-tdd" as const, reasoning: "llm" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({
+      routing: { complexity: "expert", testStrategy: "three-session-tdd", reasoning: "", profileModelTier: "fast" as const },
+    });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    // Profile "fast" fully overrides complexity-derived "powerful" (Interpretation A)
+    expect(ctx.story.routing?.modelTier).toBe("fast");
+  });
+
+  test("escalation still wins — escalated powerful is preserved over profileModelTier fast", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    // Story already escalated to powerful; profile says fast
+    const routing: StoryRouting = {
+      complexity: "simple",
+      modelTier: "powerful",    // escalated tier already stored
+      testStrategy: "test-after",
+      reasoning: "",
+      profileModelTier: "fast", // profile baseline
+    };
+    const story = makeStory({ routing });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    // Escalation wins — powerful > fast
+    expect(ctx.story.routing?.modelTier).toBe("powerful");
+  });
+
+  test("story with no profileModelTier uses complexity-derived tier (regression guard)", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "medium" as const, modelTier: "balanced" as const, testStrategy: "three-session-tdd" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({ routing: undefined });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    expect(ctx.story.routing?.modelTier).toBe("balanced");
+  });
+
+  test("unknown/custom profileModelTier passes through as start tier without crash", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({
+      routing: { complexity: "simple", testStrategy: "test-after", reasoning: "", profileModelTier: "custom-tier" as any },
+    });
+    const ctx = makeCtx(story);
+
+    // Must not throw even when TIER_RANK has no entry for "custom-tier"
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    // Custom tier becomes the starting tier (candidateRank === undefined → isEscalated === false)
+    expect(ctx.story.routing?.modelTier).toBe("custom-tier");
+  });
+
+  test("idempotence — running routingStage twice on a profile-seeded story yields stable modelTier", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({
+      routing: { complexity: "simple", testStrategy: "test-after", reasoning: "", profileModelTier: "balanced" as const },
+    });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+    const tierAfterFirst = ctx.story.routing?.modelTier;
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+    const tierAfterSecond = ctx.story.routing?.modelTier;
+
+    expect(tierAfterFirst).toBe("balanced");
+    expect(tierAfterSecond).toBe("balanced");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H2 — initialAgent / initialProfileId written once on first route
+// ---------------------------------------------------------------------------
+
+describe("routingStage — H2: initialAgent / initialProfileId written once", () => {
+  let origRoutingDeps: typeof RoutingDeps;
+
+  afterEach(() => {
+    if (origRoutingDeps) {
+      const { _routingDeps } = require("../../../../src/pipeline/stages/routing");
+      Object.assign(_routingDeps, origRoutingDeps);
+    }
+  });
+
+  test("initialAgent and initialProfileId captured from first route", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({
+      routing: {
+        complexity: "simple",
+        testStrategy: "test-after",
+        reasoning: "",
+        agent: "opencode",
+        agentProfileId: "oc-bal",
+      },
+    });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    expect(ctx.story.routing?.initialAgent).toBe("opencode");
+    expect(ctx.story.routing?.initialProfileId).toBe("oc-bal");
+  });
+
+  test("initialAgent is not overwritten after escalation changes routing.agent", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    // First route: agent = opencode, initialAgent set
+    const story = makeStory({
+      routing: {
+        complexity: "simple",
+        testStrategy: "test-after",
+        reasoning: "",
+        agent: "opencode",
+        agentProfileId: "oc-bal",
+        initialAgent: "opencode",   // already written on first route
+        initialProfileId: "oc-bal",
+      },
+    });
+
+    // Simulate escalation changing the agent
+    story.routing!.agent = "claude";
+
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    // initialAgent must remain the original value, not the escalated agent
+    expect(ctx.story.routing?.initialAgent).toBe("opencode");
+  });
+
+  test("story with no agent assignment produces no initialAgent or initialProfileId keys", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "keyword" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const story = makeStory({ routing: undefined });
+    const ctx = makeCtx(story);
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    // Neither field should be written as undefined keys
+    expect("initialAgent" in (ctx.story.routing ?? {})).toBe(false);
+    expect("initialProfileId" in (ctx.story.routing ?? {})).toBe(false);
+  });
+});

--- a/test/unit/pipeline/stages/routing-profile-tier.test.ts
+++ b/test/unit/pipeline/stages/routing-profile-tier.test.ts
@@ -182,6 +182,45 @@ describe("routingStage — H1: profileModelTier seeds starting tier", () => {
     expect(ctx.story.routing?.modelTier).toBe("custom-tier");
   });
 
+  test("mapper-produced story with profileModelTier=fast routes to fast, not the mapper default", async () => {
+    const { routingStage, _routingDeps } = await import(
+      "../../../../src/pipeline/stages/routing"
+    );
+    const { mapDecomposedStoriesToUserStories } = await import(
+      "../../../../src/prd/decompose-mapper"
+    );
+    origRoutingDeps = { ..._routingDeps };
+
+    _routingDeps.resolveRouting = () =>
+      Promise.resolve({ complexity: "medium" as const, modelTier: "balanced" as const, testStrategy: "test-after" as const, reasoning: "x" });
+    _routingDeps.isGreenfieldStory = () => Promise.resolve(false);
+    _routingDeps.savePRD = () => Promise.resolve();
+
+    const [story] = mapDecomposedStoriesToUserStories(
+      [
+        {
+          id: "US-001-A",
+          title: "t",
+          description: "d",
+          acceptanceCriteria: ["a"],
+          tags: [],
+          dependencies: [],
+          contextFiles: ["f.ts"],
+          complexity: "medium" as const,
+          testStrategy: "test-after" as const,
+          reasoning: "r",
+          routing: { agent: "opencode", agentProfileId: "oc-fast", profileModelTier: "fast" as const },
+        },
+      ],
+      "US-001",
+    );
+    const ctx = makeCtx(makeStory({ ...story }));
+
+    await routingStage.execute(ctx as Parameters<typeof routingStage.execute>[0]);
+
+    expect(ctx.story.routing?.modelTier).toBe("fast");
+  });
+
   test("idempotence — running routingStage twice on a profile-seeded story yields stable modelTier", async () => {
     const { routingStage, _routingDeps } = await import(
       "../../../../src/pipeline/stages/routing"

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -272,6 +272,8 @@ describe("modelTier seeding from profileModelTier", () => {
     complexity: "medium" as const,
     testStrategy: "test-after" as const,
     reasoning: "r",
+    estimatedLOC: 50,
+    risks: [],
   };
 
   test("seeds modelTier from profileModelTier when a profile was resolved", () => {

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -179,6 +179,48 @@ describe("mapDecomposedStoriesToUserStories — workdir inheritance", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Agent routing propagation — routing.agent, agentProfileId, profileModelTier
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("mapDecomposedStoriesToUserStories — agent routing propagation", () => {
+  test("propagates routing.agent when set on DecomposedStory", () => {
+    const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
+    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+    expect(result.routing?.agent).toBe("opencode");
+  });
+
+  test("propagates routing.agentProfileId when set on DecomposedStory", () => {
+    const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
+    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+    expect(result.routing?.agentProfileId).toBe("fast-coder");
+  });
+
+  test("propagates routing.profileModelTier when set on DecomposedStory", () => {
+    const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
+    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+    expect(result.routing?.profileModelTier).toBe("fast");
+  });
+
+  test("profileModelTier is absent when routing is not set on DecomposedStory", () => {
+    const story = makeDecomposedStory({ routing: undefined });
+    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+    expect(result.routing?.profileModelTier).toBeUndefined();
+  });
+
+  test("propagates 'balanced' profileModelTier correctly", () => {
+    const story = makeDecomposedStory({ routing: { agent: "claude", agentProfileId: "quality-agent", profileModelTier: "balanced" } });
+    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+    expect(result.routing?.profileModelTier).toBe("balanced");
+  });
+
+  test("propagates 'powerful' profileModelTier correctly", () => {
+    const story = makeDecomposedStory({ routing: { agent: "claude", agentProfileId: "expert-agent", profileModelTier: "powerful" } });
+    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+    expect(result.routing?.profileModelTier).toBe("powerful");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // AC3: validation — missing id
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -5,7 +5,7 @@
  * - AC1: routing.complexity and routing.testStrategy mapped from DecomposedStory
  * - AC2: lifecycle defaults (status, passes, escalations, attempts)
  * - AC3: NaxError DECOMPOSE_VALIDATION_FAILED with entry index for missing id
- * - AC4: NaxError DECOMPOSE_VALIDATION_FAILED with entry index for empty contextFiles
+ * - AC4: empty contextFiles warns and continues (does not throw)
  */
 
 import { describe, expect, test } from "bun:test";
@@ -257,37 +257,30 @@ describe("mapDecomposedStoriesToUserStories — validation: missing id", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC4: validation — empty contextFiles
+// AC4: validation — empty contextFiles (warn, not throw)
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("mapDecomposedStoriesToUserStories — validation: empty contextFiles", () => {
-  test("throws NaxError when contextFiles is empty array", () => {
+  test("does not throw when contextFiles is empty — warns and continues", () => {
     const story = makeDecomposedStory({ contextFiles: [] });
-    expect(() => mapDecomposedStoriesToUserStories([story], "US-001")).toThrow(NaxError);
+    expect(() => mapDecomposedStoriesToUserStories([story], "US-001")).not.toThrow();
   });
 
-  test("throws with code DECOMPOSE_VALIDATION_FAILED when contextFiles is empty", () => {
+  test("returns story with empty contextFiles when LLM omitted them", () => {
     const story = makeDecomposedStory({ contextFiles: [] });
-    let caught: NaxError | undefined;
-    try {
-      mapDecomposedStoriesToUserStories([story], "US-001");
-    } catch (err) {
-      caught = err as NaxError;
-    }
-    expect(caught?.code).toBe("DECOMPOSE_VALIDATION_FAILED");
+    const result = mapDecomposedStoriesToUserStories([story], "US-001");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.contextFiles).toEqual([]);
   });
 
-  test.each<[string, DecomposedStory[], number]>([
-    ["first", [makeDecomposedStory({ contextFiles: [] })], 0],
-    ["second", [makeDecomposedStory({ id: "US-001-A", contextFiles: ["src/x.ts"] }), makeDecomposedStory({ id: "US-001-B", contextFiles: [] })], 1],
-    ["third", [makeDecomposedStory({ id: "US-001-A", contextFiles: ["src/a.ts"] }), makeDecomposedStory({ id: "US-001-B", contextFiles: ["src/b.ts"] }), makeDecomposedStory({ id: "US-001-C", contextFiles: [] })], 2],
-  ])("includes entry index in error context for %s entry with empty contextFiles", (_pos, stories, expectedIndex) => {
-    let caught: NaxError | undefined;
-    try {
-      mapDecomposedStoriesToUserStories(stories, "US-001");
-    } catch (err) {
-      caught = err as NaxError;
-    }
-    expect(caught?.context?.entryIndex).toBe(expectedIndex);
+  test("processes all stories even when some have empty contextFiles", () => {
+    const stories = [
+      makeDecomposedStory({ id: "US-001-A", contextFiles: ["src/a.ts"] }),
+      makeDecomposedStory({ id: "US-001-B", contextFiles: [] }),
+      makeDecomposedStory({ id: "US-001-C", contextFiles: ["src/c.ts"] }),
+    ];
+    const result = mapDecomposedStoriesToUserStories(stories, "US-001");
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.id)).toEqual(["US-001-A", "US-001-B", "US-001-C"]);
   });
 });

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -257,6 +257,43 @@ describe("mapDecomposedStoriesToUserStories — validation: missing id", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// modelTier seeding from profileModelTier
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("modelTier seeding from profileModelTier", () => {
+  const baseStory = {
+    id: "US-001-A",
+    title: "Sub-story",
+    description: "Desc",
+    acceptanceCriteria: ["AC1"],
+    tags: [],
+    dependencies: [],
+    contextFiles: ["src/a.ts"],
+    complexity: "medium" as const,
+    testStrategy: "test-after" as const,
+    reasoning: "r",
+  };
+
+  test("seeds modelTier from profileModelTier when a profile was resolved", () => {
+    const result = mapDecomposedStoriesToUserStories(
+      [
+        {
+          ...baseStory,
+          routing: { agent: "opencode", agentProfileId: "oc-fast", profileModelTier: "fast" as const },
+        },
+      ],
+      "US-001",
+    );
+    expect(result[0].routing?.modelTier).toBe("fast");
+  });
+
+  test("defaults modelTier to balanced when no profileModelTier", () => {
+    const result = mapDecomposedStoriesToUserStories([{ ...baseStory }], "US-001");
+    expect(result[0].routing?.modelTier).toBe("balanced");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // AC4: validation — empty contextFiles (warn, not throw)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from "bun:test";
 import type { AgentRoutingProfile } from "@/config";
 import { OneShotPromptBuilder } from "@/prompts";
 
+describe("agentProfileInstruction", () => {
+  it("returns a non-empty string", () => {
+    const result = OneShotPromptBuilder.agentProfileInstruction();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("contains 'agentProfileId' so the LLM knows the field name", () => {
+    const result = OneShotPromptBuilder.agentProfileInstruction();
+    expect(result).toContain("agentProfileId");
+  });
+});
+
 describe("agentCapabilityCards", () => {
   it("returns empty string for empty profiles array", () => {
     expect(OneShotPromptBuilder.agentCapabilityCards([])).toBe("");

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentRoutingProfile } from "@/config";
+import { OneShotPromptBuilder } from "@/prompts/builders/one-shot-builder";
+
+describe("agentCapabilityCards", () => {
+  it("returns empty string for empty profiles array", () => {
+    expect(OneShotPromptBuilder.agentCapabilityCards([])).toBe("");
+  });
+
+  it("renders a single profile with costTier", () => {
+    const profiles: AgentRoutingProfile[] = [
+      {
+        id: "profile-a",
+        target: { agent: "claude", model: "balanced" },
+        strengths: ["fast", "reliable"],
+        costTier: "low",
+      },
+    ];
+
+    const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
+
+    expect(result).toContain("## Agent Profiles");
+    expect(result).toContain("| ID | Agent | Tier | Strengths | Cost |");
+    expect(result).toContain("| profile-a | claude | balanced | fast, reliable | low |");
+  });
+
+  it("renders '—' in cost column when costTier is absent", () => {
+    const profiles: AgentRoutingProfile[] = [
+      {
+        id: "profile-b",
+        target: { agent: "claude", model: "fast" },
+        strengths: ["cheap"],
+      },
+    ];
+
+    const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
+
+    expect(result).toContain("| profile-b | claude | fast | cheap | — |");
+  });
+
+  it("renders all rows for multiple profiles", () => {
+    const profiles: AgentRoutingProfile[] = [
+      {
+        id: "alpha",
+        target: { agent: "claude", model: "fast" },
+        strengths: ["speed"],
+        costTier: "low",
+      },
+      {
+        id: "beta",
+        target: { agent: "claude", model: "powerful" },
+        strengths: ["reasoning", "accuracy"],
+        costTier: "high",
+      },
+    ];
+
+    const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
+
+    expect(result).toContain("| alpha | claude | fast | speed | low |");
+    expect(result).toContain("| beta | claude | powerful | reasoning, accuracy | high |");
+  });
+});

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -96,4 +96,26 @@ describe("agentCapabilityCards", () => {
     const unescapedPipes = (rows[0]!.match(/(?<!\\)\|/g) ?? []).length;
     expect(unescapedPipes).toBe(6);
   });
+
+  it("neutralizes newlines in cell values to prevent broken table rows", () => {
+    const profiles: AgentRoutingProfile[] = [
+      {
+        id: "newline-profile",
+        target: { agent: "claude", model: "fast" },
+        strengths: ["handles\nmulti-line\nstrengths", "also\r\nwindows"],
+        costTier: "low",
+      },
+    ];
+
+    const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
+
+    // Each row must be a single line — no embedded newlines
+    const rows = result.split("\n").filter((l: string) => l.startsWith("| newline-profile"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toContain("\n");
+    expect(rows[0]).not.toContain("\r");
+    // Newlines replaced with spaces
+    expect(rows[0]).toContain("handles multi-line strengths");
+    expect(rows[0]).toContain("also windows");
+  });
 });

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -71,4 +71,29 @@ describe("agentCapabilityCards", () => {
     expect(result).toContain("| alpha | claude | fast | speed | low |");
     expect(result).toContain("| beta | claude | powerful | reasoning, accuracy | high |");
   });
+
+  it("escapes pipe characters in cell values to preserve markdown table structure", () => {
+    const profiles: AgentRoutingProfile[] = [
+      {
+        id: "pipe|profile",
+        target: { agent: "claude|2", model: "fast|balanced" },
+        strengths: ["strength|a", "strength|b"],
+        costTier: "low|med",
+      },
+    ];
+
+    const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
+
+    expect(result).toContain("pipe\\|profile");
+    expect(result).toContain("claude\\|2");
+    expect(result).toContain("fast\\|balanced");
+    expect(result).toContain("strength\\|a, strength\\|b");
+    expect(result).toContain("low\\|med");
+    // The row must not contain unescaped pipes beyond the column delimiters
+    const rows = result.split("\n").filter((l) => l.startsWith("| pipe"));
+    expect(rows).toHaveLength(1);
+    // A well-formed row has exactly 6 unescaped pipe chars (column delimiters)
+    const unescapedPipes = (rows[0]!.match(/(?<!\\)\|/g) ?? []).length;
+    expect(unescapedPipes).toBe(6);
+  });
 });

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -149,7 +149,7 @@ describe("agentCapabilityCards — weaknesses and affinity", () => {
       strengths: ["arch"],
     };
     const cards = OneShotPromptBuilder.agentCapabilityCards([bare]);
-    const row = cards.split("\n").find((l) => l.startsWith("| p1 |"));
+    const row = cards.split("\n").find((l: string) => l.startsWith("| p1 |"));
     expect(row).toBeDefined();
     expect(row).toContain("| — | — |");
   });

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -32,8 +32,8 @@ describe("agentCapabilityCards", () => {
     const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
 
     expect(result).toContain("## Agent Profiles");
-    expect(result).toContain("| ID | Agent | Tier | Strengths | Cost |");
-    expect(result).toContain("| profile-a | claude | balanced | fast, reliable | low |");
+    expect(result).toContain("| ID | Agent | Tier | Strengths | Weaknesses | Affinity | Cost |");
+    expect(result).toContain("| profile-a | claude | balanced | fast, reliable | — | — | low |");
   });
 
   it("renders '—' in cost column when costTier is absent", () => {
@@ -47,7 +47,7 @@ describe("agentCapabilityCards", () => {
 
     const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
 
-    expect(result).toContain("| profile-b | claude | fast | cheap | — |");
+    expect(result).toContain("| profile-b | claude | fast | cheap | — | — | — |");
   });
 
   it("renders all rows for multiple profiles", () => {
@@ -68,8 +68,8 @@ describe("agentCapabilityCards", () => {
 
     const result = OneShotPromptBuilder.agentCapabilityCards(profiles);
 
-    expect(result).toContain("| alpha | claude | fast | speed | low |");
-    expect(result).toContain("| beta | claude | powerful | reasoning, accuracy | high |");
+    expect(result).toContain("| alpha | claude | fast | speed | — | — | low |");
+    expect(result).toContain("| beta | claude | powerful | reasoning, accuracy | — | — | high |");
   });
 
   it("escapes pipe characters in cell values to preserve markdown table structure", () => {
@@ -92,9 +92,9 @@ describe("agentCapabilityCards", () => {
     // The row must not contain unescaped pipes beyond the column delimiters
     const rows = result.split("\n").filter((l: string) => l.startsWith("| pipe"));
     expect(rows).toHaveLength(1);
-    // A well-formed row has exactly 6 unescaped pipe chars (column delimiters)
+    // A well-formed row has exactly 8 unescaped pipe chars (column delimiters for 7 columns)
     const unescapedPipes = (rows[0]!.match(/(?<!\\)\|/g) ?? []).length;
-    expect(unescapedPipes).toBe(6);
+    expect(unescapedPipes).toBe(8);
   });
 
   it("neutralizes newlines in cell values to prevent broken table rows", () => {
@@ -117,5 +117,50 @@ describe("agentCapabilityCards", () => {
     // Newlines replaced with spaces
     expect(rows[0]).toContain("handles multi-line strengths");
     expect(rows[0]).toContain("also windows");
+  });
+});
+
+describe("agentCapabilityCards — weaknesses and affinity", () => {
+  const profile: AgentRoutingProfile = {
+    id: "oc-fast",
+    target: { agent: "opencode", model: "fast" as const },
+    strengths: ["general implementation"],
+    weaknesses: ["complex refactors", "TS generics"],
+    affinity: { taskTypes: ["crud"], domains: ["backend"] },
+    costTier: "low" as const,
+  };
+
+  it("renders weaknesses in the card row", () => {
+    const cards = OneShotPromptBuilder.agentCapabilityCards([profile]);
+    expect(cards).toContain("Weaknesses");
+    expect(cards).toContain("complex refactors; TS generics");
+  });
+
+  it("renders affinity taskTypes and domains in the card row", () => {
+    const cards = OneShotPromptBuilder.agentCapabilityCards([profile]);
+    expect(cards).toContain("Affinity");
+    expect(cards).toContain("crud, backend");
+  });
+
+  it("renders em-dash placeholders when weaknesses/affinity are absent", () => {
+    const bare: AgentRoutingProfile = {
+      id: "p1",
+      target: { agent: "claude", model: "powerful" as const },
+      strengths: ["arch"],
+    };
+    const cards = OneShotPromptBuilder.agentCapabilityCards([bare]);
+    const row = cards.split("\n").find((l) => l.startsWith("| p1 |"));
+    expect(row).toBeDefined();
+    expect(row).toContain("| — | — |");
+  });
+});
+
+describe("agentProfileInstruction — ordered rubric", () => {
+  it("carries the ordered elimination procedure", () => {
+    const text = OneShotPromptBuilder.agentProfileInstruction();
+    expect(text).toContain("1. Eliminate any profile whose weaknesses conflict");
+    expect(text).toContain("LOWEST cost");
+    expect(text).toContain("omit `agentProfileId`");
+    expect(text).toContain("never invent");
   });
 });

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentRoutingProfile } from "@/config";
-import { OneShotPromptBuilder } from "@/prompts/builders/one-shot-builder";
+import { OneShotPromptBuilder } from "@/prompts";
 
 describe("agentCapabilityCards", () => {
   it("returns empty string for empty profiles array", () => {

--- a/test/unit/prompts/builders/one-shot-builder.test.ts
+++ b/test/unit/prompts/builders/one-shot-builder.test.ts
@@ -90,7 +90,7 @@ describe("agentCapabilityCards", () => {
     expect(result).toContain("strength\\|a, strength\\|b");
     expect(result).toContain("low\\|med");
     // The row must not contain unescaped pipes beyond the column delimiters
-    const rows = result.split("\n").filter((l) => l.startsWith("| pipe"));
+    const rows = result.split("\n").filter((l: string) => l.startsWith("| pipe"));
     expect(rows).toHaveLength(1);
     // A well-formed row has exactly 6 unescaped pipe chars (column delimiters)
     const unescapedPipes = (rows[0]!.match(/(?<!\\)\|/g) ?? []).length;

--- a/test/unit/routing/routing-core.test.ts
+++ b/test/unit/routing/routing-core.test.ts
@@ -177,17 +177,17 @@ describe("escalateTier", () => {
     ["balanced → powerful", "balanced", { tier: "powerful", agent: undefined }],
     ["powerful → null (max reached)", "powerful", null],
   ] as const)("escalates %s", (_label, from, expected) => {
-    expect(escalateTier(from, defaultTiers)).toEqual(expected);
+    expect(escalateTier({ tier: from }, defaultTiers)).toEqual(expected);
   });
 
   test("explicit 3-tier escalation chain: fast → balanced → powerful → null", () => {
-    let result = escalateTier("fast", defaultTiers);
+    let result = escalateTier({ tier: "fast" }, defaultTiers);
     expect(result?.tier).toBe("balanced");
 
-    result = escalateTier(result!.tier, defaultTiers);
+    result = escalateTier({ tier: result!.tier }, defaultTiers);
     expect(result?.tier).toBe("powerful");
 
-    result = escalateTier(result!.tier, defaultTiers);
+    result = escalateTier({ tier: result!.tier }, defaultTiers);
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

**Part B — Fix dead cross-agent escalation config**
- Added `agent?: string` to `TierConfigSchema` (Zod was silently stripping a field that TypeScript already declared), closing the gap between schema and type
- Changed `escalateTier()` to match by `(tier, agent)` tuple so ladders with repeated tier names (e.g. `opencode@balanced → claude@balanced → claude@powerful`) advance correctly
- Added `hasAgentRungs` guard in `tier-escalation.ts` callers: standard tier orders fall back to tier-name matching, preserving backwards compatibility
- Cross-section `superRefine` on `NaxConfigSchema`: validates that each `tierOrder` rung's `agent` exists in `config.models` and that the tier is defined for that agent

**Part C — Plan-time per-story agent selection**
- New `AgentRoutingProfileSchema` / `AgentRoutingConfigSchema` (with `enabled` toggle) under `config.routing.agents`
- Profile↔ladder binding validation: each profile's `target.{agent, model}` must map to a rung in `tierOrder`
- `decomposeConfigSelector` now includes the `routing` slice so the decompose op sees profiles
- `OneShotPromptBuilder.agentCapabilityCards()` formats profiles into a markdown table for the LLM; `agentProfileInstruction()` instructs the LLM to select a profile per story
- `decomposeOp.build()` injects capability cards + selection instruction when `routing.agents.enabled === true` and profiles are non-empty
- `decomposeOp.parse()` resolves `agentProfileId` → `routing.agent + routing.agentProfileId + routing.profileModelTier`; falls back to `routing.agents.default` when the per-story selection is missing or unknown
- `StoryRouting` gets `initialProfileId?`, `initialAgent?`, `agentProfileId?`, `profileModelTier?`; `PRD` root gets `routingProfile?`
- `decompose-mapper.ts` propagates resolved routing fields to `UserStory`
- `run-setup.ts` warns when a story's `agentProfileId` no longer exists in config, and when `prd.routingProfile` differs from the current `config.routing.agents.default`

## Test Plan
- [ ] `bun run test` — all phases pass (8700+ tests, 0 failures)
- [ ] `bun run typecheck` — clean (both tsconfig.json and tsconfig.contracts.json)
- [ ] New config tests: `test/unit/config/schemas-model.test.ts`, `test/unit/config/schemas-infra.test.ts`, additions to `test/unit/config/schemas.test.ts`
- [ ] New escalation tests: additions to `test/unit/execution/escalation/escalation.test.ts`, fixture fixes in `tier-escalation.test.ts`
- [ ] New prompt tests: `test/unit/prompts/builders/one-shot-builder.test.ts`
- [ ] New operation tests: `test/unit/operations/decompose.test.ts`
- [ ] New lifecycle tests: `test/unit/execution/lifecycle/run-setup.test.ts`
- [ ] New prd mapper tests: `test/unit/prd/decompose-mapper.test.ts`
- [ ] Verify cross-agent ladder: configure `models: { claude: {...}, opencode: {...} }` with `tierOrder: [{ tier: "balanced", agent: "opencode" }, { tier: "balanced", agent: "claude" }, { tier: "powerful", agent: "claude" }]` and confirm escalation advances correctly
- [ ] Verify agent profile selection: add a profile to `config.routing.agents.profiles`, run `nax plan`, confirm the decompose prompt contains the capability cards table and `agentProfileId` instruction