### PR TITLE
fix(acceptance): retry acceptance-refine op on empty output

### DIFF
--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -78,15 +78,28 @@ async function processPackageGroup(
       featureName: ctx.prd.feature,
       agentName: ctx.agentManager.getDefault(),
     };
-    const refined = await _hardeningDeps.callOp(callCtx, acceptanceRefineOp, {
-      criteria: story.suggestedCriteria ?? [],
-      codebaseContext: "",
-      storyId: story.id,
-      testStrategy: ctx.config.acceptance?.testStrategy,
-      testFramework: ctx.config.acceptance?.testFramework,
-      storyTitle: story.title,
-      storyDescription: story.description,
-    });
+    let refined: RefinedCriterion[];
+    try {
+      refined = await _hardeningDeps.callOp(callCtx, acceptanceRefineOp, {
+        criteria: story.suggestedCriteria ?? [],
+        codebaseContext: "",
+        storyId: story.id,
+        testStrategy: ctx.config.acceptance?.testStrategy,
+        testFramework: ctx.config.acceptance?.testFramework,
+        storyTitle: story.title,
+        storyDescription: story.description,
+      });
+    } catch {
+      logger?.warn("acceptance", "AC refinement failed after retries — using unrefined criteria", {
+        storyId: story.id,
+      });
+      refined = (story.suggestedCriteria ?? []).map((c) => ({
+        original: c,
+        refined: c,
+        testable: true,
+        storyId: story.id,
+      }));
+    }
     groupRefined.push(...refined);
   }
 

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -51,8 +51,9 @@ export function parseRefinementResponse(response: string, criteria: string[]): R
  *
  * Mirrors the fallback triggers in `parseRefinementResponse` above and lives
  * beside it so the two stay in sync. Used by the acceptance-refine op (#3B) to
- * log an accurate degradation warning — the log must only claim "fell back to
- * unrefined criteria" when that is what actually happened.
+ * log an accurate degradation warning for non-empty unparseable output. Note:
+ * empty/whitespace output is handled upstream by the op's parse() — it throws
+ * ParseValidationError to trigger a retry rather than falling back immediately.
  */
 export function refinementWouldFallback(response: string): boolean {
   if (!response || !response.trim()) return true;

--- a/src/operations/acceptance-refine.ts
+++ b/src/operations/acceptance-refine.ts
@@ -1,5 +1,6 @@
 import { parseRefinementResponse, refinementWouldFallback } from "../acceptance/refinement";
 import type { RefinedCriterion } from "../acceptance/types";
+import { ParseValidationError } from "../agents/retry";
 import { acceptanceConfigSelector } from "../config";
 import type { AcceptanceConfig } from "../config/selectors";
 import { getSafeLogger } from "../logger";
@@ -24,6 +25,12 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
   stage: "acceptance",
   jsonMode: true,
   config: acceptanceConfigSelector,
+  // Retry once on empty output. In practice empty output arrives as fail-unknown
+  // (ACP process crash) which completeWithFallback does NOT retry — making this
+  // the sole retry opportunity. For fail-stale (clean empty), completeWithFallback
+  // already runs 3 stale retries before reaching parse(); the op-tier retry then
+  // adds one more completeAs call (4 more adapter attempts). Bounded at 8 total.
+  retry: { preset: "transient-network" as const, maxAttempts: 2, baseDelayMs: 0 },
   model: (_input, ctx) => ctx.config.acceptance.generateModel ?? ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
@@ -39,11 +46,14 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
     };
   },
   parse(output, input, _ctx) {
+    if (!output || !output.trim()) {
+      throw new ParseValidationError("acceptance-refine: empty output");
+    }
     if (refinementWouldFallback(output)) {
       getSafeLogger()?.warn(
         "acceptance",
         "AC refinement returned no usable JSON — falling back to unrefined criteria",
-        { storyId: input.storyId, criteriaCount: input.criteria.length, responseBytes: output?.length ?? 0 },
+        { storyId: input.storyId, criteriaCount: input.criteria.length, responseBytes: output.length },
       );
     }
     const items = parseRefinementResponse(output, input.criteria);

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -280,6 +280,21 @@ export const acceptanceSetupStage: PipelineStage = {
             .then((refined) => {
               results[i] = refined;
             })
+            .catch(() => {
+              getSafeLogger()?.warn(
+                "acceptance-setup",
+                "AC refinement failed after retries — using unrefined criteria",
+                {
+                  storyId: story.id,
+                },
+              );
+              results[i] = story.acceptanceCriteria.map((c) => ({
+                original: c,
+                refined: c,
+                testable: true,
+                storyId: story.id,
+              }));
+            })
             .finally(() => {
               executing.delete(task);
             });

--- a/test/unit/operations/acceptance-refine.test.ts
+++ b/test/unit/operations/acceptance-refine.test.ts
@@ -44,6 +44,9 @@ describe("acceptanceRefineOp shape", () => {
   test("stage is acceptance", () => {
     expect(acceptanceRefineOp.stage).toBe("acceptance");
   });
+  test("retry uses transient-network preset with maxAttempts 2", () => {
+    expect(acceptanceRefineOp.retry).toMatchObject({ preset: "transient-network", maxAttempts: 2 });
+  });
   test("model resolves from acceptance.model config", () => {
     const config = makeNaxConfig({
       acceptance: {
@@ -146,11 +149,10 @@ describe("acceptanceRefineOp.parse()", () => {
     expect(result[0].refined).toBe("User can log in");
     expect(result[0].testable).toBe(true);
   });
-  test("falls back on empty response", () => {
+  test("throws ParseValidationError on empty response to trigger retry", () => {
     const ctx = makeBuildCtx();
-    const result = acceptanceRefineOp.parse("", SAMPLE_INPUT, ctx);
-    expect(result).toHaveLength(2);
-    expect(result[0].original).toBe("User can log in");
+    expect(() => acceptanceRefineOp.parse("", SAMPLE_INPUT, ctx)).toThrow("acceptance-refine: empty output");
+    expect(() => acceptanceRefineOp.parse("   \n  ", SAMPLE_INPUT, ctx)).toThrow("acceptance-refine: empty output");
   });
 });
 

--- a/test/unit/pipeline/stages/acceptance-setup-criteria.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup-criteria.test.ts
@@ -248,6 +248,34 @@ describe("acceptance-setup: calls refinement and generation", () => {
     await acceptanceSetupStage.execute(ctx);
     expect((ctx as any).acceptanceSetup).toBeDefined();
   });
+
+  test("falls back to unrefined criteria when refine op throws (e.g. after retry exhaustion)", async () => {
+    let capturedCriteriaList: string | null = null;
+
+    _acceptanceSetupDeps.fileExists = async () => false;
+    _acceptanceSetupDeps.readMeta = async () => null;
+    _acceptanceSetupDeps.callOp = async (_ctx, _packageDir, op, input) => {
+      if (op.name === "acceptance-refine") {
+        throw new Error("acceptance-refine: empty output");
+      }
+      if (op.name === "acceptance-generate") {
+        capturedCriteriaList = (input as { criteriaList: string }).criteriaList;
+        return { testCode: 'test("AC-1", () => { throw new Error("red") })' };
+      }
+      throw new Error(`unexpected op: ${op.name}`);
+    };
+    _acceptanceSetupDeps.writeFile = async () => {};
+    _acceptanceSetupDeps.writeMeta = async () => {};
+    _acceptanceSetupDeps.runTest = async () => ({ exitCode: 1, output: "1 fail" });
+
+    await acceptanceSetupStage.execute(makeCtx());
+
+    // generate must still run — with the original (unrefined) AC text
+    expect(capturedCriteriaList).not.toBeNull();
+    expect(capturedCriteriaList!).toContain("AC-1: first criterion");
+    expect(capturedCriteriaList!).toContain("AC-2: second criterion");
+    expect(capturedCriteriaList!).toContain("AC-1: third criterion");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `acceptanceRefineOp.parse()` now throws `ParseValidationError` on empty/whitespace output instead of silently degrading to unrefined criteria
- Added `retry: { preset: "transient-network", maxAttempts: 2, baseDelayMs: 0 }` to `acceptanceRefineOp` — this is the sole retry opportunity for `fail-unknown` (ACP process crash), since `completeWithFallback` skips stale-retry when the adapter throws
- Added `.catch()` fallback in `acceptance-setup` stage and `hardening.ts` so retry exhaustion gracefully reconstructs unrefined criteria rather than propagating the throw

## Root Cause

Confirmed via prompt audit (`logs/prompt-audit/oauth-par/*-us-003-complete.txt`): the opencode ACP process crashed mid-call (1587ms, 0 bytes returned, no cost log, PID unregistered). `completeWithFallback` wrapped this as `fail-unknown, retriable: false` — skipping stale retries — and the op had no retry configured, so silent fallback was the only behaviour.

## Retry accounting

| Path | Manager-tier | Op-tier | Total adapter calls |
|:-----|:-------------|:--------|:--------------------|
| `fail-unknown` (ACP crash — observed case) | 0 | 1 retry | 2 |
| `fail-stale` (clean empty — theoretical) | 3 stale retries | 1 retry + 3 more stale | 8 (bounded) |

## Test plan

- [ ] `acceptanceRefineOp.parse("")` throws `ParseValidationError("acceptance-refine: empty output")`
- [ ] `acceptanceRefineOp.retry` matches `{ preset: "transient-network", maxAttempts: 2 }`
- [ ] `acceptance-setup` stage falls back to unrefined criteria when refine op throws after retry exhaustion
- [ ] Full suite passes: `bun run test`