### PR TITLE
feat(audit): capture interactive agent Q&A in prompt-audit trail (#1226)

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -434,6 +434,9 @@ export class AcpAgentAdapter implements AgentAdapter {
 
     let totalTokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0 };
     let totalExactCostUsd: number | undefined;
+    // Mid-turn human Q&A exchanges captured for the prompt-audit trail (issue #1226).
+    // Only human-question round-trips are recorded — context-tool pulls are excluded.
+    const interactions: import("../types").InteractionExchange[] = [];
     let turnCount = 0;
     let lastResponse: import("./adapter-session-types").AcpSessionResponse | null = null;
     let timedOut = false;
@@ -556,6 +559,7 @@ export class AcpAgentAdapter implements AgentAdapter {
             }),
           ]);
           if (response) {
+            interactions.push({ turnIndex: turnCount, question, reply: response.answer });
             currentPrompt = response.answer;
             continue;
           }
@@ -610,6 +614,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       estimatedCostUsd,
       exactCostUsd,
       internalRoundTrips: turnCount,
+      ...(interactions.length > 0 ? { interactions } : {}),
     };
   }
 

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -697,6 +697,7 @@ export class AgentManager implements IAgentManager {
           sessionId: handle.protocolIds?.sessionId ?? null,
           recordId: handle.protocolIds?.recordId ?? null,
         },
+        ...(result.interactions?.length ? { interactions: result.interactions } : {}),
         origin: "runAsSession",
         ...(opts.callId !== undefined ? { callId: opts.callId } : {}),
         ...(opts.scopeId !== undefined ? { scopeId: opts.scopeId } : {}),

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -429,6 +429,20 @@ export interface SendTurnOpts {
 }
 
 /** Result returned by sendTurn(). */
+/**
+ * A single mid-turn interactive Q&A exchange between the agent and a human
+ * operator (routed via the interaction plugin), captured for the prompt-audit
+ * trail (issue #1226).
+ */
+export interface InteractionExchange {
+  /** Internal round-trip index (1-based) at which the question was asked. */
+  readonly turnIndex: number;
+  /** The agent's question text, as surfaced to the operator. */
+  readonly question: string;
+  /** The operator's verbatim reply (or the configured fallback on timeout). */
+  readonly reply: string;
+}
+
 export interface TurnResult {
   /** Final assistant output from the last ACP response. */
   output: string;
@@ -440,6 +454,14 @@ export interface TurnResult {
   exactCostUsd?: number;
   /** Number of session.prompt() calls made. */
   internalRoundTrips: number;
+  /**
+   * Mid-turn human-in-the-loop Q&A exchanges captured during the session turn
+   * (issue #1226). Each entry pairs the agent's question with the operator's
+   * verbatim reply and the internal round-trip index at which it occurred.
+   * Omitted when no interactive question was answered — context-tool round-trips
+   * are NOT recorded here. Surfaced onto DispatchEvent and the prompt audit trail.
+   */
+  interactions?: readonly InteractionExchange[];
   /** Protocol-specific IDs for prompt-audit correlation. */
   protocolIds?: ProtocolIds;
   /**

--- a/src/runtime/dispatch-events.ts
+++ b/src/runtime/dispatch-events.ts
@@ -38,6 +38,12 @@ export interface SessionTurnDispatchEvent extends DispatchEventBase {
   readonly kind: "session-turn";
   readonly turn: number;
   readonly protocolIds: { sessionId?: string | null; recordId?: string | null; turnId?: string };
+  /**
+   * Mid-turn human-in-the-loop Q&A exchanges captured during the turn (issue #1226).
+   * Present only when the agent asked the operator a question that was answered.
+   * Surfaced to the prompt-audit trail by the audit middleware.
+   */
+  readonly interactions?: readonly import("../agents/types").InteractionExchange[];
   /** Diagnostic only — never branch subscriber logic on this. */
   readonly origin: "runAsSession" | "runTrackedSession";
 }

--- a/src/runtime/middleware/audit.ts
+++ b/src/runtime/middleware/audit.ts
@@ -22,6 +22,7 @@ export function attachAuditSubscriber(bus: IDispatchEventBus, auditor: IPromptAu
         sessionId: event.protocolIds.sessionId ?? null,
         recordId: event.protocolIds.recordId ?? null,
         turn: event.turn,
+        ...(event.interactions?.length ? { interactions: event.interactions } : {}),
       }),
     };
     auditor.record(entry);

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -47,6 +47,13 @@ export interface PromptAuditEntry {
   readonly recordId?: string | null;
   readonly sessionId?: string | null;
   readonly turn?: number;
+  /**
+   * Mid-turn human-in-the-loop Q&A exchanges for this turn (issue #1226).
+   * Present only when the agent asked the operator a question that was answered.
+   * Appended to the human-readable .txt as an `=== INTERACTIONS ===` section;
+   * absent on turns with no interaction, leaving existing .txt output unchanged.
+   */
+  readonly interactions?: readonly import("../agents/types").InteractionExchange[];
 }
 
 export interface PromptAuditErrorEntry {
@@ -154,8 +161,26 @@ function buildTxtContent(entry: PromptAuditEntry): string {
     "=== RESPONSE ===",
     "",
     entry.response,
+    ...buildInteractionLines(entry.interactions),
   ];
   return lines.join("\n");
+}
+
+/**
+ * Render mid-turn human Q&A exchanges (issue #1226) as a trailing
+ * `=== INTERACTIONS ===` section. Returns an empty array when there are no
+ * interactions, so turns without human-in-the-loop Q&A produce byte-identical
+ * output to the pre-#1226 format.
+ */
+function buildInteractionLines(interactions?: readonly import("../agents/types").InteractionExchange[]): string[] {
+  if (!interactions?.length) return [];
+  const lines = ["", "=== INTERACTIONS ===", ""];
+  for (const ix of interactions) {
+    lines.push(`[turn ${ix.turnIndex}] Q: ${ix.question}`, `         A: ${ix.reply}`, "");
+  }
+  // Drop the trailing blank separator for a clean ending.
+  lines.pop();
+  return lines;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/agents/acp/adapter-phase-a.test.ts
+++ b/test/unit/agents/acp/adapter-phase-a.test.ts
@@ -328,6 +328,96 @@ describe("sendTurn()", () => {
     expect(result.internalRoundTrips).toBe(2);
   });
 
+  test("question interaction: captures exchange (question + verbatim reply + turnIndex) in result.interactions", async () => {
+    let turnIndex = 0;
+    const session = makeSession({
+      promptFn: async () => {
+        turnIndex++;
+        if (turnIndex === 1) {
+          return {
+            messages: [{ role: "assistant", content: "Should I proceed with approach A or B?" }],
+            stopReason: "end_turn",
+            cumulative_token_usage: { input_tokens: 60, output_tokens: 25 },
+          };
+        }
+        return {
+          messages: [{ role: "assistant", content: "OK, using approach A." }],
+          stopReason: "end_turn",
+          cumulative_token_usage: { input_tokens: 80, output_tokens: 15 },
+        };
+      },
+    });
+    const handle = await openHandle(session);
+
+    const result = await adapter.sendTurn(handle, "prompt", {
+      interactionHandler: {
+        async onInteraction(req) {
+          if (req.kind === "question") return { answer: "Use approach A." };
+          return null;
+        },
+      },
+    });
+
+    expect(result.interactions).toHaveLength(1);
+    expect(result.interactions?.[0]).toEqual({
+      turnIndex: 1,
+      question: "Should I proceed with approach A or B?",
+      reply: "Use approach A.",
+    });
+  });
+
+  test("context-tool interaction: produces no interactions (only human Q&A is captured)", async () => {
+    let turnIndex = 0;
+    const session = makeSession({
+      promptFn: async () => {
+        turnIndex++;
+        if (turnIndex === 1) {
+          return {
+            messages: [{ role: "assistant", content: '<nax_tool_call name="get_context">\n{}\n</nax_tool_call>' }],
+            stopReason: "end_turn",
+            cumulative_token_usage: { input_tokens: 50, output_tokens: 20 },
+          };
+        }
+        return {
+          messages: [{ role: "assistant", content: "Used context, done." }],
+          stopReason: "end_turn",
+          cumulative_token_usage: { input_tokens: 100, output_tokens: 30 },
+        };
+      },
+    });
+    const handle = await openHandle(session);
+
+    const result = await adapter.sendTurn(handle, "prompt", {
+      interactionHandler: {
+        async onInteraction() {
+          return {
+            answer:
+              '<nax_tool_result name="get_context" status="ok">\ncontext data\n</nax_tool_result>\n\nContinue the task.',
+          };
+        },
+      },
+    });
+
+    expect(result.interactions).toBeUndefined();
+  });
+
+  test("no-interaction single turn: interactions is undefined", async () => {
+    const session = makeSession({
+      promptFn: async () => ({
+        messages: [{ role: "assistant", content: "All done." }],
+        stopReason: "end_turn",
+        cumulative_token_usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    });
+    const handle = await openHandle(session);
+
+    const result = await adapter.sendTurn(handle, "prompt", {
+      interactionHandler: NO_OP_INTERACTION_HANDLER,
+    });
+
+    expect(result.interactions).toBeUndefined();
+  });
+
   test("NO_OP_INTERACTION_HANDLER breaks loop on question", async () => {
     const session = makeSession({
       promptFn: async () => ({

--- a/test/unit/agents/manager-dispatch-emission.test.ts
+++ b/test/unit/agents/manager-dispatch-emission.test.ts
@@ -152,6 +152,53 @@ describe("runAsSession — dispatch emission", () => {
     expect(received[0]?.exactCostUsd).toBeUndefined();
   });
 
+  test("forwards TurnResult.interactions onto the session-turn event (issue #1226)", async () => {
+    const bus = new DispatchEventBus();
+    const manager = new AgentManager(DEFAULT_CONFIG, undefined, {
+      sendPrompt: mock(async () => ({
+        ...makeTurnResult("final answer"),
+        internalRoundTrips: 2,
+        interactions: [
+          { turnIndex: 1, question: "fix fixture or accept 15/17?", reply: "raise testEditDeclaration escalation" },
+        ],
+      })),
+      dispatchEvents: bus,
+    });
+
+    const received: SessionTurnDispatchEvent[] = [];
+    bus.onDispatch((e) => {
+      if (e.kind === "session-turn") received.push(e);
+    });
+
+    await manager.runAsSession("claude", makeHandle(), "test-prompt", {
+      pipelineStage: "run",
+      storyId: "US-004",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.interactions).toEqual([
+      { turnIndex: 1, question: "fix fixture or accept 15/17?", reply: "raise testEditDeclaration escalation" },
+    ]);
+  });
+
+  test("omits interactions on the session-turn event when TurnResult has none", async () => {
+    const bus = new DispatchEventBus();
+    const manager = new AgentManager(DEFAULT_CONFIG, undefined, {
+      sendPrompt: mock(async () => makeTurnResult("plain")),
+      dispatchEvents: bus,
+    });
+
+    const received: SessionTurnDispatchEvent[] = [];
+    bus.onDispatch((e) => {
+      if (e.kind === "session-turn") received.push(e);
+    });
+
+    await manager.runAsSession("claude", makeHandle(), "p", { pipelineStage: "run", storyId: "US-005" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.interactions).toBeUndefined();
+  });
+
   test("emits DispatchErrorEvent on sendPrompt throw, then re-throws", async () => {
     const bus = new DispatchEventBus();
     const manager = new AgentManager(DEFAULT_CONFIG, undefined, {

--- a/test/unit/runtime/middleware/audit.test.ts
+++ b/test/unit/runtime/middleware/audit.test.ts
@@ -96,6 +96,37 @@ describe("attachAuditSubscriber", () => {
     expect(recorded[0].runId).toBe("r-001");
   });
 
+  test("carries interactions through to the PromptAuditEntry when present", () => {
+    const recorded: PromptAuditEntry[] = [];
+    const auditor = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const bus = new DispatchEventBus();
+    attachAuditSubscriber(bus, auditor, "r-001");
+
+    bus.emitDispatch(
+      makeSessionTurnEvent({
+        interactions: [
+          { turnIndex: 1, question: "fix the fixture or accept 15/17?", reply: "raise testEditDeclaration escalation" },
+        ],
+      }),
+    );
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].interactions).toEqual([
+      { turnIndex: 1, question: "fix the fixture or accept 15/17?", reply: "raise testEditDeclaration escalation" },
+    ]);
+  });
+
+  test("omits interactions on the entry when the event has none (no noise)", () => {
+    const recorded: PromptAuditEntry[] = [];
+    const auditor = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const bus = new DispatchEventBus();
+    attachAuditSubscriber(bus, auditor, "r-001");
+
+    bus.emitDispatch(makeSessionTurnEvent());
+
+    expect(recorded[0].interactions).toBeUndefined();
+  });
+
   test("records PromptAuditEntry on complete dispatch with callType=complete", () => {
     const recorded: PromptAuditEntry[] = [];
     const auditor = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -160,6 +160,95 @@ describe("PromptAuditor", () => {
     });
   });
 
+  describe("interactions (issue #1226)", () => {
+    test("appends an === INTERACTIONS === section with question, reply, and turn index", async () => {
+      await withTempDir(async (dir) => {
+        const flushDir = join(dir, "audit");
+        let txtContent = "";
+        const orig = _promptAuditorDeps.write;
+        const origAppend = _promptAuditorDeps.appendLine;
+        _promptAuditorDeps.write = async (p, d) => {
+          if (p.endsWith(".txt")) txtContent = String(d);
+          return 0;
+        };
+        _promptAuditorDeps.appendLine = async () => {};
+        const aud = new PromptAuditor("my-run", flushDir, FEATURE);
+        aud.record(
+          makeEntry({
+            sessionName: "nax-abc-my-feature-us-004-implementer",
+            callType: "run",
+            stage: "run",
+            turn: 2,
+            prompt: "outer prompt",
+            response: "the user wants me to raise an escalation",
+            interactions: [
+              {
+                turnIndex: 2,
+                question: "fix the test fixture or accept 15/17?",
+                reply: "please raise the testEditDeclaration to escalation to test-writer",
+              },
+            ],
+          }),
+        );
+        await aud.flush();
+        expect(txtContent).toContain("=== INTERACTIONS ===");
+        expect(txtContent).toContain("fix the test fixture or accept 15/17?");
+        expect(txtContent).toContain("please raise the testEditDeclaration to escalation to test-writer");
+        // Correlatable to the enclosing round-trip index (AC3).
+        expect(txtContent).toContain("turn 2");
+        // Existing prompt/response content remains intact.
+        expect(txtContent).toContain("outer prompt");
+        expect(txtContent).toContain("=== RESPONSE ===");
+        _promptAuditorDeps.write = orig;
+        _promptAuditorDeps.appendLine = origAppend;
+      });
+    });
+
+    test("no === INTERACTIONS === section when entry has no interactions (existing output unchanged)", async () => {
+      await withTempDir(async (dir) => {
+        const flushDir = join(dir, "audit");
+        let txtContent = "";
+        const orig = _promptAuditorDeps.write;
+        const origAppend = _promptAuditorDeps.appendLine;
+        _promptAuditorDeps.write = async (p, d) => {
+          if (p.endsWith(".txt")) txtContent = String(d);
+          return 0;
+        };
+        _promptAuditorDeps.appendLine = async () => {};
+        const aud = new PromptAuditor("my-run", flushDir, FEATURE);
+        aud.record(makeEntry({ sessionName: "nax-abc-my-feature-us-004-implementer", prompt: "hello", response: "world" }));
+        await aud.flush();
+        expect(txtContent).not.toContain("=== INTERACTIONS ===");
+        _promptAuditorDeps.write = orig;
+        _promptAuditorDeps.appendLine = origAppend;
+      });
+    });
+
+    test("interactions are serialized into the JSONL line", async () => {
+      await withTempDir(async (dir) => {
+        const flushDir = join(dir, "audit");
+        const appended: string[] = [];
+        const origAppend = _promptAuditorDeps.appendLine;
+        const orig = _promptAuditorDeps.write;
+        _promptAuditorDeps.appendLine = async (_p: string, d: string) => { appended.push(d); };
+        _promptAuditorDeps.write = async () => 0;
+        const aud = new PromptAuditor("my-run", flushDir, FEATURE);
+        aud.record(
+          makeEntry({
+            sessionName: "nax-abc-my-feature-us-004-implementer",
+            interactions: [{ turnIndex: 1, question: "Q?", reply: "A." }],
+          }),
+        );
+        await aud.flush();
+        expect(appended).toHaveLength(1);
+        const parsed = JSON.parse(appended[0].trim());
+        expect(parsed.interactions).toEqual([{ turnIndex: 1, question: "Q?", reply: "A." }]);
+        _promptAuditorDeps.appendLine = origAppend;
+        _promptAuditorDeps.write = orig;
+      });
+    });
+  });
+
   describe("deriveTxtFilename fallback (no sessionName)", () => {
     test("uses <ts>-<callType>-<stage>-<storyId>.txt when all fields present", async () => {
       await withTempDir(async (dir) => {


### PR DESCRIPTION
## Summary

Fixes #1226 — interactive agent Q&A (a mid-turn question routed to the operator via the interaction plugin, plus their verbatim reply) was **invisible to the prompt-audit trail**. The exchange happens inside the ACP adapter's `sendTurn` loop and was folded into `internalRoundTrips`, so the audit captured only the outer prompt and the agent's final paraphrase — not what was asked or what the operator answered.

## Approach

Capture each exchange at the adapter (where the question, verbatim reply, and round-trip index all coexist) and flow it back through the **sanctioned result-side channel** — the adapter stays audit-blind:

```
AcpAdapter.sendTurn  ->  TurnResult.interactions
   ->  SessionTurnDispatchEvent.interactions   (manager.ts — one emit site covers runAsSession AND the callOp/hop path)
   ->  audit middleware  ->  PromptAuditEntry.interactions
   ->  JSONL line + "=== INTERACTIONS ===" section in the turn's .txt
```

- Only **human-question** round-trips are recorded; context-tool pulls are excluded.
- The `=== INTERACTIONS ===` section is appended only when interactions exist, each line tagged with its round-trip index.
- Turns with no interaction produce **byte-identical** `.txt` output to before.

## Acceptance criteria

- [x] Each interactive question recorded with stage/storyId/session/turn context
- [x] Operator's **verbatim** reply recorded (`response.answer` = plugin's `response.value`)
- [x] Correlatable to the enclosing round-trip index (`turnIndex` tag)
- [x] No-interaction turns produce no extra noise; existing audit `.txt` unchanged

## Test plan (TDD, RED -> GREEN per layer)

- **Adapter** (`adapter-phase-a.test.ts`) — captures `{ turnIndex, question, reply }`; context-tool produces none; no-interaction is `undefined`
- **Middleware** (`audit.test.ts`) — copies `event.interactions` onto the entry; omits when absent
- **Auditor** (`prompt-auditor.test.ts`) — appends turn-tagged section; no section without interactions; serialized into JSONL
- **Manager seam** (`manager-dispatch-emission.test.ts`) — `runAsSession` forwards `TurnResult.interactions` onto the event

Full suite: unit **8821 pass**, integration **1046 pass**, ui **15 pass**, 0 fail. `bun run typecheck` and `bun run lint` clean.

10 files changed, +317 (60 src / 257 test).