### PR TITLE
fix(execution): load full-suite-rectify for single-session scoped test failures

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -158,8 +158,18 @@ export async function buildPlanForStrategy(
     if (pkgQuality?.commands?.formatFix || pkgQuality?.commands?.formatFixScoped) {
       strategies.push(makeMechanicalFormatFixStrategy() as FixStrategy<Finding, unknown, unknown, unknown>);
     }
-    // Mirror the primary gate condition: TDD always, non-TDD when mode=per-story.
-    if (inputs.fullSuiteGate && (isThreeSession || regressionMode === "per-story")) {
+    // full-suite-rectify is the ONLY strategy whose appliesTo matches
+    // `source: "test-runner"` failing-test findings (category failed-test /
+    // execution-failed). Load it whenever a phase can emit such a finding:
+    //   - the full-suite gate (TDD always; non-TDD only when mode=per-story), OR
+    //   - the scoped verify phase (single-session: tdd-simple / test-after / no-test).
+    // Without the verify-scoped arm, a single-session scoped test failure had no
+    // matching strategy, so the rectification cycle exited "no-strategy" at
+    // iteration 0 and the story failed without a single fix attempt.
+    const fullSuiteGatePhasePresent =
+      Boolean(inputs.fullSuiteGate) && (isThreeSession || regressionMode === "per-story");
+    const verifyScopedPhasePresent = !isThreeSession && Boolean(inputs.verifyScoped);
+    if (fullSuiteGatePhasePresent || verifyScopedPhasePresent) {
       strategies.push(
         makeFullSuiteRectifyStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
       );

--- a/test/unit/execution/build-plan-for-strategy.test.ts
+++ b/test/unit/execution/build-plan-for-strategy.test.ts
@@ -9,18 +9,12 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { TestStrategy } from "@/config/schema-types";
-import { buildPlanForStrategy, ExecutionPlan } from "@/execution";
+import { ExecutionPlan, buildPlanForStrategy } from "@/execution";
 import type { PlanInputs } from "@/execution";
 import { _storyOrchestratorDeps } from "@/execution";
 import type { UserStory } from "@/prd/types";
-import {
-  makeMockCallContext,
-  makeMockPlanInputs,
-  makeNaxConfig,
-  makeStory,
-  makeTestRuntime,
-} from "@test/helpers";
 import type { NaxRuntime } from "@/runtime";
+import { makeMockCallContext, makeMockPlanInputs, makeNaxConfig, makeStory, makeTestRuntime } from "@test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Typed input factories — populate the slot inputs each test needs
@@ -169,7 +163,15 @@ describe("buildPlanForStrategy — fresh vs retry detection", () => {
   test("story with priorFailures stage=review is treated as retry", async () => {
     const story = makeStory({
       attempts: 0,
-      priorFailures: [{ attempt: 0, modelTier: "fast", stage: "review", summary: "review failed", timestamp: new Date().toISOString() }],
+      priorFailures: [
+        {
+          attempt: 0,
+          modelTier: "fast",
+          stage: "review",
+          summary: "review failed",
+          timestamp: new Date().toISOString(),
+        },
+      ],
     });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
@@ -255,10 +257,7 @@ describe("buildPlanForStrategy — non-TDD single-session", () => {
 describe("buildPlanForStrategy — three-session TDD strategy variants", () => {
   // tdd-simple is NOT included — it is a single-session strategy that does not
   // dispatch test-writer, full-suite-gate, or verifier slots.
-  const tddStrategies: TestStrategy[] = [
-    "three-session-tdd",
-    "three-session-tdd-lite",
-  ];
+  const tddStrategies: TestStrategy[] = ["three-session-tdd", "three-session-tdd-lite"];
 
   test.each(tddStrategies)("%s fresh includes full-suite-gate and verifier", async (strategy) => {
     const story = makeStory({ attempts: 0 });
@@ -624,6 +623,89 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     expect(capturedStrategyNames).not.toContain("autofix-implementer");
     expect(capturedStrategyNames).not.toContain("autofix-test-writer");
   });
+
+  // Regression: single-session (tdd-simple / test-after / no-test) scoped test
+  // failures emit `source: "test-runner"` findings. full-suite-rectify is the only
+  // strategy whose appliesTo matches that source. Before the fix it was gated behind
+  // TDD / per-story regression, so a single-session scoped failure had NO matching
+  // strategy and the cycle exited "no-strategy" at iteration 0 — the story failed
+  // without one fix attempt. With autofix disabled and no fix commands, the ONLY
+  // strategy that should remain is full-suite-rectify.
+  test("regression: single-session + verifyScoped phase → full-suite-rectify assembled (was no-strategy)", async () => {
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "verify-scoped") {
+        return {
+          success: false,
+          findings: [
+            { source: "test-runner", severity: "error", category: "failed-test", message: "scoped test failed" },
+          ],
+        };
+      }
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const story = makeStory();
+    const config = makeNaxConfig({
+      quality: { commands: {}, autofix: { enabled: false } },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+    });
+    const ctx = makeCtxWithRuntime(config);
+    const inputs = makeNonTddInputs(story, {
+      verifyScoped: { workdir: "/tmp/test", storyId: story.id },
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    await plan.run();
+    // autofix disabled + no fix commands → full-suite-rectify is the ONLY
+    // assemblable strategy. Exact-set assertion guards against an accidental
+    // extra strategy slipping in.
+    expect(capturedStrategyNames).toEqual(["full-suite-rectify"]);
+  });
+
+  // Negative guard: a single-session plan with NO verify-scoped phase and deferred
+  // regression must NOT load full-suite-rectify — there is no phase that can emit
+  // test-runner findings, so the strategy would be dead weight. The cycle is driven
+  // by a lint-check failure (mechanical-lintfix matches) to ensure runFixCycle runs.
+  test("single-session without verifyScoped phase → full-suite-rectify NOT assembled", async () => {
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "lint-check") {
+        return { success: false, findings: [{ source: "lint", severity: "error", message: "lint failed" }] };
+      }
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const story = makeStory();
+    const config = makeNaxConfig({
+      quality: { commands: { lintFix: "bun run lint:fix" }, autofix: { enabled: false } },
+      execution: { regressionGate: { mode: "deferred" }, rectification: { enabled: true, maxAttemptsTotal: 2 } },
+    });
+    const ctx = makeCtxWithRuntime(config);
+    const inputs = makeNonTddInputs(story, {
+      lintCheck: { workdir: "/tmp/test", storyId: story.id },
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    await plan.run();
+    expect(capturedStrategyNames).toContain("mechanical-lintfix");
+    expect(capturedStrategyNames).not.toContain("full-suite-rectify");
+  });
+
+  // No-regression guard: three-session TDD must STILL load full-suite-rectify
+  // exactly as before (the fix only widens single-session, never narrows TDD).
+  test("no-regression: three-session TDD still assembles full-suite-rectify", async () => {
+    const story = makeStory({ attempts: 1 });
+    const config = makeNaxConfig({
+      quality: { commands: {}, autofix: { enabled: false } },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+    });
+    const ctx = makeCtxWithRuntime(config);
+    const inputs = makeTddRetryInputs(story, {
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    await plan.run();
+    expect(capturedStrategyNames).toContain("full-suite-rectify");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -637,12 +719,6 @@ describe("buildPlanForStrategy — canonical phase ordering", () => {
     const ctx = makeMockCallContext();
     const inputs = makeTddFreshInputs(story);
     const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
-    expect(plan.phaseNames()).toEqual([
-      "test-writer",
-      "greenfield-gate",
-      "implementer",
-      "full-suite-gate",
-      "verifier",
-    ]);
+    expect(plan.phaseNames()).toEqual(["test-writer", "greenfield-gate", "implementer", "full-suite-gate", "verifier"]);
   });
 });


### PR DESCRIPTION
## Problem

A single-session story (`testStrategy` = `tdd-simple` / `test-after` / `no-test`) whose **scoped verify phase** fails emits findings tagged `source: "test-runner"`. The only `FixStrategy` whose `appliesTo` matches that source is **`full-suite-rectify`** (`src/operations/full-suite-rectify.ts:42`).

That strategy was gated behind `isThreeSession || regressionMode === "per-story"`, so in single-session + non-per-story mode it was **never loaded**. The rectification cycle then found no matching strategy and exited `no-strategy` at iteration 0 — the story failed **without a single fix attempt**, and the run stalled.

### Observed (feature `sentiment-foundation`, story US-004)

```
verify[scoped]      → 96 pass / 3 fail  → 3 findings { source: test-runner }
findings.cycle      → "cycle exited — no matching strategy" (reason: no-strategy)
story-orchestrator  → Rectification exited: no-strategy (iterationCount: 0)
execution           → Rectification exhausted with unfixed findings (findingSources: ["test-runner"])
```
Repeated across all 3 escalation tiers → run `stalled`.

## Fix

Widen the load condition in `buildPlanForStrategy` so `full-suite-rectify` is assembled whenever a phase can emit `test-runner` findings — the full-suite gate (unchanged) **or** the scoped verify phase:

```ts
const fullSuiteGatePhasePresent = Boolean(inputs.fullSuiteGate) && (isThreeSession || regressionMode === "per-story");
const verifyScopedPhasePresent  = !isThreeSession && Boolean(inputs.verifyScoped);
if (fullSuiteGatePhasePresent || verifyScopedPhasePresent) {
  strategies.push(makeFullSuiteRectifyStrategy(story, config, sink) as ...);
}
```

The two predicates mirror the phase-add guards earlier in the same function verbatim. This only makes existing machinery **reachable** — `STRATEGY_TO_REVALIDATION_PHASES["full-suite-rectify"]` and `collectRectificationPhases` already include `verify-scoped`, and `phasesToRevalidate` intersects against present phases, so the single-session revalidation sweep correctly resolves to just `verify-scoped`.

**Three-session TDD behaviour is unchanged.** No conflict with `autofix-implementer`: its `appliesTo` source set (`lint`/`typecheck`/`semantic-review`/`tdd-verifier`) is disjoint from `test-runner`, and `full-suite-rectify` is `coRun: "exclusive"` so it never shares an execution group.

## Behavioral effect on re-run

verify-scoped fails → `full-suite-rectify` runs the warm implementer against the failing-test prompt → re-validates scoped tests + gate → loops up to `maxAttemptsPerStrategy` → resolves, or escalates **on real evidence** instead of bailing instantly.

## Tests

Added to `test/unit/execution/build-plan-for-strategy.test.ts`:
1. **Regression** — single-session + `verifyScoped`, autofix off, no fix commands → exact strategy set is `["full-suite-rectify"]` (was empty / `no-strategy` before the fix).
2. **Negative guard** — single-session without `verifyScoped` (deferred regression) → `full-suite-rectify` NOT assembled (cycle driven by a lint failure to prove it ran).
3. **No-regression guard** — three-session TDD still assembles `full-suite-rectify`.

## Verification
- `bun run typecheck` — pass
- `bun run lint` (src/bin + check scripts) — pass
- `bun test build-plan-for-strategy.test.ts` — 39/39 pass

Reviewed via code-reviewer agent: Approve, no CRITICAL/HIGH findings.