### PR TITLE
fix: deferred-regression blame attribution + verifier-SSOT carve-out staleness

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -44,6 +44,7 @@ export {
   EXHAUSTED_EXIT_REASONS,
   phasesToRevalidate,
   orderGateLast,
+  gateFailureKeys,
   refreshReviewInputForDispatch,
   withIncreasingFailuresBail,
   type OrchestratorSlot,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -27,11 +27,13 @@ export {
 export { PidRegistry, _pidRegistryDeps } from "./pid-registry";
 export {
   runDeferredRegression,
+  findResponsibleStoryByTransition,
   _regressionDeps,
   handleRunCompletion,
   _runCompletionDeps,
   type DeferredRegressionOptions,
   type DeferredRegressionResult,
+  type StorySnapshot,
   type RunCompletionOptions,
   type RunCompletionResult,
 } from "./lifecycle";

--- a/src/execution/lifecycle/index.ts
+++ b/src/execution/lifecycle/index.ts
@@ -14,7 +14,9 @@ export { cleanupRun, type RunCleanupOptions } from "./run-cleanup";
 export { setupRun, type RunSetupOptions, type RunSetupResult } from "./run-setup";
 export {
   runDeferredRegression,
+  findResponsibleStoryByTransition,
   _regressionDeps,
   type DeferredRegressionOptions,
   type DeferredRegressionResult,
+  type StorySnapshot,
 } from "./run-regression";

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -127,6 +127,20 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
       prd,
       workdir,
       runtime: options.runtime,
+      // Per-story gate snapshots enable causal blame attribution (transition
+      // pass -> fail) instead of the git-recency heuristic. Sequential runs
+      // only: in parallel mode story completion order (`completedAt`) is not
+      // causal and each story runs in an isolated worktree, so a per-story
+      // snapshot does not reflect merged-repo state — fall back to the git
+      // heuristic there by withholding snapshots.
+      storyMetrics:
+        options.isSequential === false
+          ? undefined
+          : allStoryMetrics.map((m) => ({
+              storyId: m.storyId,
+              completedAt: m.completedAt,
+              failingTestFiles: m.failingTestFiles,
+            })),
     });
 
     const lastRunAt = new Date().toISOString();

--- a/src/execution/lifecycle/run-regression.ts
+++ b/src/execution/lifecycle/run-regression.ts
@@ -32,12 +32,33 @@ export const _regressionDeps = {
   parseTestOutput,
 };
 
+/**
+ * Per-story snapshot of which test files were failing after that story's
+ * full-suite gate ran (post-rectification). Used to attribute an end-of-run
+ * regression to the story where a test transitioned pass -> fail, instead of
+ * the cruder git-recency heuristic. Only available when the per-story gate runs
+ * (three-session strategies, or `regressionGate.mode === "per-story"`).
+ */
+export interface StorySnapshot {
+  readonly storyId: string;
+  /** ISO timestamp — used to order snapshots chronologically. */
+  readonly completedAt: string;
+  /** Test files failing at this story's gate. Absent when no gate ran. */
+  readonly failingTestFiles?: readonly string[];
+}
+
 export interface DeferredRegressionOptions {
   config: NaxConfig;
   prd: PRD;
   workdir: string;
   /** NaxRuntime — provides agentManager, sessionManager, and signal for rectification. */
   runtime: NaxRuntime;
+  /**
+   * Per-story metrics from the main run, carrying per-story gate snapshots
+   * (`failingTestFiles`). When present, regression blame is attributed via
+   * gate transition (accurate) before falling back to the git heuristic.
+   */
+  storyMetrics?: readonly StorySnapshot[];
 }
 
 export interface DeferredRegressionResult {
@@ -90,6 +111,50 @@ async function findResponsibleStory(
     }
   }
 
+  return undefined;
+}
+
+/**
+ * Attribute a failing test file to the story that introduced the regression,
+ * using per-story gate snapshots.
+ *
+ * A snapshot records the tests failing AFTER each story's full-suite gate. The
+ * earliest story (chronologically, by `completedAt`) whose snapshot contains
+ * the failing test is treated as where it transitioned pass -> fail — i.e. the
+ * story responsible for the regression. Unlike the git-recency heuristic in
+ * {@link findResponsibleStory} (which blames whichever story most recently
+ * committed, regardless of who broke the test), this follows the failing test.
+ *
+ * Assumptions / limitations (caller falls back to the git heuristic when this
+ * returns `undefined`, so a miss degrades to prior behaviour, never worse):
+ * - **Sequential only.** Callers must withhold snapshots for parallel runs:
+ *   `completedAt` order is not causal there and worktrees isolate gate state.
+ * - **Green baseline.** "Earliest containing" approximates a true pass -> fail
+ *   edge; a failure pre-existing before the run is blamed on the first story to
+ *   observe it. Pre-existing failures are normally caught earlier (greenfield
+ *   gate), so this is acceptable for the regression-introduced-mid-run case.
+ * - **Exact path match.** `testFile` must match the snapshot's stored path
+ *   verbatim. Both sides derive from the same parser, but a monorepo package
+ *   scope difference (`pkg/x/foo.test.ts` vs `foo.test.ts`) misses and falls
+ *   back to the git heuristic.
+ *
+ * Returns the responsible story ID, or `undefined` when no snapshot shows the
+ * test failing (caller should fall back to the git heuristic).
+ */
+export function findResponsibleStoryByTransition(
+  testFile: string,
+  snapshots: readonly StorySnapshot[],
+): string | undefined {
+  // Secondary sort by storyId keeps attribution deterministic when two stories
+  // share a completedAt timestamp.
+  const ordered = [...snapshots].sort(
+    (a, b) => a.completedAt.localeCompare(b.completedAt) || a.storyId.localeCompare(b.storyId),
+  );
+  for (const snap of ordered) {
+    if (snap.failingTestFiles?.includes(testFile)) {
+      return snap.storyId;
+    }
+  }
   return undefined;
 }
 
@@ -283,9 +348,26 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
     }
   } else {
     const testFilesArray = Array.from(testFilesInFailures);
+    const snapshots = options.storyMetrics ?? [];
+    const passedById = new Map(passedStories.map((s) => [s.id, s]));
 
     for (const testFile of testFilesArray) {
-      const responsibleStory = await findResponsibleStory(testFile, workdir, passedStories);
+      // Prefer transition attribution (causal: blames the story where the test
+      // went pass -> fail). Fall back to the git-recency heuristic when no gate
+      // snapshot maps the test to a *passed* story (e.g. single-session +
+      // deferred has no per-story gate, so no snapshots exist).
+      let responsibleStory: UserStory | undefined;
+      const transitionId = findResponsibleStoryByTransition(testFile, snapshots);
+      if (transitionId && passedById.has(transitionId)) {
+        responsibleStory = passedById.get(transitionId);
+        logger?.info("regression", "Mapped test to story via gate transition", {
+          storyId: transitionId,
+          testFile,
+        });
+      }
+      if (!responsibleStory) {
+        responsibleStory = await findResponsibleStory(testFile, workdir, passedStories);
+      }
       if (responsibleStory) {
         affectedStories.add(responsibleStory.id);
         affectedStoriesObjs.set(responsibleStory.id, responsibleStory);

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -99,6 +99,7 @@ export function extractPauseReason(phaseOutputs: Record<string, unknown>): strin
 export function deriveTddFailureCategory(
   phaseOutputs: Record<string, unknown>,
   unfixedFindings?: readonly Finding[],
+  gateRegressedDuringRect?: boolean,
 ): FailureCategory | undefined {
   // Test-writer failure → session-failure
   const testWriterOutput = phaseOutputs[testWriterOp.name] as { success?: boolean } | undefined;
@@ -127,8 +128,12 @@ export function deriveTddFailureCategory(
 
   // Verifier passed → it is the SSOT for the TDD verdict. Even if the gate flagged
   // failures, the verifier has judged this story OK (e.g. unrelated regressions).
-  // Skip the gate-derived category in that case.
-  const verifierPassed = verifierOutput?.success === true;
+  // Skip the gate-derived category in that case — UNLESS rectification introduced
+  // new gate failures after the verifier ran, which makes the verdict stale (the
+  // story is failed for exactly this reason; route it to escalation as a gate
+  // failure rather than dropping the category). Mirrors the success-aggregation
+  // staleness guard in ExecutionPlan.run.
+  const verifierPassed = verifierOutput?.success === true && !gateRegressedDuringRect;
 
   // Full-suite gate exhausted: rectification ran out of retry budget AND at least
   // one test-runner finding remains unfixed. Takes priority over the plain
@@ -325,7 +330,11 @@ export async function applyPostRunInspection(
   const pauseReason = extractPauseReason(planResult.phaseOutputs);
   const failureCategory =
     isTdd && !planResult.success
-      ? deriveTddFailureCategory(planResult.phaseOutputs, planResult.unfixedFindings)
+      ? deriveTddFailureCategory(
+          planResult.phaseOutputs,
+          planResult.unfixedFindings,
+          planResult.gateRegressedDuringRect,
+        )
       : undefined;
 
   // Diagnostic: if a TDD plan failed but no category was derived, the routing path

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -229,10 +229,19 @@ export async function applyPostRunInspection(
   ctx.agentResult = agentResult;
 
   // Propagate full-suite gate result so verify stage can skip redundant run (BUG-054)
-  const fullSuiteGateOutput = planResult.phaseOutputs[fullSuiteGateOp.name] as { passed?: boolean } | undefined;
+  const fullSuiteGateOutput = planResult.phaseOutputs[fullSuiteGateOp.name] as
+    | { passed?: boolean; findings?: readonly Finding[] }
+    | undefined;
   if (fullSuiteGateOutput?.passed) {
     ctx.fullSuiteGatePassed = true;
   }
+  // Snapshot failing test files from the (post-rectification) gate findings so
+  // deferred-regression blame can attribute a regression to the introducing
+  // story (three-session + deferred). See findResponsibleStoryByTransition.
+  const gateFailingFiles = [
+    ...new Set((fullSuiteGateOutput?.findings ?? []).map((f) => f.file).filter((f): f is string => !!f)),
+  ];
+  if (gateFailingFiles.length > 0) ctx.fullSuiteGateFailingFiles = gateFailingFiles;
 
   // Self-verification from implementer output
   ctx.selfVerification = parseSelfVerificationMarker(agentResult.output ?? "", ctx.workdir);

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -182,6 +182,13 @@ export interface StoryOrchestratorResult {
   readonly unfixedFindings?: readonly Finding[];
   /** Set when rectification short-circuited with empty findings — resume ran scope-backfill. */
   readonly liteScopeIncomplete?: boolean;
+  /**
+   * True when rectification introduced full-suite-gate failures absent from the
+   * verifier-time baseline — the verifier verdict is stale and no longer exempts
+   * the gate (carve-out staleness fix). Surfaced so post-run categorization can
+   * route the failure to escalation as `tests-failing`.
+   */
+  readonly gateRegressedDuringRect?: boolean;
 }
 
 export type PhaseKind =
@@ -405,6 +412,22 @@ export function extractPhaseFindings(output: unknown): Finding[] {
   const success =
     "success" in record ? record.success === true : "passed" in record ? record.passed === true : findings.length === 0;
   return success ? [] : findings;
+}
+
+/**
+ * Failing-test identity keys (`file::testName`) from a full-suite-gate output.
+ * Returns an empty set when the gate passed (extractPhaseFindings yields [] on
+ * success). Used to detect gate failures *introduced* during rectification by
+ * diffing against the verifier-time baseline — see ExecutionPlan.run success
+ * aggregation. Exported for unit testing.
+ */
+export function gateFailureKeys(gateOutput: unknown): Set<string> {
+  const keys = new Set<string>();
+  for (const f of extractPhaseFindings(gateOutput)) {
+    if (f.source !== "test-runner") continue;
+    keys.add(`${f.file ?? ""}::${f.rule ?? ""}`);
+  }
+  return keys;
 }
 
 /**
@@ -1098,6 +1121,14 @@ export class ExecutionPlan {
       }
     }
 
+    // Baseline of gate failures the verifier implicitly blessed. The main loop
+    // halts on any phase failure (no exemptions), so a verifier that ran-and-passed
+    // means the gate was green at that point — any gate failure observed after
+    // rectification was therefore introduced by it. Captured before any
+    // rectification (including the ADR-024 non-blocking pass) mutates the gate.
+    const gateName = this.state.fullSuiteGate?.slot.op.name;
+    const preRectGateFailureKeys = gateName ? gateFailureKeys(phaseOutputs[gateName]) : new Set<string>();
+
     const rectResult = await runRectification(this.ctx, this.state, phaseCosts, phaseOutputs);
 
     // Resume the canonical loop after rectification resolves. The strategy-specific
@@ -1252,12 +1283,28 @@ export class ExecutionPlan {
     // judgment). Exempt the gate from aggregation so the story doesn't roll back
     // over failures it didn't cause. The gate output stays in `phaseOutputs` for
     // diagnostics; rectification (when configured) still consumes its findings.
+    //
+    // Staleness guard: the verifier judged the *pre-rectification* tree. If
+    // rectification then introduced NEW gate failures (keys absent from the
+    // verifier-time baseline), the verdict is stale for those — it can no longer
+    // exempt the gate, else a review-fix that breaks a test is silently laundered
+    // into a pass and leaks to the deferred regression sweep.
     const verifierName = this.state.verifier?.slot.op.name;
-    const gateName = this.state.fullSuiteGate?.slot.op.name;
+    // `gateName` and `preRectGateFailureKeys` captured above, before rectification.
     // SSOT requires an explicit pass — see `phaseExplicitlyPassed` for why we
     // don't use the defensive `phasePassed` here.
-    const verifierPassedSsot = verifierName !== undefined && phaseExplicitlyPassed(phaseOutputs[verifierName]);
-    if (
+    const verifierExplicitlyPassed = verifierName !== undefined && phaseExplicitlyPassed(phaseOutputs[verifierName]);
+    const gateRegressedDuringRect =
+      gateName !== undefined &&
+      [...gateFailureKeys(phaseOutputs[gateName])].some((k) => !preRectGateFailureKeys.has(k));
+    const verifierPassedSsot = verifierExplicitlyPassed && !gateRegressedDuringRect;
+    if (verifierExplicitlyPassed && gateRegressedDuringRect) {
+      logger?.warn(
+        "story-orchestrator",
+        "Gate regressed during rectification after verifier passed — verifier verdict is stale, failing story",
+        { storyId: this.ctx.storyId, packageDir: this.ctx.packageDir },
+      );
+    } else if (
       verifierPassedSsot &&
       gateName !== undefined &&
       !phasePassed(gateName, phaseOutputs[gateName], this.ctx.storyId)
@@ -1306,6 +1353,7 @@ export class ExecutionPlan {
       durationMs,
       phaseOutputs,
       ...rectResult,
+      gateRegressedDuringRect,
     };
   }
 }

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -157,6 +157,9 @@ export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: 
     startedAt: storyStartTime,
     completedAt: new Date().toISOString(),
     fullSuiteGatePassed,
+    ...(ctx.fullSuiteGateFailingFiles && ctx.fullSuiteGateFailingFiles.length > 0
+      ? { failingTestFiles: ctx.fullSuiteGateFailingFiles }
+      : {}),
     runtimeCrashes: ctx.storyRuntimeCrashes ?? 0,
     tokens: agentResult?.tokenUsage
       ? new TokenUsage({

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -130,6 +130,13 @@ export interface StoryMetrics {
   runtimeCrashes?: number;
   /** Whether TDD full-suite gate passed (only true for TDD strategies when gate passes) */
   fullSuiteGatePassed?: boolean;
+  /**
+   * Test files failing at this story's full-suite gate (post-rectification).
+   * Snapshot used by the deferred-regression gate to attribute an end-of-run
+   * regression to the story where a test transitioned pass -> fail. Absent when
+   * no per-story gate ran (non-TDD + deferred) or the gate passed cleanly.
+   */
+  failingTestFiles?: string[];
   /** Cost incurred only during rectification (only set when source === 'rectification') */
   rectificationCost?: number;
   /** Token usage for this story */

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -225,6 +225,13 @@ export interface PipelineContext extends DispatchContext {
   tddIsolations?: Record<string, import("../execution/types").IsolationCheck>;
   /** Set to true when TDD full-suite gate already passed — verify stage skips to avoid redundant run (BUG-054) */
   fullSuiteGatePassed?: boolean;
+  /**
+   * Test files failing at this story's full-suite gate (post-rectification).
+   * Captured by applyPostRunInspection from the gate output findings; surfaced
+   * in StoryMetrics.failingTestFiles for deferred-regression blame attribution.
+   * Absent when no gate ran or the gate passed cleanly.
+   */
+  fullSuiteGateFailingFiles?: string[];
   /** Number of runtime crashes (RUNTIME_CRASH verify status) encountered for this story (BUG-070) */
   storyRuntimeCrashes?: number;
   /** Structured review findings — passed to escalation for retry context */

--- a/test/unit/execution/lifecycle/run-regression-attribution.test.ts
+++ b/test/unit/execution/lifecycle/run-regression-attribution.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for deferred-regression blame attribution.
+ *
+ * Covers the transition-based attribution that replaces the git-recency
+ * heuristic: a failing test is attributed to the EARLIEST story whose
+ * per-story full-suite-gate snapshot shows it failing (i.e. the story where
+ * the test transitioned pass -> fail). Falls back to the git heuristic when no
+ * snapshot data is available (e.g. single-session + deferred, which has no
+ * per-story gate).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _regressionDeps, findResponsibleStoryByTransition, runDeferredRegression } from "@/execution";
+import type { DeferredRegressionOptions, StorySnapshot } from "@/execution";
+import type { PRD } from "@/prd";
+import { _gitDeps } from "@/utils/git";
+import { makeMockRuntime, makeNaxConfig } from "@test/helpers";
+
+function snap(storyId: string, completedAt: string, failingTestFiles?: string[]): StorySnapshot {
+  return { storyId, completedAt, failingTestFiles };
+}
+
+describe("findResponsibleStoryByTransition", () => {
+  test("blames the earliest story whose snapshot shows the test failing", () => {
+    const snapshots: StorySnapshot[] = [
+      snap("US-001", "2026-01-01T00:00:00.000Z", []),
+      snap("US-002", "2026-01-01T00:01:00.000Z", ["foo.test.ts"]),
+      snap("US-003", "2026-01-01T00:02:00.000Z", ["foo.test.ts"]),
+    ];
+    expect(findResponsibleStoryByTransition("foo.test.ts", snapshots)).toBe("US-002");
+  });
+
+  test("returns undefined when no snapshot contains the failing test", () => {
+    const snapshots: StorySnapshot[] = [
+      snap("US-001", "2026-01-01T00:00:00.000Z", ["bar.test.ts"]),
+      snap("US-002", "2026-01-01T00:01:00.000Z", []),
+    ];
+    expect(findResponsibleStoryByTransition("foo.test.ts", snapshots)).toBeUndefined();
+  });
+
+  test("returns undefined for empty snapshot list", () => {
+    expect(findResponsibleStoryByTransition("foo.test.ts", [])).toBeUndefined();
+  });
+
+  test("orders by completedAt, not array order, when finding the first transition", () => {
+    // Array is deliberately out of chronological order.
+    const snapshots: StorySnapshot[] = [
+      snap("US-003", "2026-01-01T00:02:00.000Z", ["foo.test.ts"]),
+      snap("US-002", "2026-01-01T00:01:00.000Z", ["foo.test.ts"]),
+      snap("US-001", "2026-01-01T00:00:00.000Z", []),
+    ];
+    expect(findResponsibleStoryByTransition("foo.test.ts", snapshots)).toBe("US-002");
+  });
+
+  test("ignores snapshots with undefined failingTestFiles", () => {
+    const snapshots: StorySnapshot[] = [
+      snap("US-001", "2026-01-01T00:00:00.000Z", undefined),
+      snap("US-002", "2026-01-01T00:01:00.000Z", ["foo.test.ts"]),
+    ];
+    expect(findResponsibleStoryByTransition("foo.test.ts", snapshots)).toBe("US-002");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: transition attribution beats the git-recency heuristic
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeConfig() {
+  return makeNaxConfig({
+    quality: {
+      commands: { test: "bun test" },
+      forceExit: false,
+      detectOpenHandles: false,
+      detectOpenHandlesRetries: 0,
+      gracePeriodMs: 0,
+      drainTimeoutMs: 0,
+      shell: false,
+      stripEnvVars: [],
+    },
+    execution: {
+      regressionGate: { mode: "deferred", timeoutSeconds: 60, acceptOnTimeout: true },
+    },
+  });
+}
+
+function makePrd(storyIds: string[]): PRD {
+  return {
+    userStories: storyIds.map((id) => ({ id, status: "passed", title: id })),
+  } as unknown as PRD;
+}
+
+describe("runDeferredRegression — transition attribution", () => {
+  let savedDeps: typeof _regressionDeps;
+  beforeEach(() => {
+    savedDeps = { ..._regressionDeps };
+  });
+  afterEach(() => {
+    Object.assign(_regressionDeps, savedDeps);
+  });
+
+  test("attributes a failing test to the story where it went pass -> fail, not the most recent", async () => {
+    // foo.test.ts went red at US-002 (and stays red through US-003). The
+    // git-recency heuristic would blame US-003 (most recent); transition blames US-002.
+    _regressionDeps.runVerification = mock(async () => {
+      // call 0: initial suite fails; subsequent mid-loop re-runs pass (early exit).
+      return _regressionDeps.runVerification.mock.calls.length === 1
+        ? {
+            success: false,
+            status: "TEST_FAILURE",
+            countsTowardEscalation: true,
+            output: "fail",
+            passCount: 0,
+            failCount: 1,
+          }
+        : {
+            success: true,
+            status: "SUCCESS",
+            countsTowardEscalation: false,
+            output: "pass",
+            passCount: 10,
+            failCount: 0,
+          };
+    });
+    _regressionDeps.parseTestOutput = mock(() => ({
+      passed: 0,
+      failed: 1,
+      failures: [{ file: "foo.test.ts", testName: "t", error: "boom", stackTrace: [] }],
+    }));
+    const rectified: string[] = [];
+    _regressionDeps.runFixCycle = mock(async (_cycle, cycleCtx) => {
+      rectified.push(cycleCtx.storyId);
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as const,
+        costUsd: 0.1,
+      };
+    });
+
+    const options = {
+      config: makeConfig(),
+      prd: makePrd(["US-001", "US-002", "US-003"]),
+      workdir: "/tmp/test-workdir",
+      runtime: makeMockRuntime(),
+      storyMetrics: [
+        snap("US-001", "2026-01-01T00:00:00.000Z", []),
+        snap("US-002", "2026-01-01T00:01:00.000Z", ["foo.test.ts"]),
+        snap("US-003", "2026-01-01T00:02:00.000Z", ["foo.test.ts"]),
+      ],
+    } as unknown as DeferredRegressionOptions;
+
+    const result = await runDeferredRegression(options);
+
+    expect(result.affectedStories).toEqual(["US-002"]);
+    expect(result.affectedStories).not.toContain("US-003");
+    expect(rectified).toEqual(["US-002"]);
+  });
+
+  test("falls back to the git heuristic when no snapshot maps the failing test", async () => {
+    // No snapshot contains foo.test.ts → transition returns undefined → git
+    // fallback maps the test to the most-recently-committed passed story.
+    _regressionDeps.runVerification = mock(async () =>
+      _regressionDeps.runVerification.mock.calls.length === 1
+        ? {
+            success: false,
+            status: "TEST_FAILURE",
+            countsTowardEscalation: true,
+            output: "fail",
+            passCount: 0,
+            failCount: 1,
+          }
+        : {
+            success: true,
+            status: "SUCCESS",
+            countsTowardEscalation: false,
+            output: "pass",
+            passCount: 10,
+            failCount: 0,
+          },
+    );
+    _regressionDeps.parseTestOutput = mock(() => ({
+      passed: 0,
+      failed: 1,
+      failures: [{ file: "foo.test.ts", testName: "t", error: "boom", stackTrace: [] }],
+    }));
+    const rectified: string[] = [];
+    _regressionDeps.runFixCycle = mock(async (_cycle, cycleCtx) => {
+      rectified.push(cycleCtx.storyId);
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
+    });
+    // Make every git query report "has commits" so the heuristic returns the
+    // most-recent passed story (US-002).
+    const origSpawn = _gitDeps.spawn;
+    _gitDeps.spawn = mock(() => ({
+      exited: Promise.resolve(0),
+      stdout: "abc1234 commit",
+      stderr: "",
+      kill: () => {},
+    })) as unknown as typeof _gitDeps.spawn;
+
+    try {
+      const result = await runDeferredRegression({
+        config: makeConfig(),
+        prd: makePrd(["US-001", "US-002"]),
+        workdir: "/tmp/test-workdir",
+        runtime: makeMockRuntime(),
+        storyMetrics: [
+          snap("US-001", "2026-01-01T00:00:00.000Z", []),
+          snap("US-002", "2026-01-01T00:01:00.000Z", ["bar.test.ts"]),
+        ],
+      } as unknown as DeferredRegressionOptions);
+
+      expect(result.affectedStories).toEqual(["US-002"]);
+      expect(rectified).toEqual(["US-002"]);
+    } finally {
+      _gitDeps.spawn = origSpawn;
+    }
+  });
+
+  test("does not blame a transition hit that is not a passed story (guard)", async () => {
+    // Snapshot points at US-099, which is not among the passed stories. The
+    // guard must reject it and fall back to git (which maps nothing in /tmp),
+    // so US-099 is never added to affected stories.
+    _regressionDeps.runVerification = mock(async () => ({
+      success: false,
+      status: "TEST_FAILURE",
+      countsTowardEscalation: true,
+      output: "fail",
+      passCount: 0,
+      failCount: 1,
+    }));
+    _regressionDeps.parseTestOutput = mock(() => ({
+      passed: 0,
+      failed: 1,
+      failures: [{ file: "foo.test.ts", testName: "t", error: "boom", stackTrace: [] }],
+    }));
+    _regressionDeps.runFixCycle = mock(async () => ({
+      iterations: [],
+      finalFindings: [],
+      exitReason: "resolved" as const,
+      costUsd: 0,
+    }));
+
+    const result = await runDeferredRegression({
+      config: makeConfig(),
+      prd: makePrd(["US-001", "US-002"]),
+      workdir: "/tmp/test-workdir",
+      runtime: makeMockRuntime(),
+      storyMetrics: [snap("US-099", "2026-01-01T00:01:00.000Z", ["foo.test.ts"])],
+    } as unknown as DeferredRegressionOptions);
+
+    expect(result.affectedStories).not.toContain("US-099");
+    expect(result.affectedStories).toEqual([]);
+  });
+});

--- a/test/unit/execution/lifecycle/run-regression-attribution.test.ts
+++ b/test/unit/execution/lifecycle/run-regression-attribution.test.ts
@@ -65,23 +65,21 @@ describe("findResponsibleStoryByTransition", () => {
 // Integration: transition attribution beats the git-recency heuristic
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makeConfig() {
-  return makeNaxConfig({
-    quality: {
-      commands: { test: "bun test" },
-      forceExit: false,
-      detectOpenHandles: false,
-      detectOpenHandlesRetries: 0,
-      gracePeriodMs: 0,
-      drainTimeoutMs: 0,
-      shell: false,
-      stripEnvVars: [],
-    },
-    execution: {
-      regressionGate: { mode: "deferred", timeoutSeconds: 60, acceptOnTimeout: true },
-    },
-  });
-}
+const deferredConfig = makeNaxConfig({
+  quality: {
+    commands: { test: "bun test" },
+    forceExit: false,
+    detectOpenHandles: false,
+    detectOpenHandlesRetries: 0,
+    gracePeriodMs: 0,
+    drainTimeoutMs: 0,
+    shell: false,
+    stripEnvVars: [],
+  },
+  execution: {
+    regressionGate: { mode: "deferred", timeoutSeconds: 60, acceptOnTimeout: true },
+  },
+});
 
 function makePrd(storyIds: string[]): PRD {
   return {
@@ -138,7 +136,7 @@ describe("runDeferredRegression — transition attribution", () => {
     });
 
     const options = {
-      config: makeConfig(),
+      config: deferredConfig,
       prd: makePrd(["US-001", "US-002", "US-003"]),
       workdir: "/tmp/test-workdir",
       runtime: makeMockRuntime(),
@@ -200,7 +198,7 @@ describe("runDeferredRegression — transition attribution", () => {
 
     try {
       const result = await runDeferredRegression({
-        config: makeConfig(),
+        config: deferredConfig,
         prd: makePrd(["US-001", "US-002"]),
         workdir: "/tmp/test-workdir",
         runtime: makeMockRuntime(),
@@ -242,7 +240,7 @@ describe("runDeferredRegression — transition attribution", () => {
     }));
 
     const result = await runDeferredRegression({
-      config: makeConfig(),
+      config: deferredConfig,
       prd: makePrd(["US-001", "US-002"]),
       workdir: "/tmp/test-workdir",
       runtime: makeMockRuntime(),

--- a/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
+++ b/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Verifier-SSOT carve-out staleness fix.
+ *
+ * The carve-out exempts the full-suite gate from the story verdict when the
+ * verifier passed (treating gate failures as pre-existing/unrelated). But the
+ * verifier judged the *pre-rectification* tree. When a review-fix run during
+ * rectification introduces a NEW gate failure, the verdict is stale and must no
+ * longer exempt the gate — otherwise the regression is silently laundered into
+ * a pass and leaks to the deferred regression sweep.
+ *
+ * Covers:
+ * - gateFailureKeys (pure): failing-test identity extraction
+ * - deriveTddFailureCategory: stale verdict routes to `tests-failing`
+ * - ExecutionPlan.run: verifier-pass + gate-regressed-during-rect → success=false
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { type DEFAULT_CONFIG, pickSelector } from "@/config";
+import { StoryOrchestratorBuilder, _storyOrchestratorDeps, gateFailureKeys } from "@/execution";
+import { deriveTddFailureCategory } from "@/execution";
+import type { CallContext, DeterministicOperation, RunOperation } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+import { makeNaxConfig, makeTestRuntime } from "@test/helpers";
+
+const testSel = pickSelector("carveout-staleness-selector", "execution");
+
+const mockImplementerOp: RunOperation<{ code: string }, { success: boolean }, typeof DEFAULT_CONFIG> = {
+  kind: "run",
+  name: "mock-implementer",
+  stage: "run",
+  config: testSel,
+  session: { role: "implementer", lifetime: "warm" },
+  build: (input) => ({
+    role: { id: "r1", content: "Implement", overridable: false },
+    task: { id: "t1", content: input.code, overridable: false },
+  }),
+  parse: () => ({ success: true }),
+};
+
+function makeDeterministicOp(
+  name: string,
+  result: { success: boolean; findings?: unknown[] },
+): DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> {
+  return {
+    kind: "deterministic",
+    name,
+    stage: "verify",
+    config: testSel,
+    execute: async () => ({ ...result, estimatedCostUsd: 0, passed: result.success }),
+  };
+}
+
+const testFinding = (file: string, rule: string) => ({
+  source: "test-runner",
+  category: "failed-test",
+  severity: "error",
+  message: "boom",
+  rule,
+  file,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// gateFailureKeys — pure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("gateFailureKeys", () => {
+  test("returns empty set for a passing gate output", () => {
+    expect(gateFailureKeys({ success: true, passed: true, findings: [] }).size).toBe(0);
+  });
+
+  test("extracts file::testName keys from failing-test findings", () => {
+    const out = {
+      success: false,
+      passed: false,
+      findings: [testFinding("foo.test.ts", "t-a"), testFinding("bar.test.ts", "t-b")],
+    };
+    expect([...gateFailureKeys(out)].sort()).toEqual(["bar.test.ts::t-b", "foo.test.ts::t-a"]);
+  });
+
+  test("ignores non-test-runner findings", () => {
+    const out = {
+      success: false,
+      passed: false,
+      findings: [
+        testFinding("foo.test.ts", "t-a"),
+        { source: "lint", category: "style", severity: "error", message: "x", rule: "r", file: "y.ts" },
+      ],
+    };
+    expect([...gateFailureKeys(out)]).toEqual(["foo.test.ts::t-a"]);
+  });
+
+  test("returns empty set for undefined / non-object output", () => {
+    expect(gateFailureKeys(undefined).size).toBe(0);
+    expect(gateFailureKeys("nope").size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// deriveTddFailureCategory — staleness param
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("deriveTddFailureCategory — carve-out staleness", () => {
+  const verifierPassed = { "mock-verifier": { success: true } } as Record<string, unknown>;
+  const phaseOutputs = {
+    verifier: { success: true },
+    "full-suite-gate": { success: false, passed: false },
+  } as Record<string, unknown>;
+
+  test("verifier passed + gate failing + NOT regressed → undefined (carve-out preserved)", () => {
+    expect(deriveTddFailureCategory(phaseOutputs, undefined, false)).toBeUndefined();
+  });
+
+  test("verifier passed + gate failing + regressed-during-rect → tests-failing (escalates)", () => {
+    expect(deriveTddFailureCategory(phaseOutputs, undefined, true)).toBe("tests-failing");
+  });
+
+  // Guard against the verifierPassed-key name drift; the canonical verifier op
+  // name is "verifier" in this fixture.
+  test("default (no flag) preserves prior behaviour", () => {
+    expect(deriveTddFailureCategory(phaseOutputs)).toBeUndefined();
+    void verifierPassed;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ExecutionPlan.run — end-to-end
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ExecutionPlan.run — carve-out staleness", () => {
+  let rt: NaxRuntime | undefined;
+  afterEach(async () => {
+    await rt?.close();
+  });
+
+  function buildPlan(
+    ctx: CallContext,
+    gateOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG>,
+    reviewOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG>,
+  ) {
+    return new StoryOrchestratorBuilder()
+      .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+      .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-t" } as never, workdir: "/tmp" } })
+      .addVerifier({ op: makeDeterministicOp("verifier", { success: true }), input: {} })
+      .addSemanticReview({ op: reviewOp, input: {} })
+      .addRectification({ maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false })
+      .build(ctx);
+  }
+
+  test("verifier passed but rectification introduced a new gate failure → story fails", async () => {
+    const config = makeNaxConfig({
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2, abortOnIncreasingFailures: false } },
+    });
+    rt = makeTestRuntime({ config });
+
+    // Gate: green on the main-loop run, red (new failing test) on every re-run.
+    let gateCalls = 0;
+    const gateOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "full-suite-gate",
+      stage: "verify",
+      config: testSel,
+      execute: async () => {
+        gateCalls++;
+        const ok = gateCalls === 1;
+        return {
+          success: ok,
+          passed: ok,
+          estimatedCostUsd: 0,
+          findings: ok ? [] : [testFinding("foo.test.ts", "introduced")],
+        };
+      },
+    };
+    // Semantic review: fails first (seeds rectification), passes on re-run.
+    let reviewCalls = 0;
+    const reviewOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "semantic-review",
+      stage: "verify",
+      config: testSel,
+      execute: async () => {
+        reviewCalls++;
+        const ok = reviewCalls > 1;
+        return {
+          success: ok,
+          passed: ok,
+          estimatedCostUsd: 0,
+          findings: ok
+            ? []
+            : [{ source: "semantic", category: "x", severity: "error", message: "r", rule: "r", file: "a.ts" }],
+        };
+      },
+    };
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = (async (
+      _ctx: unknown,
+      op: { kind?: string; execute?: (i: unknown, c: unknown) => unknown },
+      input: unknown,
+    ) => {
+      if (op.kind === "deterministic" && op.execute) return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    }) as typeof _storyOrchestratorDeps.callOp;
+    // Simulate a fix iteration's revalidation, which re-runs the gate (now red).
+    _storyOrchestratorDeps.runFixCycle = (async (cycle: { validate: (c: unknown, o: unknown) => Promise<unknown> }) => {
+      await cycle.validate({}, { mode: "full", strategiesRun: ["autofix-implementer"] });
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    try {
+      const ctx = {
+        runtime: rt,
+        packageView: rt.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-t",
+      } as unknown as CallContext;
+      const result = await buildPlan(ctx, gateOp, reviewOp).run();
+      // Without the fix the carve-out would exempt the gate → success=true.
+      expect(result.success).toBe(false);
+      expect(result.gateRegressedDuringRect).toBe(true);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+
+  test("verifier passed and gate stays green through rectification → story passes (no false positive)", async () => {
+    const config = makeNaxConfig({
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2, abortOnIncreasingFailures: false } },
+    });
+    rt = makeTestRuntime({ config });
+
+    const gateOp = makeDeterministicOp("full-suite-gate", { success: true });
+    let reviewCalls = 0;
+    const reviewOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "semantic-review",
+      stage: "verify",
+      config: testSel,
+      execute: async () => {
+        reviewCalls++;
+        const ok = reviewCalls > 1;
+        return {
+          success: ok,
+          passed: ok,
+          estimatedCostUsd: 0,
+          findings: ok
+            ? []
+            : [{ source: "semantic", category: "x", severity: "error", message: "r", rule: "r", file: "a.ts" }],
+        };
+      },
+    };
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = (async (
+      _ctx: unknown,
+      op: { kind?: string; execute?: (i: unknown, c: unknown) => unknown },
+      input: unknown,
+    ) => {
+      if (op.kind === "deterministic" && op.execute) return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    }) as typeof _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.runFixCycle = (async (cycle: { validate: (c: unknown, o: unknown) => Promise<unknown> }) => {
+      await cycle.validate({}, { mode: "full", strategiesRun: ["autofix-implementer"] });
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    try {
+      const ctx = {
+        runtime: rt,
+        packageView: rt.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-t",
+      } as unknown as CallContext;
+      const result = await buildPlan(ctx, gateOp, reviewOp).run();
+      expect(result.success).toBe(true);
+      expect(result.gateRegressedDuringRect).toBe(false);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+});


### PR DESCRIPTION
Two related fixes for how nax handles a review-fix that breaks a previously-passing test in three-session TDD.

---

## Fix 1 — Attribute deferred-regression blame by gate transition

### Problem
When the end-of-run deferred sweep catches a regression, `findResponsibleStory` decided which story to blame but **never used the failing test file** — it returned the most-recently-committed passed story. So a review-fix in story B that broke story A's test was blamed on whoever committed last, not on B.

### Fix
Attribute by the **per-story gate transition**: snapshot each story's failing test files (from the full-suite gate findings) onto `StoryMetrics`, then blame the earliest story whose snapshot shows the test failing (pass→fail edge = introducer). Git heuristic preserved as fallback.

- **Sequential only** — parallel completion order isn't causal and worktrees isolate gate state, so snapshots are withheld in parallel mode.
- **Graceful degradation** — no snapshot match → git heuristic (never worse than before).

---

## Fix 2 — Invalidate the stale verifier-SSOT carve-out on gate regression

### Problem
The verifier-as-SSOT carve-out exempts the full-suite gate from the story verdict when the verifier passed. But the verifier judges the **pre-rectification** tree (the main loop halts on any phase failure, so a passing verifier means the gate was green then). When a review-fix during rectification breaks a test, the carve-out **laundered that regression into a pass**:
- three-session + **per-story** → no deferred sweep backstop → could ship green.
- three-session + **deferred** → leaked to the end-of-run sweep (then Fix 1 mis-blamed it).

### Fix
Snapshot the gate's failing-test identity keys (`file::testName`) before rectification. When the post-rectification gate has **new** failures absent from that baseline, the verifier verdict is stale and no longer exempts the gate. Genuinely pre-existing failures (same keys) still get the carve-out, so stories aren't failed over regressions they didn't cause.

- `story-orchestrator`: `gateFailureKeys()` + pre-rect baseline; `verifierPassedSsot` gated on `!gateRegressedDuringRect`.
- `post-run`: `deriveTddFailureCategory` routes the stale-verdict gate failure to `tests-failing` so it escalates instead of dropping the category.
- `shouldSkipPhaseForRectification` unchanged — the cycle still resolves review findings; the introduced gate regression fails the story and escalates.

Together these close the loop: Fix 2 makes the regression **visible and attributed to the right story in-run** (three-session); Fix 1 makes the deferred-sweep blame **accurate** when it does reach end-of-run.

---

## Test plan
- [x] TDD throughout: `findResponsibleStoryByTransition` + `gateFailureKeys` unit tests; `deriveTddFailureCategory` staleness cases; end-to-end `ExecutionPlan.run` test proving laundering→fail (+ no-false-positive control); integration test proving transition beats git-recency.
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — all phases passed (0 fail), no existing carve-out/rectification tests broken
- [x] Code review (code-reviewer agent) on Fix 1; HIGH/MEDIUM findings addressed (sequential gating, path-match docs, file-size, determinism, coverage)