### PR TITLE
refactor(setup): finish writeSetupConfig extraction + gap-analysis report

### DIFF
--- a/docs/reviews/CODEBASE-GAP-ANALYSIS-2026-06-19.md
+++ b/docs/reviews/CODEBASE-GAP-ANALYSIS-2026-06-19.md
@@ -1,0 +1,164 @@
+# nax — Codebase Gap Analysis
+
+**Date:** 2026-06-19
+**Scope:** `src/` (653 files), `test/` (834 files), `docs/` (220 files, 22 ADR files)
+**Method:** 5 parallel exploration passes (incomplete code, test coverage, documentation, tracked tech-debt/rule violations, architectural wiring) + direct verification of key claims.
+
+> **Headline:** The codebase is architecturally complete and well-tested in its core paths. "What's missing" is concentrated in five areas: a handful of genuine stubs (scoped permissions, structured test parsing, `setup-write`), file-size hard-limit breaches, stale documentation (CLAUDE.md, ADRs), duplicated/dead modules, and the absence of any coverage tooling despite a stated 80% requirement.
+
+---
+
+## 1. Severity Summary
+
+| # | Finding | Severity | Effort |
+|:--|:--------|:--------:|:------:|
+| 1 | `story-orchestrator.ts` (1462 LOC) + its test (1734 LOC) — 2.4×/2.2× over hard limit | **HIGH** | L |
+| 2 | Scoped permission profile is a non-functional Phase-2 stub | **HIGH** | M |
+| 3 | `setup-write.ts` `writeSetupConfig()` throws "not implemented", no callers | **HIGH** | M |
+| 4 | No test coverage tooling at all (vs. stated 80% rule) | **HIGH** | S |
+| 5 | Structured test-output parsing (pytest / go test) deferred — 4 TODOs | **MED** | M |
+| 6 | CLAUDE.md documents removed `src/agents/claude/` CLI adapter (ACP-only now) | **MED** | S |
+| 7 | Duplicate logging subsystems: `src/logger/` **and** `src/logging/` | **MED** | M |
+| 8 | 11 more source files over 600-line limit; 4 more tests over 800 | **MED** | L |
+| 9 | 15+ src subsystems have no architecture doc; duplicate ADR-014; missing ADR-001–004 | **MED** | M |
+| 10 | Thin/zero unit coverage in optimizer, session-manager extracts, ACP output parsing, review parsers | **MED** | M |
+| 11 | `console.log/error` outside CLI boundary (precheck, logger fallback) | **LOW** | S |
+| 12 | Misleading "STUB"/"placeholder" headers on fully-implemented files | **LOW** | S |
+| 13 | Empty catch swallows file-read errors in `test-scanner.ts:312` | **LOW** | S |
+
+---
+
+## 2. Genuine Incomplete Implementations
+
+### 2.1 Scoped permission profile — HIGH
+`src/config/permissions.ts` — `resolveScopedPermissions()` is a Phase-2 stub returning `{ mode: "approve-reads", skipPermissions: false }` (identical to `safe`). The `allowedTools?: string[]` field is declared but never populated.
+
+**Impact:** `execution.permissionProfile: "scoped"` silently behaves like `safe`. A user who sets it believes they have tool-scoped permissions but does not. Either implement Phase 2 or reject the value at config-parse time until it lands.
+
+### 2.2 `setup-write.ts` — HIGH
+`src/cli/setup-write.ts:14` — `writeSetupConfig()` is `throw new Error("not implemented")` and has **no callers anywhere in `src/`**. Dead orphan stub: either wire it up or remove it.
+
+### 2.3 Structured test-output parsing — MED
+`src/test-runners/parser.ts:10-11, 261-262, 301-302` — pytest and `go test` fall back to the common heuristic regex parser; structured error/stack extraction is `TODO`. Reduces failure-diagnosis quality for Python/Go monorepo packages (a core polyglot promise of nax).
+
+### 2.4 `init-context.ts` injected LLM — MED
+`src/cli/init-context.ts:55` — `_initContextDeps.callLLM()` throws "callLLM not implemented"; it is a DI seam meant to be overridden by callers. Confirm every production caller injects a real `callLLM`, or it will fail at runtime.
+
+### 2.5 Constitution section parsing — LOW
+`src/constitution/generator.ts:60` — `sections: {}, // TODO: implement section parsing if needed`. Markdown loads fine; structured section access unavailable. Likely intentional ("if needed").
+
+### 2.6 Silent error swallow — LOW
+`src/context/test-scanner.ts:312` — empty `} catch {}` hides file-I/O errors during the glob scan. Add a `logger.debug` with `storyId`/`packageDir`.
+
+---
+
+## 3. File-Size Hard-Limit Breaches
+
+Project rule: **600-line hard limit (source), 800 (test)** — "split before adding more code."
+
+### Source (>600)
+| File | LOC | Over |
+|:-----|---:|---:|
+| `src/execution/story-orchestrator.ts` | 1462 | **+862** |
+| `src/prompts/builders/rectifier-builder.ts` | 902 | +302 |
+| `src/agents/manager.ts` | 820 | +220 |
+| `src/agents/acp/spawn-client.ts` | 737 | +137 |
+| `src/session/manager.ts` | 707 | +107 |
+| `src/execution/unified-executor.ts` | 689 | +89 |
+| `src/operations/call.ts` | 631 | +31 |
+| `src/agents/acp/adapter.ts` | 629 | +29 |
+| `src/config/runtime-types.ts` | 626 | +26 |
+| `src/review/adversarial.ts` | 622 | +22 |
+| `src/context/engine/providers/code-neighbor.ts` | 613 | +13 |
+| `src/execution/post-run.ts` | 607 | +7 |
+
+### Test (>800)
+| File | LOC | Over |
+|:-----|---:|---:|
+| `test/unit/execution/story-orchestrator.test.ts` | 1734 | **+934** |
+| `test/unit/cli/plan.test.ts` | 1087 | +287 |
+| `test/unit/debate/runner-plan.test.ts` | 1048 | +248 |
+| `test/unit/execution/escalation/tier-escalation.test.ts` | 948 | +148 |
+| `test/unit/operations/plan-refine.test.ts` | 818 | +18 |
+
+**Priority:** `story-orchestrator.ts` is the clear outlier and the orchestration hub — split by concern (CANONICAL_ORDER stages vs. fix cycle vs. wiring). No lint rule currently enforces the limit; consider a `scripts/check-file-sizes.ts` gate so the baseline cannot grow.
+
+---
+
+## 4. Duplication & Dead Code
+
+- **Two logging subsystems:** `src/logger/` (`logger.ts`, `formatters.ts`, `redact.ts`, `types.ts`) and `src/logging/` (`formatter.ts`, `types.ts`). The project standard cites `src/logger`. `src/logging/` looks like a leftover/parallel implementation — confirm which is canonical and delete or merge the other. Singleton-fragmentation risk if both are imported.
+- **`writeSetupConfig`** — orphan stub (see §2.2).
+
+---
+
+## 5. Stale / Inconsistent Documentation
+
+- **CLAUDE.md is stale on the agent adapter.** It documents two protocol modes ("CLI and ACP") and a `src/agents/claude/` directory. **Verified: that directory does not exist** — the registry hard-codes `protocol: "acp"` (`src/agents/registry.ts:50`) and the config schema only accepts `"acp"`. Update the "Agent Adapter & LLM Calls" section and the `src/agents/claude/` row in the directory table.
+- **ADR hygiene:**
+  - Missing **ADR-001–004** (sequence starts at 005) with no explanation.
+  - **Duplicate ADR-014**: `ADR-014-runscope-and-middleware.md` and `ADR-014-runscope-and-operation-standardization.md` (both rejected, superseded by ADR-018) — collapse to one with a historical note.
+  - **ADR-006 / ADR-009** still read as "proposed" though their decisions are in force (ADR-009's test-pattern SSOT is implemented and its tracked violations are resolved — see §6). Finalize their status.
+- **Architecture doc coverage:** 15+ `src/` subsystems have no dedicated architecture doc — notably `agents/`, `config/`, `runtime/`, `logger`/`logging`, `cli/`, `commands/`, `optimizer/`, `plan/`, `precheck/`, `project/`. Consider one "remaining subsystems" overview rather than 15 stubs.
+- **Index gap:** `docs/architecture/spec-to-prd-pipeline.md` exists but isn't linked from `ARCHITECTURE.md`.
+
+---
+
+## 6. Tracked Tech Debt — Status
+
+The "Known Violations (2026-04-18)" table in `.claude/rules/monorepo-awareness.md` is **stale in a good way**: all four code violations appear **resolved**.
+
+| Issue | Site | Status |
+|:------|:-----|:------:|
+| #533 | `context/test-scanner.ts` hardcoded test dirs | Resolved |
+| #534 | `verification/smart-runner.ts` hardcoded layout | Resolved |
+| #535 | `context/builder.ts` cwd fallback | Resolved |
+| #536 | `prompts/sections/role-task.ts` `startsWith("bun test")` | Resolved (now uses `buildTestFrameworkHint()`) |
+| #530 | descriptor absolute-path migration | Design item, still open |
+
+**Action:** update/retire the table so it doesn't mislead. ~40 `#NNN` issue refs remain in source comments (e.g. #1131 agent-swap metrics, #993 disk recovery, #1116 regression timeout) tracking genuine but non-blocking follow-ups.
+
+**Compliant (no violations found):** `process.cwd()` outside CLI, `mock.module()`, `setTimeout`-for-delay (all paired with `clearTimeout`), real-home `.nax` paths. `as any` appears only twice; zero `@ts-ignore`.
+
+---
+
+## 7. Test Coverage Gaps
+
+**No coverage tooling exists.** `package.json` has no `--coverage` script and no threshold gate, despite the stated 80% requirement. This is the single highest-leverage fix: add `bun test --coverage` with a CI threshold so the rest of this section becomes measurable rather than estimated.
+
+Overall ratio ~1.28 tests:source. Well-covered: `execution/` (~2.1:1), `tdd/` (~3:1), `config/` (~1.9:1), `operations/` (~1.5:1).
+
+Thin or zero **isolated** coverage:
+- **`src/optimizer/`** — ~0.25:1; `rule-based.optimizer.ts` core logic untested.
+- **`src/session/`** — recently-extracted `manager-deps.ts`, `manager-sweep.ts`, `session-runner.ts` lack dedicated tests.
+- **`src/agents/acp/`** — `adapter-output.ts` (the agent-output parsing integration point), `adapter-session-types.ts`, `wire-types.ts`.
+- **`src/review/lint-parsing` & `typecheck-parsing`** — only `biome-json` has a dedicated test; `eslint-json`, `ruff-annotated`, `tsc`, `text-block` parsers untested (polyglot risk).
+- **`src/context/engine/`** — `available-budget.ts`, `render-utils.ts`.
+- **`src/tui/hooks`** — hook implementations not unit-tested in isolation.
+- **E2E** — 6 journeys (happy-path, agent-fix, mechanical-fix, exhaustion-edge, scripted-agent, harness). Gaps: multi-story parallel runs, worktree execution, escalation-to-exhaustion across tiers, error-recovery paths.
+
+---
+
+## 8. Quick Wins (recommended order)
+
+1. **Add coverage tooling** + CI threshold (`bun test --coverage`). Small, unblocks everything else. *(§7)*
+2. **Fix or reject scoped permissions** so it can't silently degrade to `safe`. *(§2.1)*
+3. **Update CLAUDE.md** — remove CLI-adapter / `src/agents/claude/` references. Cheap, prevents agent confusion (it's loaded into every session). *(§5)*
+4. **Resolve the duplicate logging dir** — pick canonical, delete the other. *(§4)*
+5. **Add a file-size lint gate** and split `story-orchestrator.ts`. *(§3)*
+6. **Refresh the Known-Violations table** (mark #533–536 resolved). *(§6)*
+7. **Land structured test parsers** for pytest/go test. *(§2.3)*
+
+---
+
+## 9. What's Healthy (for balance)
+
+- All **6 plugin extension points** are loaded and invoked — no dead seams.
+- All **10 pipeline stages** registered and run; tier escalation (fast→balanced→powerful) fully implemented.
+- **60+ operations** exported and used; dispatch flows through the middleware chain per ADR-019/020.
+- Permission SSOT (`resolvePermissions`) is honored — no hardcoded `?? true`/`approve-all` fallbacks.
+- Error handling (`NaxError` + cause chaining), Bun-native API usage, and barrel-import discipline are consistently applied.
+
+---
+
+*Generated from a 5-way parallel codebase analysis. File:line citations are point-in-time (HEAD `fd1e0cf5`); verify before acting on any single item.*

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ export {
 } from "./prompts";
 export { initCommand, type InitOptions } from "./init";
 export { setupCommand, type SetupOptions } from "./setup";
+export { writeSetupConfig, _writeSetupDeps, type WriteSetupConfigResult } from "./setup-write";
 export { pluginsListCommand } from "./plugins";
 export {
   interactListCommand,

--- a/src/cli/setup-write.ts
+++ b/src/cli/setup-write.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type { NaxConfig } from "../config";
 import type { MonoPackageConfig } from "../operations/setup-generate";
 
@@ -5,11 +6,45 @@ export interface WriteSetupConfigResult {
   written: string[];
 }
 
+export const _writeSetupDeps = {
+  writeFile: (path: string, content: string): Promise<void> => Bun.write(path, content).then(() => {}),
+  mkdir: async (path: string): Promise<void> => {
+    const proc = Bun.spawn(["mkdir", "-p", path]);
+    await proc.exited;
+  },
+};
+
+/**
+ * Writes the nax setup config files to disk.
+ *
+ * The collision check (refusing if .nax/config.json already exists without
+ * --force) is intentionally kept in setupCommand, which runs before plan
+ * generation and exits early with a user-facing message. At write time, the
+ * plan has already been generated and the force decision has already been
+ * made, so `opts.force` carries no additional write-time semantics here.
+ */
 export async function writeSetupConfig(
-  _workdir: string,
-  _config: NaxConfig,
-  _monoConfigs: MonoPackageConfig[],
+  workdir: string,
+  config: NaxConfig,
+  monoConfigs: MonoPackageConfig[],
   _opts?: { force?: boolean },
+  deps: typeof _writeSetupDeps = _writeSetupDeps,
 ): Promise<WriteSetupConfigResult> {
-  throw new Error("not implemented");
+  const naxDir = join(workdir, ".nax");
+  const naxConfigPath = join(naxDir, "config.json");
+  const written: string[] = [];
+
+  await deps.mkdir(naxDir);
+  await deps.writeFile(naxConfigPath, JSON.stringify(config, null, 2));
+  written.push(naxConfigPath);
+
+  for (const mc of monoConfigs) {
+    const monoDir = join(naxDir, "mono", mc.relativeDir);
+    const monoConfigPath = join(monoDir, "config.json");
+    await deps.mkdir(monoDir);
+    await deps.writeFile(monoConfigPath, JSON.stringify(mc.config, null, 2));
+    written.push(monoConfigPath);
+  }
+
+  return { written };
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,13 +1,15 @@
 import { join } from "node:path";
 import type { NaxConfig } from "../config";
 import { NaxError } from "../errors";
-import type { SetupPlan } from "../operations/setup-generate";
+import type { MonoPackageConfig, SetupPlan } from "../operations/setup-generate";
 import type { CallContext } from "../operations/types";
 import { analyzeRepo } from "./setup-analyze";
 import { fillScripts } from "./setup-fill";
 import { generateSetupPlan as _generateSetupPlan } from "./setup-llm";
 import type { RepoAnalysis } from "./setup-types";
 import { runSetupGate } from "./setup-verify";
+import { writeSetupConfig as _writeSetupConfig } from "./setup-write";
+import type { WriteSetupConfigResult } from "./setup-write";
 
 export interface SetupOptions {
   dir?: string;
@@ -42,11 +44,12 @@ export const _setupDeps = {
     _generateSetupPlan(ctx, analysis),
   runGate: (workdir: string, config: NaxConfig): Promise<number> => runSetupGate(workdir, config),
   fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
-  writeFile: (path: string, content: string): Promise<void> => Bun.write(path, content).then(() => {}),
-  mkdir: async (path: string): Promise<void> => {
-    const proc = Bun.spawn(["mkdir", "-p", path]);
-    await proc.exited;
-  },
+  writeSetupConfig: (
+    workdir: string,
+    config: NaxConfig,
+    monoConfigs: MonoPackageConfig[],
+    opts?: { force?: boolean },
+  ): Promise<WriteSetupConfigResult> => _writeSetupConfig(workdir, config, monoConfigs, opts),
   stdout: (msg: string): void => {
     process.stdout.write(`${msg}\n`);
   },
@@ -95,14 +98,7 @@ export async function setupCommand(options: SetupOptions = {}): Promise<number> 
       await _setupDeps.fillScripts(workdir, analysis);
     }
 
-    await _setupDeps.mkdir(naxDir);
-    await _setupDeps.writeFile(naxConfigPath, JSON.stringify(plan.config, null, 2));
-
-    for (const mc of plan.monoConfigs) {
-      const monoDir = join(naxDir, "mono", mc.relativeDir);
-      await _setupDeps.mkdir(monoDir);
-      await _setupDeps.writeFile(join(monoDir, "config.json"), JSON.stringify(mc.config, null, 2));
-    }
+    await _setupDeps.writeSetupConfig(workdir, plan.config, plan.monoConfigs, { force: options.force });
 
     const gateResult = await _setupDeps.runGate(workdir, plan.config);
     if (gateResult !== 0) {

--- a/test/unit/cli/setup-write.test.ts
+++ b/test/unit/cli/setup-write.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for writeSetupConfig (src/cli/setup-write.ts)
+ *
+ * All deps are injected via the `deps` parameter — no real filesystem I/O.
+ * mirror: src/cli/setup-write.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "node:path";
+import { _writeSetupDeps, writeSetupConfig } from "@/cli";
+import { DEFAULT_CONFIG } from "@/config";
+import type { MonoPackageConfig } from "@/operations/setup-generate";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const WORKDIR = "/fake/workdir";
+const NAX_DIR = join(WORKDIR, ".nax");
+const ROOT_CONFIG_PATH = join(NAX_DIR, "config.json");
+const BASE_CONFIG = DEFAULT_CONFIG;
+
+const NO_MONO: MonoPackageConfig[] = [];
+
+const MONO_CONFIGS: MonoPackageConfig[] = [
+  { relativeDir: "packages/a", config: {} },
+  { relativeDir: "packages/b", config: { quality: { language: "go" } } },
+];
+
+// ─── Save / restore _writeSetupDeps ──────────────────────────────────────────
+
+type WriteDeps = typeof _writeSetupDeps;
+let savedDeps: WriteDeps;
+
+beforeEach(() => {
+  savedDeps = { ..._writeSetupDeps };
+});
+
+afterEach(() => {
+  Object.assign(_writeSetupDeps, savedDeps);
+});
+
+// ─── Helper: build a fake deps object ────────────────────────────────────────
+
+function makeFakeDeps() {
+  const writtenFiles: Array<{ path: string; content: string }> = [];
+  const createdDirs: string[] = [];
+
+  const deps: WriteDeps = {
+    writeFile: mock(async (path: string, content: string) => {
+      writtenFiles.push({ path, content });
+    }),
+    mkdir: mock(async (path: string) => {
+      createdDirs.push(path);
+    }),
+  };
+
+  return { deps, writtenFiles, createdDirs };
+}
+
+// ─── AC1: single-package — only root config.json written ─────────────────────
+
+describe("writeSetupConfig — AC1: single-package writes only root config", () => {
+  test("AC1: writes exactly one file when monoConfigs is empty", async () => {
+    const { deps, writtenFiles } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, NO_MONO, undefined, deps);
+    expect(writtenFiles).toHaveLength(1);
+  });
+
+  test("AC1 boundary: the written file path is .nax/config.json", async () => {
+    const { deps, writtenFiles } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, NO_MONO, undefined, deps);
+    expect(writtenFiles[0]?.path).toBe(ROOT_CONFIG_PATH);
+  });
+
+  test("AC1 boundary: written content is valid JSON matching the config", async () => {
+    const { deps, writtenFiles } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, NO_MONO, undefined, deps);
+    const parsed = JSON.parse(writtenFiles[0]?.content ?? "null");
+    expect(parsed).toEqual(BASE_CONFIG);
+  });
+});
+
+// ─── AC2: single-package — mkdir called for .nax dir ─────────────────────────
+
+describe("writeSetupConfig — AC2: single-package calls mkdir for .nax", () => {
+  test("AC2: calls mkdir with .nax path", async () => {
+    const { deps, createdDirs } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, NO_MONO, undefined, deps);
+    expect(createdDirs).toContain(NAX_DIR);
+  });
+
+  test("AC2 boundary: mkdir is called before writeFile", async () => {
+    const callOrder: string[] = [];
+    const deps: WriteDeps = {
+      mkdir: mock(async () => { callOrder.push("mkdir"); }),
+      writeFile: mock(async () => { callOrder.push("writeFile"); }),
+    };
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, NO_MONO, undefined, deps);
+    expect(callOrder.indexOf("mkdir")).toBeLessThan(callOrder.indexOf("writeFile"));
+  });
+});
+
+// ─── AC3: multi-package — root + each mono config written ────────────────────
+
+describe("writeSetupConfig — AC3: multi-package writes root and each mono config", () => {
+  test("AC3: writes root config plus one file per mono package", async () => {
+    const { deps, writtenFiles } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, MONO_CONFIGS, undefined, deps);
+    expect(writtenFiles).toHaveLength(1 + MONO_CONFIGS.length);
+  });
+
+  test("AC3 boundary: root config is written first", async () => {
+    const { deps, writtenFiles } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, MONO_CONFIGS, undefined, deps);
+    expect(writtenFiles[0]?.path).toBe(ROOT_CONFIG_PATH);
+  });
+
+  test("AC3 boundary: each mono config is written at .nax/mono/<relativeDir>/config.json", async () => {
+    const { deps, writtenFiles } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, MONO_CONFIGS, undefined, deps);
+    const monoFiles = writtenFiles.slice(1);
+    expect(monoFiles[0]?.path).toBe(join(NAX_DIR, "mono", "packages/a", "config.json"));
+    expect(monoFiles[1]?.path).toBe(join(NAX_DIR, "mono", "packages/b", "config.json"));
+  });
+
+  test("AC3 boundary: mono config content matches each MonoPackageConfig.config", async () => {
+    const { deps, writtenFiles } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, MONO_CONFIGS, undefined, deps);
+    const monoFiles = writtenFiles.slice(1);
+    expect(JSON.parse(monoFiles[0]?.content ?? "null")).toEqual(MONO_CONFIGS[0]?.config);
+    expect(JSON.parse(monoFiles[1]?.content ?? "null")).toEqual(MONO_CONFIGS[1]?.config);
+  });
+});
+
+// ─── AC4: multi-package — mkdir called for each mono dir ─────────────────────
+
+describe("writeSetupConfig — AC4: multi-package calls mkdir for each mono dir", () => {
+  test("AC4: calls mkdir for .nax and each .nax/mono/<relativeDir>", async () => {
+    const { deps, createdDirs } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, MONO_CONFIGS, undefined, deps);
+    expect(createdDirs).toContain(NAX_DIR);
+    expect(createdDirs).toContain(join(NAX_DIR, "mono", "packages/a"));
+    expect(createdDirs).toContain(join(NAX_DIR, "mono", "packages/b"));
+  });
+
+  test("AC4 boundary: total mkdir call count equals 1 + number of mono packages", async () => {
+    const { deps, createdDirs } = makeFakeDeps();
+    await writeSetupConfig(WORKDIR, BASE_CONFIG, MONO_CONFIGS, undefined, deps);
+    expect(createdDirs).toHaveLength(1 + MONO_CONFIGS.length);
+  });
+});
+
+// ─── AC5: returned written[] paths are correct and ordered ───────────────────
+
+describe("writeSetupConfig — AC5: returned written[] is ordered (root first, then mono)", () => {
+  test("AC5: returns root config path for single-package", async () => {
+    const { deps } = makeFakeDeps();
+    const result = await writeSetupConfig(WORKDIR, BASE_CONFIG, NO_MONO, undefined, deps);
+    expect(result.written).toEqual([ROOT_CONFIG_PATH]);
+  });
+
+  test("AC5 boundary: returns root + mono paths in order for multi-package", async () => {
+    const { deps } = makeFakeDeps();
+    const result = await writeSetupConfig(WORKDIR, BASE_CONFIG, MONO_CONFIGS, undefined, deps);
+    expect(result.written).toEqual([
+      ROOT_CONFIG_PATH,
+      join(NAX_DIR, "mono", "packages/a", "config.json"),
+      join(NAX_DIR, "mono", "packages/b", "config.json"),
+    ]);
+  });
+});

--- a/test/unit/cli/setup.test.ts
+++ b/test/unit/cli/setup.test.ts
@@ -12,6 +12,8 @@ import { DEFAULT_CONFIG, NaxConfigSchema } from "../../../src/config";
 import { NaxError } from "../../../src/errors";
 import type { RepoAnalysis } from "../../../src/cli/setup-types";
 import type { SetupPlan } from "../../../src/operations/setup-generate";
+import type { NaxConfig } from "@/config";
+import type { MonoPackageConfig } from "@/operations/setup-generate";
 import { withTempDir } from "../../helpers/temp";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -69,8 +71,7 @@ beforeEach(() => {
   _setupDeps.stdout = mock((_msg: string) => {});
   _setupDeps.stderr = mock((_msg: string) => {});
   _setupDeps.fileExists = mock(async () => false);
-  _setupDeps.writeFile = mock(async () => {});
-  _setupDeps.mkdir = mock(async () => {});
+  _setupDeps.writeSetupConfig = mock(async () => ({ written: [] }));
   _setupDeps.fillScripts = mock(async () => {});
 });
 
@@ -98,17 +99,17 @@ describe("setupCommand — AC1: exits 0 and produces .nax/config.json", () => {
     });
   });
 
-  test("AC1 boundary: written config passes NaxConfigSchema.safeParse", async () => {
-    let writtenContent: string | undefined;
-    _setupDeps.writeFile = mock(async (_path: string, content: string) => {
-      if (_path.endsWith("config.json") && !_path.includes("mono")) writtenContent = content;
+  test("AC1 boundary: config passed to writeSetupConfig passes NaxConfigSchema.safeParse", async () => {
+    let capturedConfig: NaxConfig | undefined;
+    _setupDeps.writeSetupConfig = mock(async (_workdir: string, config: NaxConfig) => {
+      capturedConfig = config;
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       await runSetup({ dir });
-      expect(writtenContent).toBeDefined();
-      const parsed = JSON.parse(writtenContent ?? "{}");
-      expect(NaxConfigSchema.safeParse(parsed).success).toBe(true);
+      expect(capturedConfig).toBeDefined();
+      expect(NaxConfigSchema.safeParse(capturedConfig).success).toBe(true);
     });
   });
 });
@@ -116,35 +117,40 @@ describe("setupCommand — AC1: exits 0 and produces .nax/config.json", () => {
 // ─── AC2: monorepo → one .nax/mono/<relativeDir>/config.json per package ─────
 
 describe("setupCommand — AC2: writes mono configs for each member package", () => {
-  test("AC2: calls writeFile for each relativeDir in monoConfigs", async () => {
+  test("AC2: passes all monoConfigs to writeSetupConfig", async () => {
     _setupDeps.analyzeRepo = mock(async () => MONO_ANALYSIS);
     _setupDeps.generateSetupPlan = mock(async () => MONO_PLAN);
 
-    const writtenPaths: string[] = [];
-    _setupDeps.writeFile = mock(async (path: string) => {
-      writtenPaths.push(path);
-    });
+    let capturedMonoConfigs: MonoPackageConfig[] | undefined;
+    _setupDeps.writeSetupConfig = mock(
+      async (_workdir: string, _config: NaxConfig, monoConfigs: MonoPackageConfig[]) => {
+        capturedMonoConfigs = monoConfigs;
+        return { written: [] };
+      },
+    );
 
     await withTempDir(async (dir) => {
       await runSetup({ dir });
-      const monoConfigPaths = writtenPaths.filter((p) => p.includes("mono"));
-      expect(monoConfigPaths).toHaveLength(2);
+      expect(capturedMonoConfigs).toHaveLength(2);
     });
   });
 
-  test("AC2 boundary: mono config paths include each package relativeDir", async () => {
+  test("AC2 boundary: mono configs include each package relativeDir", async () => {
     _setupDeps.analyzeRepo = mock(async () => MONO_ANALYSIS);
     _setupDeps.generateSetupPlan = mock(async () => MONO_PLAN);
 
-    const writtenPaths: string[] = [];
-    _setupDeps.writeFile = mock(async (path: string) => {
-      writtenPaths.push(path);
-    });
+    let capturedMonoConfigs: MonoPackageConfig[] | undefined;
+    _setupDeps.writeSetupConfig = mock(
+      async (_workdir: string, _config: NaxConfig, monoConfigs: MonoPackageConfig[]) => {
+        capturedMonoConfigs = monoConfigs;
+        return { written: [] };
+      },
+    );
 
     await withTempDir(async (dir) => {
       await runSetup({ dir });
-      expect(writtenPaths.some((p) => p.includes("packages/a"))).toBe(true);
-      expect(writtenPaths.some((p) => p.includes("packages/b"))).toBe(true);
+      expect(capturedMonoConfigs?.some((mc) => mc.relativeDir === "packages/a")).toBe(true);
+      expect(capturedMonoConfigs?.some((mc) => mc.relativeDir === "packages/b")).toBe(true);
     });
   });
 });
@@ -152,28 +158,32 @@ describe("setupCommand — AC2: writes mono configs for each member package", ()
 // ─── AC3: single-package → no .nax/mono/ directory ──────────────────────────
 
 describe("setupCommand — AC3: single-package produces no mono directory entries", () => {
-  test("AC3: does not write any mono config paths when monoConfigs is empty", async () => {
-    const writtenPaths: string[] = [];
-    _setupDeps.writeFile = mock(async (path: string) => {
-      writtenPaths.push(path);
-    });
+  test("AC3: passes empty monoConfigs to writeSetupConfig for single-package plan", async () => {
+    let capturedMonoConfigs: MonoPackageConfig[] | undefined;
+    _setupDeps.writeSetupConfig = mock(
+      async (_workdir: string, _config: NaxConfig, monoConfigs: MonoPackageConfig[]) => {
+        capturedMonoConfigs = monoConfigs;
+        return { written: [] };
+      },
+    );
 
     await withTempDir(async (dir) => {
       const exitCode = await runSetup({ dir });
       expect(exitCode).toBe(0);
-      expect(writtenPaths.some((p) => p.includes("mono"))).toBe(false);
+      expect(capturedMonoConfigs).toEqual([]);
     });
   });
 
-  test("AC3 boundary: does not call mkdir with a mono path for single-package plan", async () => {
-    const createdDirs: string[] = [];
-    _setupDeps.mkdir = mock(async (path: string) => {
-      createdDirs.push(path);
+  test("AC3 boundary: writeSetupConfig is called exactly once for single-package plan", async () => {
+    let callCount = 0;
+    _setupDeps.writeSetupConfig = mock(async () => {
+      callCount++;
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       await runSetup({ dir });
-      expect(createdDirs.some((p) => p.includes("mono"))).toBe(false);
+      expect(callCount).toBe(1);
     });
   });
 });
@@ -181,16 +191,17 @@ describe("setupCommand — AC3: single-package produces no mono directory entrie
 // ─── AC4: --dry-run → exits 0, no files, prints summary ─────────────────────
 
 describe("setupCommand — AC4: dry-run creates no files and prints summary", () => {
-  test("AC4: exits 0 and writes no files when dryRun is true", async () => {
-    const writtenPaths: string[] = [];
-    _setupDeps.writeFile = mock(async (path: string) => {
-      writtenPaths.push(path);
+  test("AC4: exits 0 and does not call writeSetupConfig when dryRun is true", async () => {
+    let writeCallCount = 0;
+    _setupDeps.writeSetupConfig = mock(async () => {
+      writeCallCount++;
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       const exitCode = await runSetup({ dir, dryRun: true });
       expect(exitCode).toBe(0);
-      expect(writtenPaths).toHaveLength(0);
+      expect(writeCallCount).toBe(0);
     });
   });
 
@@ -221,20 +232,20 @@ describe("setupCommand — AC5: exits 1 when generateSetupPlan rejects with SETU
     });
   });
 
-  test("AC5 boundary: does not write config.json when SETUP_PLAN_INVALID", async () => {
+  test("AC5 boundary: does not call writeSetupConfig when SETUP_PLAN_INVALID", async () => {
     _setupDeps.generateSetupPlan = mock(async () => {
       throw new NaxError("plan failed", "SETUP_PLAN_INVALID");
     });
 
-    const writtenPaths: string[] = [];
-    _setupDeps.writeFile = mock(async (path: string) => {
-      writtenPaths.push(path);
+    let writeCallCount = 0;
+    _setupDeps.writeSetupConfig = mock(async () => {
+      writeCallCount++;
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       await runSetup({ dir });
-      const configWrites = writtenPaths.filter((p) => p.endsWith("config.json") && !p.includes("mono"));
-      expect(configWrites).toHaveLength(0);
+      expect(writeCallCount).toBe(0);
     });
   });
 });
@@ -254,17 +265,18 @@ describe("setupCommand — AC6: collision refusal without --force", () => {
     });
   });
 
-  test("AC6 boundary: does not call writeFile for root config when collision detected", async () => {
+  test("AC6 boundary: does not call writeSetupConfig when collision detected", async () => {
     _setupDeps.fileExists = mock(async (path: string) => path.endsWith("config.json"));
 
-    const writtenPaths: string[] = [];
-    _setupDeps.writeFile = mock(async (path: string) => {
-      writtenPaths.push(path);
+    let writeCallCount = 0;
+    _setupDeps.writeSetupConfig = mock(async () => {
+      writeCallCount++;
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       await runSetup({ dir });
-      expect(writtenPaths.some((p) => p.endsWith(".nax/config.json"))).toBe(false);
+      expect(writeCallCount).toBe(0);
     });
   });
 });
@@ -272,36 +284,35 @@ describe("setupCommand — AC6: collision refusal without --force", () => {
 // ─── AC7: existing config + --force → replaces content ──────────────────────
 
 describe("setupCommand — AC7: --force overwrites existing config", () => {
-  test("AC7: exits 0 and writes config even when file already exists", async () => {
+  test("AC7: exits 0 and calls writeSetupConfig even when file already exists", async () => {
     _setupDeps.fileExists = mock(async (path: string) => path.endsWith("config.json"));
 
-    const writtenPaths: string[] = [];
-    _setupDeps.writeFile = mock(async (path: string) => {
-      writtenPaths.push(path);
+    let writeCallCount = 0;
+    _setupDeps.writeSetupConfig = mock(async () => {
+      writeCallCount++;
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       const exitCode = await runSetup({ dir, force: true });
       expect(exitCode).toBe(0);
-      expect(writtenPaths.some((p) => p.endsWith("config.json") && !p.includes("mono"))).toBe(true);
+      expect(writeCallCount).toBe(1);
     });
   });
 
-  test("AC7 boundary: written content under --force matches generated plan config", async () => {
+  test("AC7 boundary: config passed under --force matches generated plan config", async () => {
     _setupDeps.fileExists = mock(async () => true);
 
-    let writtenContent: string | undefined;
-    _setupDeps.writeFile = mock(async (path: string, content: string) => {
-      if (!path.includes("mono")) writtenContent = content;
+    let capturedConfig: NaxConfig | undefined;
+    _setupDeps.writeSetupConfig = mock(async (_workdir: string, config: NaxConfig) => {
+      capturedConfig = config;
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       await runSetup({ dir, force: true });
-      if (writtenContent !== undefined) {
-        expect(NaxConfigSchema.safeParse(JSON.parse(writtenContent)).success).toBe(true);
-      } else {
-        expect(writtenContent).toBeDefined();
-      }
+      expect(capturedConfig).toBeDefined();
+      expect(NaxConfigSchema.safeParse(capturedConfig).success).toBe(true);
     });
   });
 });
@@ -460,19 +471,20 @@ describe("setupCommand — AC13: fillScripts invoked iff --fill-scripts flag set
     });
   });
 
-  test("AC13: fillScripts is called before writeFile for config", async () => {
+  test("AC13: fillScripts is called before writeSetupConfig", async () => {
     const callOrder: string[] = [];
     _setupDeps.fillScripts = mock(async () => {
       callOrder.push("fillScripts");
     });
-    _setupDeps.writeFile = mock(async () => {
-      callOrder.push("writeFile");
+    _setupDeps.writeSetupConfig = mock(async () => {
+      callOrder.push("writeSetupConfig");
+      return { written: [] };
     });
 
     await withTempDir(async (dir) => {
       await runSetup({ dir, fillScripts: true });
       const fillIdx = callOrder.indexOf("fillScripts");
-      const writeIdx = callOrder.indexOf("writeFile");
+      const writeIdx = callOrder.indexOf("writeSetupConfig");
       expect(fillIdx).toBeGreaterThanOrEqual(0);
       expect(fillIdx).toBeLessThan(writeIdx);
     });


### PR DESCRIPTION
## Summary

Finishes a half-done refactor: `src/cli/setup-write.ts` held an orphan `writeSetupConfig()` stub that threw `"not implemented"` and had no callers, while the real config-writing logic was inlined in `setupCommand`. This extracts that logic into the function, wires it in, and adds tests. Also lands a codebase gap-analysis report (separate commit) that surfaced this stub.

## Commits
1. **`refactor(setup): extract writeSetupConfig from setupCommand`**
   - Implement `writeSetupConfig` — writes `.nax/config.json` + per-package `.nax/mono/<pkg>/config.json`, returns ordered `{ written: string[] }`
   - Injectable `_writeSetupDeps` (Bun-native `Bun.write` / `mkdir`) for FS-free unit testing
   - Wire into `setupCommand`; remove now-unused `mkdir`/`writeFile` from `_setupDeps`
   - `--force` collision check stays in `setupCommand`; write-time `force` is a documented no-op
   - New `test/unit/cli/setup-write.test.ts` (13 DI-based tests)
2. **`docs: add 2026-06-19 codebase gap analysis report`** — `docs/reviews/CODEBASE-GAP-ANALYSIS-2026-06-19.md`

## Behavior
No change to observable `nax setup` behavior — pure extraction.

## Test plan
- [x] `bun x tsc --noEmit` — exit 0
- [x] `bun test test/unit/cli/setup-write.test.ts` — 13 pass, 0 fail
- [x] `bun test test/unit/cli/` — 577 pass, 2 skip, 0 fail
- [x] `bun run lint` — Biome + 5 custom checks all pass (deep-relatives ↓1)