### PR TITLE
fix(execution): drain nbSink declarations in nbf rectification cycle (#1227)

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -135,18 +135,18 @@ export async function buildPlanForStrategy(
     builder.addAdversarialReview(inputs.adversarialReview);
   }
 
+  // Path anchors shared by both the main-rectification postValidate and the nbf postValidate.
+  // Computed once here; used in both closures below to avoid duplicate async FS reads.
+  // ctx.packageDir = repo root (absolute); story.workdir = relative sub-path to package.
+  const packageDir = join(ctx.packageDir, story.workdir ?? "");
+  const resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.packageDir, story.workdir);
+
   // Rectification: requires both config gate and typed inputs.
   // Assemble strategies: mechanical fixes first, then full-suite (TDD), then autofix agents.
   if (shouldRunRectification(config) && inputs.rectification) {
     // One shared sink for the implementer and test-writer strategies so
     // declarations accumulate and mock handoffs are consumed by postValidate.
     const sink = makeDeclarationSink();
-
-    // Resolve test-file patterns once at plan-build time — postValidate uses
-    // them to validate mock-structure file paths during the rectification cycle.
-    // ctx.packageDir = repo root (absolute); story.workdir = relative sub-path to package.
-    const packageDir = join(ctx.packageDir, story.workdir ?? "");
-    const resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.packageDir, story.workdir);
 
     const strategies: FixStrategy<Finding, unknown, unknown, unknown>[] = [];
 
@@ -225,6 +225,7 @@ export async function buildPlanForStrategy(
   const nbStrategies: FixStrategy<Finding, unknown, unknown, unknown>[] = [];
   if (nbf?.enabled && inputs.adversarialReview) {
     const nbSink = makeDeclarationSink();
+
     if (nbf.scope === "source") {
       // implementer claims adversarial findings in SOURCE scope (both session modes)
       nbStrategies.push(
@@ -242,13 +243,32 @@ export async function buildPlanForStrategy(
       );
     }
     // Always: recover from a test regression that the best-effort fix introduces.
-    // nbSink is wired here so declarations from the non-blocking recovery pass are
-    // captured, but the end-to-end path (postValidate → test-writer handoff) is not
-    // yet connected for ADR-024 (#1227).
     nbStrategies.push(
       makeFullSuiteRectifyStrategy(story, config, nbSink) as FixStrategy<Finding, unknown, unknown, unknown>,
     );
-    builder.addNonBlockingFix(nbf, nbStrategies);
+
+    // Mirror the main rectification postValidate but bound to nbSink (#1227).
+    const nbPostValidate = async (findings: Finding[], _validateCtx: FixCycleContext): Promise<Finding[]> => {
+      if (nbSink.testEdits.length === 0 && nbSink.mockHandoffs.length === 0) return findings;
+
+      const pendingMock: TestEditDeclaration[] = nbSink.mockHandoffs.map((h) => ({
+        reason: "mock_structure" as const,
+        file: h.files[0] ?? "",
+        files: h.files,
+        reasonDetail: h.reasonDetail,
+      }));
+
+      const { valid, invalid } = await validateMockStructureFiles(pendingMock, resolvedTestPatterns, packageDir);
+
+      nbSink.mockHandoffs = valid.map((d) => ({ files: d.files ?? [], reasonDetail: d.reasonDetail ?? "" }));
+
+      const allDeclarations = [...nbSink.testEdits, ...valid];
+      nbSink.testEdits = [];
+
+      return applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+    };
+
+    builder.addNonBlockingFix(nbf, nbStrategies, nbPostValidate);
   }
 
   return builder.build(ctx, { isThreeSession });

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -245,6 +245,8 @@ interface InternalBuildState {
   nonBlockingFix?: NonBlockingFixConfig;
   /** ADR-024 — scope-aware best-effort strategy set, built at plan time. */
   nonBlockingFixStrategies?: FixStrategy<Finding, unknown, unknown, unknown>[];
+  /** ADR-024 — postValidate bound to nbSink; drains declarations from the nbf cycle (#1227). */
+  nonBlockingFixPostValidate?: (findings: Finding[], ctx: FixCycleContext) => Promise<Finding[]>;
 }
 
 const CANONICAL_ORDER: readonly PhaseKind[] = [
@@ -845,6 +847,8 @@ export interface RectificationOverrides {
   extraRevalidationKinds?: readonly PhaseKind[];
   /** maxAttemptsTotal override (1 + regressionAttempts for best-effort). */
   maxAttempts?: number;
+  /** Override postValidate — nbf path uses a closure bound to nbSink instead of the main sink. */
+  postValidate?: (findings: Finding[], ctx: FixCycleContext) => Promise<Finding[]>;
 }
 
 /**
@@ -963,9 +967,8 @@ export async function runRectification(
           break;
         }
       }
-      const validated = rectification.postValidate
-        ? await rectification.postValidate(findings, _validateCtx)
-        : findings;
+      const postValidateFn = overrides?.postValidate ?? rectification.postValidate;
+      const validated = postValidateFn ? await postValidateFn(findings, _validateCtx) : findings;
       return { findings: validated, shortCircuited };
     },
   };
@@ -1235,6 +1238,7 @@ export class ExecutionPlan {
             excludePhaseKinds: nonBlockingExcludePhases(),
             extraRevalidationKinds: nonBlockingExtraPhases(advCfg),
             maxAttempts,
+            postValidate: this.state.nonBlockingFixPostValidate,
           }),
       });
     }
@@ -1385,9 +1389,14 @@ export class StoryOrchestratorBuilder {
   }
 
   /** ADR-024 — set the non-blocking best-effort fix config + scope-aware strategy set. */
-  addNonBlockingFix(cfg: NonBlockingFixConfig, strategies: FixStrategy<Finding, unknown, unknown, unknown>[]): this {
+  addNonBlockingFix(
+    cfg: NonBlockingFixConfig,
+    strategies: FixStrategy<Finding, unknown, unknown, unknown>[],
+    postValidate?: (findings: Finding[], ctx: FixCycleContext) => Promise<Finding[]>,
+  ): this {
     this.state.nonBlockingFix = cfg;
     this.state.nonBlockingFixStrategies = strategies;
+    this.state.nonBlockingFixPostValidate = postValidate;
     return this;
   }
 

--- a/test/integration/execution/nbf-rectify-declaration.test.ts
+++ b/test/integration/execution/nbf-rectify-declaration.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Integration tests: nbf (non-blocking-fix) declaration wiring (#1227).
+ *
+ * AC-NBF1: mock_structure declaration emitted during the nbf cycle is validated and
+ *          applied via nbPostValidate — autofix-test-writer picks up the handoff.
+ * AC-NBF2: nbSink is drained by nbPostValidate; the main sink (empty at this point)
+ *          is not double-drained.
+ * AC-NBF3: invalid mock_structure files in the nbf cycle → advisory finding appended.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { dirname, join } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { buildPlanForStrategy, _storyOrchestratorDeps } from "@/execution";
+import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
+import type { Finding } from "@/findings/types";
+import type { FullSuiteRectifyInput, FullSuiteRectifyOutput } from "@/operations/full-suite-rectify-op";
+import { _rollbackDeps } from "@/tdd";
+import {
+  makeMockCallContext,
+  makeMockPlanInputs,
+  makeNaxConfig,
+  makeStory,
+  makeTestRuntime,
+  withTempDir,
+} from "@test/helpers";
+import type { NaxRuntime } from "@/runtime";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared setup/teardown
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origCallOp: typeof _storyOrchestratorDeps.callOp;
+let origRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
+let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
+let origRollbackSpawn: typeof _rollbackDeps.spawn;
+let origRollbackAutoCommit: typeof _rollbackDeps.autoCommitIfDirty;
+let runtime: NaxRuntime | undefined;
+
+beforeEach(() => {
+  origCallOp = _storyOrchestratorDeps.callOp;
+  origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+  origCaptureGitRef = _storyOrchestratorDeps.captureGitRef;
+  origRollbackSpawn = _rollbackDeps.spawn;
+  origRollbackAutoCommit = _rollbackDeps.autoCommitIfDirty;
+  _storyOrchestratorDeps.captureGitRef = mock(async () => "HEAD");
+  // captureSnapshotRef uses _rollbackDeps.spawn for git rev-parse HEAD.
+  _rollbackDeps.autoCommitIfDirty = mock(async () => {});
+  _rollbackDeps.spawn = mock((_cmd: string[], _opts: unknown) => ({
+    stdout: new Response("abc1234\n").body,
+    stderr: new Response("").body,
+    exited: Promise.resolve(0),
+  })) as typeof _rollbackDeps.spawn;
+});
+
+afterEach(async () => {
+  _storyOrchestratorDeps.callOp = origCallOp;
+  _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+  _storyOrchestratorDeps.captureGitRef = origCaptureGitRef;
+  _rollbackDeps.spawn = origRollbackSpawn;
+  _rollbackDeps.autoCommitIfDirty = origRollbackAutoCommit;
+  await runtime?.close();
+  runtime = undefined;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeAdvisoryFinding(): Finding {
+  return {
+    source: "adversarial-review",
+    severity: "warning",
+    category: "style",
+    message: "Advisory: consider refactoring mock setup",
+  };
+}
+
+function makeNbfConfig() {
+  return makeNaxConfig({
+    quality: { autofix: { enabled: true } },
+    execution: { rectification: { enabled: true, maxAttemptsTotal: 3 } },
+    review: {
+      adversarial: {
+        model: "balanced",
+        diffMode: "ref",
+        rules: [],
+        timeoutMs: 600_000,
+        parallel: false,
+        maxConcurrentSessions: 2,
+        nonBlockingFix: { enabled: true, scope: "both", regressionAttempts: 1, verifierGuard: false },
+      },
+    },
+  });
+}
+
+function makeNbfCtx(packageDir: string, config = makeNbfConfig()) {
+  runtime = makeTestRuntime({ config });
+  return {
+    runtime,
+    packageView: runtime!.packages.repo(),
+    packageDir,
+    agentName: "claude",
+    storyId: "US-nbf",
+  } as ReturnType<typeof makeMockCallContext>;
+}
+
+function makeNbfInputs(story: ReturnType<typeof makeStory>, packageDir: string, config = makeNbfConfig()) {
+  return makeMockPlanInputs({
+    story,
+    implementer: { story },
+    fullSuiteGate: { story, workdir: packageDir },
+    adversarialReview: {
+      workdir: packageDir,
+      story,
+      adversarialConfig: config.review.adversarial!,
+      mode: config.review.adversarial!.diffMode,
+    },
+    rectification: { maxAttempts: 3, strategies: [], abortOnIncreasingFailures: false },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-NBF1: mock_structure handoff during nbf → test-writer picks it up
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AC-NBF1: nbf cycle drains nbSink — test-writer receives mock-structure handoff", () => {
+  test(
+    "AC-NBF1: after extractApplied + nbPostValidate, autofix-test-writer appliesTo returns true",
+    async () => {
+      await withTempDir(async (tmpDir) => {
+        const testFilePath = join(tmpDir, "test/unit/service.test.ts");
+        await mkdir(dirname(testFilePath), { recursive: true });
+        await Bun.write(testFilePath, "// test file for nbf integration test");
+
+        const story = makeStory({ id: "US-nbf1", attempts: 1 });
+        const config = makeNbfConfig();
+        const ctx = makeNbfCtx(tmpDir, config);
+        const inputs = makeNbfInputs(story, tmpDir, config);
+
+        // All phases pass; adversarial review emits advisory findings (no blocking).
+        _storyOrchestratorDeps.callOp = mock(async (_ctx, op) => {
+          if (op.name === "adversarial-review") {
+            return { passed: true, blockingFindings: [], advisoryFindings: [makeAdvisoryFinding()] };
+          }
+          return { success: true };
+        }) as typeof _storyOrchestratorDeps.callOp;
+
+        // Capture the FixCycle constructed by runRectification for the nbf path.
+        // The main rectification has no findings (all phases pass), so runFixCycle
+        // is called exactly once — from the nbf path.
+        let capturedCycle: FixCycle<Finding> | null = null;
+        let capturedCycleCtx: FixCycleContext | null = null;
+        _storyOrchestratorDeps.runFixCycle = mock(async (cycle, cycleCtx) => {
+          capturedCycle = cycle as FixCycle<Finding>;
+          capturedCycleCtx = cycleCtx as FixCycleContext;
+          return {
+            iterations: [],
+            finalFindings: [],
+            exitReason: "no-strategy" as FixCycleExitReason,
+            costUsd: 0,
+          };
+        }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+        const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+        await plan.run();
+
+        expect(capturedCycle).not.toBeNull();
+        expect(capturedCycleCtx).not.toBeNull();
+
+        // The nbf cycle contains the full-suite-rectify strategy.
+        const fullSuiteStrategy = capturedCycle!.strategies.find((s) => s.name === "full-suite-rectify");
+        expect(fullSuiteStrategy).toBeDefined();
+
+        // Simulate the strategy emitting a mock_structure declaration.
+        const mockOutput: FullSuiteRectifyOutput = {
+          applied: true,
+          testEditDeclarations: [
+            {
+              reason: "mock_structure",
+              file: "test/unit/service.test.ts",
+              files: ["test/unit/service.test.ts"],
+              reasonDetail: "Mock setup needs restructuring in nbf cycle",
+            },
+          ],
+        };
+        const mockInput: FullSuiteRectifyInput = { story, findings: [] };
+        await fullSuiteStrategy!.extractApplied!(mockOutput as any, mockInput as any);
+
+        _storyOrchestratorDeps.callOp = mock(async () => ({ success: true })) as typeof _storyOrchestratorDeps.callOp;
+
+        // Call validate — this triggers nbPostValidate which drains nbSink (#1227 fix).
+        await capturedCycle!.validate(capturedCycleCtx!, {
+          mode: "full",
+          strategiesRun: ["full-suite-rectify"],
+        });
+
+        // AC-NBF1: autofix-test-writer must apply now that nbSink.mockHandoffs is populated.
+        const testWriterStrategy = capturedCycle!.strategies.find((s) => s.name === "autofix-test-writer");
+        expect(testWriterStrategy).toBeDefined();
+
+        const dummyFinding: Finding = { source: "lint", severity: "error", category: "style", message: "dummy" };
+        expect(testWriterStrategy!.appliesTo(dummyFinding)).toBe(true);
+
+        const builtInput = testWriterStrategy!.buildInput([dummyFinding], [], capturedCycleCtx!);
+        expect((builtInput as any).mode).toBe("mock-restructure");
+        expect((builtInput as any).handoffFiles).toContain("test/unit/service.test.ts");
+      });
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-NBF2: nbf cycle validate uses nbPostValidate (bound to nbSink, not main sink)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Symmetric complement to AC-NBF1: when nbSink is empty, nbPostValidate is a
+// no-op, so the autofix-test-writer does not become eligible after validate.
+//
+// This verifies the fix routing: overrides?.postValidate ?? rectification.postValidate
+// selects nbPostValidate for the nbf cycle.  If the old code ran rectification.postValidate
+// (draining the empty main sink) instead, the result is identical in this scenario — so
+// the value of the test is catching any future regression that wires a non-empty sink
+// through the wrong postValidate.
+
+describe("AC-NBF2: nbf cycle validate uses nbPostValidate bound to nbSink", () => {
+  test(
+    "AC-NBF2: empty nbSink → nbPostValidate is a no-op → autofix-test-writer does not apply",
+    async () => {
+      await withTempDir(async (tmpDir) => {
+        const testFilePath = join(tmpDir, "test/unit/service.test.ts");
+        await mkdir(dirname(testFilePath), { recursive: true });
+        await Bun.write(testFilePath, "// test file for AC-NBF2");
+
+        const story = makeStory({ id: "US-nbf2", attempts: 1 });
+        const config = makeNbfConfig();
+        const ctx = makeNbfCtx(tmpDir, config);
+        const inputs = makeNbfInputs(story, tmpDir, config);
+
+        // Gate passes on all calls → main rect does not fire.
+        // Adversarial review emits advisory findings → only the NBF cycle fires.
+        // (When gate fails the main loop short-circuits before adversarial-review
+        //  runs, so advisory findings are never set and NBF never fires — hence
+        //  we keep gate green for this test.)
+        _storyOrchestratorDeps.callOp = mock(async (_ctx, op) => {
+          if (op.name === "adversarial-review") {
+            return { passed: true, blockingFindings: [], advisoryFindings: [makeAdvisoryFinding()] };
+          }
+          return { success: true };
+        }) as typeof _storyOrchestratorDeps.callOp;
+
+        let capturedCycle: FixCycle<Finding> | null = null;
+        let capturedCycleCtx: FixCycleContext | null = null;
+        _storyOrchestratorDeps.runFixCycle = mock(async (cycle, cycleCtx) => {
+          capturedCycle = cycle as FixCycle<Finding>;
+          capturedCycleCtx = cycleCtx as FixCycleContext;
+          return {
+            iterations: [],
+            finalFindings: [],
+            exitReason: "no-strategy" as FixCycleExitReason,
+            costUsd: 0,
+          };
+        }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+        const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+        await plan.run();
+
+        // Only the NBF cycle should have fired.
+        expect(capturedCycle).not.toBeNull();
+        expect(capturedCycleCtx).not.toBeNull();
+
+        _storyOrchestratorDeps.callOp = mock(async () => ({ success: true })) as typeof _storyOrchestratorDeps.callOp;
+
+        // Call validate without injecting anything into nbSink.
+        await capturedCycle!.validate(capturedCycleCtx!, {
+          mode: "full",
+          strategiesRun: ["full-suite-rectify"],
+        });
+
+        // AC-NBF2: empty nbSink → nbPostValidate is a no-op → test-writer must not apply.
+        const testWriterStrategy = capturedCycle!.strategies.find((s) => s.name === "autofix-test-writer");
+        expect(testWriterStrategy).toBeDefined();
+        const dummyFinding: Finding = { source: "lint", severity: "error", category: "style", message: "dummy" };
+        expect(testWriterStrategy!.appliesTo(dummyFinding)).toBe(false);
+      });
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-NBF3: invalid mock_structure in nbf cycle → advisory finding appended
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AC-NBF3: invalid mock_structure in nbf cycle → advisory with category mock_structure_invalid_files", () => {
+  test(
+    "AC-NBF3: nbPostValidate appends advisory when declared test file does not exist",
+    async () => {
+      const packageDir = "/tmp/nax-test-nbf-ac3-nonexistent";
+      const story = makeStory({ id: "US-nbf3", attempts: 1 });
+      const config = makeNbfConfig();
+      const ctx = makeNbfCtx(packageDir, config);
+      const inputs = makeNbfInputs(story, packageDir, config);
+
+      _storyOrchestratorDeps.callOp = mock(async (_ctx, op) => {
+        if (op.name === "adversarial-review") {
+          return { passed: true, blockingFindings: [], advisoryFindings: [makeAdvisoryFinding()] };
+        }
+        return { success: true };
+      }) as typeof _storyOrchestratorDeps.callOp;
+
+      let capturedCycle: FixCycle<Finding> | null = null;
+      let capturedCycleCtx: FixCycleContext | null = null;
+      _storyOrchestratorDeps.runFixCycle = mock(async (cycle, cycleCtx) => {
+        capturedCycle = cycle as FixCycle<Finding>;
+        capturedCycleCtx = cycleCtx as FixCycleContext;
+        return {
+          iterations: [],
+          finalFindings: [],
+          exitReason: "no-strategy" as FixCycleExitReason,
+          costUsd: 0,
+        };
+      }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+      const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+      await plan.run();
+
+      expect(capturedCycle).not.toBeNull();
+
+      const fullSuiteStrategy = capturedCycle!.strategies.find((s) => s.name === "full-suite-rectify");
+      expect(fullSuiteStrategy).toBeDefined();
+
+      // Declare a mock_structure referencing a file that does not exist.
+      const invalidOutput: FullSuiteRectifyOutput = {
+        applied: true,
+        testEditDeclarations: [
+          {
+            reason: "mock_structure",
+            file: "test/unit/nonexistent.test.ts",
+            files: ["test/unit/nonexistent.test.ts"],
+            reasonDetail: "This file does not exist on disk",
+          },
+        ],
+      };
+      const mockInput: FullSuiteRectifyInput = { story, findings: [] };
+      await fullSuiteStrategy!.extractApplied!(invalidOutput as any, mockInput as any);
+
+      _storyOrchestratorDeps.callOp = mock(async () => ({ success: true })) as typeof _storyOrchestratorDeps.callOp;
+
+      const validateResult = await capturedCycle!.validate(capturedCycleCtx!, {
+        mode: "full",
+        strategiesRun: ["full-suite-rectify"],
+      });
+
+      const findings = Array.isArray(validateResult) ? validateResult : validateResult.findings;
+      const hasAdvisory = (findings as Finding[]).some((f) => f.category === "mock_structure_invalid_files");
+      expect(hasAdvisory).toBe(true);
+    },
+  );
+});

--- a/test/unit/execution/rectification-overrides.test.ts
+++ b/test/unit/execution/rectification-overrides.test.ts
@@ -1,6 +1,8 @@
 // test/unit/execution/rectification-overrides.test.ts
 import { describe, expect, test } from "bun:test";
-import { phasesToRevalidate } from "../../../src/execution/story-orchestrator";
+import { phasesToRevalidate, StoryOrchestratorBuilder } from "@/execution";
+import type { FixCycleContext } from "@/findings/cycle-types";
+import type { Finding } from "@/findings/types";
 
 // phasesToRevalidate is the pure function the overrides path relies on: stripping
 // review phases from the input set must remove them from the selected set even
@@ -18,5 +20,29 @@ describe("review-stripped revalidation", () => {
     const stripped = all.filter((p) => !["semantic-review", "adversarial-review"].includes((p as { kind: string }).kind));
     const selected = phasesToRevalidate(["autofix-implementer"], stripped);
     expect(selected.map((p) => (p as { kind: string }).kind)).toEqual(["lint-check", "typecheck-check", "full-suite-gate"]);
+  });
+});
+
+// addNonBlockingFix stores the postValidate override so runRectification can use it
+// instead of the main sink's postValidate (#1227).
+describe("RectificationOverrides.postValidate — addNonBlockingFix stores nbPostValidate", () => {
+  test("addNonBlockingFix accepts a postValidate and builder does not throw", () => {
+    const nbPostValidate = async (findings: Finding[], _ctx: FixCycleContext): Promise<Finding[]> => findings;
+    expect(() =>
+      new StoryOrchestratorBuilder().addNonBlockingFix(
+        { enabled: true, scope: "both", regressionAttempts: 1, verifierGuard: false },
+        [],
+        nbPostValidate,
+      ),
+    ).not.toThrow();
+  });
+
+  test("addNonBlockingFix without postValidate is backwards-compatible (postValidate omitted)", () => {
+    expect(() =>
+      new StoryOrchestratorBuilder().addNonBlockingFix(
+        { enabled: true, scope: "source", regressionAttempts: 1, verifierGuard: false },
+        [],
+      ),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- The non-blocking-fix (ADR-024) `runRectification` call had no `postValidate` override, so the validate closure always fell through to `rectification.postValidate` (bound to the main `sink`). Declarations emitted into `nbSink` by fix agents — `testEdits` and `mock_structure` handoffs — accumulated silently and were never applied.
- Added `postValidate?` to `RectificationOverrides` and `nonBlockingFixPostValidate?` to `InternalBuildState`; `addNonBlockingFix` now accepts an optional `postValidate` arg
- `validate` closure selects `overrides?.postValidate ?? rectification.postValidate` so the NBF path routes to `nbPostValidate` (bound to `nbSink`)
- `build-plan-for-strategy.ts`: hoisted shared `packageDir`/`resolvedTestPatterns` before both rect blocks; built `nbPostValidate` mirroring the main `postValidate` but bound to `nbSink`; passes it to `addNonBlockingFix`

## Test plan

- [ ] `AC-NBF1`: mock_structure declaration emitted during nbf cycle is validated via `nbPostValidate` → autofix-test-writer picks up the handoff
- [ ] `AC-NBF2`: empty `nbSink` → `nbPostValidate` is a no-op → test-writer does not apply after validate
- [ ] `AC-NBF3`: invalid mock_structure file in nbf cycle → advisory finding appended with `category: mock_structure_invalid_files`
- [ ] Unit: `addNonBlockingFix` stores `postValidate` in builder state without throwing; backwards-compatible when omitted
- [ ] Full suite: `bun run test:bail` all pass (9859 tests)

Fixes #1227