### PR TITLE
feat(operations): disk-keyed self-heal helper + acceptance path correction

### DIFF
--- a/src/operations/acceptance-generate.ts
+++ b/src/operations/acceptance-generate.ts
@@ -3,6 +3,7 @@ import { hasLikelyTestContent, isStubTestContent } from "../acceptance/heuristic
 import { acceptanceGenConfigSelector } from "../config";
 import type { AcceptanceGenConfig } from "../config/selectors";
 import { AcceptancePromptBuilder } from "../prompts";
+import { makeSelfHealStep, runSelfHealChain, type SelfHealStep } from "./self-heal";
 import type { RunOperation } from "./types";
 
 export interface AcceptanceGenerateInput {
@@ -15,6 +16,36 @@ export interface AcceptanceGenerateInput {
 
 export interface AcceptanceGenerateOutput {
   testCode: string | null;
+}
+
+/** Injectable I/O for the hopBody path-correction step (testable without disk). */
+export const _acceptanceGenerateDeps = {
+  fileExists: async (path: string): Promise<boolean> => {
+    try {
+      return await Bun.file(path).exists();
+    } catch {
+      return false;
+    }
+  },
+};
+
+/**
+ * Path-correction self-heal: if the generation turn did not leave a file at
+ * `targetTestFilePath` (agents often rename the dotfile/dashed name), issue one
+ * corrective turn telling the agent the exact path. `verify` then reads the file
+ * and only falls back to a skeleton if this still misses.
+ */
+function pathCorrectionStep(): SelfHealStep<AcceptanceGenerateInput> {
+  return makeSelfHealStep<AcceptanceGenerateInput, string>({
+    detect: async (input) =>
+      (await _acceptanceGenerateDeps.fileExists(input.targetTestFilePath)) ? [] : [input.targetTestFilePath],
+    buildRepair: (_deviations, input) => new AcceptancePromptBuilder().buildPathCorrection(input.targetTestFilePath),
+    log: {
+      kind: "acceptance",
+      message: "Acceptance test not found at target path — issuing one corrective turn",
+      meta: (input) => ({ targetTestFilePath: input.targetTestFilePath }),
+    },
+  });
 }
 
 export const acceptanceGenerateOp: RunOperation<
@@ -41,6 +72,10 @@ export const acceptanceGenerateOp: RunOperation<
       role: { id: "role", content: "", overridable: false },
       task: { id: "task", content: prompt, overridable: false },
     };
+  },
+  async hopBody(initialPrompt, ctx) {
+    const turn1 = await ctx.sendWithParseRetry(initialPrompt);
+    return runSelfHealChain(ctx, turn1, [pathCorrectionStep()]);
   },
   parse(output, _input, _ctx) {
     return { testCode: extractTestCode(output) };

--- a/src/operations/acceptance-generate.ts
+++ b/src/operations/acceptance-generate.ts
@@ -3,7 +3,7 @@ import { hasLikelyTestContent, isStubTestContent } from "../acceptance/heuristic
 import { acceptanceGenConfigSelector } from "../config";
 import type { AcceptanceGenConfig } from "../config/selectors";
 import { AcceptancePromptBuilder } from "../prompts";
-import { makeSelfHealStep, runSelfHealChain, type SelfHealStep } from "./self-heal";
+import { type SelfHealStep, makeSelfHealStep, runSelfHealChain } from "./self-heal";
 import type { RunOperation } from "./types";
 
 export interface AcceptanceGenerateInput {

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -12,7 +12,7 @@ export { buildHopCallback, _buildHopCallbackDeps } from "./build-hop-callback";
 export type { BuildHopCallbackContext } from "./build-hop-callback";
 export { classifyRouteOp, classifyRouteBatchOp } from "./classify-route";
 export type { ClassifyRouteInput, ClassifyRouteOutput } from "./classify-route";
-export { acceptanceGenerateOp } from "./acceptance-generate";
+export { acceptanceGenerateOp, _acceptanceGenerateDeps } from "./acceptance-generate";
 export type { AcceptanceGenerateInput, AcceptanceGenerateOutput } from "./acceptance-generate";
 export { acceptanceRefineOp } from "./acceptance-refine";
 export type { AcceptanceRefineInput, AcceptanceRefineOutput } from "./acceptance-refine";

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -3,6 +3,8 @@ export { planInteractiveOp } from "./plan";
 export type { PlanInteractiveInput } from "./plan";
 export { planRefineOp, _planRefineDeps, normalizeCreatedContextFiles } from "./plan-refine";
 export type { PlanRefineInput } from "./plan-refine";
+export { makeSelfHealStep, runSelfHealChain } from "./self-heal";
+export type { SelfHealStep, SelfHealSpec } from "./self-heal";
 export { warnOnDroppedVerbatimAcs } from "./verbatim-warn";
 export { decomposeOp } from "./decompose";
 export type { DecomposeOpInput, DecomposeOpOutput } from "./decompose";

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { makeParseRetryStrategy } from "../agents/retry";
+import type { TurnResult } from "../agents/types";
 import { planConfigSelector } from "../config";
 import type { ProjectProfile } from "../config/runtime-types";
 import type { PlanConfig } from "../config/selectors";
@@ -13,9 +14,8 @@ import type { UserStory } from "../prd/types";
 import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
 import type { SessionRole } from "../session/types";
+import { type SelfHealStep, makeSelfHealStep, runSelfHealChain } from "./self-heal";
 import type { RunOperation } from "./types";
-import type { TurnResult } from "../agents/types";
-import { makeSelfHealStep, runSelfHealChain, type SelfHealStep } from "./self-heal";
 import { warnOnDroppedVerbatimAcs, warnOnSpecDrift } from "./verbatim-warn";
 
 /** Injectable I/O for the hopBody self-heal step (testable without disk). */

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -14,6 +14,8 @@ import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
 import type { SessionRole } from "../session/types";
 import type { RunOperation } from "./types";
+import type { TurnResult } from "../agents/types";
+import { makeSelfHealStep, runSelfHealChain, type SelfHealStep } from "./self-heal";
 import { warnOnDroppedVerbatimAcs, warnOnSpecDrift } from "./verbatim-warn";
 
 /** Injectable I/O for the hopBody self-heal step (testable without disk). */
@@ -299,6 +301,32 @@ export async function normalizeCreatedContextFiles(
   return { ...prd, userStories: results.map((r) => r.story) };
 }
 
+/** `[verbatim]` fidelity self-heal — restores spec ACs the refine turn dropped. */
+function verbatimSelfHealStep(builder: PlanPromptBuilder): SelfHealStep<PlanRefineInput> {
+  return makeSelfHealStep<PlanRefineInput, string>({
+    detect: (input) => readMissingVerbatimAcs(input),
+    buildRepair: (missing, input) => builder.buildVerbatimRepair(missing, input.outputPath),
+    log: {
+      kind: "plan",
+      message: "Refine dropped [verbatim] spec ACs — issuing one repair turn",
+      meta: (input, missing) => ({ featureName: input.featureName, missingCount: missing.length }),
+    },
+  });
+}
+
+/** Spec-drift self-heal (specGuard only) — rewrites ACs with deprecated tags / shell patterns. */
+function specDriftSelfHealStep(builder: PlanPromptBuilder): SelfHealStep<PlanRefineInput> {
+  return makeSelfHealStep<PlanRefineInput, SpecDriftViolation>({
+    detect: (input) => readSpecDriftViolations(input),
+    buildRepair: (drifted, input) => builder.buildSpecDriftRepair(drifted, input.outputPath),
+    log: {
+      kind: "plan",
+      message: "specGuard: spec-drift violations found — issuing one repair turn",
+      meta: (input, drifted) => ({ featureName: input.featureName, violationCount: drifted.length }),
+    },
+  });
+}
+
 export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
   kind: "run",
   name: "plan-refine",
@@ -352,43 +380,19 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
     const turn1 = await ctx.sendWithParseRetry(initialPrompt);
     const turn2 = await ctx.send(builder.buildRefineContinuation(ctx.input.outputPath, specGuard));
 
-    let totalCost = (turn1.estimatedCostUsd ?? 0) + (turn2.estimatedCostUsd ?? 0);
-    let last = turn2;
+    const seed: TurnResult = {
+      ...turn2,
+      estimatedCostUsd: (turn1.estimatedCostUsd ?? 0) + (turn2.estimatedCostUsd ?? 0),
+    };
 
-    // Deterministic [verbatim] self-heal: if the rewritten PRD dropped any
-    // verbatim spec AC, issue exactly one targeted repair turn in the same
-    // session. `verify` re-runs the same check and warns if this turn still
-    // misses, so the repair prompt and the warning must stay in sync — both
-    // route through findMissingVerbatimAcs (src/prd/verbatim-fidelity.ts).
-    const missing = await readMissingVerbatimAcs(ctx.input);
-    if (missing.length > 0) {
-      getSafeLogger()?.info("plan", "Refine dropped [verbatim] spec ACs — issuing one repair turn", {
-        featureName: ctx.input.featureName,
-        missingCount: missing.length,
-      });
-      const turn3 = await ctx.send(builder.buildVerbatimRepair(missing, ctx.input.outputPath));
-      totalCost += turn3.estimatedCostUsd ?? 0;
-      last = turn3;
-    }
-
-    // Deterministic spec-drift repair (specGuard only): if the PRD contains
-    // deprecated tags or shell-command patterns that signal behavioral
-    // regression, issue one targeted repair turn. `verify` re-runs the same
-    // check and warns if violations remain after this turn.
-    if (specGuard) {
-      const drifted = await readSpecDriftViolations(ctx.input);
-      if (drifted.length > 0) {
-        getSafeLogger()?.info("plan", "specGuard: spec-drift violations found — issuing one repair turn", {
-          featureName: ctx.input.featureName,
-          violationCount: drifted.length,
-        });
-        const turn4 = await ctx.send(builder.buildSpecDriftRepair(drifted, ctx.input.outputPath));
-        totalCost += turn4.estimatedCostUsd ?? 0;
-        last = turn4;
-      }
-    }
-
-    return { ...last, estimatedCostUsd: totalCost };
+    // Deterministic same-session self-heal: [verbatim] fidelity always; spec-drift
+    // only under specGuard. Each step issues at most one corrective turn; `verify`
+    // re-runs the same checks and warns if a repair still misses (the plan continues).
+    const steps: SelfHealStep<PlanRefineInput>[] = [
+      verbatimSelfHealStep(builder),
+      ...(specGuard ? [specDriftSelfHealStep(builder)] : []),
+    ];
+    return runSelfHealChain(ctx, seed, steps);
   },
   parse(output, input) {
     return validatePlanOutput(output, input.featureName, input.branchName);

--- a/src/operations/self-heal.ts
+++ b/src/operations/self-heal.ts
@@ -1,0 +1,72 @@
+import type { TurnResult } from "../agents/types";
+import { getSafeLogger } from "../logger";
+import type { HopBodyContext } from "./types";
+
+/**
+ * One disk-keyed self-heal step inside a `hopBody`. The deviation type `D` is
+ * captured inside `makeSelfHealStep` and erased here, so heterogeneous steps
+ * (different `D` per step) compose in a single `runSelfHealChain` array without
+ * `any`.
+ */
+export interface SelfHealStep<I> {
+  /** Returns the corrective TurnResult, or null when nothing needed healing. */
+  readonly run: (ctx: HopBodyContext<I>) => Promise<TurnResult | null>;
+}
+
+/** Declarative spec for a self-heal step. `detect` reads disk; [] means healthy. */
+export interface SelfHealSpec<I, D> {
+  /** Disk-aware deviation detector. Empty result = no corrective turn. */
+  readonly detect: (input: I) => Promise<readonly D[]>;
+  /** Builds the single corrective re-prompt sent via `ctx.send`. */
+  readonly buildRepair: (deviations: readonly D[], input: I) => string;
+  /** Optional structured log emitted once, only when a corrective turn fires. */
+  readonly log?: {
+    readonly kind: string;
+    readonly message: string;
+    readonly meta?: (input: I, deviations: readonly D[]) => Record<string, unknown>;
+  };
+}
+
+/**
+ * Build a `SelfHealStep<I>` from a typed spec. The deviation type `D` stays
+ * internal — `detect`'s output feeds `buildRepair` with full typing, and the
+ * returned step erases `D` so the chain can hold steps with differing `D`.
+ */
+export function makeSelfHealStep<I, D>(spec: SelfHealSpec<I, D>): SelfHealStep<I> {
+  return {
+    async run(ctx) {
+      const deviations = await spec.detect(ctx.input);
+      if (deviations.length === 0) return null;
+      if (spec.log) {
+        getSafeLogger()?.info(spec.log.kind, spec.log.message, spec.log.meta?.(ctx.input, deviations) ?? {});
+      }
+      return ctx.send(spec.buildRepair(deviations, ctx.input));
+    },
+  };
+}
+
+/**
+ * Run `seed`'s session through `steps` in order, inside one hop. Each step that
+ * detects deviations issues exactly one corrective turn via `ctx.send`. Cost is
+ * accumulated onto the returned TurnResult; the most recent corrective turn (or
+ * the seed, if none fired) becomes the returned output.
+ *
+ * The op's `verify` should re-check the same conditions and warn on residual
+ * deviations — see `planRefineOp` for the canonical pairing.
+ */
+export async function runSelfHealChain<I>(
+  ctx: HopBodyContext<I>,
+  seed: TurnResult,
+  steps: readonly SelfHealStep<I>[],
+): Promise<TurnResult> {
+  let last = seed;
+  let totalCost = seed.estimatedCostUsd ?? 0;
+  for (const step of steps) {
+    const turn = await step.run(ctx);
+    if (turn) {
+      totalCost += turn.estimatedCostUsd ?? 0;
+      last = turn;
+    }
+  }
+  return { ...last, estimatedCostUsd: totalCost };
+}

--- a/src/operations/self-heal.ts
+++ b/src/operations/self-heal.ts
@@ -1,5 +1,6 @@
 import type { TurnResult } from "../agents/types";
 import { getSafeLogger } from "../logger";
+import { errorMessage } from "../utils/errors";
 import type { HopBodyContext } from "./types";
 
 /**
@@ -62,10 +63,14 @@ export async function runSelfHealChain<I>(
   let last = seed;
   let totalCost = seed.estimatedCostUsd ?? 0;
   for (const step of steps) {
-    const turn = await step.run(ctx);
-    if (turn) {
-      totalCost += turn.estimatedCostUsd ?? 0;
-      last = turn;
+    try {
+      const turn = await step.run(ctx);
+      if (turn) {
+        totalCost += turn.estimatedCostUsd ?? 0;
+        last = turn;
+      }
+    } catch (err) {
+      getSafeLogger()?.warn("self-heal", "step threw — skipping", { error: errorMessage(err) });
     }
   }
   return { ...last, estimatedCostUsd: totalCost };

--- a/src/prompts/builders/acceptance-builder.ts
+++ b/src/prompts/builders/acceptance-builder.ts
@@ -153,6 +153,26 @@ ${STEP3_SHARED_RULES}
 - **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming.${implSection}`;
   }
 
+  /**
+   * Corrective re-prompt for acceptanceGenerateOp's hopBody. Fired when the test
+   * file is absent from `targetTestFilePath` after the generation turn (the agent
+   * commonly "sanitizes" the dotfile/dashed name). Issued once, same session;
+   * `verify` re-checks the path and falls back to a skeleton only if this misses.
+   */
+  buildPathCorrection(targetTestFilePath: string): string {
+    return `The acceptance test file was NOT found at the required path. You likely wrote it to a different filename or directory (for example, by renaming a dotfile or replacing dashes with underscores).
+
+Move (or re-write) the acceptance test you just created so it lives at EXACTLY this path:
+${targetTestFilePath}
+
+Requirements:
+- The file must be at that exact path — same directory and same filename, including any leading dot and dashes. Do NOT sanitize, rename, or relocate it.
+- Preserve the test content you already wrote. Do not regenerate, weaken, or stub the assertions.
+- If you wrote it somewhere else, delete the misplaced copy after moving it so only the canonical path remains.
+
+After writing the file to the exact path above, reply with a brief confirmation only.`;
+  }
+
   /** Prompt for generateAcceptanceTests() — agent returns raw test code. */
   buildGeneratorFromSpecPrompt(p: GeneratorFromSpecParams): string {
     return `You are a senior test engineer. Your task is to generate a complete acceptance test file for the "${p.featureName}" feature.

--- a/test/unit/operations/acceptance-generate.test.ts
+++ b/test/unit/operations/acceptance-generate.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { join } from "node:path";
-import { acceptanceGenerateOp } from "@/operations";
+import { acceptanceGenerateOp, _acceptanceGenerateDeps } from "@/operations";
 import type { AcceptanceGenerateInput } from "@/operations/acceptance-generate";
-import type { BuildContext, VerifyContext } from "@/operations/types";
+import type { BuildContext, HopBodyContext, VerifyContext } from "@/operations/types";
+import type { TurnResult } from "@/agents/types";
 import { acceptanceGenConfigSelector } from "@/config";
 import type { AcceptanceGenConfig } from "@/config/selectors";
 import { makeNaxConfig, makeTestRuntime } from "../../helpers";
@@ -202,5 +203,61 @@ describe("acceptanceGenerateOp.verify()", () => {
     const ctx = makeVerifyCtx({ readFile });
     const result = await acceptanceGenerateOp.verify!({ testCode: null }, SAMPLE_INPUT, ctx);
     expect(result).toBeNull();
+  });
+});
+
+function makeTurn(output: string, cost: number): TurnResult {
+  return { output, estimatedCostUsd: cost, internalRoundTrips: 1, tokenUsage: { inputTokens: 0, outputTokens: 0 } };
+}
+
+describe("_acceptanceGenerateDeps.fileExists", () => {
+  test("returns true for an existing file and false for a missing one", async () => {
+    await withTempDir(async (dir) => {
+      const present = join(dir, "present.test.ts");
+      await Bun.write(present, "ok");
+      expect(await _acceptanceGenerateDeps.fileExists(present)).toBe(true);
+      expect(await _acceptanceGenerateDeps.fileExists(join(dir, "absent.test.ts"))).toBe(false);
+    });
+  });
+});
+
+describe("acceptanceGenerateOp.hopBody", () => {
+  const origFileExists = _acceptanceGenerateDeps.fileExists;
+  afterEach(() => {
+    _acceptanceGenerateDeps.fileExists = origFileExists;
+  });
+
+  test("issues no corrective turn when the file is present at the target path", async () => {
+    _acceptanceGenerateDeps.fileExists = async () => true;
+    const send = mock(async (_p: string) => makeTurn("corrective", 2));
+    const sendWithParseRetry = mock(async (_p: string) => makeTurn("gen-confirmation", 3));
+    const ctx: HopBodyContext<AcceptanceGenerateInput> = {
+      input: { ...SAMPLE_INPUT, targetTestFilePath: "/tmp/x/.nax-acceptance.test.ts" },
+      send,
+      sendWithParseRetry,
+    };
+    const result = await acceptanceGenerateOp.hopBody!("gen prompt", ctx);
+    expect(sendWithParseRetry).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(0);
+    expect(result.output).toBe("gen-confirmation");
+    expect(result.estimatedCostUsd).toBe(3);
+  });
+
+  test("issues exactly one corrective turn carrying the target path when the file is missing", async () => {
+    _acceptanceGenerateDeps.fileExists = async () => false;
+    const target = "/tmp/x/.nax-acceptance.test.tsx";
+    const send = mock(async (_p: string) => makeTurn("moved-confirmation", 2));
+    const sendWithParseRetry = mock(async (_p: string) => makeTurn("gen-confirmation", 3));
+    const ctx: HopBodyContext<AcceptanceGenerateInput> = {
+      input: { ...SAMPLE_INPUT, targetTestFilePath: target },
+      send,
+      sendWithParseRetry,
+    };
+    const result = await acceptanceGenerateOp.hopBody!("gen prompt", ctx);
+    expect(sendWithParseRetry).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0]).toContain(target);
+    expect(result.output).toBe("moved-confirmation");
+    expect(result.estimatedCostUsd).toBe(5); // 3 + 2
   });
 });

--- a/test/unit/operations/self-heal.test.ts
+++ b/test/unit/operations/self-heal.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, mock, test } from "bun:test";
+import { makeSelfHealStep, runSelfHealChain } from "@/operations";
+import type { HopBodyContext } from "@/operations/types";
+import type { TurnResult } from "@/agents/types";
+
+function makeTurn(output: string, cost: number): TurnResult {
+  return { output, estimatedCostUsd: cost, internalRoundTrips: 1, tokenUsage: { inputTokens: 0, outputTokens: 0 } };
+}
+
+interface Input {
+  readonly value: string;
+}
+
+function makeCtx(send: (p: string) => Promise<TurnResult>): HopBodyContext<Input> {
+  return { input: { value: "x" }, send, sendWithParseRetry: send };
+}
+
+describe("runSelfHealChain", () => {
+  test("returns the seed unchanged when there are no steps", async () => {
+    const send = mock(async (_p: string) => makeTurn("unused", 9));
+    const seed = makeTurn("seed-out", 3);
+    const result = await runSelfHealChain(makeCtx(send), seed, []);
+    expect(send).toHaveBeenCalledTimes(0);
+    expect(result.output).toBe("seed-out");
+    expect(result.estimatedCostUsd).toBe(3);
+  });
+
+  test("a healthy step (detect -> []) issues no turn and preserves the seed", async () => {
+    const send = mock(async (_p: string) => makeTurn("repair", 5));
+    const seed = makeTurn("seed-out", 2);
+    const step = makeSelfHealStep<Input, string>({
+      detect: async () => [],
+      buildRepair: () => "should-not-be-sent",
+    });
+    const result = await runSelfHealChain(makeCtx(send), seed, [step]);
+    expect(send).toHaveBeenCalledTimes(0);
+    expect(result.output).toBe("seed-out");
+    expect(result.estimatedCostUsd).toBe(2);
+  });
+
+  test("a deviating step sends one corrective turn, accumulates cost, returns that turn", async () => {
+    const send = mock(async (_p: string) => makeTurn("repair-out", 4));
+    const seed = makeTurn("seed-out", 1);
+    const step = makeSelfHealStep<Input, string>({
+      detect: async () => ["dev-a"],
+      buildRepair: (deviations, input) => `fix ${deviations.join(",")} for ${input.value}`,
+    });
+    const result = await runSelfHealChain(makeCtx(send), seed, [step]);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("fix dev-a for x");
+    expect(result.output).toBe("repair-out");
+    expect(result.estimatedCostUsd).toBe(5);
+  });
+
+  test("multiple steps: cost sums across deviating steps; last turn wins; healthy steps are skipped", async () => {
+    let n = 0;
+    const send = mock(async (_p: string) => {
+      n += 1;
+      return makeTurn(`repair-${n}`, n === 1 ? 4 : 6);
+    });
+    const seed = makeTurn("seed-out", 1);
+    const deviating1 = makeSelfHealStep<Input, string>({
+      detect: async () => ["a"],
+      buildRepair: () => "fix-1",
+    });
+    const healthy = makeSelfHealStep<Input, string>({
+      detect: async () => [],
+      buildRepair: () => "never",
+    });
+    const deviating2 = makeSelfHealStep<Input, string>({
+      detect: async () => ["b"],
+      buildRepair: () => "fix-2",
+    });
+    const result = await runSelfHealChain(makeCtx(send), seed, [deviating1, healthy, deviating2]);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenNthCalledWith(1, "fix-1");
+    expect(send).toHaveBeenNthCalledWith(2, "fix-2");
+    expect(result.output).toBe("repair-2");
+    expect(result.estimatedCostUsd).toBe(11); // 1 + 4 + 6
+  });
+});

--- a/test/unit/operations/self-heal.test.ts
+++ b/test/unit/operations/self-heal.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { makeSelfHealStep, runSelfHealChain } from "@/operations";
 import type { HopBodyContext } from "@/operations/types";
 import type { TurnResult } from "@/agents/types";
@@ -77,5 +77,64 @@ describe("runSelfHealChain", () => {
     expect(send).toHaveBeenNthCalledWith(2, "fix-2");
     expect(result.output).toBe("repair-2");
     expect(result.estimatedCostUsd).toBe(11); // 1 + 4 + 6
+  });
+
+  test("a throwing detector logs a warning and preserves the seed (throw isolation)", async () => {
+    const send = mock(async (_p: string) => makeTurn("repair", 5));
+    const seed = makeTurn("seed-out", 2);
+    const throwing = makeSelfHealStep<Input, string>({
+      detect: async () => { throw new Error("disk read failed"); },
+      buildRepair: () => "should-not-be-sent",
+    });
+    // Should not throw; seed must be preserved
+    const result = await runSelfHealChain(makeCtx(send), seed, [throwing]);
+    expect(send).toHaveBeenCalledTimes(0);
+    expect(result.output).toBe("seed-out");
+    expect(result.estimatedCostUsd).toBe(2);
+  });
+});
+
+describe("makeSelfHealStep — log branch", () => {
+  let infoSpy: ReturnType<typeof spyOn> | undefined;
+
+  beforeEach(async () => {
+    const { resetLogger, initLogger } = await import("@/logger");
+    resetLogger();
+    const logger = initLogger({ level: "silent" });
+    infoSpy = spyOn(logger, "info");
+  });
+
+  afterEach(async () => {
+    infoSpy?.mockRestore();
+    infoSpy = undefined;
+    const { resetLogger } = await import("@/logger");
+    resetLogger();
+  });
+
+  test("emits logger.info once when deviations are present", async () => {
+    const send = mock(async (_p: string) => makeTurn("repair", 1));
+    const step = makeSelfHealStep<Input, string>({
+      detect: async () => ["missing-ac"],
+      buildRepair: () => "fix",
+      log: {
+        kind: "test-kind",
+        message: "test message",
+        meta: (_input, deviations) => ({ count: deviations.length }),
+      },
+    });
+    await step.run(makeCtx(send));
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith("test-kind", "test message", { count: 1 });
+  });
+
+  test("does not call logger.info when there are no deviations (healthy)", async () => {
+    const send = mock(async (_p: string) => makeTurn("repair", 1));
+    const step = makeSelfHealStep<Input, string>({
+      detect: async () => [],
+      buildRepair: () => "fix",
+      log: { kind: "test-kind", message: "test message" },
+    });
+    await step.run(makeCtx(send));
+    expect(infoSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/test/unit/prompts/builders/acceptance-builder.test.ts
+++ b/test/unit/prompts/builders/acceptance-builder.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { AcceptancePromptBuilder } from "@/prompts";
+
+describe("AcceptancePromptBuilder.buildPathCorrection", () => {
+  const target = "/repo/apps/web/.nax/features/foo/.nax-acceptance.test.tsx";
+
+  test("embeds the exact target path", () => {
+    const prompt = new AcceptancePromptBuilder().buildPathCorrection(target);
+    expect(prompt).toContain(target);
+  });
+
+  test("instructs the agent not to rename/sanitize and to preserve content", () => {
+    const prompt = new AcceptancePromptBuilder().buildPathCorrection(target);
+    expect(prompt.toLowerCase()).toContain("exact");
+    expect(prompt.toLowerCase()).toContain("do not");
+    expect(prompt.toLowerCase()).toContain("preserve");
+  });
+});


### PR DESCRIPTION
## Summary

- **New helper** `src/operations/self-heal.ts` — exports `makeSelfHealStep<I,D>` and `runSelfHealChain`, a reusable pattern for disk-keyed "detect deviation → send one corrective in-session turn" logic inside a `hopBody`. Throwing detectors are caught and logged as warnings so a bad disk read can't kill an otherwise-healthy op.
- **Refactor** `planRefineOp.hopBody` onto the helper — behavior-preserving; all 31 existing regression tests still pass.
- **New** `AcceptancePromptBuilder.buildPathCorrection()` — corrective re-prompt instructing the agent to move/re-write the test to the exact `targetTestFilePath`.
- **New** `acceptanceGenerateOp.hopBody` + `_acceptanceGenerateDeps` — after the generation turn, detects whether the file landed at `targetTestFilePath`; if not (agent renamed the dotfile/dashed name), issues one corrective in-session turn before `verify` runs. The existing skeleton fallback in `verify` is untouched.

## Motivation

Agents commonly "sanitize" `targetTestFilePath` (`.nax-acceptance.test.tsx` → `_nax_acceptance_test.test.tsx`). `verify` reads only the exact path, finds nothing, and falls back to a skeleton — silently discarding correct tests. This PR fixes that in-session rather than requiring a full retry.

## Test Plan

- [ ] `timeout 30 bun test test/unit/operations/self-heal.test.ts` — 7 tests (chain semantics, throw isolation, log branch)
- [ ] `timeout 60 bun test test/unit/operations/plan-refine.test.ts` — 31 regression tests all pass
- [ ] `timeout 30 bun test test/unit/prompts/builders/acceptance-builder.test.ts` — `buildPathCorrection` content assertions
- [ ] `timeout 30 bun test test/unit/operations/acceptance-generate.test.ts` — 23 tests including new `_acceptanceGenerateDeps.fileExists` and `hopBody` path-correction tests
- [ ] `bun run lint && bun run typecheck` — clean
- [ ] `bun run test` — full suite green