### PR TITLE
feat(config): multi-profile chain override for --profile

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -93,6 +93,16 @@ program.name("nax").description("AI Coding Agent Orchestrator — loops until do
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Commander collector for repeatable `--profile` flags. Accumulates each
+ * occurrence into an array; comma-separated values within a single flag are
+ * split downstream by parseProfileList, so `--profile a,b` and
+ * `--profile a --profile b` both resolve to the chain ["a", "b"].
+ */
+function collectProfile(value: string, previous: string[]): string[] {
+  return previous.concat(value);
+}
+
+/**
  * Prompt user for a yes/no confirmation via stdin.
  * In tests or non-TTY environments, defaults to true.
  *
@@ -371,7 +381,12 @@ program
   .option("--json", "JSON mode (raw JSONL output to stdout)", false)
   .option("-d, --dir <path>", "Working directory", process.cwd())
   .option("--skip-precheck", "Skip precheck validations (advanced users only)", false)
-  .option("--profile <name>", "Profile to use (overrides config.json profile)")
+  .option(
+    "--profile <name>",
+    "Profile(s) to overlay (comma-separated or repeated; later overrides earlier)",
+    collectProfile,
+    [],
+  )
   .action(async (options) => {
     // Validate directory path
     let workdir: string;
@@ -420,16 +435,18 @@ program
     const naxDir = findProjectDir(workdir);
     const cliOverrides: Record<string, unknown> = {};
     // Delta C4: nax run defaults to the profile the PRD was planned with,
-    // unless --profile or NAX_PROFILE overrides it.
+    // unless --profile or NAX_PROFILE overrides it. --profile accepts a chain
+    // (comma-separated or repeated flags) where a later profile overrides earlier.
+    const cliProfiles: string[] = options.profile ?? [];
     const profileOverride = naxDir
       ? await resolveRunProfileOverride({
           prdPath: join(naxDir, "features", options.feature, "prd.json"),
           projectRoot: workdir,
-          cliProfile: options.profile,
+          cliProfile: cliProfiles,
           envProfile: process.env.NAX_PROFILE,
         })
-      : options.profile;
-    if (profileOverride) {
+      : cliProfiles;
+    if (profileOverride && profileOverride.length > 0) {
       cliOverrides.profile = profileOverride;
     }
     const config = await loadConfig(naxDir ?? undefined, cliOverrides);
@@ -839,7 +856,12 @@ program
   .option("-b, --branch <branch>", "Override default branch name")
   .option("-d, --dir <path>", "Project directory", process.cwd())
   .option("--decompose <storyId>", "Decompose an existing story into sub-stories")
-  .option("--profile <name>", "Profile to use (overrides config.json profile)")
+  .option(
+    "--profile <name>",
+    "Profile(s) to overlay (comma-separated or repeated; later overrides earlier)",
+    collectProfile,
+    [],
+  )
   .action(async (description, options) => {
     // AC-3: Detect and reject old positional argument form
     if (description) {
@@ -863,10 +885,11 @@ program
       process.exit(1);
     }
 
-    // Load config
+    // Load config — --profile accepts a chain (comma-separated or repeated flags).
     const cliOverrides: Record<string, unknown> = {};
-    if (options.profile) {
-      cliOverrides.profile = options.profile;
+    const cliProfiles: string[] = options.profile ?? [];
+    if (cliProfiles.length > 0) {
+      cliOverrides.profile = cliProfiles;
     }
     const config = await loadConfig(workdir, cliOverrides);
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -67,7 +67,7 @@ nax plan -f my-feature --from spec.md
 | `--auto` / `--one-shot` | Skip interactive Q&A — single LLM call, no back-and-forth |
 | `-b, --branch <branch>` | Override default branch name |
 | `--decompose <storyId>` | Decompose an existing story into sub-stories |
-| `--profile <name>` | Profile to use (overrides `config.json` profile) |
+| `--profile <name>` | Profile(s) to overlay on config (overrides `config.json` profile). Repeatable and comma-separated for a chain — `--profile a,b` or `--profile a --profile b` — where a later profile overrides an earlier one (`b` over `a` over project + global). Accepts the comma form in `NAX_PROFILE` and `config.json` too. |
 | `-d, --dir <path>` | Project directory |
 
 **Interactive vs one-shot:**
@@ -107,7 +107,7 @@ nax run -f my-feature
 | `--no-context` | Disable context builder (skip file context in prompts) |
 | `--no-batch` | Execute all stories individually (disable batching) |
 | `-m, --max-iterations <n>` | Max iterations (default: `20`) |
-| `--profile <name>` | Profile to use (overrides `config.json` profile) |
+| `--profile <name>` | Profile(s) to overlay on config (overrides `config.json` profile). Repeatable and comma-separated for a chain — `--profile a,b` or `--profile a --profile b` — where a later profile overrides an earlier one (`b` over `a` over project + global). Accepts the comma form in `NAX_PROFILE` and `config.json` too. |
 | `-d, --dir <path>` | Working directory |
 
 **Examples:**

--- a/src/cli/resolve-run-profile.ts
+++ b/src/cli/resolve-run-profile.ts
@@ -1,4 +1,4 @@
-import { listProfiles } from "../config";
+import { listProfiles, parseProfileList } from "../config";
 import { getSafeLogger } from "../logger";
 
 /**
@@ -7,24 +7,29 @@ import { getSafeLogger } from "../logger";
  * Precedence: CLI --profile > NAX_PROFILE env (handled inside loadConfig — we
  * return undefined so it applies) > PRD routingProfile > loadConfig defaults.
  *
- * GUARD: loadProfile THROWS on a missing profile file, so a PRD profile is
- * adopted only when it actually resolves (or is "default", which the loader
- * treats as no-overlay). Stale/legacy values warn and are skipped.
+ * Multi-profile: CLI and PRD values accept the comma form (and the CLI also the
+ * array form, from repeated flags); both resolve to an ordered chain where a
+ * later profile overrides an earlier one.
  *
- * Returns the profile name to pass as a CLI override into loadConfig, or
+ * GUARD: loadProfile THROWS on a missing profile file, so a PRD chain is adopted
+ * only when EVERY non-"default" name resolves. If any is missing, the whole PRD
+ * chain is skipped (warn) and config resolution falls through.
+ *
+ * Returns the profile chain to pass as a CLI override into loadConfig, or
  * undefined to let loadConfig's own resolution run.
  */
 export async function resolveRunProfileOverride(opts: {
   prdPath: string;
   projectRoot: string;
-  cliProfile: string | undefined;
+  cliProfile: string | string[] | undefined;
   envProfile: string | undefined;
   /** Test seam — defaults to reading prdPath via Bun.file */
   _readJson?: (path: string) => Promise<unknown>;
   /** Test seam — defaults to listProfiles(projectRoot) name extraction */
   _listProfileNames?: () => Promise<string[]>;
-}): Promise<string | undefined> {
-  if (opts.cliProfile) return opts.cliProfile;
+}): Promise<string[] | undefined> {
+  const cliChain = parseProfileList(opts.cliProfile);
+  if (cliChain.length > 0) return cliChain;
   if (opts.envProfile) return undefined;
 
   const readJson =
@@ -37,17 +42,21 @@ export async function resolveRunProfileOverride(opts: {
 
   try {
     const prd = (await readJson(opts.prdPath)) as { routingProfile?: unknown } | undefined;
-    if (prd && typeof prd.routingProfile === "string" && prd.routingProfile.length > 0) {
-      const name = prd.routingProfile;
-      if (name === "default") return name;
+    const rp = prd?.routingProfile;
+    const prdChain = parseProfileList(
+      typeof rp === "string" || Array.isArray(rp) ? (rp as string | string[]) : undefined,
+    );
+    if (prdChain.length > 0) {
       const listNames =
         opts._listProfileNames ?? (async () => (await listProfiles(opts.projectRoot)).map((p) => p.name));
       const available = await listNames();
-      if (available.includes(name)) return name;
+      // "default" never needs a profile file; everything else must resolve.
+      const missing = prdChain.filter((name) => name !== "default" && !available.includes(name));
+      if (missing.length === 0) return prdChain;
       getSafeLogger()?.warn(
         "run",
-        `PRD was planned with config profile "${name}" but no such profile exists — continuing with current config resolution`,
-        { storyId: "prd", plannedProfile: name },
+        `PRD was planned with config profile(s) "${prdChain.join(",")}" but ${missing.join(", ")} not found — continuing with current config resolution`,
+        { storyId: "prd", plannedProfile: prdChain.join(","), missing },
       );
     }
   } catch {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,7 +55,14 @@ export { validateDirectory, validateFilePath, isWithinDirectory, MAX_DIRECTORY_D
 export { globalConfigDir, projectConfigDir } from "./paths";
 export { deepMergeConfig } from "./merger";
 export type { PipelineStage } from "./permissions";
-export { resolveProfileName, loadProfile, loadProfileEnv, listProfiles } from "./profile";
+export {
+  resolveProfileName,
+  resolveProfileNames,
+  parseProfileList,
+  loadProfile,
+  loadProfileEnv,
+  listProfiles,
+} from "./profile";
 export { pickSelector, reshapeSelector } from "./selector";
 export type { ConfigSelector } from "./selector";
 export {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -59,6 +59,7 @@ export {
   resolveProfileName,
   resolveProfileNames,
   parseProfileList,
+  profileOverrideFromConfig,
   loadProfile,
   loadProfileEnv,
   listProfiles,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -404,7 +404,9 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   const hasMergedConfigs = globalConfRaw || projDir !== null || cliOverrides !== undefined || overlayChain.length > 0;
 
   // Parse and validate with Zod
-  // Skip validation if no configs were merged (rawConfig is just DEFAULT_CONFIG)
+  // Skip validation if no configs were merged (rawConfig is just DEFAULT_CONFIG).
+  // DEFAULT_CONFIG already carries profile="default" and profileChain=[] (schema
+  // defaults), so this fast path stays consistent with the full path's chain fields.
   if (!hasMergedConfigs) {
     return structuredClone(DEFAULT_CONFIG as unknown as Record<string, unknown>) as unknown as NaxConfig;
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -541,14 +541,21 @@ export async function loadConfigForWorkdir(
     rejectLegacyAgentKeys(rawMerged);
     rejectLegacyRectificationKeys(rawMerged);
     const result = NaxConfigSchema.safeParse(rawMerged);
-    if (result.success) {
-      merged = result.data as NaxConfig;
-    } else {
-      logger.warn("config", "Per-package profile failed validation — using merged config without profile", {
-        packageDir,
-        packageProfile,
+    if (!result.success) {
+      // Fail-fast — consistent with root-chain resolution (a missing profile file
+      // throws in loadProfile). Silently dropping the overlay would run the package
+      // with a config the user did not ask for, which is hard to debug.
+      const errors = result.error.issues.map((err) => {
+        const path = String(err.path.join("."));
+        return path ? `${path}: ${err.message}` : err.message;
       });
+      throw new NaxError(
+        `Per-package profile "${packageChain.join("+")}" produced an invalid config for package "${packageDir}":\n${errors.join("\n")}`,
+        "PER_PACKAGE_PROFILE_INVALID",
+        { stage: "config", packageDir, profileChain: packageChain },
+      );
     }
+    merged = result.data as NaxConfig;
   }
 
   return merged;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -14,7 +14,7 @@ import { deepMergeConfig } from "./merger";
 import { migrateLegacyReviewModelKey, migrateLegacyTestPattern } from "./migrations";
 import { MAX_DIRECTORY_DEPTH } from "./path-security";
 import { PROJECT_NAX_DIR, globalConfigDir } from "./paths";
-import { loadProfile, loadProfileEnv, resolveProfileName } from "./profile";
+import { loadProfile, loadProfileEnv, parseProfileList, resolveProfileNames } from "./profile";
 import { DEFAULT_CONFIG, type NaxConfig, NaxConfigSchema } from "./schema";
 
 /** Global config path */
@@ -330,12 +330,15 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
       : startDir
     : process.cwd();
 
-  // Resolve profile name: CLI > NAX_PROFILE env > project config.json > "default"
-  const profileName = await resolveProfileName(
-    cliOverrides ?? {},
+  // Resolve profile chain: CLI > NAX_PROFILE env > project config.json > global > ["default"].
+  // Each source accepts the comma form; the chain overlays left-to-right (later wins).
+  const profileChain = await resolveProfileNames(
+    (cliOverrides ?? {}) as { profile?: string | string[] },
     process.env as Record<string, string | undefined>,
     projectRoot,
   );
+  // "default" entries carry no overlay — drop them so only meaningful profiles merge.
+  const overlayChain = profileChain.filter((name) => name && name !== "default");
 
   // Layer 1: Global config (~/.nax/config.json) — strip "profile" field before merging (AC 7)
   const globalConfRaw = await loadJsonFile<Record<string, unknown>>(globalConfigPath(), "config");
@@ -377,13 +380,14 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     }
   }
 
-  // Layer 3: Profile data (overrides global + project — it's a run-time mode selection)
-  // "default" profile applies no overlay (AC 10)
-  if (profileName !== "default") {
-    const profileData = await loadProfile(profileName, projectRoot);
+  // Layer 3: Profile chain (overrides global + project — it's a run-time mode selection).
+  // Profiles overlay in order; a later profile overrides an earlier one. A missing
+  // profile file throws fail-fast (loadProfile). "default"-only chains apply no overlay.
+  for (const name of overlayChain) {
+    const profileData = await loadProfile(name, projectRoot);
     rawConfig = deepMergeConfig(rawConfig, profileData);
     // Load companion .env for $VAR resolution — do NOT write to process.env (AC 9)
-    await loadProfileEnv(profileName, projectRoot);
+    await loadProfileEnv(name, projectRoot);
   }
 
   // Layer 4: CLI overrides (highest priority)
@@ -391,11 +395,13 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     rawConfig = deepMergeConfig(rawConfig, cliOverrides);
   }
 
-  // Force-set profile to the resolved name after all merges (AC 6)
-  rawConfig.profile = profileName;
+  // Force-set profile + chain to the resolved values after all merges (AC 6).
+  // `profile` is the composite display string ("a+b"); "default" when no overlay applied.
+  rawConfig.profile = overlayChain.length > 0 ? overlayChain.join("+") : "default";
+  rawConfig.profileChain = overlayChain;
 
   // Track if any configs were merged (for optimization - skip safeParse when just using defaults)
-  const hasMergedConfigs = globalConfRaw || projDir !== null || cliOverrides !== undefined || profileName !== "default";
+  const hasMergedConfigs = globalConfRaw || projDir !== null || cliOverrides !== undefined || overlayChain.length > 0;
 
   // Parse and validate with Zod
   // Skip validation if no configs were merged (rawConfig is just DEFAULT_CONFIG)
@@ -476,7 +482,8 @@ export async function loadConfigForWorkdir(
 
   // Include the profile in the cache key so that --profile overrides are not
   // shadowed by a cached root config that was loaded without the profile flag.
-  const profileKey = (cliOverrides?.profile as string | undefined) ?? "";
+  // Normalize the chain to a stable string so comma and array forms key alike.
+  const profileKey = parseProfileList(cliOverrides?.profile as string | string[] | undefined).join(",");
   const cacheKey = profileKey ? `${resolvedRootConfigPath}:${profileKey}` : resolvedRootConfigPath;
 
   // Cache root config load — avoids repeated I/O for each package in a monorepo run.
@@ -514,15 +521,20 @@ export async function loadConfigForWorkdir(
   const { profile: packageProfile, ...packageFields } = packageOverride;
   let merged = mergePackageConfig(rootConfig, packageFields);
 
-  // Per-package profile: apply profile overlay on top of merged config
-  if (packageProfile && packageProfile !== "default") {
+  // Per-package profile: apply the profile chain overlay on top of merged config.
+  // Accepts the comma form; profiles overlay left-to-right (later overrides earlier).
+  const packageChain = parseProfileList(packageProfile as string | string[] | undefined).filter(
+    (name) => name && name !== "default",
+  );
+  if (packageChain.length > 0) {
     const packageRoot = join(repoRoot, packageDir);
-    const profileData = await loadProfile(packageProfile, packageRoot);
-    const rawMerged = deepMergeConfig<Record<string, unknown>>(
-      merged as unknown as Record<string, unknown>,
-      profileData,
-    );
-    rawMerged.profile = packageProfile;
+    let rawMerged = merged as unknown as Record<string, unknown>;
+    for (const name of packageChain) {
+      const profileData = await loadProfile(name, packageRoot);
+      rawMerged = deepMergeConfig<Record<string, unknown>>(rawMerged, profileData);
+    }
+    rawMerged.profile = packageChain.join("+");
+    rawMerged.profileChain = packageChain;
     // ADR-012 Phase 6 — legacy-key guard applies to per-package overlays too.
     rejectLegacyAgentKeys(rawMerged);
     rejectLegacyRectificationKeys(rawMerged);

--- a/src/config/profile.ts
+++ b/src/config/profile.ts
@@ -107,6 +107,31 @@ export function parseProfileList(input: string | string[] | null | undefined): s
   return out;
 }
 
+/**
+ * Derives the profile override to re-feed into `loadConfigForWorkdir` when
+ * resolving a per-package / per-story effective config from an already-loaded
+ * root config.
+ *
+ * Returns the resolved chain as an array (which {@link parseProfileList}
+ * round-trips cleanly) — NEVER the composite display string (`"a+b"`), because
+ * that string is joined with `+` and parseProfileList only splits on `,`, so
+ * re-feeding it would resolve a bogus single profile named `"a+b"`.
+ */
+export function profileOverrideFromConfig(config: {
+  profile?: string;
+  profileChain?: string[];
+}): { profile: string[] } | undefined {
+  if (config.profileChain && config.profileChain.length > 0) {
+    return { profile: config.profileChain };
+  }
+  // Back-compat: a config carrying only the single `profile` string (e.g. a
+  // hand-built NaxConfig in tests, or a pre-chain serialized config).
+  if (config.profile && config.profile !== "default") {
+    return { profile: [config.profile] };
+  }
+  return undefined;
+}
+
 /** Reads and parses the `profile` field of a config.json in the given dir into a chain. */
 async function readProfileChainFromConfig(dir: string): Promise<string[]> {
   const configFile = Bun.file(join(dir, "config.json"));

--- a/src/config/profile.ts
+++ b/src/config/profile.ts
@@ -6,6 +6,7 @@
 
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { NaxError } from "../errors";
 import { parseDotenv } from "./dotenv";
 import { deepMergeConfig } from "./merger";
 import { globalConfigDir, projectConfigDir } from "./paths";
@@ -32,7 +33,11 @@ export async function loadProfile(profileName: string, projectRoot: string): Pro
   if (!globalExists && !projectExists) {
     const available = await listAvailableProfileNames(projectRoot);
     const availableList = available.length > 0 ? available.join(", ") : "(none)";
-    throw new Error(`Profile "${profileName}" not found. Available: ${availableList}`);
+    throw new NaxError(`Profile "${profileName}" not found. Available: ${availableList}`, "PROFILE_NOT_FOUND", {
+      stage: "config",
+      profileName,
+      available,
+    });
   }
 
   let base: Record<string, unknown> = {};

--- a/src/config/profile.ts
+++ b/src/config/profile.ts
@@ -83,46 +83,86 @@ export async function loadProfileEnv(profileName: string, projectRoot: string): 
 }
 
 /**
- * Resolves the active profile name using priority:
- * CLI option > NAX_PROFILE env var > project config.json > global config.json > "default"
+ * Normalizes a profile override into an ordered chain of profile names.
  *
- * For the config.json fallback, project takes precedence over global — consistent
- * with the existing config merge order where project overrides global.
+ * Accepts the comma form (`"a,b"`) AND the array form (`["a", "b"]`, from
+ * repeated `--profile` flags); array entries may themselves contain commas and
+ * are flattened. Whitespace is trimmed and empty segments dropped. Order is
+ * preserved (later entries override earlier ones); duplicates are NOT removed.
+ *
+ * SSOT for "turn a profile override value into a chain" — used by the CLI,
+ * loader, and run-side resolver so the comma form behaves identically everywhere.
+ */
+export function parseProfileList(input: string | string[] | null | undefined): string[] {
+  if (input == null) return [];
+  const parts = Array.isArray(input) ? input : [input];
+  const out: string[] = [];
+  for (const part of parts) {
+    if (typeof part !== "string") continue;
+    for (const segment of part.split(",")) {
+      const trimmed = segment.trim();
+      if (trimmed) out.push(trimmed);
+    }
+  }
+  return out;
+}
+
+/** Reads and parses the `profile` field of a config.json in the given dir into a chain. */
+async function readProfileChainFromConfig(dir: string): Promise<string[]> {
+  const configFile = Bun.file(join(dir, "config.json"));
+  if (!(await configFile.exists())) return [];
+  const config = await configFile.json();
+  return parseProfileList(config.profile as string | string[] | undefined);
+}
+
+/** A chain that carries no meaningful overlay (empty, or only the implicit "default"). */
+function isDefaultOnlyChain(chain: string[]): boolean {
+  return chain.length === 0 || (chain.length === 1 && chain[0] === "default");
+}
+
+/**
+ * Resolves the active profile chain using priority:
+ * CLI option > NAX_PROFILE env var > project config.json > global config.json > ["default"]
+ *
+ * Every source accepts the comma form (and the CLI also the array form). The
+ * config.json fallback applies project before global — consistent with the
+ * config merge order where project overrides global. A source that resolves to
+ * only "default" is treated as unset and falls through to the next source.
+ */
+export async function resolveProfileNames(
+  cliOptions: { profile?: string | string[] },
+  env: Record<string, string | undefined>,
+  projectRoot: string,
+): Promise<string[]> {
+  const fromCli = parseProfileList(cliOptions.profile);
+  if (fromCli.length) return fromCli;
+
+  const fromEnv = parseProfileList(env.NAX_PROFILE);
+  if (fromEnv.length) return fromEnv;
+
+  // Project config.json takes precedence over global config.json
+  const projectChain = await readProfileChainFromConfig(projectConfigDir(projectRoot));
+  if (!isDefaultOnlyChain(projectChain)) return projectChain;
+
+  // Fall back to global config.json
+  const globalChain = await readProfileChainFromConfig(globalConfigDir());
+  if (!isDefaultOnlyChain(globalChain)) return globalChain;
+
+  return ["default"];
+}
+
+/**
+ * Resolves the single active profile name (back-compat wrapper around
+ * {@link resolveProfileNames}). Returns the last meaningful name in the chain,
+ * or "default" when nothing is set.
  */
 export async function resolveProfileName(
-  cliOptions: { profile?: string },
+  cliOptions: { profile?: string | string[] },
   env: Record<string, string | undefined>,
   projectRoot: string,
 ): Promise<string> {
-  if (cliOptions.profile) {
-    return cliOptions.profile;
-  }
-
-  if (env.NAX_PROFILE) {
-    return env.NAX_PROFILE;
-  }
-
-  // Project config.json takes precedence over global config.json
-  const projectConfigPath = join(projectConfigDir(projectRoot), "config.json");
-  const projectConfigFile = Bun.file(projectConfigPath);
-  if (await projectConfigFile.exists()) {
-    const config = await projectConfigFile.json();
-    if (typeof config.profile === "string" && config.profile && config.profile !== "default") {
-      return config.profile;
-    }
-  }
-
-  // Fall back to global config.json
-  const globalConfigPath = join(globalConfigDir(), "config.json");
-  const globalConfigFile = Bun.file(globalConfigPath);
-  if (await globalConfigFile.exists()) {
-    const config = await globalConfigFile.json();
-    if (typeof config.profile === "string" && config.profile && config.profile !== "default") {
-      return config.profile;
-    }
-  }
-
-  return "default";
+  const chain = await resolveProfileNames(cliOptions, env, projectRoot);
+  return chain[chain.length - 1] ?? "default";
 }
 
 /** Internal helper — returns deduplicated sorted profile names from both scopes. */

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -579,8 +579,13 @@ export interface NaxConfig {
   debate?: import("../debate/types").DebateConfig;
   /** Curator configuration */
   curator?: CuratorConfig;
-  /** Configuration profile name (default: "default") */
+  /** Configuration profile name. For a multi-profile chain this is the composite, e.g. "a+b" (default: "default") */
   profile: string;
+  /**
+   * Ordered chain of profile names actually overlaid (later overrides earlier),
+   * excluding implicit "default" entries. Empty when no profile overlay applied.
+   */
+  profileChain?: string[];
 }
 
 export interface CuratorThresholds {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -400,6 +400,7 @@ export const NaxConfigSchema = z
     })),
     curator: CuratorConfigSchema.optional(),
     profile: z.string().default("default"),
+    profileChain: z.array(z.string()).default([]),
   })
   .refine((data) => data.version === 1, {
     message: "Invalid version: expected 1",

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -7,6 +7,7 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { profileOverrideFromConfig } from "../config";
 import { loadConfigForWorkdir } from "../config/loader";
 import { getLogger } from "../logger";
 import type { StoryMetrics } from "../metrics";
@@ -105,8 +106,8 @@ export async function runIteration(
 
   // PKG-003: Resolve per-package effective config once per story (not per-stage)
   // Thread the CLI profile override through so --profile flags apply to per-package configs.
-  const profileOverride =
-    ctx.config.profile && ctx.config.profile !== "default" ? { profile: ctx.config.profile } : undefined;
+  // Use profileOverrideFromConfig (passes the round-trippable chain array, not the "a+b" composite).
+  const profileOverride = profileOverrideFromConfig(ctx.config);
   const effectiveConfig = story.workdir
     ? await _iterationRunnerDeps.loadConfigForWorkdir(
         join(ctx.workdir, ".nax", "config.json"),

--- a/src/execution/parallel-batch.ts
+++ b/src/execution/parallel-batch.ts
@@ -11,6 +11,7 @@
  */
 
 import path from "node:path";
+import { profileOverrideFromConfig } from "../config";
 import type { NaxConfig } from "../config";
 import { loadConfigForWorkdir } from "../config/loader";
 import type { LoadedHooksConfig } from "../hooks";
@@ -145,7 +146,7 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
   // Without this, all parallel stories use the root config regardless of story.workdir.
   // allSettled so a single malformed per-package config doesn't crash the whole batch.
   const rootConfigPath = path.join(workdir, ".nax", "config.json");
-  const profileOverride = config.profile && config.profile !== "default" ? { profile: config.profile } : undefined;
+  const profileOverride = profileOverrideFromConfig(config);
   const storyEffectiveConfigs = new Map<string, NaxConfig>();
   const configResults = await Promise.allSettled(
     stories

--- a/src/execution/parallel-coordinator.ts
+++ b/src/execution/parallel-coordinator.ts
@@ -5,6 +5,7 @@
 import { existsSync, symlinkSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
+import { profileOverrideFromConfig } from "../config";
 import type { NaxConfig } from "../config";
 import { loadConfigForWorkdir } from "../config/loader";
 import type { LoadedHooksConfig } from "../hooks";
@@ -190,7 +191,7 @@ export async function executeParallel(
     // Runs after all worktrees are created so git state is stable.
     // Only loads for stories whose worktrees were successfully created.
     const rootConfigPath = join(projectRoot, ".nax", "config.json");
-    const profileOverride = config.profile && config.profile !== "default" ? { profile: config.profile } : undefined;
+    const profileOverride = profileOverrideFromConfig(config);
     await Promise.all(
       batch
         .filter((story) => worktreePaths.has(story.id))

--- a/test/integration/config/profile-loader.test.ts
+++ b/test/integration/config/profile-loader.test.ts
@@ -307,3 +307,117 @@ describe("loadConfig — profile activation (US-002)", () => {
     expect(typeof barrel.listProfiles).toBe("function");
   });
 });
+
+describe("loadConfig — multi-profile chain override", () => {
+  let globalDir: string;
+  let projectDir: string;
+  let origGlobalConfigDir: string | undefined;
+  let origNaxProfile: string | undefined;
+
+  beforeEach(() => {
+    globalDir = makeTempDir("nax-test-global-");
+    projectDir = makeTempDir("nax-test-project-");
+    mkdirSync(join(globalDir), { recursive: true });
+    mkdirSync(join(projectDir, ".nax"), { recursive: true });
+    origGlobalConfigDir = process.env.NAX_GLOBAL_CONFIG_DIR;
+    process.env.NAX_GLOBAL_CONFIG_DIR = globalDir;
+    origNaxProfile = process.env.NAX_PROFILE;
+    delete process.env.NAX_PROFILE;
+  });
+
+  afterEach(() => {
+    cleanupTempDir(globalDir);
+    cleanupTempDir(projectDir);
+    if (origGlobalConfigDir === undefined) delete process.env.NAX_GLOBAL_CONFIG_DIR;
+    else process.env.NAX_GLOBAL_CONFIG_DIR = origGlobalConfigDir;
+    if (origNaxProfile === undefined) delete process.env.NAX_PROFILE;
+    else process.env.NAX_PROFILE = origNaxProfile;
+  });
+
+  test("later profile in the chain overrides the earlier one (B overrides A)", async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), {
+      execution: { sessionTimeoutSeconds: 100, maxIterations: 5 },
+    });
+    writeJson(join(globalDir, "profiles", "b.json"), {
+      execution: { sessionTimeoutSeconds: 200 },
+    });
+
+    const config = await loadConfig(projectDir, { profile: "a,b" });
+
+    // B wins on the shared key
+    expect(config.execution.sessionTimeoutSeconds).toBe(200);
+    // A's unique key survives (deep merge, not replace)
+    expect(config.execution.maxIterations).toBe(5);
+  });
+
+  test("records composite profile string and ordered profileChain", async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 1 } });
+    writeJson(join(globalDir, "profiles", "b.json"), { execution: { sessionTimeoutSeconds: 2 } });
+
+    const config = await loadConfig(projectDir, { profile: "a,b" });
+
+    expect(config.profile).toBe("a+b");
+    expect(config.profileChain).toEqual(["a", "b"]);
+  });
+
+  test("chain overrides project config, which overrides global", async () => {
+    writeJson(join(globalDir, "config.json"), { execution: { sessionTimeoutSeconds: 10 } });
+    writeJson(join(projectDir, ".nax", "config.json"), {
+      execution: { sessionTimeoutSeconds: 20 },
+    });
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 30 } });
+    writeJson(join(globalDir, "profiles", "b.json"), { execution: { sessionTimeoutSeconds: 40 } });
+
+    const config = await loadConfig(projectDir, { profile: "a,b" });
+    expect(config.execution.sessionTimeoutSeconds).toBe(40);
+  });
+
+  test("array (repeated-flag) form produces an identical result to comma form", async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 1 } });
+    writeJson(join(globalDir, "profiles", "b.json"), { execution: { sessionTimeoutSeconds: 2 } });
+
+    const comma = await loadConfig(projectDir, { profile: "a,b" });
+    const array = await loadConfig(projectDir, { profile: ["a", "b"] });
+
+    expect(array.profile).toBe(comma.profile);
+    expect(array.profileChain).toEqual(comma.profileChain);
+    expect(array.execution.sessionTimeoutSeconds).toBe(comma.execution.sessionTimeoutSeconds);
+  });
+
+  test("NAX_PROFILE comma form applies the whole chain", async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 1 } });
+    writeJson(join(globalDir, "profiles", "b.json"), { execution: { sessionTimeoutSeconds: 2 } });
+    process.env.NAX_PROFILE = "a,b";
+
+    const config = await loadConfig(projectDir);
+    expect(config.profileChain).toEqual(["a", "b"]);
+    expect(config.execution.sessionTimeoutSeconds).toBe(2);
+  });
+
+  test("a missing name anywhere in the chain throws fail-fast with the available list", async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 1 } });
+
+    const err = await loadConfig(projectDir, { profile: "a,nope" }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("nope");
+    expect((err as Error).message).toContain("Available:");
+  });
+
+  test('a single profile still works and yields a one-element chain', async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 7 } });
+
+    const config = await loadConfig(projectDir, { profile: "a" });
+    expect(config.profile).toBe("a");
+    expect(config.profileChain).toEqual(["a"]);
+    expect(config.execution.sessionTimeoutSeconds).toBe(7);
+  });
+
+  test('"default" entries in the chain are no-op overlays', async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 9 } });
+
+    const config = await loadConfig(projectDir, { profile: "default,a" });
+    expect(config.profile).toBe("a");
+    expect(config.profileChain).toEqual(["a"]);
+    expect(config.execution.sessionTimeoutSeconds).toBe(9);
+  });
+});

--- a/test/integration/config/profile-loader.test.ts
+++ b/test/integration/config/profile-loader.test.ts
@@ -462,4 +462,24 @@ describe("loadConfig — multi-profile chain override", () => {
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toContain("a+b");
   });
+
+  // M2: a per-package profile that yields an invalid config fails fast rather than
+  // silently dropping the overlay and running with a config the user did not ask for.
+  test("per-package profile producing an invalid config throws fail-fast", async () => {
+    writeJson(join(projectDir, ".nax", "config.json"), { execution: { sessionTimeoutSeconds: 100 } });
+    // Profile sets a field to the wrong type so Zod validation fails after overlay.
+    writeJson(join(globalDir, "profiles", "broken.json"), {
+      execution: { sessionTimeoutSeconds: "not-a-number" },
+    });
+    // Package opts into the broken profile.
+    writeJson(join(projectDir, ".nax", "mono", "pkg", "config.json"), { profile: "broken" });
+
+    const { loadConfigForWorkdir } = await import("../../../src/config/loader");
+    const rootConfigPath = join(projectDir, ".nax", "config.json");
+
+    const err = await loadConfigForWorkdir(rootConfigPath, "pkg").catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { code?: string }).code).toBe("PER_PACKAGE_PROFILE_INVALID");
+    expect((err as Error).message).toContain("pkg");
+  });
 });

--- a/test/integration/config/profile-loader.test.ts
+++ b/test/integration/config/profile-loader.test.ts
@@ -420,4 +420,46 @@ describe("loadConfig — multi-profile chain override", () => {
     expect(config.profileChain).toEqual(["a"]);
     expect(config.execution.sessionTimeoutSeconds).toBe(9);
   });
+
+  // Regression: per-package / parallel executors re-feed an already-resolved root
+  // config back into loadConfigForWorkdir. The composite "a+b" profile string is
+  // NOT round-trippable — only the profileChain array is. profileOverrideFromConfig
+  // is the SSOT that picks the array; this test locks the round trip.
+  test("a resolved chain round-trips through loadConfigForWorkdir via profileOverrideFromConfig", async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), {
+      execution: { sessionTimeoutSeconds: 1, maxIterations: 5 },
+    });
+    writeJson(join(globalDir, "profiles", "b.json"), { execution: { sessionTimeoutSeconds: 2 } });
+
+    const { loadConfigForWorkdir } = await import("../../../src/config/loader");
+    const { profileOverrideFromConfig } = await import("../../../src/config/profile");
+    const rootConfigPath = join(projectDir, ".nax", "config.json");
+
+    const rootConfig = await loadConfig(projectDir, { profile: "a,b" });
+    expect(rootConfig.profile).toBe("a+b");
+
+    // Mirror what iteration-runner / parallel executors do.
+    const override = profileOverrideFromConfig(rootConfig);
+    expect(override).toEqual({ profile: ["a", "b"] });
+
+    const effective = await loadConfigForWorkdir(rootConfigPath, undefined, override);
+    expect(effective.profileChain).toEqual(["a", "b"]);
+    expect(effective.execution.sessionTimeoutSeconds).toBe(2);
+    expect(effective.execution.maxIterations).toBe(5);
+  });
+
+  test("feeding the composite profile string back in would fail — proving the array form is required", async () => {
+    writeJson(join(globalDir, "profiles", "a.json"), { execution: { sessionTimeoutSeconds: 1 } });
+    writeJson(join(globalDir, "profiles", "b.json"), { execution: { sessionTimeoutSeconds: 2 } });
+
+    const { loadConfigForWorkdir } = await import("../../../src/config/loader");
+    const rootConfigPath = join(projectDir, ".nax", "config.json");
+
+    // The old (buggy) behavior passed the composite string; "a+b" is not a profile.
+    const err = await loadConfigForWorkdir(rootConfigPath, undefined, { profile: "a+b" }).catch(
+      (e: Error) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("a+b");
+  });
 });

--- a/test/unit/cli/resolve-run-profile.test.ts
+++ b/test/unit/cli/resolve-run-profile.test.ts
@@ -14,7 +14,7 @@ describe("resolveRunProfileOverride", () => {
       _readJson: readReturning({ routingProfile: "prd-prof" }),
       _listProfileNames: profilesAvailable("prd-prof"),
     });
-    expect(result).toBe("cli-prof");
+    expect(result).toEqual(["cli-prof"]);
   });
 
   test("NAX_PROFILE env defers to loadConfig (returns undefined, does not read PRD)", async () => {
@@ -43,7 +43,7 @@ describe("resolveRunProfileOverride", () => {
       _readJson: readReturning({ routingProfile: "aggressive" }),
       _listProfileNames: profilesAvailable("aggressive", "cheap"),
     });
-    expect(result).toBe("aggressive");
+    expect(result).toEqual(["aggressive"]);
   });
 
   test('adopts "default" without consulting the profile list (loader applies no overlay)', async () => {
@@ -55,7 +55,7 @@ describe("resolveRunProfileOverride", () => {
       _readJson: readReturning({ routingProfile: "default" }),
       _listProfileNames: profilesAvailable(), // empty — must not matter
     });
-    expect(result).toBe("default");
+    expect(result).toEqual(["default"]);
   });
 
   test("skips adoption (returns undefined) when the PRD profile has no profile file — stale/legacy value", async () => {
@@ -97,5 +97,77 @@ describe("resolveRunProfileOverride", () => {
       _listProfileNames: profilesAvailable("aggressive"),
     });
     expect(result).toBeUndefined();
+  });
+
+  test("CLI --profile comma form returns the full chain, winning over PRD", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: "a,b",
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: "prd-prof" }),
+      _listProfileNames: profilesAvailable("prd-prof"),
+    });
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  test("CLI --profile array form (repeated flags) returns the full chain", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: ["a", "b"],
+      envProfile: undefined,
+      _readJson: readReturning(undefined),
+      _listProfileNames: profilesAvailable(),
+    });
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  test("adopts a PRD routingProfile array when all names exist", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: ["aggressive", "cheap"] }),
+      _listProfileNames: profilesAvailable("aggressive", "cheap"),
+    });
+    expect(result).toEqual(["aggressive", "cheap"]);
+  });
+
+  test("adopts a PRD routingProfile comma string when all names exist", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: "aggressive,cheap" }),
+      _listProfileNames: profilesAvailable("aggressive", "cheap"),
+    });
+    expect(result).toEqual(["aggressive", "cheap"]);
+  });
+
+  test("skips PRD adoption when any name in the chain is missing", async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: ["aggressive", "nope"] }),
+      _listProfileNames: profilesAvailable("aggressive"),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('"default" entries in a PRD chain do not require a profile file', async () => {
+    const result = await resolveRunProfileOverride({
+      prdPath: "/x/prd.json",
+      projectRoot: "/x",
+      cliProfile: undefined,
+      envProfile: undefined,
+      _readJson: readReturning({ routingProfile: ["default", "aggressive"] }),
+      _listProfileNames: profilesAvailable("aggressive"),
+    });
+    expect(result).toEqual(["default", "aggressive"]);
   });
 });

--- a/test/unit/config/defaults-ssot.test.ts
+++ b/test/unit/config/defaults-ssot.test.ts
@@ -45,6 +45,7 @@ const NAX_CONFIG_KEYS: (keyof NaxConfig)[] = [
   "curator",
   "debate",
   "profile",
+  "profileChain",
 ];
 
 describe("NaxConfigSchema.parse({}) does not throw (AC-4)", () => {

--- a/test/unit/config/profile.test.ts
+++ b/test/unit/config/profile.test.ts
@@ -13,6 +13,7 @@ import {
   loadProfile,
   loadProfileEnv,
   parseProfileList,
+  profileOverrideFromConfig,
   resolveProfileName,
   resolveProfileNames,
 } from "../../../src/config/profile";
@@ -264,6 +265,28 @@ describe("config/profile", () => {
 
     test("ignores non-string array entries", () => {
       expect(parseProfileList(["a", 42 as unknown as string, "b"])).toEqual(["a", "b"]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // profileOverrideFromConfig
+  // ---------------------------------------------------------------------------
+
+  describe("profileOverrideFromConfig", () => {
+    test("returns the round-trippable chain array, not the composite string", () => {
+      expect(profileOverrideFromConfig({ profile: "a+b", profileChain: ["a", "b"] })).toEqual({
+        profile: ["a", "b"],
+      });
+    });
+
+    test("falls back to the single profile string when no chain is present", () => {
+      expect(profileOverrideFromConfig({ profile: "fast" })).toEqual({ profile: ["fast"] });
+    });
+
+    test('returns undefined for "default" / empty', () => {
+      expect(profileOverrideFromConfig({ profile: "default" })).toBeUndefined();
+      expect(profileOverrideFromConfig({ profile: "default", profileChain: [] })).toBeUndefined();
+      expect(profileOverrideFromConfig({})).toBeUndefined();
     });
   });
 

--- a/test/unit/config/profile.test.ts
+++ b/test/unit/config/profile.test.ts
@@ -12,7 +12,9 @@ import {
   listProfiles,
   loadProfile,
   loadProfileEnv,
+  parseProfileList,
   resolveProfileName,
+  resolveProfileNames,
 } from "../../../src/config/profile";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 
@@ -229,6 +231,102 @@ describe("config/profile", () => {
     test('returns "default" when no profile is set anywhere', async () => {
       const result = await resolveProfileName({}, {}, projectDir);
       expect(result).toBe("default");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // parseProfileList
+  // ---------------------------------------------------------------------------
+
+  describe("parseProfileList", () => {
+    test("returns empty array for undefined/null/empty", () => {
+      expect(parseProfileList(undefined)).toEqual([]);
+      expect(parseProfileList(null)).toEqual([]);
+      expect(parseProfileList("")).toEqual([]);
+      expect(parseProfileList([])).toEqual([]);
+    });
+
+    test("splits a comma-separated string into an ordered chain", () => {
+      expect(parseProfileList("a,b,c")).toEqual(["a", "b", "c"]);
+    });
+
+    test("trims whitespace and drops empty segments", () => {
+      expect(parseProfileList(" a , b ,, c ,")).toEqual(["a", "b", "c"]);
+    });
+
+    test("flattens an array of values, splitting each on commas (repeated-flag form)", () => {
+      expect(parseProfileList(["a", "b,c"])).toEqual(["a", "b", "c"]);
+    });
+
+    test("preserves order and does not dedupe", () => {
+      expect(parseProfileList("a,b,a")).toEqual(["a", "b", "a"]);
+    });
+
+    test("ignores non-string array entries", () => {
+      expect(parseProfileList(["a", 42 as unknown as string, "b"])).toEqual(["a", "b"]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resolveProfileNames (chain)
+  // ---------------------------------------------------------------------------
+
+  describe("resolveProfileNames", () => {
+    test("returns CLI chain (comma form) — CLI wins over env", async () => {
+      const result = await resolveProfileNames(
+        { profile: "a,b" },
+        { NAX_PROFILE: "env" },
+        projectDir,
+      );
+      expect(result).toEqual(["a", "b"]);
+    });
+
+    test("returns CLI chain (array form, repeated flags)", async () => {
+      const result = await resolveProfileNames({ profile: ["a", "b"] }, {}, projectDir);
+      expect(result).toEqual(["a", "b"]);
+    });
+
+    test("parses NAX_PROFILE comma form when no CLI override", async () => {
+      const result = await resolveProfileNames({}, { NAX_PROFILE: "x,y" }, projectDir);
+      expect(result).toEqual(["x", "y"]);
+    });
+
+    test("parses project config.json profile comma form", async () => {
+      const projectNaxDir = join(projectDir, ".nax");
+      mkdirSync(projectNaxDir, { recursive: true });
+      await Bun.write(join(projectNaxDir, "config.json"), JSON.stringify({ profile: "p,q" }));
+
+      const result = await resolveProfileNames({}, {}, projectDir);
+      expect(result).toEqual(["p", "q"]);
+    });
+
+    test("parses project config.json profile array form", async () => {
+      const projectNaxDir = join(projectDir, ".nax");
+      mkdirSync(projectNaxDir, { recursive: true });
+      await Bun.write(join(projectNaxDir, "config.json"), JSON.stringify({ profile: ["p", "q"] }));
+
+      const result = await resolveProfileNames({}, {}, projectDir);
+      expect(result).toEqual(["p", "q"]);
+    });
+
+    test('a single "default" in project config falls through to global then "default"', async () => {
+      const projectNaxDir = join(projectDir, ".nax");
+      mkdirSync(projectNaxDir, { recursive: true });
+      await Bun.write(join(projectNaxDir, "config.json"), JSON.stringify({ profile: "default" }));
+      await Bun.write(join(globalDir, "config.json"), JSON.stringify({ profile: "g1,g2" }));
+
+      const result = await resolveProfileNames({}, {}, projectDir);
+      expect(result).toEqual(["g1", "g2"]);
+    });
+
+    test('returns ["default"] when nothing is set anywhere', async () => {
+      const result = await resolveProfileNames({}, {}, projectDir);
+      expect(result).toEqual(["default"]);
+    });
+
+    test("resolveProfileName (singular) returns the last meaningful name for back-compat", async () => {
+      const result = await resolveProfileName({ profile: "a,b" }, {}, projectDir);
+      expect(result).toBe("b");
     });
   });
 

--- a/test/unit/config/profile.test.ts
+++ b/test/unit/config/profile.test.ts
@@ -94,6 +94,7 @@ describe("config/profile", () => {
 
       const err = await loadProfile("nonexistent", projectDir).catch((e: Error) => e);
       expect(err).toBeInstanceOf(Error);
+      expect((err as { code?: string }).code).toBe("PROFILE_NOT_FOUND");
       expect(err.message).toContain("nonexistent");
       expect(err.message).toContain("Available:");
       expect(err.message).toContain("fast");


### PR DESCRIPTION
## Summary

Adds **multi-profile chain override** to `--profile` for `nax run` and `nax plan`. Today `--profile` takes a single profile; this lets you stack several, where a later profile overrides an earlier one.

```bash
nax run -f feat --profile a,b           # comma form
nax run -f feat --profile a --profile b # repeated-flag form (identical result)
```

Resolution (later wins): `DEFAULT → global → project → profile[0] → profile[1] → … → CLI`. So `--profile a,b` overlays `b` over `a` over project + global config.

The comma form is accepted **everywhere**: CLI, `NAX_PROFILE`, root `config.json`, per-package `config.json`, and PRD `routingProfile`.

## What changed

- **`parseProfileList`** (`src/config/profile.ts`) — SSOT that normalizes the comma form and the array form (repeated flags) into one ordered chain. Trims, drops empties, preserves order, no dedupe.
- **`resolveProfileNames`** — chain-aware resolver (`CLI > NAX_PROFILE > project > global > ["default"]`); a source resolving to only `"default"` falls through. `resolveProfileName` kept as a back-compat wrapper returning the last meaningful name.
- **Loader** — overlays each profile in order; records a composite display string on `config.profile` (`"a+b"`) plus a new ordered `config.profileChain: string[]`. `"default"` entries are no-op overlays. A missing name anywhere in the chain fails fast.
- **`bin/nax.ts`** — `collectProfile` commander collector on both `run` and `plan`.
- **Per-package profiles** and **`resolveRunProfileOverride`** (PRD `routingProfile`) accept chains the same way.
- **Schema/types** — `profileChain` (`z.array(z.string()).default([])`; optional in the interface to avoid breaking hand-built `NaxConfig` literals).
- **Docs** — `docs/guides/cli-reference.md` updated.

## Config recording

| Field | Meaning | Example (`--profile a,b`) |
|:--|:--|:--|
| `config.profile` | composite display string | `"a+b"` |
| `config.profileChain` | ordered overlay names (excl. implicit `"default"`) | `["a","b"]` |

## Self-review fixes (folded into this branch)

A `code-reviewer` pass caught one real bug and two convention gaps:

- **C1 (critical) — round-trip crash.** Per-package/parallel executors re-feed `config.profile` into `loadConfigForWorkdir`, but the composite `"a+b"` isn't round-trippable (`parseProfileList` splits on `,`, not `+`), so any monorepo/parallel run with a 2+ profile chain crashed with `Profile "a+b" not found`. Fix: added `profileOverrideFromConfig()` SSOT that passes the round-trippable `profileChain` **array**; `iteration-runner`, `parallel-batch`, `parallel-coordinator` now use it. Regression tests lock both directions.
- **M2 — fail-fast.** A per-package profile producing an invalid config now throws `NaxError(PER_PACKAGE_PROFILE_INVALID)` instead of warn-and-continue (silently running unprofiled is hard to debug).
- **L1 — `NaxError`.** `loadProfile` now throws `NaxError(PROFILE_NOT_FOUND)` with structured context instead of a plain `Error`.

## Backward compatibility

Single-profile usage is unchanged: `--profile fast` → `profileChain: ["fast"]`, `profile: "fast"`. `NAX_PROFILE`/`config.json` single values behave exactly as before.

## Test plan

- [x] `parseProfileList` / `resolveProfileNames` / `profileOverrideFromConfig` unit tests (comma + array forms, whitespace, dedupe-preserving, `"default"` handling, non-string entries)
- [x] Loader chain ordering, composite + `profileChain`, comma≡array, `NAX_PROFILE` comma, fail-fast on missing name, `"default"` no-op
- [x] Round-trip through `loadConfigForWorkdir` (regression for C1) + composite-string-fails guard
- [x] Per-package invalid-profile fail-fast (M2) + `NaxError` codes (L1)
- [x] Commander collector verified for both flag forms
- [x] `bun run typecheck`, `bun run lint`, full `bun run test` (unit + integration + ui) — all green
