### PR TITLE
Refine usage of model in place of generateModel

### DIFF
--- a/src/operations/acceptance-refine.ts
+++ b/src/operations/acceptance-refine.ts
@@ -31,7 +31,7 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
   // already runs 3 stale retries before reaching parse(); the op-tier retry then
   // adds one more completeAs call (4 more adapter attempts). Bounded at 8 total.
   retry: { preset: "transient-network" as const, maxAttempts: 2, baseDelayMs: 0 },
-  model: (_input, ctx) => ctx.config.acceptance.generateModel ?? ctx.config.acceptance.model,
+  model: (_input, ctx) => ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildRefinementPrompt(input.criteria, input.codebaseContext, {

--- a/test/unit/operations/acceptance-refine.test.ts
+++ b/test/unit/operations/acceptance-refine.test.ts
@@ -79,8 +79,8 @@ describe("acceptanceRefineOp shape", () => {
     const modelResolver = acceptanceRefineOp.model as (input: AcceptanceRefineInput, ctx: BuildContext<AcceptanceConfig>) => unknown;
 
     expect(modelResolver(SAMPLE_INPUT, ctx)).toEqual({
-      agent: "claude",
-      model: "balanced",
+      agent: "opencode",
+      model: "opencode-go/minimax-m2.7",
     });
   });
 


### PR DESCRIPTION
## What

Fix Acceptance Refine ops to use config.acceptance.model instaed of config.acceptance.generateModel

## Why

The config.acceptance.generateModel is for Acceptance Generate Ops only, this changes is to flip the model for refine ops back to config.acceptance.model

Closes #

## How

<!-- Key implementation details, if non-obvious -->

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

