### PR TITLE
feat(regression): per-story mode also runs deferred regression

### DIFF
--- a/docs/guides/regression-gate.md
+++ b/docs/guides/regression-gate.md
@@ -22,12 +22,12 @@ After all stories pass their individual verification, nax can run a deferred ful
 | Mode | Behaviour |
 |:-----|:----------|
 | `disabled` | No regression gate |
-| `per-story` | Full suite after each story — higher cost and slower if stories fail regression |
+| `per-story` | Full suite after each story **and** the deferred full suite once after all stories complete — a superset of `deferred`. Higher cost and slower if stories fail regression |
 | `deferred` | Full suite once after all stories pass (recommended) — **default** |
 
-If the regression gate detects failures, nax maps them to the responsible story via git blame and attempts automated rectification. If rectification fails, affected stories are marked as `regression-failed`.
+`per-story` is a superset of `deferred`: the per-story gate runs during the main loop, and the deferred end-of-run pass still runs afterwards. The end-of-run pass is intentionally never skipped — the post-run acceptance/hardening phase runs *after* the per-story gates, so a fix applied there can reintroduce a regression no per-story gate ever saw.
 
-> **Smart skip (v0.34.0):** When all stories used `three-session-tdd` or `three-session-tdd-lite` in sequential mode, each story already ran the full suite gate. nax will skip the redundant deferred regression in this case.
+If the regression gate detects failures, nax maps them to the responsible story via git blame and attempts automated rectification. If rectification fails, affected stories are marked as `regression-failed`.
 
 ---
 

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -81,7 +81,13 @@ export interface RegressionGateConfig {
   timeoutSeconds: number;
   /** Accept timeout as pass instead of failing (BUG-026, default: true) */
   acceptOnTimeout?: boolean;
-  /** Mode of regression gate: 'deferred' (run once after all stories), 'per-story' (run after each story), 'disabled' (default: 'deferred') */
+  /**
+   * Mode of regression gate (default: 'deferred'):
+   * - 'deferred': run the full-suite regression once after all stories complete.
+   * - 'per-story': run the full-suite gate after each story AND the deferred
+   *   regression once after all stories complete (per-story is a superset of deferred).
+   * - 'disabled': run neither.
+   */
   mode?: "deferred" | "per-story" | "disabled";
 }
 

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -118,7 +118,12 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   const regressionMode = config.execution.regressionGate?.mode;
   if (options.skipRegression) {
     // Regression phase already passed on a prior run — skip
-  } else if (regressionMode === "deferred" && config.quality.commands.test) {
+  } else if (
+    // 'per-story' is a superset of 'deferred': the per-story full-suite gate runs
+    // during the main loop AND the deferred regression runs once at end-of-run.
+    (regressionMode === "deferred" || regressionMode === "per-story") &&
+    config.quality.commands.test
+  ) {
     statusWriter.setPostRunPhase("regression", { status: "running" });
     pipelineEventBus.emit({ type: "postrun:phase:started", phase: "regression" });
 

--- a/src/execution/lifecycle/run-regression.ts
+++ b/src/execution/lifecycle/run-regression.ts
@@ -172,25 +172,12 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
   const logger = getSafeLogger();
   const { config, prd, workdir, runtime } = options;
 
-  // Check if regression gate is deferred
+  // The deferred regression runs for both 'deferred' and 'per-story' modes
+  // ('per-story' is a superset: per-story gate during the loop + deferred at end-of-run).
+  // Only 'disabled' suppresses it entirely.
   const regressionMode = config.execution.regressionGate?.mode ?? "deferred";
   if (regressionMode === "disabled") {
     logger?.info("regression", "Deferred regression gate disabled");
-    return {
-      success: true,
-      failedTests: 0,
-      failedTestFiles: [],
-      passedTests: 0,
-      rectificationAttempts: 0,
-      affectedStories: [],
-      storyCosts: {},
-      storyDurations: {},
-      storyOutcomes: {},
-    };
-  }
-
-  if (regressionMode !== "deferred") {
-    logger?.info("regression", "Regression gate mode is not deferred, skipping");
     return {
       success: true,
       failedTests: 0,

--- a/test/unit/execution/lifecycle-completion.test.ts
+++ b/test/unit/execution/lifecycle-completion.test.ts
@@ -412,8 +412,17 @@ describe("handleRunCompletion - deferred regression gate", () => {
     expect((mockRunDeferredRegression.mock.calls[0][0] as { workdir: string }).workdir).toBe("/custom/workdir");
   });
 
+  test("calls runDeferredRegression when mode is 'per-story' (superset of deferred)", async () => {
+    const story = makeStory("US-001", "passed");
+    const prd = makePRD([{ id: story.id, status: story.status }]);
+    const config = makeConfig("per-story", "bun test");
+
+    try { await handleRunCompletion(makeOpts(config, prd)); } catch { /* ignore */ }
+
+    expect(mockRunDeferredRegression).toHaveBeenCalledTimes(1);
+  });
+
   test.each([
-    ["mode is 'per-story'", makeConfig("per-story", "bun test")],
     ["mode is 'disabled'", makeConfig("disabled", "bun test")],
     ["no test command is configured", makeConfig("deferred", undefined)],
   ])("does NOT call runDeferredRegression when %s", async (_label, config) => {

--- a/test/unit/execution/lifecycle-execution.test.ts
+++ b/test/unit/execution/lifecycle-execution.test.ts
@@ -107,21 +107,37 @@ describe("runDeferredRegression", () => {
     expect(result.affectedStories).toEqual([]);
   });
 
-  test("returns success immediately when mode is 'per-story' (deferred not applicable)", async () => {
+  test("runs the deferred suite when mode is 'per-story' (superset of deferred)", async () => {
     const { runDeferredRegression } = await import(
       "../../../src/execution/lifecycle/run-regression"
     );
 
-    const result = await runDeferredRegression({
-      config: makeConfig("per-story", "bun test"),
-      prd: makePRD([{ id: "US-001", status: "passed" }]),
-      workdir: WORKDIR_PER_STORY,
-      runtime: makeRuntime(),
-    });
+    // per-story no longer short-circuits — it runs the full suite. Mock it so we
+    // don't spawn a real `bun test` in a nonexistent temp dir.
+    const saved = { ..._regressionDeps };
+    _regressionDeps.runVerification = mock(async () => ({
+      success: true,
+      status: "SUCCESS" as const,
+      countsTowardEscalation: false,
+      output: "5 pass | 0 fail",
+      passCount: 5,
+      failCount: 0,
+    }));
+    try {
+      const result = await runDeferredRegression({
+        config: makeConfig("per-story", "bun test"),
+        prd: makePRD([{ id: "US-001", status: "passed" }]),
+        workdir: WORKDIR_PER_STORY,
+        runtime: makeRuntime(),
+      });
 
-    expect(result.success).toBe(true);
-    expect(result.rectificationAttempts).toBe(0);
-    expect(result.affectedStories).toEqual([]);
+      expect(result.success).toBe(true);
+      expect(result.rectificationAttempts).toBe(0);
+      expect(result.affectedStories).toEqual([]);
+      expect(_regressionDeps.runVerification).toHaveBeenCalled();
+    } finally {
+      Object.assign(_regressionDeps, saved);
+    }
   });
 
   test("returns success when no passed stories exist (partial completion)", async () => {

--- a/test/unit/execution/lifecycle/run-completion-postrun.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-postrun.test.ts
@@ -197,6 +197,20 @@ describe("handleRunCompletion - AC4: sets regression running before runDeferredR
     expect(regressionCalls.length).toBe(0);
   });
 
+  test("DOES call setPostRunPhase + runDeferredRegression when mode is per-story (superset of deferred)", async () => {
+    const statusWriter = makeStatusWriter();
+    const prd = makePRD([{ id: "US-001", status: "passed" }]);
+    const config = makeConfig("per-story", "bun test");
+
+    await handleRunCompletion(makeOpts(config, prd, { statusWriter }));
+
+    expect(_runCompletionDeps.runDeferredRegression).toHaveBeenCalled();
+    const regressionCalls = statusWriter.setPostRunPhase.mock.calls.filter(
+      (c: unknown[]) => c[0] === "regression",
+    );
+    expect(regressionCalls.length).toBeGreaterThan(0);
+  });
+
   test("does NOT call setPostRunPhase for regression when no test command configured", async () => {
     const statusWriter = makeStatusWriter();
     const prd = makePRD([{ id: "US-001", status: "passed" }]);

--- a/test/unit/execution/lifecycle/run-regression.test.ts
+++ b/test/unit/execution/lifecycle/run-regression.test.ts
@@ -335,7 +335,7 @@ describe("runDeferredRegression — test output context forwarding", () => {
 // disabled / non-deferred mode
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("runDeferredRegression — disabled mode", () => {
+describe("runDeferredRegression — mode gating", () => {
   test("returns success immediately when mode is disabled", async () => {
     const config = makeConfig();
     (config.execution.regressionGate as { mode: string }).mode = "disabled";
@@ -352,6 +352,25 @@ describe("runDeferredRegression — disabled mode", () => {
     expect(result.success).toBe(true);
     expect(_regressionDeps.runVerification).not.toHaveBeenCalled();
     expect(result.storyCosts).toEqual({});
+  });
+
+  test("runs the deferred suite when mode is per-story (superset of deferred)", async () => {
+    const config = makeConfig();
+    (config.execution.regressionGate as { mode: string }).mode = "per-story";
+
+    _regressionDeps.runVerification = mock(async () => makePassResult());
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 150, failed: 0, failures: [] }));
+
+    const result = await runDeferredRegression({
+      config,
+      prd: makePrd(["US-001"]),
+      workdir: "/tmp/test",
+      runtime: makeMockRuntime(),
+    } as unknown as DeferredRegressionOptions);
+
+    expect(result.success).toBe(true);
+    // per-story no longer short-circuits — the full suite is actually run.
+    expect(_regressionDeps.runVerification).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Makes `regressionGate.mode: "per-story"` a **superset** of `"deferred"` instead of a mutually exclusive choice.

Previously `mode` was an exclusive switch:
- `deferred` → only the end-of-run deferred regression ran
- `per-story` → only the per-story full-suite gate ran; the deferred pass was **explicitly skipped**
- `disabled` → neither

Now:

| `mode` | Per-story full-suite gate | Deferred end-of-run regression |
|:--|:--|:--|
| `deferred` | TDD strategies only | ✅ runs |
| `per-story` | ✅ runs (incl. non-TDD) | ✅ **now runs too** (previously skipped) |
| `disabled` | not planned | ❌ |

### Why

The post-run acceptance/hardening phase runs **after** the per-story gates. A fix applied there can reintroduce a regression that no per-story gate ever saw. The deferred end-of-run pass is the safety net, so `per-story` should run it too. (This is also why the old "smart skip" of the deferred pass was removed — it's no longer safe to skip.)

## Changes

- `src/execution/lifecycle/run-regression.ts` — drop the `mode !== "deferred"` early-return; only `disabled` short-circuits now.
- `src/execution/lifecycle/run-completion.ts` — `handleRunCompletion` invokes `runDeferredRegression` for `per-story` as well as `deferred`.
- `src/config/runtime-types.ts` — document the superset semantics on `RegressionGateConfig.mode`.
- `docs/guides/regression-gate.md` — update the `per-story` row; remove the stale v0.34.0 "smart skip" note.
- Tests at both layers (`run-regression.test.ts`, `run-completion-postrun.test.ts`) pin that `per-story` now runs the deferred suite.

## Behavior notes

- **Double full-suite run in `per-story`:** the last per-story gate plus the end-of-run deferred pass. Intended (safety net). Mitigated by existing early-exits: the deferred pass does a single `runVerification` and returns immediately when the suite is green or there are no passed stories.
- **`deferred` / `disabled` unchanged.**
- **Pre-existing, out of scope:** the deferred path gates only on `mode` + `commands.test`, not on `regressionGate.enabled` (unlike `fullSuiteGateOp`). So `mode: "per-story"` + `enabled: false` skips the per-story gate but still runs the deferred pass. `mode: "disabled"` remains the canonical full off-switch. Not changed here to avoid altering `enabled` semantics.

## Test plan

- [x] `bun test test/unit/execution/lifecycle/run-regression.test.ts test/unit/execution/lifecycle/run-completion-postrun.test.ts` — 30 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Code review (no CRITICAL/HIGH; LOW doc findings addressed)
