### PR TITLE
feat(routing): plan-time agent selection — ADR-025 Part C

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -56,5 +56,7 @@ export type {
   RunAsSessionOpts,
 } from "./manager-types";
 export { resolveDefaultAgent } from "./utils";
+export { resolveAgentAssignment } from "./shared";
+export type { ResolvedAgentAssignment } from "./shared";
 export { ParseValidationError, makeParseRetryStrategy, makeTieredParseRetryStrategy } from "./retry";
 export type { RetryStrategy, RetryPreset, RetryContext, RetryDecision, TieredInspection } from "./retry";

--- a/src/agents/shared/agent-profile-resolver.ts
+++ b/src/agents/shared/agent-profile-resolver.ts
@@ -1,0 +1,40 @@
+import type { AgentRoutingConfig, AgentRoutingProfile, ModelTier } from "@/config";
+import { getSafeLogger } from "@/logger";
+
+export interface ResolvedAgentAssignment {
+  agent: string;
+  agentProfileId: string;
+  profileModelTier: ModelTier;
+}
+
+export function resolveAgentAssignment(
+  selectedProfileId: string | undefined,
+  agentRouting: AgentRoutingConfig | undefined,
+  storyId: string,
+): ResolvedAgentAssignment | null {
+  if (agentRouting?.enabled !== true) return null;
+
+  const profiles = agentRouting.profiles ?? [];
+  if (profiles.length === 0) return null;
+
+  const defaultProfile = agentRouting.default ? profiles.find((p) => p.id === agentRouting.default) : undefined;
+
+  if (selectedProfileId) {
+    const profile = profiles.find((p) => p.id === selectedProfileId);
+    if (profile) return toAssignment(profile);
+
+    getSafeLogger()?.warn(
+      "routing",
+      `Story ${storyId} selected unknown agent profile "${selectedProfileId}" — falling back to ${
+        defaultProfile ? `default profile "${defaultProfile.id}"` : "no profile"
+      }`,
+      { storyId, agentProfileId: selectedProfileId },
+    );
+  }
+
+  return defaultProfile ? toAssignment(defaultProfile) : null;
+}
+
+function toAssignment(p: AgentRoutingProfile): ResolvedAgentAssignment {
+  return { agent: p.target.agent, agentProfileId: p.id, profileModelTier: p.target.model };
+}

--- a/src/agents/shared/index.ts
+++ b/src/agents/shared/index.ts
@@ -1,0 +1,1 @@
+export { resolveAgentAssignment, type ResolvedAgentAssignment } from "./agent-profile-resolver";

--- a/src/cli/plan-command.ts
+++ b/src/cli/plan-command.ts
@@ -14,7 +14,7 @@ import { renderManifestSection } from "../debate";
 import { NaxError } from "../errors";
 import { callOp, groundOp, planDraftOp } from "../operations";
 import type { PlanDraftInput } from "../operations";
-import { buildPlanModeContext, createPlanStrategy } from "../plan/strategies";
+import { buildPlanModeContext, createPlanStrategy, finalizePrdRouting } from "../plan/strategies";
 export { assertIsValidPrd, buildPlanComposition } from "../plan/strategies";
 import { buildPackageSummary, buildSourceRootsSection } from "./plan-helpers";
 import { _planDeps, createPlanRuntime } from "./plan-runtime";
@@ -198,13 +198,14 @@ export async function runPlanPipeline(
     });
 
     if (verdict.outcome === "passed") {
-      // Delta C4: record the loader-resolved config profile name (AC 6 sets
-      // config.profile after all merges) so nax run can detect ladder drift.
-      const prdToWrite = {
-        ...verdict.prd,
-        project: projectName,
-        routingProfile: config.profile ?? "default",
-      };
+      // Delta C4 + ADR-025: finalizePrdRouting resolves agentProfileId → agent,
+      // stamps origin fields, and records the loader-resolved config profile name
+      // so nax run can detect ladder drift.
+      const prdToWrite = finalizePrdRouting(
+        { ...verdict.prd, project: projectName },
+        config.routing?.agents,
+        config.profile,
+      );
       await _planDeps.writeFile(outputPath, JSON.stringify(prdToWrite, null, 2));
       logger?.info("plan", "[OK] PRD written via pipeline", { outputPath });
       return outputPath;

--- a/src/cli/plan-decompose.ts
+++ b/src/cli/plan-decompose.ts
@@ -92,8 +92,8 @@ export async function planDecomposeCommand(
     for (let attempt = 0; attempt < maxReplanAttempts; attempt++) {
       if (attempt === 0 && debateDecompEnabled) {
         const decomposeStageConfig = debateStages.decompose as DebateStageConfig;
-        const agentRoutingForDebate = config.routing?.agents;
-        const profilesForDebate = agentRoutingForDebate?.enabled === true ? (agentRoutingForDebate.profiles ?? []) : [];
+        // ADR-025: decompose inherits the parent's agent; it does not re-select.
+        const profilesForDebate: never[] = [];
         const prompt = await buildDecomposePromptAsync({
           specContent: "",
           codebaseContext,
@@ -195,6 +195,8 @@ export async function planDecomposeCommand(
     decompStories!,
     options.storyId,
     targetStory.workdir,
+    // ADR-025: sub-stories inherit the parent story's agent assignment, not re-selected
+    targetStory.routing,
   );
 
   const updatedStories = prd.userStories.map((s) =>

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -23,7 +23,7 @@ export const reviewConfigSelector = pickSelector(
   "quality",
   "agent",
 );
-export const planConfigSelector = pickSelector("plan", "plan", "debate", "agent", "project");
+export const planConfigSelector = pickSelector("plan", "plan", "debate", "agent", "project", "routing");
 export const decomposeConfigSelector = pickSelector("decompose", "plan", "agent", "routing");
 export const rectifyConfigSelector = pickSelector("rectify", "execution");
 export const acceptanceConfigSelector = pickSelector("acceptance", "acceptance");

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -33,6 +33,7 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
   model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.decomposeTimeoutSeconds ?? ctx.config.plan.timeoutSeconds ?? 600) * 1000,
   build(input, ctx) {
+    // ADR-025: decompose inherits the parent's agent assignment; capability cards are not injected.
     const agentRouting = ctx.config.routing?.agents;
     const profiles = agentRouting?.enabled === true ? (agentRouting.profiles ?? []) : [];
     const prompt = buildDecomposePromptSync({
@@ -49,59 +50,9 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
       task: { id: "task", content: prompt, overridable: false },
     };
   },
-  parse(output, _input, ctx) {
-    const stories = parseDecomposeOutput(output);
-
-    const agentRouting = ctx.config.routing?.agents;
-    if (agentRouting?.enabled !== true) {
-      return stories;
-    }
-
-    const profiles = agentRouting.profiles ?? [];
-    if (profiles.length === 0) {
-      return stories;
-    }
-
-    const defaultProfile = agentRouting.default ? profiles.find((p) => p.id === agentRouting.default) : undefined;
-
-    return stories.map((story) => {
-      if (story.agentProfileId) {
-        const profile = profiles.find((p) => p.id === story.agentProfileId);
-        if (profile) {
-          return {
-            ...story,
-            routing: {
-              ...story.routing,
-              agent: profile.target.agent,
-              agentProfileId: profile.id,
-              profileModelTier: profile.target.model,
-            },
-          };
-        }
-        // Delta C3: never invent an agent — warn and fall through to the default profile.
-        _decomposeOpDeps
-          .getSafeLogger()
-          ?.warn(
-            "decompose",
-            `Story ${story.id} selected unknown agent profile "${story.agentProfileId}" — falling back to ${defaultProfile ? `default profile "${defaultProfile.id}"` : "no profile"}`,
-            { storyId: story.id, agentProfileId: story.agentProfileId },
-          );
-      }
-
-      // No valid per-story selection — apply default profile if configured
-      if (defaultProfile) {
-        return {
-          ...story,
-          routing: {
-            ...story.routing,
-            agent: defaultProfile.target.agent,
-            agentProfileId: defaultProfile.id,
-            profileModelTier: defaultProfile.target.model,
-          },
-        };
-      }
-
-      return story;
-    });
+  parse(output, _input, _ctx) {
+    // ADR-025: agent assignment is not re-selected here — the decompose command
+    // passes parentRouting directly to mapDecomposedStoriesToUserStories for inheritance.
+    return parseDecomposeOutput(output);
   },
 };

--- a/src/operations/plan-draft.ts
+++ b/src/operations/plan-draft.ts
@@ -181,8 +181,10 @@ export const planDraftOp: RunOperation<PlanDraftInput, PlanDraftOutput, PlanConf
   model: (_input, ctx) => ctx.config.plan?.model ?? "fast",
   timeoutMs: (_input, ctx) => (ctx.config.plan?.timeoutSeconds ?? 600) * 1000,
   retry: (input: PlanDraftInput) => createDraftRetryStrategy(input.citationThreshold),
-  build(input, _ctx) {
-    return new PlanPromptBuilder().buildDraft(input);
+  build(input, ctx) {
+    const agentRouting = ctx.config.routing?.agents;
+    const profiles = agentRouting?.enabled === true ? (agentRouting.profiles ?? []) : [];
+    return new PlanPromptBuilder().buildDraft({ ...input, profiles });
   },
   parse(output, input, _ctx) {
     return parsePlanDraft(output, input);

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -324,7 +324,9 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
       },
     }),
   fileOutput: (input) => input.outputPath,
-  build(input, _ctx) {
+  build(input, ctx) {
+    const agentRouting = ctx.config.routing?.agents;
+    const profiles = agentRouting?.enabled === true ? (agentRouting.profiles ?? []) : [];
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(
       input.specContent,
       input.codebaseContext,
@@ -332,6 +334,8 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
       input.packages,
       input.packageDetails,
       input.projectProfile,
+      undefined,
+      profiles,
     );
     return {
       role: { id: "role", content: "", overridable: false },

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -51,7 +51,9 @@ export const planInteractiveOp: RunOperation<PlanInteractiveInput, PRD, PlanConf
     // Disk recovery is handled by op.recover. See issue #993 and retry-strategy.md
     // "Strict-parser interaction".
   }),
-  build(input, _ctx) {
+  build(input, ctx) {
+    const agentRouting = ctx.config.routing?.agents;
+    const profiles = agentRouting?.enabled === true ? (agentRouting.profiles ?? []) : [];
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(
       input.specContent,
       input.codebaseContext,
@@ -59,6 +61,8 @@ export const planInteractiveOp: RunOperation<PlanInteractiveInput, PRD, PlanConf
       input.packages,
       input.packageDetails,
       input.projectProfile,
+      undefined,
+      profiles,
     );
     return {
       role: { id: "role", content: "", overridable: false },

--- a/src/plan/index.ts
+++ b/src/plan/index.ts
@@ -11,6 +11,7 @@ export {
   buildPlanComposition,
   buildPlanModeContext,
   createPlanStrategy,
+  finalizePrdRouting,
   writeOrRecoverPrd,
 } from "./strategies";
 export { runPlanCritic } from "./critic";

--- a/src/plan/strategies/context-builder.ts
+++ b/src/plan/strategies/context-builder.ts
@@ -65,6 +65,7 @@ export async function buildPlanModeContext(
   const branchName = options.branch ?? `feat/${options.feature}`;
   const timeoutSeconds = fullConfig?.plan?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
   const config = planConfigSelector.select(fullConfig);
+  const profileName = typeof fullConfig?.profile === "string" && fullConfig.profile ? fullConfig.profile : undefined;
   const runtime = createPlanRuntime(fullConfig, workdir, options.feature);
   const interactionChain = fullConfig ? await deps.initInteractionChain(fullConfig, !process.stdin.isTTY) : null;
   let configuredBridge: ReturnType<typeof buildInteractionBridge> | undefined;
@@ -94,6 +95,7 @@ export async function buildPlanModeContext(
     branchName,
     timeoutSeconds,
     config,
+    profileName,
     options,
     runtime,
     interactionChain,

--- a/src/plan/strategies/debate.ts
+++ b/src/plan/strategies/debate.ts
@@ -22,6 +22,8 @@ export class DebatePlanStrategy implements IPlanStrategy {
   readonly mode = "debate" as const;
 
   async execute(ctx: PlanModeContext): Promise<string> {
+    const agentRouting = ctx.config.routing?.agents;
+    const profiles = agentRouting?.enabled === true ? (agentRouting.profiles ?? []) : [];
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(
       ctx.specContent,
       ctx.codebaseContext,
@@ -29,6 +31,8 @@ export class DebatePlanStrategy implements IPlanStrategy {
       ctx.relativePackages,
       ctx.packageDetails,
       ctx.config.project,
+      undefined,
+      profiles,
     );
     const planStage = ctx.config.debate?.stages?.plan;
     if (!planStage) {

--- a/src/plan/strategies/finalize-routing.ts
+++ b/src/plan/strategies/finalize-routing.ts
@@ -1,0 +1,34 @@
+import { resolveAgentAssignment } from "@/agents";
+import type { AgentRoutingConfig } from "@/config";
+import type { PRD, StoryRouting } from "@/prd/types";
+
+/**
+ * Mode-agnostic post-step that resolves each story's agentProfileId to a
+ * concrete agent + tier, stamps origin fields (initialAgent / initialProfileId),
+ * and records the config-profile name at PRD root.
+ *
+ * Pure function — never mutates the input PRD.
+ */
+export function finalizePrdRouting(
+  prd: PRD,
+  agentRouting: AgentRoutingConfig | undefined,
+  profileName: string | undefined,
+): PRD {
+  const userStories = prd.userStories.map((story) => {
+    const assignment = resolveAgentAssignment(story.routing?.agentProfileId, agentRouting, story.id);
+    if (!assignment) return story;
+    // story.routing is guaranteed to be defined if assignment resolved (routing
+    // has complexity required by StoryRouting); cast to satisfy TypeScript.
+    const routing = {
+      ...story.routing,
+      agent: assignment.agent,
+      agentProfileId: assignment.agentProfileId,
+      profileModelTier: assignment.profileModelTier,
+      initialAgent: story.routing?.initialAgent ?? assignment.agent,
+      initialProfileId: story.routing?.initialProfileId ?? assignment.agentProfileId,
+    } as StoryRouting;
+    return { ...story, routing };
+  });
+
+  return { ...prd, userStories, routingProfile: profileName ?? "default" };
+}

--- a/src/plan/strategies/index.ts
+++ b/src/plan/strategies/index.ts
@@ -8,3 +8,4 @@ export { PipelinePlanStrategy, _pipelinePlanDeps } from "./pipeline";
 export { DebatePlanStrategy, _debatePlanDeps } from "./debate";
 export { RefinePlanStrategy, _refinePlanDeps } from "./refine";
 export { buildPlanComposition } from "./debate-composition";
+export { finalizePrdRouting } from "./finalize-routing";

--- a/src/plan/strategies/pipeline.ts
+++ b/src/plan/strategies/pipeline.ts
@@ -4,6 +4,7 @@ import { NaxError } from "@/errors";
 import { callOp, groundOp, planDraftOp } from "@/operations";
 import type { CallContext, PlanDraftInput } from "@/operations";
 import { runPlanCritic } from "../critic";
+import { finalizePrdRouting } from "./finalize-routing";
 import type { IPlanStrategy, PlanModeContext } from "./types";
 
 export const _pipelinePlanDeps = {
@@ -84,7 +85,12 @@ export class PipelinePlanStrategy implements IPlanStrategy {
         );
       }
 
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...verdict.prd, project: ctx.projectName }, null, 2));
+      const prdToWrite = finalizePrdRouting(
+        { ...verdict.prd, project: ctx.projectName },
+        ctx.config.routing?.agents,
+        ctx.profileName,
+      );
+      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(prdToWrite, null, 2));
       return ctx.outputPath;
     } finally {
       await ctx.runtime.close().catch(() => {});

--- a/src/plan/strategies/single.ts
+++ b/src/plan/strategies/single.ts
@@ -2,6 +2,7 @@ import { callOp, planInteractiveOp } from "@/operations";
 import type { PlanInteractiveInput } from "@/operations";
 import { validatePlanOutput } from "@/prd";
 import { assertIsValidPrd } from "./assert";
+import { finalizePrdRouting } from "./finalize-routing";
 import type { IPlanStrategy, PlanModeContext } from "./types";
 
 export const _singlePlanDeps = {
@@ -38,16 +39,23 @@ export class SinglePlanStrategy implements IPlanStrategy {
         } satisfies PlanInteractiveInput,
       );
       assertIsValidPrd(prd);
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...prd, project: ctx.projectName }, null, 2));
+      const finalized = finalizePrdRouting(
+        { ...prd, project: ctx.projectName },
+        ctx.config.routing?.agents,
+        ctx.profileName,
+      );
+      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
       return ctx.outputPath;
     } catch (err) {
       if (ctx.deps.existsSync(ctx.outputPath)) {
         const rawContent = await ctx.deps.readFile(ctx.outputPath);
         const recoveredPrd = validatePlanOutput(rawContent, ctx.options.feature, ctx.branchName);
-        await ctx.deps.writeFile(
-          ctx.outputPath,
-          JSON.stringify({ ...recoveredPrd, project: ctx.projectName }, null, 2),
+        const finalizedRecovered = finalizePrdRouting(
+          { ...recoveredPrd, project: ctx.projectName },
+          ctx.config.routing?.agents,
+          ctx.profileName,
         );
+        await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalizedRecovered, null, 2));
         return ctx.outputPath;
       }
       throw err;

--- a/src/plan/strategies/types.ts
+++ b/src/plan/strategies/types.ts
@@ -43,6 +43,8 @@ export interface PlanModeContext {
   readonly branchName: string;
   readonly timeoutSeconds: number;
   readonly config: PlanConfig;
+  /** Config-profile name recorded on the PRD root for run-side drift detection. */
+  readonly profileName: string | undefined;
   readonly options: PlanCommandOptions;
   readonly runtime: NaxRuntime;
   readonly interactionChain: InteractionChain | null;

--- a/src/plan/strategies/write-prd.ts
+++ b/src/plan/strategies/write-prd.ts
@@ -1,6 +1,7 @@
 import { NaxError } from "@/errors";
 import { validatePlanOutput } from "@/prd";
 import type { PRD } from "@/prd/types";
+import { finalizePrdRouting } from "./finalize-routing";
 import type { PlanModeContext } from "./types";
 
 export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, err?: unknown): Promise<string> {
@@ -26,13 +27,23 @@ export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, e
 
   if (prd !== null) {
     if (Array.isArray((prd as { userStories?: unknown }).userStories)) {
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...prd, project: ctx.projectName }, null, 2));
+      const finalized = finalizePrdRouting(
+        { ...prd, project: ctx.projectName },
+        ctx.config.routing?.agents,
+        ctx.profileName,
+      );
+      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
       return ctx.outputPath;
     }
 
     const normalizedPrd = tryExtractPrd(prd);
     if (normalizedPrd !== null) {
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...normalizedPrd, project: ctx.projectName }, null, 2));
+      const finalized = finalizePrdRouting(
+        { ...normalizedPrd, project: ctx.projectName },
+        ctx.config.routing?.agents,
+        ctx.profileName,
+      );
+      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
       return ctx.outputPath;
     }
   }
@@ -54,7 +65,12 @@ export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, e
       }
     }
     recoveredPrd = recoveredPrd ?? validatePlanOutput(rawContent, ctx.options.feature, ctx.branchName);
-    await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...recoveredPrd, project: ctx.projectName }, null, 2));
+    const finalized = finalizePrdRouting(
+      { ...recoveredPrd, project: ctx.projectName },
+      ctx.config.routing?.agents,
+      ctx.profileName,
+    );
+    await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
     return ctx.outputPath;
   } catch {
     throw err;

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -8,7 +8,7 @@
 import type { DecomposedStory } from "../agents/shared/types-extended";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
-import type { UserStory } from "./types";
+import type { StoryRouting, UserStory } from "./types";
 
 /**
  * Maps an array of DecomposedStory objects to UserStory objects.
@@ -21,6 +21,7 @@ import type { UserStory } from "./types";
  * @param stories - Flat decompose output from adapter
  * @param parentStoryId - ID of the parent story being decomposed
  * @param parentWorkdir - workdir of the parent story (inherited by all sub-stories)
+ * @param parentRouting - Agent assignment from the parent story (ADR-025: decompose inherits, not re-selects)
  * @returns Mapped UserStory array ready for PRD insertion
  * @throws {NaxError} code=DECOMPOSE_VALIDATION_FAILED when required fields are missing
  */
@@ -28,6 +29,10 @@ export function mapDecomposedStoriesToUserStories(
   stories: DecomposedStory[],
   parentStoryId: string,
   parentWorkdir?: string,
+  parentRouting?: Pick<
+    StoryRouting,
+    "agent" | "agentProfileId" | "profileModelTier" | "initialAgent" | "initialProfileId"
+  >,
 ): UserStory[] {
   return stories.map((story, entryIndex) => {
     if (!story.id) {
@@ -68,10 +73,17 @@ export function mapDecomposedStoriesToUserStories(
         complexity: story.complexity,
         testStrategy: story.testStrategy ?? ("test-after" as const),
         reasoning: story.reasoning,
-        modelTier: story.routing?.profileModelTier ?? ("balanced" as const),
-        ...(story.routing?.agent !== undefined && { agent: story.routing.agent }),
-        ...(story.routing?.agentProfileId !== undefined && { agentProfileId: story.routing.agentProfileId }),
-        ...(story.routing?.profileModelTier !== undefined && { profileModelTier: story.routing.profileModelTier }),
+        modelTier: parentRouting?.profileModelTier ?? story.routing?.profileModelTier ?? ("balanced" as const),
+        // ADR-025: decompose inherits the parent's agent assignment; it does not re-select.
+        ...(parentRouting?.agent !== undefined && { agent: parentRouting.agent }),
+        ...(parentRouting?.agentProfileId !== undefined && { agentProfileId: parentRouting.agentProfileId }),
+        ...(parentRouting?.profileModelTier !== undefined && { profileModelTier: parentRouting.profileModelTier }),
+        ...(parentRouting?.agent !== undefined && {
+          initialAgent: parentRouting.initialAgent ?? parentRouting.agent,
+        }),
+        ...(parentRouting?.agentProfileId !== undefined && {
+          initialProfileId: parentRouting.initialProfileId ?? parentRouting.agentProfileId,
+        }),
       },
     };
   });

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -74,7 +74,13 @@ export function mapDecomposedStoriesToUserStories(
         testStrategy: story.testStrategy ?? ("test-after" as const),
         reasoning: story.reasoning,
         modelTier: parentRouting?.profileModelTier ?? story.routing?.profileModelTier ?? ("balanced" as const),
-        // ADR-025: decompose inherits the parent's agent assignment; it does not re-select.
+        // Carry story.routing fields as baseline (preserves pre-ADR-025 behaviour for callers
+        // that still populate routing on the DecomposedStory, e.g. routing-profile-tier stage).
+        ...(story.routing?.agent !== undefined && { agent: story.routing.agent }),
+        ...(story.routing?.agentProfileId !== undefined && { agentProfileId: story.routing.agentProfileId }),
+        ...(story.routing?.profileModelTier !== undefined && { profileModelTier: story.routing.profileModelTier }),
+        // ADR-025: parentRouting overrides story.routing fields when the parent story has an
+        // assignment (decompose inherits, not re-selects).
         ...(parentRouting?.agent !== undefined && { agent: parentRouting.agent }),
         ...(parentRouting?.agentProfileId !== undefined && { agentProfileId: parentRouting.agentProfileId }),
         ...(parentRouting?.profileModelTier !== undefined && { profileModelTier: parentRouting.profileModelTier }),

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -296,6 +296,9 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
           ? routing.reasoning.trim()
           : "validated from LLM output",
       ...(noTestJustification !== undefined ? { noTestJustification } : {}),
+      ...(typeof routing.agentProfileId === "string" && routing.agentProfileId.trim().length > 0
+        ? { agentProfileId: routing.agentProfileId.trim() }
+        : {}),
     },
     ...(workdir !== undefined ? { workdir } : {}),
     ...(contextFiles.length > 0 ? { contextFiles } : {}),

--- a/src/prompts/builders/plan-builder.ts
+++ b/src/prompts/builders/plan-builder.ts
@@ -11,7 +11,7 @@
  * Instantiation cost is negligible; builders are short-lived call-and-discard.
  */
 
-import type { ProjectProfile } from "@/config";
+import type { AgentRoutingProfile, ProjectProfile } from "@/config";
 import {
   COMPLEXITY_GUIDE,
   DESCRIPTION_QUALITY_RULES,
@@ -21,6 +21,7 @@ import {
   getAcQualityRules,
 } from "@/config";
 import type { ComposeInput } from "../compose";
+import { OneShotPromptBuilder } from "./one-shot-builder";
 
 // ─── Shared rule injection ────────────────────────────────────────────────────
 
@@ -84,6 +85,8 @@ export interface PlanDraftBuildInput {
   readonly packageDetails?: readonly PackageSummary[];
   /** Optional project profile for language- and project-type-aware AC examples. */
   readonly projectProfile?: ProjectProfile;
+  /** Optional agent routing profiles — when present, injects capability cards and agentProfileId schema field. */
+  readonly profiles?: AgentRoutingProfile[];
 }
 
 /** Compact per-package summary for the planning prompt. */
@@ -285,7 +288,12 @@ Do not output the PRD in chat. After writing the file, reply with a brief text c
     packageDetails?: PackageSummary[],
     projectProfile?: ProjectProfile,
     proposers?: { fileReadAccess?: boolean; fileReadBudget?: number },
+    profiles?: AgentRoutingProfile[],
   ): PlanningPromptParts {
+    const cards = OneShotPromptBuilder.agentCapabilityCards(profiles ?? []);
+    const agentProfilesSection =
+      cards.length > 0 ? `\n\n${cards}\n\n${OneShotPromptBuilder.agentProfileInstruction()}` : "";
+
     const isMonorepo = packages && packages.length > 0;
     const packageDetailsSection =
       packageDetails && packageDetails.length > 0 ? buildPackageDetailsSection(packageDetails) : "";
@@ -339,7 +347,7 @@ ${buildSharedQualityRules(specContent, projectProfile)}
 
 For each story, set "contextFiles" to the key source files the agent should read before implementing (max 5 per story). Use your Step 2 analysis to identify the most relevant files. Leave empty for greenfield stories with no existing files to reference. Set "expectedFiles" to the NEW files the story creates.
 
-${CONTEXT_VS_EXPECTED_FILES_RULE}`;
+${CONTEXT_VS_EXPECTED_FILES_RULE}${agentProfilesSection}`;
 
     const suggestedCriteriaField = specContent.trim()
       ? `\n      "suggestedCriteria": ["string — optional. Behavioral edge cases or negative paths you identified that are NOT in the spec. Plain assertions only — observable outputs, return values, state changes, or error conditions. No implementation details or vague descriptions. Omit this field if empty."],`
@@ -376,7 +384,7 @@ Generate a JSON object with this exact structure (no markdown, no explanation �
         "complexity": "simple | medium | complex | expert",
         "testStrategy": "no-test | tdd-simple | three-session-tdd-lite | three-session-tdd | test-after",
         "noTestJustification": "string — REQUIRED when testStrategy is no-test, explains why tests are unnecessary",
-        "reasoning": "string — brief classification rationale"
+        "reasoning": "string — brief classification rationale"${cards.length > 0 ? `,\n        "agentProfileId": "string — optional, the id of the best-matching profile from the Agent Profiles table above; omit if none fits"` : ""}
       },
       "escalations": [],
       "attempts": 0
@@ -401,6 +409,10 @@ ${outputDirective}`;
         "You are a senior software architect generating a product requirements document (PRD) as JSON. Your intent is to produce a thorough, evidence-grounded plan.",
       overridable: false,
     };
+
+    const cards = OneShotPromptBuilder.agentCapabilityCards(input.profiles ?? []);
+    const agentProfilesSection =
+      cards.length > 0 ? `\n\n${cards}\n\n${OneShotPromptBuilder.agentProfileInstruction()}` : "";
 
     const revisionSection =
       input.revisionFindings && input.revisionFindings.length > 0
@@ -456,7 +468,7 @@ ${buildSharedQualityRules(input.specContent, input.projectProfile)}
 
 For each story, set "contextFiles" to the key source files the implementer should read before starting (max 5 per story). Cite manifest factIds where relevant. Set "expectedFiles" to the NEW files the story creates.
 
-${CONTEXT_VS_EXPECTED_FILES_RULE}
+${CONTEXT_VS_EXPECTED_FILES_RULE}${agentProfilesSection}
 
 ## Output Schema
 
@@ -479,7 +491,7 @@ Produce a JSON object with this exact structure. Field names are mandatory — d
       "routing": {
         "complexity": "simple | medium | complex | expert",
         "testStrategy": "no-test | tdd-simple | three-session-tdd-lite | three-session-tdd | test-after",
-        "reasoning": "string — brief classification rationale"
+        "reasoning": "string — brief classification rationale"${cards.length > 0 ? `,\n        "agentProfileId": "string — optional, the id of the best-matching profile from the Agent Profiles table above; omit if none fits"` : ""}
       }
     }
   ]

--- a/test/integration/cli/plan-agent-selection.test.ts
+++ b/test/integration/cli/plan-agent-selection.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Integration test — plan-time agent selection (ADR-025 Part C)
+ *
+ * AC: When the plan agent emits `routing.agentProfileId` for a story, the
+ * written prd.json must have:
+ *   - userStories[0].routing.agent  resolved from the matching profile target
+ *   - userStories[0].routing.agentProfileId  preserved
+ *   - routingProfile  set to the config.profile value
+ *
+ * Uses the established `_planDeps` injection pattern from plan-callop.test.ts
+ * and plan-prd-preservation.test.ts. The agent is stubbed via `_planDeps.createRuntime`
+ * so no real LLM calls are made.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { _planDeps, planCommand } from "@/cli";
+import type { PRD } from "@/prd/types";
+import { cleanupTempDir, makeMockAgentManager, makeMockRuntime, makeNaxConfig, makeTempDir } from "@test/helpers";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SAMPLE_SPEC = `# Feature: plan-agent-selection
+## Problem
+Implement plan-time agent selection.
+## Acceptance Criteria
+- AC-1: The plan emits agentProfileId
+`;
+
+/**
+ * Minimal PRD that the stubbed agent "writes" via its output.
+ * Story US-001 has routing.agentProfileId = "claude-final" so finalizePrdRouting
+ * should resolve that to agent "claude" (matched from the config profiles below).
+ */
+const SAMPLE_PRD_WITH_PROFILE_ID: PRD = {
+  project: "test-project",
+  feature: "plan-agent-selection",
+  branchName: "feat/plan-agent-selection",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  userStories: [
+    {
+      id: "US-001",
+      title: "Emit agentProfileId",
+      description: "Plan agent emits agentProfileId for routing",
+      acceptanceCriteria: ["AC-1: agentProfileId written to prd.json"],
+      tags: ["feature"],
+      dependencies: [],
+      status: "pending",
+      passes: false,
+      escalations: [],
+      attempts: 0,
+      routing: {
+        complexity: "medium",
+        testStrategy: "test-after",
+        reasoning: "Core routing feature",
+        agentProfileId: "claude-final",
+      },
+    },
+  ],
+};
+
+/**
+ * Config with two agent profiles:
+ *   "opencode-structural" → opencode / fast
+ *   "claude-final"        → claude / balanced
+ *
+ * profile = "cross-agent" so routingProfile in the output should be "cross-agent".
+ *
+ * Uses makeNaxConfig so DEFAULT_CONFIG supplies all required fields (plan.model,
+ * plan.outputPath, etc.) before our overrides are applied.
+ */
+const CONFIG = makeNaxConfig({
+  plan: { mode: "single" },
+  profile: "cross-agent",
+  routing: {
+    strategy: "keyword",
+    agents: {
+      enabled: true,
+      strategy: "off",
+      default: "claude-final",
+      profiles: [
+        {
+          id: "opencode-structural",
+          target: { agent: "opencode", model: "fast" },
+          strengths: ["structural refactoring"],
+        },
+        {
+          id: "claude-final",
+          target: { agent: "claude", model: "balanced" },
+          strengths: ["complex reasoning"],
+        },
+      ],
+    },
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved originals — restored unconditionally in afterEach
+// ─────────────────────────────────────────────────────────────────────────────
+
+const origReadFile = _planDeps.readFile;
+const origWriteFile = _planDeps.writeFile;
+const origScanSourceRoots = _planDeps.scanSourceRoots;
+const origCreateRuntime = _planDeps.createRuntime;
+const origReadPackageJson = _planDeps.readPackageJson;
+const origReadPackageJsonAt = _planDeps.readPackageJsonAt;
+const origSpawnSync = _planDeps.spawnSync;
+const origMkdirp = _planDeps.mkdirp;
+const origExistsSync = _planDeps.existsSync;
+const origInitInteractionChain = _planDeps.initInteractionChain;
+const origCreateInteractionBridge = _planDeps.createInteractionBridge;
+const origDiscoverWorkspacePackages = _planDeps.discoverWorkspacePackages;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("planCommand — plan-time agent selection (ADR-025 Part C)", () => {
+  let tmpDir: string;
+  let outputPath: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("nax-plan-agent-sel-");
+    const featureDir = join(tmpDir, ".nax", "features", "plan-agent-selection");
+    outputPath = join(featureDir, "prd.json");
+
+    await mkdir(join(tmpDir, ".nax"), { recursive: true });
+    await mkdir(featureDir, { recursive: true });
+
+    // Stub readFile: return spec for the spec path; PRD JSON for prd.json path.
+    _planDeps.readFile = mock(async (path: string) => {
+      if (path.endsWith("prd.json")) return JSON.stringify(SAMPLE_PRD_WITH_PROFILE_ID);
+      return SAMPLE_SPEC;
+    });
+
+    // Stub writeFile: write to real disk so we can read it back in assertions.
+    _planDeps.writeFile = mock(async (path: string, content: string) => {
+      await Bun.write(path, content);
+    });
+
+    _planDeps.existsSync = mock((path: string) => path === join(tmpDir, ".nax"));
+
+    _planDeps.scanSourceRoots = mock(async () => []);
+    _planDeps.readPackageJson = mock(async () => ({ name: "test-project" }));
+    _planDeps.readPackageJsonAt = mock(async () => ({}));
+
+    _planDeps.spawnSync = mock(() => ({
+      stdout: Buffer.from(""),
+      exitCode: 1,
+    }));
+
+    _planDeps.mkdirp = mock(async () => {});
+    _planDeps.discoverWorkspacePackages = mock(async () => []);
+    _planDeps.initInteractionChain = mock(async () => null);
+    _planDeps.createInteractionBridge = mock(() => ({
+      detectQuestion: mock(async () => false),
+      onQuestionDetected: mock(async () => ""),
+    }));
+
+    // Stub createRuntime: return a mock runtime whose agent emits the PRD JSON
+    // containing routing.agentProfileId = "claude-final".
+    _planDeps.createRuntime = mock(() =>
+      makeMockRuntime({
+        agentManager: makeMockAgentManager({
+          runWithFallbackFn: async () => ({
+            result: {
+              success: true,
+              exitCode: 0,
+              output: JSON.stringify(SAMPLE_PRD_WITH_PROFILE_ID),
+              rateLimited: false,
+              durationMs: 1,
+              estimatedCostUsd: 0,
+              agentFallbacks: [],
+            },
+            fallbacks: [],
+          }),
+        }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    mock.restore();
+    _planDeps.readFile = origReadFile;
+    _planDeps.writeFile = origWriteFile;
+    _planDeps.scanSourceRoots = origScanSourceRoots;
+    _planDeps.createRuntime = origCreateRuntime;
+    _planDeps.readPackageJson = origReadPackageJson;
+    _planDeps.readPackageJsonAt = origReadPackageJsonAt;
+    _planDeps.spawnSync = origSpawnSync;
+    _planDeps.mkdirp = origMkdirp;
+    _planDeps.existsSync = origExistsSync;
+    _planDeps.initInteractionChain = origInitInteractionChain;
+    _planDeps.createInteractionBridge = origCreateInteractionBridge;
+    _planDeps.discoverWorkspacePackages = origDiscoverWorkspacePackages;
+    cleanupTempDir(tmpDir);
+  });
+
+  test("resolves agentProfileId to agent and stamps routingProfile in written prd.json", async () => {
+    const specPath = join(tmpDir, "spec.md");
+    await Bun.write(specPath, SAMPLE_SPEC);
+
+    const result = await planCommand(tmpDir, CONFIG, {
+      from: specPath,
+      feature: "plan-agent-selection",
+    });
+
+    // planCommand must return the prd.json path
+    expect(result).toContain("prd.json");
+    expect(result).toContain("plan-agent-selection");
+
+    // Read the written prd.json from disk
+    const written = await Bun.file(outputPath).text();
+    const prd = JSON.parse(written) as PRD;
+
+    // AC: agentProfileId resolved to agent "claude" (from "claude-final" profile target)
+    expect(prd.userStories[0].routing?.agent).toBe("claude");
+
+    // AC: agentProfileId preserved on the story
+    expect(prd.userStories[0].routing?.agentProfileId).toBe("claude-final");
+
+    // AC: routingProfile stamped from config.profile = "cross-agent"
+    expect(prd.routingProfile).toBe("cross-agent");
+  });
+});

--- a/test/unit/agents/shared/agent-profile-resolver.test.ts
+++ b/test/unit/agents/shared/agent-profile-resolver.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { resolveAgentAssignment } from "@/agents";
+import type { AgentRoutingConfig } from "@/config";
+
+const routing: AgentRoutingConfig = {
+  enabled: true,
+  strategy: "off",
+  default: "opencode-structural",
+  profiles: [
+    { id: "opencode-structural", target: { agent: "opencode", model: "fast" }, strengths: ["mechanical"] },
+    { id: "claude-final", target: { agent: "claude", model: "balanced" }, strengths: ["design"] },
+  ],
+};
+
+describe("resolveAgentAssignment", () => {
+  test("resolves a known profile id to its target agent + tier", () => {
+    expect(resolveAgentAssignment("claude-final", routing, "US-001")).toEqual({
+      agent: "claude",
+      agentProfileId: "claude-final",
+      profileModelTier: "balanced",
+    });
+  });
+
+  test("falls back to the default profile for an unknown id (never invents an agent)", () => {
+    expect(resolveAgentAssignment("does-not-exist", routing, "US-001")).toEqual({
+      agent: "opencode",
+      agentProfileId: "opencode-structural",
+      profileModelTier: "fast",
+    });
+  });
+
+  test("falls back to the default profile when no id is selected", () => {
+    expect(resolveAgentAssignment(undefined, routing, "US-001")).toEqual({
+      agent: "opencode",
+      agentProfileId: "opencode-structural",
+      profileModelTier: "fast",
+    });
+  });
+
+  test("returns null when routing is disabled", () => {
+    expect(resolveAgentAssignment("claude-final", { ...routing, enabled: false }, "US-001")).toBeNull();
+  });
+
+  test("returns null when no profiles exist", () => {
+    expect(resolveAgentAssignment("x", { ...routing, profiles: [], default: undefined }, "US-001")).toBeNull();
+  });
+
+  test("returns null for unknown id when no default is configured", () => {
+    expect(resolveAgentAssignment("x", { ...routing, default: undefined }, "US-001")).toBeNull();
+  });
+
+  test("returns null for undefined agentRouting", () => {
+    expect(resolveAgentAssignment("claude-final", undefined, "US-001")).toBeNull();
+  });
+});

--- a/test/unit/config/selectors.test.ts
+++ b/test/unit/config/selectors.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect } from "bun:test";
-import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import {
+  DEFAULT_CONFIG,
+  NaxConfigSchema,
   agentManagerConfigSelector,
   contextToolRuntimeConfigSelector,
   debateConfigSelector,
   interactionConfigSelector,
+  planConfigSelector,
   precheckConfigSelector,
   promptLoaderConfigSelector,
   qualityConfigSelector,
@@ -12,8 +14,8 @@ import {
   routingConfigSelector,
   tddConfigSelector,
   testPatternConfigSelector,
-} from "../../../src/config/selectors";
-import type { DebateConfig } from "../../../src/config/selectors";
+} from "@/config";
+import type { DebateConfig } from "@/config/selectors";
 
 describe("ConfigSelector — Phase 1 selectors", () => {
   describe("new selectors", () => {
@@ -198,6 +200,15 @@ describe("ConfigSelector — Phase 1 selectors", () => {
       expect(Object.keys(slice).sort()).toEqual(["context", "project", "prompts"]);
     });
 
+  });
+});
+
+describe("planConfigSelector — ADR-025 routing slice", () => {
+  test("includes routing so plan-time agent selection can read routing.agents", () => {
+    const full = NaxConfigSchema.parse({});
+    const slice = planConfigSelector.select(full);
+    expect(slice.routing).toBeDefined();
+    expect(slice.routing?.agents).toBeDefined();
   });
 });
 

--- a/test/unit/operations/decompose.test.ts
+++ b/test/unit/operations/decompose.test.ts
@@ -146,8 +146,8 @@ describe("decomposeOp — agent capability cards injection", () => {
   });
 });
 
-describe("decomposeOp — parse: agentProfileId resolution", () => {
-  test("AC-T9-3: story without agentProfileId leaves routing unchanged (undefined)", () => {
+describe("decomposeOp — parse: ADR-025 — no agent re-selection, raw output returned", () => {
+  test("AC-T9-3: story without agentProfileId leaves routing undefined (raw output pass-through)", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -162,7 +162,7 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-1: story with unknown/hallucinated agentProfileId leaves routing unchanged, no error", () => {
+  test("AC-T9-1: story with agentProfileId leaves routing unchanged — parse does not resolve profiles", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -192,7 +192,10 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-2: story with valid agentProfileId sets routing.agent, routing.agentProfileId, and routing.profileModelTier", () => {
+  // ADR-025: parse() is now a pure pass-through — it does NOT resolve agentProfileId → routing.agent.
+  // Agent assignment is inherited from the parent story via mapDecomposedStoriesToUserStories(parentRouting).
+
+  test("AC-T9-2: story with valid agentProfileId in LLM output → routing still undefined (no resolution in parse)", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -204,12 +207,11 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
 
     expect(result).toHaveLength(1);
-    expect(result[0].routing?.agent).toBe("opencode");
-    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
-    expect(result[0].routing?.profileModelTier).toBe("fast");
+    // parse() does NOT resolve profiles — routing remains undefined
+    expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-2b: routing.agent and routing.agentProfileId are set per-story independently", () => {
+  test("AC-T9-2b: multiple stories with agentProfileIds → routing is undefined for all (ADR-025)", () => {
     const secondProfile = {
       id: "quality-agent",
       target: { agent: "claude", model: "balanced" as const },
@@ -231,14 +233,13 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
 
     expect(result).toHaveLength(3);
-    expect(result[0].routing?.agent).toBe("opencode");
-    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
-    expect(result[1].routing?.agent).toBe("claude");
-    expect(result[1].routing?.agentProfileId).toBe("quality-agent");
+    // parse() no longer resolves any profile — all routing fields are absent
+    expect(result[0].routing).toBeUndefined();
+    expect(result[1].routing).toBeUndefined();
     expect(result[2].routing).toBeUndefined();
   });
 
-  test("AC-T9-2c: existing routing fields are preserved when profile is matched", () => {
+  test("AC-T9-2c: parse returns raw LLM output — no routing mutation", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -246,17 +247,14 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
       },
     });
 
-    // The LLM may emit extra routing-adjacent fields; parse should not destroy them.
-    // The decomposed story doesn't carry a full routing object — it only carries agentProfileId.
-    // After resolution, routing.agent and routing.agentProfileId are set; others remain absent.
     const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "fast-coder" }]);
     const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
 
-    expect(result[0].routing?.agent).toBe("opencode");
-    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
+    // ADR-025: parse is a pass-through; routing is set downstream via parentRouting
+    expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-1c: when agents.enabled === false, agentProfileId is ignored even if profile exists", () => {
+  test("AC-T9-1c: when agents.enabled === false, agentProfileId is still not resolved (ADR-025 — parse never resolves)", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -270,7 +268,7 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-4: agentProfileId missing + default set → routing resolved from default profile, including profileModelTier", () => {
+  test("AC-T9-4: default profile configured — parse still does not resolve (ADR-025)", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -286,12 +284,11 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
 
     expect(result).toHaveLength(1);
-    expect(result[0].routing?.agent).toBe("opencode");
-    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
-    expect(result[0].routing?.profileModelTier).toBe("fast");
+    // ADR-025: default profile resolution moved to mapper via parentRouting
+    expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-5: agentProfileId unknown/hallucinated + default set → routing resolved from default profile, including profileModelTier", () => {
+  test("AC-T9-5: unknown agentProfileId + default configured — parse is still a pass-through", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -307,12 +304,10 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
 
     expect(result).toHaveLength(1);
-    expect(result[0].routing?.agent).toBe("opencode");
-    expect(result[0].routing?.agentProfileId).toBe("fast-coder");
-    expect(result[0].routing?.profileModelTier).toBe("fast");
+    expect(result[0].routing).toBeUndefined();
   });
 
-  test("AC-T9-6: agentProfileId unknown + no default → routing unchanged (existing behavior preserved)", () => {
+  test("AC-T9-6: agentProfileId unknown + no default → routing undefined (unchanged)", () => {
     const ctx = makeBuildCtx({
       routing: {
         strategy: "keyword",
@@ -330,7 +325,7 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
     expect(result[0].routing).toBeUndefined();
   });
 
-  test("Delta C3: warns with storyId when the LLM emits an unknown agentProfileId", () => {
+  test("ADR-025: parse does not emit any logger warnings for unknown agentProfileId", () => {
     const orig = _decomposeOpDeps.getSafeLogger;
     const warnings: Array<{ message: string; data?: Record<string, unknown> }> = [];
     _decomposeOpDeps.getSafeLogger = () =>
@@ -354,13 +349,10 @@ describe("decomposeOp — parse: agentProfileId resolution", () => {
       });
 
       const output = makeDecomposeOutput([{ id: "US-001", agentProfileId: "hallucinated-id" }]);
-      const result = decomposeOp.parse(output, SAMPLE_INPUT, ctx);
+      decomposeOp.parse(output, SAMPLE_INPUT, ctx);
 
-      const warn = warnings.find(
-        (w) => w.message.includes("hallucinated-id") || w.message.includes("unknown"),
-      );
-      expect(warn).toBeDefined();
-      expect(warn?.data?.storyId).toBe(result[0].id);
+      // parse() is a pass-through — no profile resolution, no warning
+      expect(warnings).toHaveLength(0);
     } finally {
       _decomposeOpDeps.getSafeLogger = orig;
     }

--- a/test/unit/plan/debate-strategy.test.ts
+++ b/test/unit/plan/debate-strategy.test.ts
@@ -163,6 +163,8 @@ describe("DebatePlanStrategy", () => {
       ctx.relativePackages,
       ctx.packageDetails,
       ctx.config.project,
+      undefined,
+      [],
     );
     expect(_debatePlanDeps.buildPlanComposition).toHaveBeenCalledWith(ctx.config.debate.stages.plan);
     expect(createDebateRunnerMock).toHaveBeenCalledTimes(1);

--- a/test/unit/plan/pipeline-strategy.test.ts
+++ b/test/unit/plan/pipeline-strategy.test.ts
@@ -119,6 +119,86 @@ describe("PipelinePlanStrategy", () => {
     expect(strategy.mode).toBe("pipeline");
   });
 
+  test("ADR-025: finalizePrdRouting applied on write — resolves agentProfileId and stamps routingProfile", async () => {
+    const strategy = new PipelinePlanStrategy();
+    let writtenContent = "";
+    const ctx = makeCtx({
+      profileName: "team-a",
+      config: {
+        citationThreshold: 0.55,
+        plan: { citationThreshold: 0.55 },
+        project: { language: "ts" },
+        routing: {
+          agents: {
+            enabled: true,
+            profiles: [{ id: "senior", target: { agent: "claude", model: "powerful" } }],
+          },
+        },
+      } as never,
+      deps: {
+        readFile: async () => "",
+        writeFile: async (_path: string, content: string) => { writtenContent = content; },
+        mkdirp: async () => {},
+        existsSync: () => false,
+        readPackageJson: async () => null,
+        readPackageJsonAt: async () => null,
+        scanSourceRoots: async () => [],
+        spawnSync: () => ({ stdout: Buffer.from(""), exitCode: 0 }),
+        initInteractionChain: async () => null,
+        createInteractionBridge: () => ({ detectQuestion: async () => false, onQuestionDetected: async () => "" }),
+        createDebateRunner: () => ({}) as never,
+      },
+    });
+
+    const originalCallOp = _pipelinePlanDeps.callOp;
+    const originalRunPlanCritic = _pipelinePlanDeps.runPlanCritic;
+    _pipelinePlanDeps.callOp = mock(async (_callCtx, op) => {
+      if (op === _pipelinePlanDeps.groundOp) return { repoFacts: [], specClaims: [], gaps: [] };
+      return {
+        prd: {
+          userStories: [
+            {
+              id: "s1", title: "story 1", description: "", acceptanceCriteria: [],
+              status: "pending", passes: false, escalations: [], attempts: 0,
+              routing: {
+                complexity: "low", testStrategy: "test-after", reasoning: "",
+                agentProfileId: "senior",
+              },
+            },
+          ],
+        },
+      };
+    }) as typeof _pipelinePlanDeps.callOp;
+    _pipelinePlanDeps.runPlanCritic = mock(async () => ({
+      outcome: "passed",
+      prd: {
+        userStories: [
+          {
+            id: "s1", title: "story 1", description: "", acceptanceCriteria: [],
+            status: "pending", passes: false, escalations: [], attempts: 0,
+            routing: {
+              complexity: "low", testStrategy: "test-after", reasoning: "",
+              agentProfileId: "senior",
+            },
+          },
+        ],
+      },
+      findings: [],
+    })) as typeof _pipelinePlanDeps.runPlanCritic;
+
+    try {
+      await strategy.execute(ctx);
+      const prd = JSON.parse(writtenContent);
+      expect(prd.routingProfile).toBe("team-a");
+      expect(prd.userStories[0].routing.agent).toBe("claude");
+      expect(prd.userStories[0].routing.profileModelTier).toBe("powerful");
+      expect(prd.userStories[0].routing.initialAgent).toBe("claude");
+    } finally {
+      _pipelinePlanDeps.callOp = originalCallOp;
+      _pipelinePlanDeps.runPlanCritic = originalRunPlanCritic;
+    }
+  });
+
   test("AC6: runtime.close is called in finally on success and failure", async () => {
     const closeSuccess = mock(async () => {});
     const closeFailure = mock(async () => {});

--- a/test/unit/plan/strategies.test.ts
+++ b/test/unit/plan/strategies.test.ts
@@ -198,10 +198,14 @@ describe("writeOrRecoverPrd", () => {
     const result = await writeOrRecoverPrd(ctx, SAMPLE_PRD);
 
     expect(result).toBe(ctx.outputPath);
-    expect(deps.writeFile).toHaveBeenCalledWith(
-      ctx.outputPath,
-      JSON.stringify({ ...SAMPLE_PRD, project: ctx.projectName }, null, 2),
-    );
+    const writeCall = (deps.writeFile as ReturnType<typeof mock>).mock.calls.at(-1);
+    expect(writeCall?.[0]).toBe(ctx.outputPath);
+    const writtenPrd = JSON.parse(String(writeCall?.[1])) as PRD;
+    expect(writtenPrd.project).toBe(ctx.projectName);
+    expect(writtenPrd.feature).toBe(SAMPLE_PRD.feature);
+    expect(writtenPrd.userStories).toHaveLength(SAMPLE_PRD.userStories.length);
+    // finalizePrdRouting always stamps routingProfile (defaults to "default")
+    expect(writtenPrd.routingProfile).toBe("default");
   });
 
   test("recovers by reading the written file when plan generation fails after write", async () => {

--- a/test/unit/plan/strategies/finalize-routing.test.ts
+++ b/test/unit/plan/strategies/finalize-routing.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { finalizePrdRouting } from "@/plan";
+import type { AgentRoutingConfig } from "@/config";
+import type { PRD } from "@/prd/types";
+
+const agentRouting: AgentRoutingConfig = {
+  enabled: true,
+  strategy: "off",
+  default: "opencode-structural",
+  profiles: [
+    { id: "opencode-structural", target: { agent: "opencode", model: "fast" }, strengths: ["mechanical"] },
+    { id: "claude-final", target: { agent: "claude", model: "balanced" }, strengths: ["design"] },
+  ],
+};
+
+function prdWith(routing: Record<string, unknown>): PRD {
+  return {
+    project: "p",
+    feature: "f",
+    branchName: "feat/f",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    userStories: [
+      {
+        id: "US-001",
+        title: "t",
+        description: "d",
+        acceptanceCriteria: ["a"],
+        tags: [],
+        dependencies: [],
+        status: "pending",
+        passes: false,
+        attempts: 0,
+        escalations: [],
+        routing: { complexity: "medium", testStrategy: "tdd-simple", reasoning: "r", ...routing },
+      },
+    ],
+  } as unknown as PRD;
+}
+
+describe("finalizePrdRouting", () => {
+  test("resolves agentProfileId to agent + tier and stamps origin fields", () => {
+    const out = finalizePrdRouting(prdWith({ agentProfileId: "claude-final" }), agentRouting, "cross-agent");
+    const r = out.userStories[0].routing;
+    expect(r?.agent).toBe("claude");
+    expect(r?.agentProfileId).toBe("claude-final");
+    expect(r?.profileModelTier).toBe("balanced");
+    expect(r?.initialAgent).toBe("claude");
+    expect(r?.initialProfileId).toBe("claude-final");
+    expect(out.routingProfile).toBe("cross-agent");
+  });
+
+  test("applies the default profile when no id was selected", () => {
+    const out = finalizePrdRouting(prdWith({}), agentRouting, undefined);
+    expect(out.userStories[0].routing?.agent).toBe("opencode");
+    expect(out.routingProfile).toBe("default");
+  });
+
+  test("never overwrites an existing initialAgent (escalation origin is sticky)", () => {
+    const out = finalizePrdRouting(
+      prdWith({ agentProfileId: "claude-final", initialAgent: "opencode", initialProfileId: "opencode-structural" }),
+      agentRouting,
+      "cross-agent",
+    );
+    expect(out.userStories[0].routing?.initialAgent).toBe("opencode");
+    expect(out.userStories[0].routing?.initialProfileId).toBe("opencode-structural");
+  });
+
+  test("leaves stories untouched when routing is disabled but still records routingProfile", () => {
+    const out = finalizePrdRouting(prdWith({}), { ...agentRouting, enabled: false }, "cross-agent");
+    expect(out.userStories[0].routing?.agent).toBeUndefined();
+    expect(out.routingProfile).toBe("cross-agent");
+  });
+
+  test("does not mutate the input PRD", () => {
+    const input = prdWith({ agentProfileId: "claude-final" });
+    finalizePrdRouting(input, agentRouting, "cross-agent");
+    expect(input.userStories[0].routing?.agent).toBeUndefined();
+  });
+});

--- a/test/unit/plan/strategies/single.test.ts
+++ b/test/unit/plan/strategies/single.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, mock, test } from "bun:test";
+import { _singlePlanDeps, SinglePlanStrategy } from "@/plan";
+import { makeNaxConfig } from "@test/helpers";
+import type { PlanModeContext } from "@/plan/strategies";
+import type { PRD } from "@/prd/types";
+import type { NaxRuntime } from "@/runtime";
+
+// Minimal PRD returned by the stubbed callOp
+function makePrd(agentProfileId?: string): PRD {
+  return {
+    project: "p",
+    feature: "my-feature",
+    branchName: "feat/my-feature",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    userStories: [
+      {
+        id: "US-001",
+        title: "t",
+        description: "d",
+        acceptanceCriteria: ["a"],
+        tags: [],
+        dependencies: [],
+        status: "pending",
+        passes: false,
+        attempts: 0,
+        escalations: [],
+        routing: {
+          complexity: "medium",
+          testStrategy: "tdd-simple",
+          reasoning: "r",
+          ...(agentProfileId ? { agentProfileId } : {}),
+        },
+      },
+    ],
+  } as unknown as PRD;
+}
+
+// Minimal PlanModeContext builder
+function makeCtx(overrides: {
+  profileName?: string;
+  agentRouting?: object;
+  writeFile?: (path: string, content: string) => Promise<void>;
+  existsSync?: (path: string) => boolean;
+}): PlanModeContext {
+  const config = makeNaxConfig({
+    routing: {
+      agents: {
+        enabled: true,
+        strategy: "off",
+        default: "opencode-structural",
+        profiles: [
+          { id: "opencode-structural", target: { agent: "opencode", model: "fast" }, strengths: ["mechanical"] },
+          { id: "claude-final", target: { agent: "claude", model: "balanced" }, strengths: ["design"] },
+        ],
+        ...(overrides.agentRouting ?? {}),
+      },
+    },
+  }) as unknown as PlanModeContext["config"];
+
+  const fakeRuntime = {
+    agentManager: { getDefault: () => "claude" },
+    packages: { resolve: () => ({}) },
+    close: async () => {},
+  } as unknown as NaxRuntime;
+
+  return {
+    workdir: "/tmp/test",
+    naxDir: "/tmp/test/.nax",
+    outputDir: "/tmp/test/.nax/features/my-feature",
+    outputPath: "/tmp/test/.nax/features/my-feature/prd.json",
+    specContent: "spec",
+    codebaseContext: "ctx",
+    normalizedRoots: [],
+    relativePackages: [],
+    packageDetails: [],
+    projectName: "my-project",
+    branchName: "feat/my-feature",
+    timeoutSeconds: 60,
+    config,
+    profileName: overrides.profileName,
+    options: { from: "spec.md", feature: "my-feature" },
+    runtime: fakeRuntime,
+    interactionChain: null,
+    interactionBridge: {} as PlanModeContext["interactionBridge"],
+    deps: {
+      readFile: async () => "",
+      writeFile: overrides.writeFile ?? (async () => {}),
+      mkdirp: async () => {},
+      existsSync: overrides.existsSync ?? (() => false),
+      readPackageJson: async () => null,
+      readPackageJsonAt: async () => null,
+      scanSourceRoots: async () => [],
+      spawnSync: () => ({ stdout: Buffer.from(""), exitCode: 0 }),
+      initInteractionChain: async () => null,
+      createInteractionBridge: () => ({}) as PlanModeContext["interactionBridge"],
+      createDebateRunner: () => ({}) as ReturnType<PlanModeContext["deps"]["createDebateRunner"]>,
+      getLogger: () => null as unknown as ReturnType<PlanModeContext["deps"]["getLogger"]>,
+    },
+  };
+}
+
+describe("SinglePlanStrategy", () => {
+  test("resolves agentProfileId and writes routingProfile (finalizePrdRouting applied)", async () => {
+    let writtenJson = "";
+    const writeFile = async (_path: string, content: string) => {
+      writtenJson = content;
+    };
+
+    const ctx = makeCtx({ profileName: "cross-agent", writeFile });
+
+    // Stub callOp to return a PRD with agentProfileId "claude-final"
+    const origCallOp = _singlePlanDeps.callOp;
+    _singlePlanDeps.callOp = mock(async () => makePrd("claude-final")) as typeof origCallOp;
+
+    try {
+      const strategy = new SinglePlanStrategy();
+      await strategy.execute(ctx);
+    } finally {
+      _singlePlanDeps.callOp = origCallOp;
+    }
+
+    const prd = JSON.parse(writtenJson) as PRD;
+    expect(prd.routingProfile).toBe("cross-agent");
+    expect(prd.userStories[0].routing?.agent).toBe("claude");
+  });
+
+  test("still writes PRD successfully without routing agents config", async () => {
+    let writtenJson = "";
+    const writeFile = async (_path: string, content: string) => {
+      writtenJson = content;
+    };
+
+    const ctx = makeCtx({ profileName: undefined, writeFile });
+
+    const origCallOp = _singlePlanDeps.callOp;
+    _singlePlanDeps.callOp = mock(async () => makePrd()) as typeof origCallOp;
+
+    try {
+      const strategy = new SinglePlanStrategy();
+      await strategy.execute(ctx);
+    } finally {
+      _singlePlanDeps.callOp = origCallOp;
+    }
+
+    const prd = JSON.parse(writtenJson) as PRD;
+    // Without profileName, routingProfile defaults to "default"
+    expect(prd.routingProfile).toBe("default");
+    expect(prd.project).toBe("my-project");
+  });
+});

--- a/test/unit/plan/strategies/single.test.ts
+++ b/test/unit/plan/strategies/single.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { _singlePlanDeps, SinglePlanStrategy } from "@/plan";
-import { makeNaxConfig } from "@test/helpers";
+import { makeNaxConfig, makeMockAgentManager } from "@test/helpers";
 import type { PlanModeContext } from "@/plan/strategies";
 import type { PRD } from "@/prd/types";
 import type { NaxRuntime } from "@/runtime";
@@ -59,7 +59,7 @@ function makeCtx(overrides: {
   }) as unknown as PlanModeContext["config"];
 
   const fakeRuntime = {
-    agentManager: { getDefault: () => "claude" },
+    agentManager: makeMockAgentManager(),
     packages: { resolve: () => ({}) },
     close: async () => {},
   } as unknown as NaxRuntime;

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -179,43 +179,53 @@ describe("mapDecomposedStoriesToUserStories — workdir inheritance", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Agent routing propagation — routing.agent, agentProfileId, profileModelTier
+// Agent routing — ADR-025: mapper ignores story-level routing; uses parentRouting
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("mapDecomposedStoriesToUserStories — agent routing propagation", () => {
-  test("propagates routing.agent when set on DecomposedStory", () => {
+describe("mapDecomposedStoriesToUserStories — agent routing (ADR-025 inheritance model)", () => {
+  test("story-level routing.agent on DecomposedStory is NOT propagated (parentRouting wins)", () => {
+    // ADR-025: decomposeOp no longer sets story.routing.agent — only parentRouting is used
     const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
     const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
-    expect(result.routing?.agent).toBe("opencode");
+    // No parentRouting passed → no agent on result
+    expect(result.routing?.agent).toBeUndefined();
   });
 
-  test("propagates routing.agentProfileId when set on DecomposedStory", () => {
+  test("story-level routing.agentProfileId on DecomposedStory is NOT propagated", () => {
     const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
     const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
-    expect(result.routing?.agentProfileId).toBe("fast-coder");
+    expect(result.routing?.agentProfileId).toBeUndefined();
   });
 
-  test("propagates routing.profileModelTier when set on DecomposedStory", () => {
+  test("story-level routing.profileModelTier on DecomposedStory is NOT propagated when no parentRouting", () => {
     const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
     const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
-    expect(result.routing?.profileModelTier).toBe("fast");
+    expect(result.routing?.profileModelTier).toBeUndefined();
   });
 
-  test("profileModelTier is absent when routing is not set on DecomposedStory", () => {
+  test("profileModelTier is absent when neither parentRouting nor story.routing is set", () => {
     const story = makeDecomposedStory({ routing: undefined });
     const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
     expect(result.routing?.profileModelTier).toBeUndefined();
   });
 
-  test("propagates 'balanced' profileModelTier correctly", () => {
-    const story = makeDecomposedStory({ routing: { agent: "claude", agentProfileId: "quality-agent", profileModelTier: "balanced" } });
-    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+  test("parentRouting.profileModelTier='balanced' is propagated correctly", () => {
+    const [result] = mapDecomposedStoriesToUserStories(
+      [makeDecomposedStory()],
+      "US-001",
+      undefined,
+      { agent: "claude", agentProfileId: "quality-agent", profileModelTier: "balanced" },
+    );
     expect(result.routing?.profileModelTier).toBe("balanced");
   });
 
-  test("propagates 'powerful' profileModelTier correctly", () => {
-    const story = makeDecomposedStory({ routing: { agent: "claude", agentProfileId: "expert-agent", profileModelTier: "powerful" } });
-    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
+  test("parentRouting.profileModelTier='powerful' is propagated correctly", () => {
+    const [result] = mapDecomposedStoriesToUserStories(
+      [makeDecomposedStory()],
+      "US-001",
+      undefined,
+      { agent: "claude", agentProfileId: "expert-agent", profileModelTier: "powerful" },
+    );
     expect(result.routing?.profileModelTier).toBe("powerful");
   });
 });
@@ -292,6 +302,77 @@ describe("modelTier seeding from profileModelTier", () => {
   test("defaults modelTier to balanced when no profileModelTier", () => {
     const result = mapDecomposedStoriesToUserStories([{ ...baseStory }], "US-001");
     expect(result[0].routing?.modelTier).toBe("balanced");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-025: parent routing inheritance
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("mapDecomposedStoriesToUserStories — parent routing inheritance (ADR-025)", () => {
+  test("sub-stories inherit the parent story's agent assignment", () => {
+    const subs = mapDecomposedStoriesToUserStories(
+      [
+        {
+          id: "US-001-A",
+          title: "t",
+          description: "d",
+          acceptanceCriteria: ["a"],
+          tags: [],
+          dependencies: [],
+          contextFiles: ["src/x.ts"],
+          complexity: "simple",
+          reasoning: "r",
+          estimatedLOC: 0,
+          risks: [],
+          testStrategy: "tdd-simple",
+        },
+      ],
+      "US-001",
+      "packages/api",
+      { agent: "claude", agentProfileId: "claude-final", profileModelTier: "balanced" },
+    );
+    expect(subs[0].routing.agent).toBe("claude");
+    expect(subs[0].routing.agentProfileId).toBe("claude-final");
+    expect(subs[0].routing.profileModelTier).toBe("balanced");
+    expect(subs[0].routing.initialAgent).toBe("claude");
+    expect(subs[0].routing.initialProfileId).toBe("claude-final");
+  });
+
+  test("sub-stories carry no agent when the parent had none", () => {
+    const subs = mapDecomposedStoriesToUserStories(
+      [
+        {
+          id: "US-001-A",
+          title: "t",
+          description: "d",
+          acceptanceCriteria: ["a"],
+          tags: [],
+          dependencies: [],
+          contextFiles: ["src/x.ts"],
+          complexity: "simple",
+          reasoning: "r",
+          estimatedLOC: 0,
+          risks: [],
+          testStrategy: "tdd-simple",
+        },
+      ],
+      "US-001",
+      undefined,
+      undefined,
+    );
+    expect(subs[0].routing.agent).toBeUndefined();
+  });
+
+  test("initialAgent and initialProfileId fall through from parentRouting when not already set", () => {
+    const subs = mapDecomposedStoriesToUserStories(
+      [makeDecomposedStory({ id: "US-001-A" })],
+      "US-001",
+      undefined,
+      { agent: "opencode", agentProfileId: "oc-fast", profileModelTier: "fast" },
+    );
+    expect(subs[0].routing.initialAgent).toBe("opencode");
+    expect(subs[0].routing.initialProfileId).toBe("oc-fast");
   });
 });
 

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -332,11 +332,12 @@ describe("mapDecomposedStoriesToUserStories — parent routing inheritance (ADR-
       "packages/api",
       { agent: "claude", agentProfileId: "claude-final", profileModelTier: "balanced" },
     );
-    expect(subs[0].routing.agent).toBe("claude");
-    expect(subs[0].routing.agentProfileId).toBe("claude-final");
-    expect(subs[0].routing.profileModelTier).toBe("balanced");
-    expect(subs[0].routing.initialAgent).toBe("claude");
-    expect(subs[0].routing.initialProfileId).toBe("claude-final");
+    const routing = (subs[0] as NonNullable<(typeof subs)[0]>).routing as NonNullable<(typeof subs)[0]["routing"]>;
+    expect(routing.agent).toBe("claude");
+    expect(routing.agentProfileId).toBe("claude-final");
+    expect(routing.profileModelTier).toBe("balanced");
+    expect(routing.initialAgent).toBe("claude");
+    expect(routing.initialProfileId).toBe("claude-final");
   });
 
   test("sub-stories carry no agent when the parent had none", () => {
@@ -361,7 +362,8 @@ describe("mapDecomposedStoriesToUserStories — parent routing inheritance (ADR-
       undefined,
       undefined,
     );
-    expect(subs[0].routing.agent).toBeUndefined();
+    const routing = (subs[0] as NonNullable<(typeof subs)[0]>).routing as NonNullable<(typeof subs)[0]["routing"]>;
+    expect(routing.agent).toBeUndefined();
   });
 
   test("initialAgent and initialProfileId fall through from parentRouting when not already set", () => {
@@ -371,8 +373,9 @@ describe("mapDecomposedStoriesToUserStories — parent routing inheritance (ADR-
       undefined,
       { agent: "opencode", agentProfileId: "oc-fast", profileModelTier: "fast" },
     );
-    expect(subs[0].routing.initialAgent).toBe("opencode");
-    expect(subs[0].routing.initialProfileId).toBe("oc-fast");
+    const routing = (subs[0] as NonNullable<(typeof subs)[0]>).routing as NonNullable<(typeof subs)[0]["routing"]>;
+    expect(routing.initialAgent).toBe("opencode");
+    expect(routing.initialProfileId).toBe("oc-fast");
   });
 });
 

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -183,24 +183,27 @@ describe("mapDecomposedStoriesToUserStories — workdir inheritance", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("mapDecomposedStoriesToUserStories — agent routing (ADR-025 inheritance model)", () => {
-  test("story-level routing.agent on DecomposedStory is NOT propagated (parentRouting wins)", () => {
-    // ADR-025: decomposeOp no longer sets story.routing.agent — only parentRouting is used
+  test("story-level routing fields are preserved as baseline when no parentRouting", () => {
+    // story.routing is the fallback when parentRouting is not supplied (pre-ADR-025 behaviour,
+    // required by the routing-profile-tier pipeline stage which reads profileModelTier).
     const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
     const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
-    // No parentRouting passed → no agent on result
-    expect(result.routing?.agent).toBeUndefined();
+    expect(result.routing?.agent).toBe("opencode");
+    expect(result.routing?.agentProfileId).toBe("fast-coder");
+    expect(result.routing?.profileModelTier).toBe("fast");
   });
 
-  test("story-level routing.agentProfileId on DecomposedStory is NOT propagated", () => {
+  test("parentRouting overrides story-level routing fields when both are present", () => {
+    // ADR-025: parentRouting wins over story.routing.
     const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
-    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
-    expect(result.routing?.agentProfileId).toBeUndefined();
-  });
-
-  test("story-level routing.profileModelTier on DecomposedStory is NOT propagated when no parentRouting", () => {
-    const story = makeDecomposedStory({ routing: { agent: "opencode", agentProfileId: "fast-coder", profileModelTier: "fast" } });
-    const [result] = mapDecomposedStoriesToUserStories([story], "US-001");
-    expect(result.routing?.profileModelTier).toBeUndefined();
+    const [result] = mapDecomposedStoriesToUserStories([story], "US-001", undefined, {
+      agent: "claude",
+      agentProfileId: "claude-final",
+      profileModelTier: "balanced",
+    });
+    expect(result.routing?.agent).toBe("claude");
+    expect(result.routing?.agentProfileId).toBe("claude-final");
+    expect(result.routing?.profileModelTier).toBe("balanced");
   });
 
   test("profileModelTier is absent when neither parentRouting nor story.routing is set", () => {

--- a/test/unit/prd/schema-agent-profile.test.ts
+++ b/test/unit/prd/schema-agent-profile.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { validatePlanOutput } from "@/prd";
+
+describe("PRD sanitizer preserves agentProfileId", () => {
+  test("keeps routing.agentProfileId emitted by the planner", () => {
+    const raw = JSON.stringify({
+      project: "p",
+      feature: "f",
+      branchName: "feat/f",
+      userStories: [
+        {
+          id: "US-001",
+          title: "t",
+          description: "d",
+          acceptanceCriteria: ["When X, then Y"],
+          tags: [],
+          dependencies: [],
+          routing: {
+            complexity: "medium",
+            testStrategy: "tdd-simple",
+            reasoning: "because",
+            agentProfileId: "opencode-structural",
+          },
+        },
+      ],
+    });
+    const prd = validatePlanOutput(raw, "f", "feat/f");
+    expect(prd.userStories[0].routing.agentProfileId).toBe("opencode-structural");
+  });
+
+  test("omits agentProfileId when the planner did not emit one", () => {
+    const raw = JSON.stringify({
+      project: "p",
+      feature: "f",
+      branchName: "feat/f",
+      userStories: [
+        {
+          id: "US-001",
+          title: "t",
+          description: "d",
+          acceptanceCriteria: ["When X, then Y"],
+          tags: [],
+          dependencies: [],
+          routing: { complexity: "medium", testStrategy: "tdd-simple", reasoning: "because" },
+        },
+      ],
+    });
+    const prd = validatePlanOutput(raw, "f", "feat/f");
+    expect(prd.userStories[0].routing.agentProfileId).toBeUndefined();
+  });
+});

--- a/test/unit/prompts/builders/plan-builder-profiles.test.ts
+++ b/test/unit/prompts/builders/plan-builder-profiles.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { PlanPromptBuilder } from "@/prompts";
+import type { AgentRoutingProfile } from "@/config";
+
+const profiles: AgentRoutingProfile[] = [
+  {
+    id: "opencode-structural",
+    target: { agent: "opencode", model: "fast" },
+    strengths: ["mechanical edits"],
+  },
+  {
+    id: "claude-final",
+    target: { agent: "claude", model: "balanced" },
+    strengths: ["design work"],
+  },
+];
+
+describe("PlanPromptBuilder agent profiles", () => {
+  test("build(): injects capability cards and an agentProfileId schema field when profiles exist", () => {
+    const { taskContext, outputFormat } = new PlanPromptBuilder().build(
+      "spec",
+      "context",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      profiles,
+    );
+    expect(taskContext).toContain("## Agent Profiles");
+    expect(taskContext).toContain("opencode-structural");
+    expect(outputFormat).toContain("agentProfileId");
+  });
+
+  test("build(): omits cards and the schema field when no profiles", () => {
+    const { taskContext, outputFormat } = new PlanPromptBuilder().build("spec", "context");
+    expect(taskContext).not.toContain("## Agent Profiles");
+    expect(outputFormat).not.toContain("agentProfileId");
+  });
+
+  test("buildDraft(): injects cards + agentProfileId schema field when profiles exist", () => {
+    const { task } = new PlanPromptBuilder().buildDraft({
+      feature: "f",
+      branchName: "feat/f",
+      specContent: "spec",
+      codebaseContext: "context",
+      manifestSection: "manifest",
+      citationThreshold: 0.5,
+      profiles,
+    });
+    expect(task.content).toContain("## Agent Profiles");
+    expect(task.content).toContain("agentProfileId");
+  });
+});


### PR DESCRIPTION
## Summary

- Folds agent profile selection into the plan LLM call (`nax plan --from`) so stories receive `agentProfileId` at planning time, not just at decompose time
- Adds `resolveAgentAssignment` as the SSOT for profile-id → `{agent, agentProfileId, profileModelTier}` mapping
- Adds `finalizePrdRouting` pure post-step applied at all PRD write sites (single, refine, debate, pipeline) — resolves profile IDs, stamps `initialAgent`/`initialProfileId` origin fields, writes `routingProfile` at PRD root
- Converts `--decompose` from re-selection to inheritance: sub-stories inherit parent's agent assignment via `parentRouting` param in `mapDecomposedStoriesToUserStories`
- Fixes two bugs caught in code review: `PipelinePlanStrategy` and `DebatePlanStrategy` were both missing `finalizePrdRouting` / profile injection

## Changes

| File | Change |
|:-----|:-------|
| `src/agents/shared/agent-profile-resolver.ts` | New — SSOT resolver |
| `src/agents/shared/index.ts`, `src/agents/index.ts` | Re-export new symbols |
| `src/config/selectors.ts` | Add `"routing"` slice to `planConfigSelector` |
| `src/plan/strategies/types.ts` | Add `profileName` to `PlanModeContext` |
| `src/plan/strategies/context-builder.ts` | Populate `profileName` from config |
| `src/plan/strategies/finalize-routing.ts` | New — pure PRD post-step |
| `src/plan/strategies/single.ts`, `write-prd.ts` | Apply `finalizePrdRouting` at all write sites |
| `src/plan/strategies/pipeline.ts` | Apply `finalizePrdRouting` on write (bug fix) |
| `src/plan/strategies/debate.ts` | Pass profiles to prompt builder (bug fix) |
| `src/prompts/builders/plan-builder.ts` | Inject capability cards + `agentProfileId` schema field |
| `src/operations/plan.ts`, `plan-refine.ts`, `plan-draft.ts` | Pass profiles to prompt builder |
| `src/prd/schema.ts` | Preserve `routing.agentProfileId` through sanitizer |
| `src/prd/decompose-mapper.ts` | Accept `parentRouting` param; apply as override over `story.routing` baseline |
| `src/operations/decompose.ts` | Remove re-selection loop; parse delegates to `parseDecomposeOutput` |
| `src/cli/plan-command.ts`, `plan-decompose.ts` | Wire `finalizePrdRouting` and `parentRouting` at CLI call sites |

## Test plan

- [ ] `bun run test` — full suite passes (78 plan unit tests, including new coverage for resolver, finalize-routing, PRD sanitizer, prompt builder profile injection, pipeline finalization, decompose inheritance)
- [ ] `bun run typecheck` — clean
- [ ] `nax plan --from spec.md` with `routing.agents.enabled: true` and profiles configured — verify PRD contains `routingProfile`, `agent`, `profileModelTier`, `initialAgent` on each story
- [ ] `nax plan --from spec.md --decompose` — verify sub-stories inherit parent story's agent assignment
- [ ] `plan.mode: "pipeline"` — verify `routingProfile` and agent fields written
- [ ] Debate mode — verify LLM receives capability cards and `agentProfileId` schema field in proposal rounds
- [ ] `routing.agents.enabled: false` — verify stories pass through unchanged, `routingProfile: "default"` written