### PR TITLE
fix(perf): memory leaks, pipe-buffer deadlocks, and concurrency races

### DIFF
--- a/src/agents/acp/parser.ts
+++ b/src/agents/acp/parser.ts
@@ -178,6 +178,11 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLine
     }
 
     // ── Legacy flat NDJSON format ───────────────────────────────────────────
+    // Each event carries exactly one of: result (final full text), content
+    // (streaming chunk), or text (older streaming chunk name). They are
+    // mutually exclusive in the acpx protocol — no single event emits more
+    // than one. Using else-if is intentional: result wins and resets state.text;
+    // content and text are additive but never appear together.
     if (event.result && typeof event.result === "string") {
       state.text = event.result;
     } else if (event.content && typeof event.content === "string") {

--- a/src/agents/acp/parser.ts
+++ b/src/agents/acp/parser.ts
@@ -178,9 +178,13 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLine
     }
 
     // ── Legacy flat NDJSON format ───────────────────────────────────────────
-    if (event.content && typeof event.content === "string") state.text += event.content;
-    if (event.text && typeof event.text === "string") state.text += event.text;
-    if (event.result && typeof event.result === "string") state.text = event.result;
+    if (event.result && typeof event.result === "string") {
+      state.text = event.result;
+    } else if (event.content && typeof event.content === "string") {
+      state.text += event.content;
+    } else if (event.text && typeof event.text === "string") {
+      state.text += event.text;
+    }
 
     if (event.cumulative_token_usage) state.tokenUsage = event.cumulative_token_usage;
     if (event.usage) {

--- a/src/agents/manager-types.ts
+++ b/src/agents/manager-types.ts
@@ -137,6 +137,9 @@ export interface IAgentManager {
   /** Reset per-run state. Called at run boundary. */
   reset(): void;
 
+  /** Release internal resources (EventEmitter listeners). Called from NaxRuntime.close(). */
+  close(): void;
+
   /**
    * Validate credentials for the default agent and every agent referenced in
    * agent.fallback.map. Prunes fallback candidates with missing credentials;

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -69,7 +69,11 @@ export class AgentManager implements IAgentManager {
   private _registry: AgentRegistry | undefined;
   private readonly _unavailable = new Map<string, AdapterFailure>();
   private readonly _prunedFallback = new Set<string>();
-  private readonly _emitter = new EventEmitter();
+  private readonly _emitter = (() => {
+    const ee = new EventEmitter();
+    ee.setMaxListeners(0);
+    return ee;
+  })();
   private readonly _logger: LoggerLike;
   private _middleware: MiddlewareChain;
   private _runId: string;
@@ -782,6 +786,10 @@ export class AgentManager implements IAgentManager {
       this._dispatchEvents.emitDispatchError(errEvent);
       throw err;
     }
+  }
+
+  close(): void {
+    this._emitter.removeAllListeners();
   }
 
   private _resolveRegistry(): AgentRegistry {

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -48,6 +48,15 @@ type LoggerLike = {
   info: (scope: string, msg: string, data?: Record<string, unknown>) => void;
 };
 
+/**
+ * Upper bound on dispatch-event listeners before EventEmitter warns of a leak.
+ * A single run legitimately attaches several listeners per concurrent story
+ * (parallel mode), so the Node default of 10 is too low. We raise the ceiling
+ * but deliberately keep it finite — `setMaxListeners(0)` (unlimited) would
+ * disable the very warning that surfaces a genuine listener leak.
+ */
+const MAX_EMITTER_LISTENERS = 100;
+
 export type SendPromptFn = (
   handle: import("./types").SessionHandle,
   prompt: string,
@@ -71,7 +80,7 @@ export class AgentManager implements IAgentManager {
   private readonly _prunedFallback = new Set<string>();
   private readonly _emitter = (() => {
     const ee = new EventEmitter();
-    ee.setMaxListeners(0);
+    ee.setMaxListeners(MAX_EMITTER_LISTENERS);
     return ee;
   })();
   private readonly _logger: LoggerLike;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -492,7 +492,11 @@ export async function loadConfigForWorkdir(
   // LRU eviction: evict oldest entry when cap is reached to bound memory in long-lived processes.
   let rootConfigPromise = _rootConfigCache.get(cacheKey);
   if (!rootConfigPromise) {
-    rootConfigPromise = loadConfig(rootNaxDir, cliOverrides);
+    rootConfigPromise = loadConfig(rootNaxDir, cliOverrides).catch((err) => {
+      // Remove rejected promise from cache so the next call retries the load.
+      _rootConfigCache.delete(cacheKey);
+      throw err;
+    });
     if (_rootConfigCache.size >= ROOT_CONFIG_CACHE_MAX) {
       const firstKey = _rootConfigCache.keys().next().value;
       if (firstKey !== undefined) _rootConfigCache.delete(firstKey);

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -97,6 +97,8 @@ export interface SmartTestRunnerConfig {
   testFilePatterns?: string[];
   /** Fallback strategy when path-convention mapping yields no results */
   fallback: "import-grep" | "full-suite";
+  /** Max test files scanned (post-filter) before truncating (default: 200) */
+  maxScanFiles: number;
 }
 
 /** Worktree dependency preparation strategy (WT-DEPS-001) */

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -61,11 +61,18 @@ const SmartTestRunnerConfigSchema = z.object({
    */
   testFilePatterns: z.array(z.string()).optional(),
   fallback: z.enum(["import-grep", "full-suite"]).default("import-grep"),
+  /**
+   * Max test files scanned (post-filter) before truncating. Single source of
+   * truth for both the import-grep fallback scan (smart-runner) and the
+   * test-coverage context scan (test-scanner).
+   */
+  maxScanFiles: z.number().int().min(1).max(5000).default(200),
 });
 
 const SMART_TEST_RUNNER_DEFAULT = {
   enabled: true,
   fallback: "import-grep" as const,
+  maxScanFiles: 200,
 };
 
 /** Coerces boolean → SmartTestRunnerConfig for backward compat */

--- a/src/context/engine/providers/session-scratch.ts
+++ b/src/context/engine/providers/session-scratch.ts
@@ -171,7 +171,9 @@ export class SessionScratchProvider implements IContextProvider {
       return { chunks: [], pullTools: [] };
     }
 
-    const ignoreMatchers = await resolveNaxIgnorePatterns(request.repoRoot, request.packageDir);
+    const ignoreMatchers =
+      request.naxIgnoreIndex?.getMatchers(request.packageDir) ??
+      (await resolveNaxIgnorePatterns(request.repoRoot, request.packageDir));
     const chunks: RawChunk[] = [];
     for (const dir of dirs) {
       const chunk = await readScratchDir(dir, request.agentId, ignoreMatchers);

--- a/src/context/engine/providers/test-coverage.ts
+++ b/src/context/engine/providers/test-coverage.ts
@@ -9,6 +9,7 @@
 
 import { createHash } from "node:crypto";
 import { relative } from "node:path";
+import { coerceSmartRunner } from "@/test-runners";
 import type { NaxConfig } from "../../../config/types";
 import { getLogger } from "../../../logger";
 import { getContextFiles } from "../../../prd";
@@ -81,12 +82,14 @@ export class TestCoverageProvider implements IContextProvider {
       const globs =
         (resolved as { globs?: readonly string[]; patterns?: readonly string[] }).patterns ?? resolved.globs;
 
+      const smartCfg = coerceSmartRunner(this.config.execution?.smartTestRunner);
       const scanOptions: TestScanOptions = {
         workdir: request.packageDir,
         testDir: tcConfig.testDir,
         maxTokens: tcConfig.maxTokens ?? 500,
         detail: tcConfig.detail ?? "names-and-counts",
         scopeToStory: tcConfig.scopeToStory ?? true,
+        maxScanFiles: smartCfg.maxScanFiles,
         contextFiles,
         resolvedTestGlobs: globs,
       };

--- a/src/context/greenfield.ts
+++ b/src/context/greenfield.ts
@@ -46,9 +46,10 @@ async function gitLsFiles(workdir: string): Promise<string[] | null> {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const exitCode = await proc.exited;
+    // Drain stdout concurrently with exited to avoid pipe-buffer deadlock on
+    // large repos (git blocks writing when the ~64KB OS buffer fills).
+    const [exitCode, output] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
     if (exitCode !== 0) return null;
-    const output = await new Response(proc.stdout).text();
     return output.split("\n").filter(Boolean);
   } catch {
     return null;

--- a/src/context/test-scanner.ts
+++ b/src/context/test-scanner.ts
@@ -259,10 +259,21 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
     allowedBasenames = new Set(patterns);
   }
 
+  const MAX_SCAN_FILES = 200;
   const glob = new Glob(testPattern);
   const files: TestFileInfo[] = [];
+  let scanCount = 0;
 
   for await (const filePath of glob.scan({ cwd: scanDir, absolute: false })) {
+    if (scanCount >= MAX_SCAN_FILES) {
+      getLogger().debug("test-scanner", "Glob cap reached — results truncated", {
+        cap: MAX_SCAN_FILES,
+        scanDir,
+      });
+      break;
+    }
+    scanCount++;
+
     // Filter by derived patterns if scoping is enabled
     if (allowedBasenames !== null) {
       const basename = path.basename(filePath);

--- a/src/context/test-scanner.ts
+++ b/src/context/test-scanner.ts
@@ -16,6 +16,14 @@ import { DEFAULT_SCAN_TEST_DIRS, DEFAULT_TS_DERIVE_SUFFIXES, extractTestDirs } f
 // Types
 // ============================================================================
 
+/**
+ * Fallback cap for direct callers that don't pass `maxScanFiles`. Production
+ * threads config.execution.smartTestRunner.maxScanFiles (SSOT) via the
+ * test-coverage provider; this only applies to unit tests calling scanTestFiles
+ * directly. Mirrors the schema default in schemas-execution.ts.
+ */
+const DEFAULT_MAX_SCAN_FILES = 200;
+
 /** Detail level for test summary */
 export type TestSummaryDetail = "names-only" | "names-and-counts" | "describe-blocks";
 
@@ -37,6 +45,12 @@ export interface TestScanOptions {
   contextFiles?: string[];
   /** Enable scoping to context files (default: true) */
   scopeToStory?: boolean;
+  /**
+   * Max test files scanned (post-filter) before truncating. Production threads
+   * config.execution.smartTestRunner.maxScanFiles via the test-coverage provider;
+   * defaults to DEFAULT_MAX_SCAN_FILES for direct callers (unit tests).
+   */
+  maxScanFiles?: number;
 }
 
 /** A single describe block extracted from a test file */
@@ -262,7 +276,7 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
   // Cap is applied to *kept* files (post-filter) to match smart-runner.ts convention.
   // Counting pre-filter scans would exhaust the budget on scope-skipped files and
   // silently drop relevant test files when scoping is active.
-  const MAX_SCAN_FILES = 200;
+  const maxScanFiles = options.maxScanFiles ?? DEFAULT_MAX_SCAN_FILES;
   const glob = new Glob(testPattern);
   const files: TestFileInfo[] = [];
 
@@ -275,9 +289,9 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
       }
     }
 
-    if (files.length >= MAX_SCAN_FILES) {
+    if (files.length >= maxScanFiles) {
       getLogger().debug("test-scanner", "Glob cap reached — results truncated", {
-        cap: MAX_SCAN_FILES,
+        cap: maxScanFiles,
         scanDir,
       });
       break;

--- a/src/context/test-scanner.ts
+++ b/src/context/test-scanner.ts
@@ -259,27 +259,28 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
     allowedBasenames = new Set(patterns);
   }
 
+  // Cap is applied to *kept* files (post-filter) to match smart-runner.ts convention.
+  // Counting pre-filter scans would exhaust the budget on scope-skipped files and
+  // silently drop relevant test files when scoping is active.
   const MAX_SCAN_FILES = 200;
   const glob = new Glob(testPattern);
   const files: TestFileInfo[] = [];
-  let scanCount = 0;
 
   for await (const filePath of glob.scan({ cwd: scanDir, absolute: false })) {
-    if (scanCount >= MAX_SCAN_FILES) {
-      getLogger().debug("test-scanner", "Glob cap reached — results truncated", {
-        cap: MAX_SCAN_FILES,
-        scanDir,
-      });
-      break;
-    }
-    scanCount++;
-
     // Filter by derived patterns if scoping is enabled
     if (allowedBasenames !== null) {
       const basename = path.basename(filePath);
       if (!allowedBasenames.has(basename)) {
         continue; // Skip test files not matching context files
       }
+    }
+
+    if (files.length >= MAX_SCAN_FILES) {
+      getLogger().debug("test-scanner", "Glob cap reached — results truncated", {
+        cap: MAX_SCAN_FILES,
+        scanDir,
+      });
+      break;
     }
 
     const fullPath = path.join(scanDir, filePath);

--- a/src/execution/crash-heartbeat.ts
+++ b/src/execution/crash-heartbeat.ts
@@ -12,14 +12,19 @@ export const _heartbeatDeps = {
   getSafeLogger,
 };
 
-let heartbeatActive = false;
+// Generation counter: each startHeartbeat() increments this, invalidating any
+// in-flight loop on its next tick — prevents duplicate loops when startHeartbeat()
+// is called again while a prior loop is mid-sleep.
+let _heartbeatGen = 0;
+let _heartbeatActive = false;
 
 /**
- * Inner loop — runs while heartbeatActive is true.
+ * Inner loop — runs while both the generation token matches and active flag is set.
  * Uses Bun.sleep so each tick fully completes before the next begins,
  * avoiding the tick-overlap issue of setInterval with async callbacks.
  */
 async function heartbeatLoop(
+  gen: number,
   statusWriter: StatusWriter,
   getTotalCost: () => number,
   getIterations: () => number,
@@ -27,9 +32,9 @@ async function heartbeatLoop(
 ): Promise<void> {
   const logger = _heartbeatDeps.getSafeLogger();
 
-  while (heartbeatActive) {
+  while (gen === _heartbeatGen && _heartbeatActive) {
     await _heartbeatDeps.sleep(60_000);
-    if (!heartbeatActive) break;
+    if (gen !== _heartbeatGen || !_heartbeatActive) break;
 
     try {
       logger?.debug("crash-recovery", "Heartbeat");
@@ -71,10 +76,10 @@ export function startHeartbeat(
 ): void {
   const logger = _heartbeatDeps.getSafeLogger();
 
-  stopHeartbeat();
-
-  heartbeatActive = true;
-  heartbeatLoop(statusWriter, getTotalCost, getIterations, jsonlFilePath).catch((err: unknown) => {
+  // Increment generation to invalidate any in-flight loop, then launch a fresh one.
+  _heartbeatActive = true;
+  const gen = ++_heartbeatGen;
+  heartbeatLoop(gen, statusWriter, getTotalCost, getIterations, jsonlFilePath).catch((err: unknown) => {
     _heartbeatDeps.getSafeLogger()?.warn("crash-recovery", "Heartbeat loop crashed; status updates stopped", {
       error: err instanceof Error ? err.message : String(err),
     });
@@ -87,8 +92,9 @@ export function startHeartbeat(
  * Stop heartbeat loop
  */
 export function stopHeartbeat(): void {
-  if (heartbeatActive) {
-    heartbeatActive = false;
+  if (_heartbeatActive) {
+    _heartbeatActive = false;
+    _heartbeatGen++; // invalidate the running loop on its next tick
     getSafeLogger()?.debug("crash-recovery", "Heartbeat stopped");
   }
 }
@@ -98,5 +104,5 @@ export function stopHeartbeat(): void {
  * @internal - test use only.
  */
 export function _isHeartbeatActive(): boolean {
-  return heartbeatActive;
+  return _heartbeatActive;
 }

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -29,6 +29,7 @@ import type { PluginRegistry } from "../../plugins/registry";
 import type { PRD } from "../../prd";
 import { countStories, loadPRD, savePRD } from "../../prd";
 import { detectProjectProfile } from "../../project";
+import { clearCache as clearRoutingCache } from "../../routing";
 import { type NaxRuntime, createRuntime } from "../../runtime";
 import { SessionManager } from "../../session";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
@@ -417,6 +418,12 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
       config.disabledPlugins,
       isTestFileFn,
     );
+
+    // Clear LLM routing cache at run start — prevents cross-run pollution
+    // when story IDs repeat across features, and fixes the parallel-mode race
+    // where the per-story guard (ctx.story.id === stories[0]?.id) could miss
+    // stories that start routing before the first story clears the cache.
+    clearRoutingCache();
 
     // Log plugins loaded
     logger?.info("plugins", `Loaded ${pluginRegistry.plugins.length} plugins`, {

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -14,6 +14,7 @@
 
 import path from "node:path";
 import { pipelineEventBus } from "@/pipeline";
+import { clearCache as clearRoutingCache } from "@/routing";
 import { discoverWorkspacePackages, resolveTestFilePatterns } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
 import type { NaxConfig } from "../../config";
@@ -29,7 +30,6 @@ import type { PluginRegistry } from "../../plugins/registry";
 import type { PRD } from "../../prd";
 import { countStories, loadPRD, savePRD } from "../../prd";
 import { detectProjectProfile } from "../../project";
-import { clearCache as clearRoutingCache } from "../../routing";
 import { type NaxRuntime, createRuntime } from "../../runtime";
 import { SessionManager } from "../../session";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";

--- a/src/execution/pid-registry.ts
+++ b/src/execution/pid-registry.ts
@@ -29,6 +29,8 @@ export class PidRegistry {
   private readonly pidsFilePath: string;
   private readonly pids: Set<number> = new Set();
   private frozen = false;
+  private _writing = false;
+  private _pendingWrite = false;
   private writeQueueTail: Promise<void> = Promise.resolve();
 
   constructor(workdir: string, _platform?: NodeJS.Platform) {
@@ -375,13 +377,25 @@ export class PidRegistry {
   }
 
   private enqueueWrite(): Promise<void> {
-    this.writeQueueTail = this.writeQueueTail.then(() =>
-      this.writePidsFile().catch((err) => {
+    if (this._writing) {
+      // A write is in-flight — coalesce: schedule exactly one follow-up write.
+      this._pendingWrite = true;
+      return this.writeQueueTail;
+    }
+    this._writing = true;
+    this.writeQueueTail = this.writePidsFile()
+      .catch((err) => {
         getSafeLogger()?.warn("pid-registry", "Failed to flush PID file — on-disk registry may be stale", {
           error: errorMessage(err),
         });
-      }),
-    );
+      })
+      .then(async () => {
+        this._writing = false;
+        if (this._pendingWrite) {
+          this._pendingWrite = false;
+          await this.enqueueWrite();
+        }
+      });
     return this.writeQueueTail;
   }
 }

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -641,11 +641,10 @@ export async function executeUnified(
     // accumulate on pipelineEventBus across failed runs. On normal return, leave
     // them active so runner.ts can emit run:ended with reporters still subscribed.
     // Guard: a subsequent execute() call may have already replaced _prevRunUnsubscribers.
-    if (_executeThrew && _prevRunUnsubscribers === thisRunUnsubscribers)
+    if (_executeThrew && _prevRunUnsubscribers === thisRunUnsubscribers) {
       for (const fn of thisRunUnsubscribers) fn();
-    // Separate guard — same condition but no await between them; written as two
-    // statements to avoid nested braces that break the RL-007 source-inspection test.
-    if (_executeThrew && _prevRunUnsubscribers === thisRunUnsubscribers) _prevRunUnsubscribers = [];
+      _prevRunUnsubscribers = [];
+    }
   }
 }
 

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -643,6 +643,8 @@ export async function executeUnified(
     // Guard: a subsequent execute() call may have already replaced _prevRunUnsubscribers.
     if (_executeThrew && _prevRunUnsubscribers === thisRunUnsubscribers)
       for (const fn of thisRunUnsubscribers) fn();
+    // Separate guard — same condition but no await between them; written as two
+    // statements to avoid nested braces that break the RL-007 source-inspection test.
     if (_executeThrew && _prevRunUnsubscribers === thisRunUnsubscribers) _prevRunUnsubscribers = [];
   }
 }

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -87,13 +87,16 @@ export async function executeUnified(
   // Calling stored unsubscribers instead of pipelineEventBus.clear() preserves
   // external subscribers (e.g. TUI's usePipelineBusEvents) across run boundaries.
   for (const fn of _prevRunUnsubscribers) fn();
-  _prevRunUnsubscribers = [
+  _prevRunUnsubscribers = [];
+  const thisRunUnsubscribers = [
     wireHooks(pipelineEventBus, ctx.hooks, ctx.workdir, ctx.feature),
     wireReporters(pipelineEventBus, ctx.pluginRegistry, ctx.runId, ctx.startTime),
     wireInteraction(pipelineEventBus, ctx.interactionChain, ctx.config),
     wireEventsWriter(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir),
     wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir, ctx.runtime.outputDir),
   ];
+  // Store for next run's cleanup; also ensures teardown on throw via the finally block.
+  _prevRunUnsubscribers = thisRunUnsubscribers;
 
   // Emit run:started once — subscribers (hooks.ts, reporters.ts) own the fan-out.
   // Direct fireHook("on-start") and reporter.onRunStart() calls have been removed.
@@ -121,6 +124,7 @@ export async function executeUnified(
     ctx.logFilePath,
   );
 
+  let _executeThrew = false;
   try {
     if (isComplete(prd)) {
       logger?.info("execution", "All stories already complete — skipping pre-run pipeline");
@@ -623,12 +627,23 @@ export async function executeUnified(
     }
 
     return buildResult("max-iterations");
+  } catch (err) {
+    _executeThrew = true;
+    throw err;
   } finally {
     // NOTE: stopHeartbeat() is intentionally NOT called here.
     // The heartbeat must stay alive until runner-completion.ts finishes the
     // regression gate and exit summary — those run AFTER executeUnified returns.
     // stopHeartbeat() is called by runner.ts:finally (catches all exit paths)
     // and by runner-completion.ts after handleRunCompletion().
+
+    // On throw only: tear down this run's subscribers immediately so they don't
+    // accumulate on pipelineEventBus across failed runs. On normal return, leave
+    // them active so runner.ts can emit run:ended with reporters still subscribed.
+    // Guard: a subsequent execute() call may have already replaced _prevRunUnsubscribers.
+    if (_executeThrew && _prevRunUnsubscribers === thisRunUnsubscribers)
+      for (const fn of thisRunUnsubscribers) fn();
+    if (_executeThrew && _prevRunUnsubscribers === thisRunUnsubscribers) _prevRunUnsubscribers = [];
   }
 }
 

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -283,21 +283,24 @@ export async function saveRunMetrics(outputDir: string, runMetrics: RunMetrics):
   const hasTokenData =
     totalInputTokens > 0 || totalOutputTokens > 0 || totalCacheReadInputTokens > 0 || totalCacheCreationInputTokens > 0;
 
-  if (hasTokenData) {
-    runMetrics.totalTokens = new TokenUsage({
-      inputTokens: totalInputTokens,
-      outputTokens: totalOutputTokens,
-      cacheReadInputTokens: totalCacheReadInputTokens,
-      cacheCreationInputTokens: totalCacheCreationInputTokens,
-    });
-  }
+  const finalMetrics: RunMetrics = hasTokenData
+    ? {
+        ...runMetrics,
+        totalTokens: new TokenUsage({
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          cacheReadInputTokens: totalCacheReadInputTokens,
+          cacheCreationInputTokens: totalCacheCreationInputTokens,
+        }),
+      }
+    : runMetrics;
 
   // Load existing metrics (returns empty array if file doesn't exist or is invalid)
   const existing = await loadJsonFile<RunMetrics[]>(metricsPath, "metrics");
   const allMetrics = Array.isArray(existing) ? existing : [];
 
   // Append new run
-  allMetrics.push(runMetrics);
+  allMetrics.push(finalMetrics);
 
   // Write back
   await saveJsonFile(metricsPath, allMetrics, "metrics");

--- a/src/queue/manager.ts
+++ b/src/queue/manager.ts
@@ -135,14 +135,19 @@ export class QueueManager {
    * Get queue statistics.
    */
   getStats(): QueueStats {
-    return {
-      total: this.items.length,
-      pending: this.items.filter((i) => i.status === "pending").length,
-      inProgress: this.items.filter((i) => i.status === "in-progress").length,
-      completed: this.items.filter((i) => i.status === "completed").length,
-      failed: this.items.filter((i) => i.status === "failed").length,
-      skipped: this.items.filter((i) => i.status === "skipped").length,
-    };
+    let pending = 0;
+    let inProgress = 0;
+    let completed = 0;
+    let failed = 0;
+    let skipped = 0;
+    for (const item of this.items) {
+      if (item.status === "pending") pending++;
+      else if (item.status === "in-progress") inProgress++;
+      else if (item.status === "completed") completed++;
+      else if (item.status === "failed") failed++;
+      else if (item.status === "skipped") skipped++;
+    }
+    return { total: this.items.length, pending, inProgress, completed, failed, skipped };
   }
 
   /**

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -52,7 +52,7 @@ export async function collectDiff(
   storyGitRef: string,
   excludePatterns: string[],
   options?: DiffIgnoreOptions,
-): Promise<string> {
+): Promise<string | null> {
   const naxIgnoreExcludes = await resolveNaxIgnorePathspecExcludes(workdir, options);
   const merged = [...new Set([...excludePatterns, ...naxIgnoreExcludes, ...ALWAYS_EXCLUDED])];
   const cmd = ["git", "diff", "--unified=3", `${storyGitRef}..HEAD`, "--", ".", ...merged];
@@ -63,13 +63,17 @@ export async function collectDiff(
     stderr: "pipe",
   });
 
-  const [exitCode, stdout] = await Promise.all([
+  const [exitCode, stdout, stderr] = await Promise.all([
     proc.exited,
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
   ]);
 
-  return exitCode === 0 ? stdout : "";
+  if (exitCode !== 0) {
+    getSafeLogger()?.warn("diff-utils", "git diff failed — skipping review diff", { storyGitRef, stderr });
+    return null;
+  }
+  return stdout;
 }
 
 /**

--- a/src/review/prepare-inputs.ts
+++ b/src/review/prepare-inputs.ts
@@ -143,6 +143,9 @@ export async function prepareSemanticReviewInput(
   }
 
   const rawDiff = await collectDiff(workdir, effectiveRef, excludePatterns, { naxIgnoreIndex, packageDir });
+  if (rawDiff === null) {
+    return { effectiveRef, stat, diff: undefined, excludePatterns, skipReason: "git diff failed" };
+  }
   const diff = truncateDiff(rawDiff, rawDiff.length > DIFF_CAP_BYTES ? stat : undefined);
   if (!diff) {
     return { effectiveRef, stat, diff: undefined, excludePatterns, skipReason: "no production code changes" };

--- a/src/review/scoped-lint.ts
+++ b/src/review/scoped-lint.ts
@@ -68,9 +68,10 @@ async function listChangedFiles(workdir: string, baseRef: string): Promise<strin
     stdout: "pipe",
     stderr: "pipe",
   });
-  const exitCode = await proc.exited;
+  // Drain stdout concurrently with exited to avoid pipe-buffer deadlock on
+  // large changesets (git blocks writing when the ~64KB OS buffer fills).
+  const [exitCode, output] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
   if (exitCode !== 0) return null;
-  const output = await new Response(proc.stdout).text();
   return output
     .split("\n")
     .map((line) => line.trim())

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -281,6 +281,8 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
       if (opts?.parentSignal && parentAbortHandler) {
         opts.parentSignal.removeEventListener("abort", parentAbortHandler);
       }
+      agentManager.close();
+      if (sessionManager instanceof SessionManager) sessionManager.close();
       const results = await Promise.allSettled([promptAuditor.flush(), reviewAuditor.flush(), costAggregator.drain()]);
       for (const r of results) {
         if (r.status === "rejected") {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -532,6 +532,7 @@ export class SessionManager implements ISessionManager {
 
     this._busySessions.delete(handle.id);
     this._cancelledSessions.delete(handle.id);
+    this._clearWatchdogCancelledCalls(handle.id);
   }
 
   async sendPrompt(handle: SessionHandle, prompt: string, opts?: SendPromptOpts): Promise<TurnResult> {
@@ -697,5 +698,10 @@ export class SessionManager implements ISessionManager {
 
   sweepOrphans(ttlMs = DEFAULT_ORPHAN_TTL_MS): number {
     return sweepOrphansImpl(this._sessions, ttlMs);
+  }
+
+  close(): void {
+    this._agentStreamUnsubscribe?.();
+    this._agentStreamUnsubscribe = undefined;
   }
 }

--- a/src/tdd/rollback.ts
+++ b/src/tdd/rollback.ts
@@ -21,11 +21,10 @@ export async function rollbackToRef(workdir: string, ref: string): Promise<void>
     stderr: "pipe",
   });
 
-  const exitCode = await resetProc.exited;
+  const [exitCode, resetStderr] = await Promise.all([resetProc.exited, new Response(resetProc.stderr).text()]);
   if (exitCode !== 0) {
-    const stderr = await new Response(resetProc.stderr).text();
-    logger.error("tdd", "Failed to rollback git changes", { ref, stderr });
-    throw new Error(`Git rollback failed: ${stderr}`);
+    logger.error("tdd", "Failed to rollback git changes", { ref, stderr: resetStderr });
+    throw new Error(`Git rollback failed: ${resetStderr}`);
   }
 
   const cleanProc = _rollbackDeps.spawn(["git", "clean", "-fd"], {
@@ -34,10 +33,9 @@ export async function rollbackToRef(workdir: string, ref: string): Promise<void>
     stderr: "pipe",
   });
 
-  const cleanExitCode = await cleanProc.exited;
+  const [cleanExitCode, cleanStderr] = await Promise.all([cleanProc.exited, new Response(cleanProc.stderr).text()]);
   if (cleanExitCode !== 0) {
-    const stderr = await new Response(cleanProc.stderr).text();
-    logger.warn("tdd", "Failed to clean untracked files", { stderr });
+    logger.warn("tdd", "Failed to clean untracked files", { stderr: cleanStderr });
   }
 
   logger.info("tdd", "Successfully rolled back git changes", { ref });
@@ -53,8 +51,8 @@ export async function rollbackToRef(workdir: string, ref: string): Promise<void>
 export async function captureSnapshotRef(workdir: string, storyId: string): Promise<string> {
   await _rollbackDeps.autoCommitIfDirty(workdir, "non-blocking-fix-snapshot", "snapshot", storyId);
   const proc = _rollbackDeps.spawn(["git", "rev-parse", "HEAD"], { cwd: workdir, stdout: "pipe", stderr: "pipe" });
-  const sha = (await new Response(proc.stdout).text()).trim();
-  const exitCode = await proc.exited;
+  const [exitCode, shaRaw] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+  const sha = shaRaw.trim();
   if (exitCode !== 0) {
     throw new NaxError("git rev-parse HEAD failed in non-blocking-fix snapshot", "SNAPSHOT_REF_FAILED", {
       storyId,

--- a/src/test-runners/scoped-selection.ts
+++ b/src/test-runners/scoped-selection.ts
@@ -14,19 +14,21 @@
 import { getLogger } from "@/logger";
 import { DEFAULT_TEST_FILE_PATTERNS, globsToTestRegex } from "@/test-runners";
 import type { NaxIgnoreIndex } from "@/utils/path-filters";
-import { _smartRunnerDeps } from "../verification/smart-runner";
+import { MAX_GREP_TEST_FILES, _smartRunnerDeps } from "../verification/smart-runner";
 import type { ResolvedTestPatterns } from "./resolver";
 
 const DEFAULT_SMART_RUNNER_CONFIG = {
   enabled: true,
   testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS],
   fallback: "import-grep" as const,
+  maxScanFiles: MAX_GREP_TEST_FILES,
 };
 
 export interface SmartRunnerConfigRaw {
   enabled?: boolean;
   testFilePatterns?: string[];
   fallback?: "import-grep" | "full-suite";
+  maxScanFiles?: number;
 }
 
 export function coerceSmartRunner(val: unknown) {
@@ -192,7 +194,12 @@ export async function selectScopedTests(input: SelectScopedTestsInput): Promise<
     return fullSuite();
   }
 
-  const pass2Files = await _scopedSelectionDeps.importGrepFallback(nonTestFiles, input.workdir, mappingGlobs);
+  const pass2Files = await _scopedSelectionDeps.importGrepFallback(
+    nonTestFiles,
+    input.workdir,
+    mappingGlobs,
+    smartCfg.maxScanFiles,
+  );
   if (pass2Files.length > threshold) {
     logger.warn(
       "verify[scoped]",

--- a/src/utils/queue-writer.ts
+++ b/src/utils/queue-writer.ts
@@ -7,6 +7,8 @@
 
 import type { QueueCommand } from "../queue/types";
 
+const _writeChains = new Map<string, Promise<void>>();
+
 /**
  * Write a queue command to the queue file.
  *
@@ -45,10 +47,19 @@ export async function writeQueueCommand(queueFilePath: string, command: QueueCom
     }
   }
 
-  // Append command to queue file (create if doesn't exist)
-  const file = Bun.file(queueFilePath);
-  const existingContent = await file.text().catch(() => "");
-  const newContent = existingContent ? `${existingContent.trimEnd()}\n${commandLine}\n` : `${commandLine}\n`;
-
-  await Bun.write(queueFilePath, newContent);
+  // Serialize writes per file path to prevent read-modify-write races when
+  // multiple commands are issued concurrently (e.g. rapid PAUSE + SKIP from TUI).
+  const chain = _writeChains.get(queueFilePath) ?? Promise.resolve();
+  const next = chain.then(async () => {
+    const existing = await Bun.file(queueFilePath)
+      .text()
+      .catch(() => "");
+    const content = existing ? `${existing.trimEnd()}\n${commandLine}\n` : `${commandLine}\n`;
+    await Bun.write(queueFilePath, content);
+  });
+  _writeChains.set(
+    queueFilePath,
+    next.catch(() => {}),
+  );
+  await next;
 }

--- a/src/utils/queue-writer.ts
+++ b/src/utils/queue-writer.ts
@@ -7,7 +7,8 @@
 
 import type { QueueCommand } from "../queue/types";
 
-const _writeChains = new Map<string, Promise<void>>();
+/** Per-file write chains. Exported underscore-prefixed for test introspection only. */
+export const _writeChains = new Map<string, Promise<void>>();
 
 /**
  * Write a queue command to the queue file.
@@ -57,9 +58,12 @@ export async function writeQueueCommand(queueFilePath: string, command: QueueCom
     const content = existing ? `${existing.trimEnd()}\n${commandLine}\n` : `${commandLine}\n`;
     await Bun.write(queueFilePath, content);
   });
-  _writeChains.set(
-    queueFilePath,
-    next.catch(() => {}),
-  );
+  const settled = next.catch(() => {});
+  _writeChains.set(queueFilePath, settled);
+  // Evict the entry once it settles, unless a newer write has already taken its
+  // place — keeps the map bounded instead of growing one entry per file path.
+  settled.then(() => {
+    if (_writeChains.get(queueFilePath) === settled) _writeChains.delete(queueFilePath);
+  });
   await next;
 }

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -137,21 +137,23 @@ export async function importGrepFallback(
   sourceFiles: string[],
   workdir: string,
   testFilePatterns: string[],
+  maxScanFiles: number = MAX_GREP_TEST_FILES,
 ): Promise<string[]> {
   if (sourceFiles.length === 0 || testFilePatterns.length === 0) return [];
 
   // Collect search terms from all changed source files
   const searchTerms = sourceFiles.flatMap(extractSearchTerms);
 
-  // Scan all test files matching the configured patterns, capped at MAX_GREP_TEST_FILES
+  // Scan all test files matching the configured patterns, capped at maxScanFiles
+  // (config.execution.smartTestRunner.maxScanFiles; defaults to MAX_GREP_TEST_FILES).
   const testFilePaths: string[] = [];
   outer: for (const pattern of testFilePatterns) {
     const g = _bunDeps.glob(pattern);
     for await (const file of g.scan({ cwd: workdir, absolute: false })) {
       testFilePaths.push(`${workdir}/${file}`);
-      if (testFilePaths.length >= MAX_GREP_TEST_FILES) {
+      if (testFilePaths.length >= maxScanFiles) {
         getSafeLogger()?.debug("smart-runner", "import-grep glob cap reached — results truncated", {
-          cap: MAX_GREP_TEST_FILES,
+          cap: maxScanFiles,
         });
         break outer;
       }

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -147,7 +147,7 @@ export async function importGrepFallback(
   const testFilePaths: string[] = [];
   outer: for (const pattern of testFilePatterns) {
     const g = _bunDeps.glob(pattern);
-    for await (const file of g.scan(workdir)) {
+    for await (const file of g.scan({ cwd: workdir, absolute: false })) {
       testFilePaths.push(`${workdir}/${file}`);
       if (testFilePaths.length >= MAX_GREP_TEST_FILES) {
         getSafeLogger()?.debug("smart-runner", "import-grep glob cap reached — results truncated", {

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -114,9 +114,8 @@ export class WorktreeManager {
         stderr: "pipe",
       });
 
-      const exitCode = await proc.exited;
+      const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
       if (exitCode !== 0) {
-        const stderr = await new Response(proc.stderr).text();
         throw new Error(`Failed to create worktree: ${stderr || "unknown error"}`);
       }
     } catch (error) {
@@ -161,9 +160,8 @@ export class WorktreeManager {
         stderr: "pipe",
       });
 
-      const exitCode = await proc.exited;
+      const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
       if (exitCode !== 0) {
-        const stderr = await new Response(proc.stderr).text();
         if (
           stderr.includes("not found") ||
           stderr.includes("does not exist") ||
@@ -189,9 +187,8 @@ export class WorktreeManager {
         stderr: "pipe",
       });
 
-      const exitCode = await proc.exited;
+      const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
       if (exitCode !== 0) {
-        const stderr = await new Response(proc.stderr).text();
         // Don't fail if branch doesn't exist
         if (!stderr.includes("not found")) {
           const logger = getSafeLogger();
@@ -218,13 +215,15 @@ export class WorktreeManager {
         stderr: "pipe",
       });
 
-      const exitCode = await proc.exited;
+      const [exitCode, stderr, stdout] = await Promise.all([
+        proc.exited,
+        new Response(proc.stderr).text(),
+        new Response(proc.stdout).text(),
+      ]);
       if (exitCode !== 0) {
-        const stderr = await new Response(proc.stderr).text();
         throw new Error(`Failed to list worktrees: ${stderr || "unknown error"}`);
       }
 
-      const stdout = await new Response(proc.stdout).text();
       return this.parseWorktreeList(stdout);
     } catch (error) {
       if (error instanceof Error) {

--- a/src/worktree/merge.ts
+++ b/src/worktree/merge.ts
@@ -42,9 +42,11 @@ export class MergeEngine {
         },
       );
 
-      const exitCode = await mergeProc.exited;
-      const stderr = await new Response(mergeProc.stderr).text();
-      const stdout = await new Response(mergeProc.stdout).text();
+      const [exitCode, stderr, stdout] = await Promise.all([
+        mergeProc.exited,
+        new Response(mergeProc.stderr).text(),
+        new Response(mergeProc.stdout).text(),
+      ]);
 
       if (exitCode === 0) {
         // Clean merge - cleanup worktree
@@ -227,12 +229,15 @@ export class MergeEngine {
         stderr: "pipe",
       });
 
-      const exitCode = await currentBranchProc.exited;
+      const [exitCode, currentBranchRaw] = await Promise.all([
+        currentBranchProc.exited,
+        new Response(currentBranchProc.stdout).text(),
+      ]);
       if (exitCode !== 0) {
         throw new Error("Failed to get current branch");
       }
 
-      const currentBranch = (await new Response(currentBranchProc.stdout).text()).trim();
+      const currentBranch = currentBranchRaw.trim();
 
       // Rebase worktree branch onto current branch
       const rebaseProc = _mergeDeps.spawn(["git", "rebase", currentBranch], {
@@ -241,9 +246,12 @@ export class MergeEngine {
         stderr: "pipe",
       });
 
-      const rebaseExitCode = await rebaseProc.exited;
+      const [rebaseExitCode, rebaseStderr] = await Promise.all([
+        rebaseProc.exited,
+        new Response(rebaseProc.stderr).text(),
+      ]);
       if (rebaseExitCode !== 0) {
-        const stderr = await new Response(rebaseProc.stderr).text();
+        const stderr = rebaseStderr;
 
         // Abort rebase on failure
         const abortProc = _mergeDeps.spawn(["git", "rebase", "--abort"], {
@@ -274,12 +282,10 @@ export class MergeEngine {
         stderr: "pipe",
       });
 
-      const exitCode = await proc.exited;
+      const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
       if (exitCode !== 0) {
         return [];
       }
-
-      const stdout = await new Response(proc.stdout).text();
       return stdout
         .trim()
         .split("\n")

--- a/test/helpers/fake-agent-manager.ts
+++ b/test/helpers/fake-agent-manager.ts
@@ -179,6 +179,7 @@ export function fakeAgentManager(
     runAsSession: async (_agentName, handle, prompt, _opts) => {
       return adapter.sendTurn(handle, prompt, { interactionHandler: NO_OP_INTERACTION_HANDLER });
     },
+    close: () => {},
   };
   return mgr;
 }

--- a/test/helpers/mock-agent-manager.ts
+++ b/test/helpers/mock-agent-manager.ts
@@ -171,6 +171,7 @@ export function makeMockAgentManager(opts: MockAgentManagerOptions = {}): IAgent
               internalRoundTrips: 0,
             } satisfies TurnResult),
         ),
+    close: () => {},
   } as IAgentManager;
 }
 

--- a/test/unit/agents/acp/parser.test.ts
+++ b/test/unit/agents/acp/parser.test.ts
@@ -73,6 +73,34 @@ describe("parseAcpxJsonOutput — legacy flat NDJSON format", () => {
     expect(result.tokenUsage?.input_tokens).toBe(100);
     expect(result.tokenUsage?.output_tokens).toBe(50);
   });
+
+  // The legacy NDJSON branch treats result/content/text as mutually exclusive
+  // per event (see parser.ts comment). These tests pin that contract so a future
+  // refactor away from else-if is caught.
+  test("legacy content chunk accumulates", () => {
+    const result = parseAcpxJsonOutput('{"content":"foo"}\n{"content":"bar"}');
+    expect(result.text).toBe("foobar");
+  });
+
+  test("legacy text chunk accumulates (older field name)", () => {
+    const result = parseAcpxJsonOutput('{"text":"foo"}\n{"text":"bar"}');
+    expect(result.text).toBe("foobar");
+  });
+
+  test("legacy result resets accumulated text (final full text wins)", () => {
+    const result = parseAcpxJsonOutput('{"content":"partial"}\n{"result":"final"}');
+    expect(result.text).toBe("final");
+  });
+
+  test("within one event, result wins over content and text", () => {
+    const result = parseAcpxJsonOutput('{"result":"R","content":"C","text":"T"}');
+    expect(result.text).toBe("R");
+  });
+
+  test("within one event, content wins over text", () => {
+    const result = parseAcpxJsonOutput('{"content":"C","text":"T"}');
+    expect(result.text).toBe("C");
+  });
 });
 
 describe("incremental API — createParseState / parseAcpxJsonLine / finalizeParseState", () => {

--- a/test/unit/config/smart-runner-flag.test.ts
+++ b/test/unit/config/smart-runner-flag.test.ts
@@ -112,6 +112,7 @@ describe("execution.smartTestRunner config flag", () => {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
         fallback: "import-grep",
+        maxScanFiles: 200,
       });
     }
   });
@@ -126,6 +127,7 @@ describe("execution.smartTestRunner config flag", () => {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: false,
         fallback: "import-grep",
+        maxScanFiles: 200,
       });
     }
   });
@@ -140,6 +142,7 @@ describe("execution.smartTestRunner config flag", () => {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
         fallback: "import-grep",
+        maxScanFiles: 200,
       });
     }
   });
@@ -152,6 +155,7 @@ describe("execution.smartTestRunner config flag", () => {
     expect(config.execution.smartTestRunner).toEqual({
       enabled: true,
       fallback: "import-grep",
+      maxScanFiles: 200,
     });
   });
 
@@ -163,6 +167,7 @@ describe("execution.smartTestRunner config flag", () => {
     expect(config.execution.smartTestRunner).toEqual({
       enabled: false,
       fallback: "import-grep",
+      maxScanFiles: 200,
     });
   });
 
@@ -175,6 +180,7 @@ describe("execution.smartTestRunner config flag", () => {
     expect(config.execution.smartTestRunner).toEqual({
       enabled: true,
       fallback: "import-grep",
+      maxScanFiles: 200,
     });
   });
 });

--- a/test/unit/execution/unified-executor-rl007.test.ts
+++ b/test/unit/execution/unified-executor-rl007.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import {
   _isHeartbeatActive,
@@ -99,7 +99,14 @@ function makeMinimalContext(): SequentialExecutionContext {
     runtime: {
       outputDir: "/tmp/nax-test-rl007-output",
       costAggregator: {
-        snapshot: () => ({ totalCostUsd: 0, totalEstimatedCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, callCount: 0, errorCount: 0 }),
+        snapshot: () => ({
+          totalCostUsd: 0,
+          totalEstimatedCostUsd: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          callCount: 0,
+          errorCount: 0,
+        }),
         byStage: () => ({}),
         byStory: () => ({}),
         byAgent: () => ({}),
@@ -123,11 +130,24 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 function extractFinallyBlocks(src: string): string[] {
-  // Collect text inside all `finally { ... }` blocks (single-level braces only)
+  // Collect text inside all `finally { ... }` blocks. Brace-aware: walks the
+  // body tracking brace depth so nested if/for blocks don't truncate the match
+  // (a naive `[^{}]*` regex would stop at the first inner `{`, forcing the
+  // production code into an unnatural brace-free shape).
   const blocks: string[] = [];
-  const pattern = /finally\s*\{([^{}]*)\}/gs;
-  for (const m of src.matchAll(pattern)) {
-    blocks.push(m[1]);
+  const opener = /finally\s*\{/g;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = opener.exec(src)) !== null) {
+    const start = m.index + m[0].length;
+    let depth = 1;
+    let i = start;
+    for (; i < src.length && depth > 0; i++) {
+      if (src[i] === "{") depth++;
+      else if (src[i] === "}") depth--;
+    }
+    // i points one past the closing brace; exclude it from the captured body.
+    blocks.push(src.slice(start, i - 1));
   }
   return blocks;
 }
@@ -173,7 +193,11 @@ describe("RL-007 AC#2: heartbeat remains active after executeUnified returns", (
   test("heartbeat is still running after executeUnified completes normally", async () => {
     const statusWriter = makeStatusWriter();
     // Simulate what runner.ts does: start heartbeat before delegating to executor
-    startHeartbeat(statusWriter as unknown as Parameters<typeof startHeartbeat>[0], () => 0, () => 0);
+    startHeartbeat(
+      statusWriter as unknown as Parameters<typeof startHeartbeat>[0],
+      () => 0,
+      () => 0,
+    );
 
     expect(_isHeartbeatActive()).toBe(true);
 
@@ -188,7 +212,11 @@ describe("RL-007 AC#2: heartbeat remains active after executeUnified returns", (
 
   test("heartbeat is still running when all stories are skipped", async () => {
     const statusWriter = makeStatusWriter();
-    startHeartbeat(statusWriter as unknown as Parameters<typeof startHeartbeat>[0], () => 0, () => 0);
+    startHeartbeat(
+      statusWriter as unknown as Parameters<typeof startHeartbeat>[0],
+      () => 0,
+      () => 0,
+    );
 
     const prd = makeCompletePRD([makeStory("US-001", "skipped"), makeStory("US-002", "skipped")]);
     const ctx = makeMinimalContext();

--- a/test/unit/review/diff-utils.test.ts
+++ b/test/unit/review/diff-utils.test.ts
@@ -144,12 +144,12 @@ describe("collectDiff()", () => {
     expect(captured.value).toContain(":!.nax-pids");
   });
 
-  test("returns stdout string on exit code 0; empty string on non-zero", async () => {
+  test("returns stdout string on exit code 0; null on non-zero", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("diff content");
     expect(await collectDiff("/repo", "abc123", [])).toBe("diff content");
 
     _diffUtilsDeps.spawn = makeSpawnMock("some output", 1);
-    expect(await collectDiff("/repo", "abc123", [])).toBe("");
+    expect(await collectDiff("/repo", "abc123", [])).toBeNull();
   });
 });
 

--- a/test/unit/utils/queue-writer.test.ts
+++ b/test/unit/utils/queue-writer.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { parseQueueFile } from "../../../src/queue/manager";
+import { _writeChains, writeQueueCommand } from "../../../src/utils/queue-writer";
+import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
+
+describe("writeQueueCommand", () => {
+  let tempDir: string;
+  let queueFile: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-queue-writer-");
+    queueFile = join(tempDir, "queue.txt");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  test("appends each command on its own line", async () => {
+    await writeQueueCommand(queueFile, { type: "PAUSE" });
+    await writeQueueCommand(queueFile, { type: "SKIP", storyId: "US-001" });
+    await writeQueueCommand(queueFile, { type: "ABORT" });
+
+    const { commands } = parseQueueFile(await Bun.file(queueFile).text());
+    expect(commands).toEqual([{ type: "PAUSE" }, { type: "SKIP", storyId: "US-001" }, { type: "ABORT" }]);
+  });
+
+  test("serializes concurrent writes without clobbering (no read-modify-write race)", async () => {
+    // Fire many writes concurrently — the per-path chain must serialize them so
+    // every command lands instead of overwriting each other's read-modify-write.
+    const count = 25;
+    await Promise.all(
+      Array.from({ length: count }, (_, i) => writeQueueCommand(queueFile, { type: "SKIP", storyId: `US-${i}` })),
+    );
+
+    const { commands } = parseQueueFile(await Bun.file(queueFile).text());
+    expect(commands).toHaveLength(count);
+    const ids = new Set(commands.map((c) => (c.type === "SKIP" ? c.storyId : "")));
+    expect(ids.size).toBe(count);
+  });
+
+  test("evicts the chain entry once writes settle (map stays bounded)", async () => {
+    expect(_writeChains.has(queueFile)).toBe(false);
+
+    const inFlight = writeQueueCommand(queueFile, { type: "PAUSE" });
+    // While a write is pending, the chain is tracked.
+    expect(_writeChains.has(queueFile)).toBe(true);
+
+    await inFlight;
+    // Once settled with no newer write queued, the entry is evicted.
+    expect(_writeChains.has(queueFile)).toBe(false);
+  });
+});

--- a/test/unit/utils/queue-writer.test.ts
+++ b/test/unit/utils/queue-writer.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { parseQueueFile } from "../../../src/queue/manager";
-import { _writeChains, writeQueueCommand } from "../../../src/utils/queue-writer";
-import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
+import { parseQueueFile } from "@/queue";
+import { _writeChains, writeQueueCommand } from "@/utils/queue-writer";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
 
 describe("writeQueueCommand", () => {
   let tempDir: string;

--- a/test/unit/verification/import-grep-fallback.test.ts
+++ b/test/unit/verification/import-grep-fallback.test.ts
@@ -24,4 +24,33 @@ describe("importGrepFallback", () => {
       _bunDeps.file = origFile;
     }
   });
+
+  test("honors an explicit maxScanFiles cap (config.execution.smartTestRunner.maxScanFiles)", async () => {
+    const many = Array.from({ length: 1000 }, (_, i) => `test/a${i}.test.ts`);
+    const origGlob = _bunDeps.glob;
+    _bunDeps.glob = (() => ({
+      async *scan() {
+        for (const f of many) yield f;
+      },
+    })) as any;
+    let reads = 0;
+    const origFile = _bunDeps.file;
+    _bunDeps.file = ((_p: string) => ({
+      async text() {
+        reads++;
+        return "needle";
+      },
+      async exists() {
+        return true;
+      },
+    })) as any;
+
+    try {
+      await importGrepFallback(["src/x.ts"], "/repo", ["test/**/*.test.ts"], 5);
+      expect(reads).toBeLessThanOrEqual(5);
+    } finally {
+      _bunDeps.glob = origGlob;
+      _bunDeps.file = origFile;
+    }
+  });
 });

--- a/test/unit/verification/smart-runner-config.test.ts
+++ b/test/unit/verification/smart-runner-config.test.ts
@@ -84,6 +84,7 @@ describe("SmartTestRunner config coercion", () => {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
         fallback: "import-grep",
+        maxScanFiles: 200,
       });
     }
   });
@@ -95,6 +96,7 @@ describe("SmartTestRunner config coercion", () => {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: false,
         fallback: "import-grep",
+        maxScanFiles: 200,
       });
     }
   });
@@ -106,6 +108,7 @@ describe("SmartTestRunner config coercion", () => {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
         fallback: "import-grep",
+        maxScanFiles: 200,
       });
     }
   });
@@ -122,6 +125,7 @@ describe("SmartTestRunner config coercion", () => {
         enabled: true,
         testFilePatterns: ["test/custom/**/*.test.ts"],
         fallback: "import-grep",
+        maxScanFiles: 200,
       });
     }
   });


### PR DESCRIPTION
## Summary

Performance, memory-leak, and concurrency-bug fixes across the runner, agent, review, and worktree subsystems, followed by a round of code-review findings.

### Memory leaks
- **EventEmitter listener cleanup** — `AgentManager` and `SessionManager` now expose `close()` (wired into `NaxRuntime.close()`) to remove listeners/stream subscriptions on teardown. Listener ceiling is a finite `MAX_EMITTER_LISTENERS = 100` (not `setMaxListeners(0)`), so a genuine leak still warns.
- **Run-subscriber accumulation** — `unified-executor` tears down a failed run's pipeline-bus subscribers on the throw path (guarded against a concurrent `execute()` swap) instead of leaking them across runs.
- **Bounded caches** — routing cache cleared at run start; `queue-writer` serialization map evicts entries once they settle; config-loader cache evicts rejected promises so failed loads retry.

### Pipe-buffer deadlocks
Drained `stdout`/`stderr` concurrently with `proc.exited` (via `Promise.all`) everywhere git output can exceed the ~64KB OS pipe buffer: `greenfield`, `scoped-lint`, `tdd/rollback`, `worktree/manager`, `worktree/merge`, `review/diff-utils`.

### Race conditions & bug fixes
- **Heartbeat** — generation counter prevents duplicate overlapping loops when `startHeartbeat()` races a mid-sleep loop.
- **PID registry** — write coalescing prevents redundant flushes while one is in flight.
- **Queue writer** — per-path write serialization eliminates read-modify-write races from rapid TUI commands.
- **ACP parser** — `result`/`content`/`text` handled as mutually exclusive per event (else-if).
- **diff-utils** — distinguishes git failure (`null`) from an empty diff (`""`), threaded into `prepare-inputs` skip reasons.
- **metrics/tracker** — immutable `finalMetrics` object instead of mutating `runMetrics`.
- **Glob caps** — `test-scanner` and `smart-runner` cap scanned test files (now config-driven, see below); `smart-runner` glob scans pass explicit `cwd` per monorepo-awareness rules.

### Configurable test-file scan cap
The 200-file scan caps were hardcoded in two places (`test-scanner.ts` and `smart-runner.ts`). Consolidated into a single source of truth:
- New config field **`execution.smartTestRunner.maxScanFiles`** (default 200) in the schema + runtime type.
- `smart-runner`'s `importGrepFallback` takes the cap as a parameter; `scoped-selection` threads `smartCfg.maxScanFiles` into it.
- `test-scanner` reads `options.maxScanFiles` (with a documented `DEFAULT_MAX_SCAN_FILES` fallback for direct callers); the test-coverage context provider passes the config value via `coerceSmartRunner`.
- Module-level constants remain only as fallbacks for direct/unit-test callers — production always resolves from config.

### Code-review findings (follow-up commits)
- Finite listener bound with named constant + rationale.
- Queue-writer map eviction (bounded growth).
- Made the RL-007 source-inspection test brace-aware so production code uses idiomatic braces rather than being shaped around a regex.
- Pinned the acpx parser mutual-exclusivity contract with tests.
- Added a dedicated `queue-writer` test (append, concurrent serialization, eviction).
- New-import path-alias cleanup to keep the deep-relatives ratchet at baseline.

## Test plan
- [x] `bun run typecheck` — clean (both tsconfig projects)
- [x] `bun run lint` — clean (Biome + all custom checks; deep-relatives at baseline)
- [x] `bun run test` — full suite green: unit 8865, integration 1057, ui 15 (0 fail)
