### PR TITLE
chore(test): add coverage gate enforcing 80% floor

### DIFF
--- a/.claude/rules/testing-commands.md
+++ b/.claude/rules/testing-commands.md
@@ -13,6 +13,17 @@ This rule is enforced by a PreToolUse hook: `.claude/hooks/guard-bun-test.ts`. B
 | One file / directory (iteration) | `timeout 30 bun test <path> --timeout=5000` |
 | Long-running targeted test | `timeout -k 5s 60s bun test <path> --timeout=60000` |
 | AGENT Friendly (Only print errors) | `AGENT=1 timeout 30 bun test <path> --timeout=5000` |
+| Coverage gate (enforces 80% floor) | `bun run test:coverage` |
+| Coverage report (no gate) | `bun run test:coverage:report` |
+
+## Coverage
+
+`bun run test:coverage` runs the unit suite with coverage and **fails if overall line or
+function coverage drops below 80%** (the rule in `common/testing.md`). The floor is enforced
+by `scripts/check-coverage.ts`, which parses `coverage/lcov.info` — Bun 1.3.x's `bunfig`
+`coverageThreshold` computes coverage but does NOT gate the exit code, so the script does.
+Scope is `test/unit/` (the bulk, fast and reliable); raise the floor in `check-coverage.ts`
+as coverage improves.
 
 ## Rules
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -13,3 +13,12 @@ preload = ["./test/preload.ts"]
 # Exclude nax dogfood feature directories (contain acceptance tests from nax runs, not source tests)
 exclude = [".nax/**"]
 AGENT = 1
+
+# Coverage — only collected when `--coverage` is passed (e.g. `bun run test:coverage`);
+# normal `bun test` runs are unaffected. Test files themselves are excluded from the
+# report. NOTE: Bun 1.3.x computes `coverageThreshold` but does NOT enforce it via exit
+# code, so the floor is enforced by scripts/check-coverage.ts (which parses coverage/
+# lcov.info), not here.
+coverageSkipTestFiles = true
+coverageReporter = ["text", "lcov"]
+coverageDir = "coverage"

--- a/docs/reviews/CODEBASE-GAP-ANALYSIS-2026-06-19.md
+++ b/docs/reviews/CODEBASE-GAP-ANALYSIS-2026-06-19.md
@@ -15,7 +15,7 @@
 | 1 | `story-orchestrator.ts` (1462 LOC) + its test (1734 LOC) — 2.4×/2.2× over hard limit | **HIGH** | L |
 | 2 | Scoped permission profile is a non-functional Phase-2 stub | **HIGH** | M |
 | 3 | `setup-write.ts` `writeSetupConfig()` throws "not implemented", no callers | **HIGH** | M |
-| 4 | No test coverage tooling at all (vs. stated 80% rule) | **HIGH** | S |
+| 4 | ~~No test coverage tooling at all (vs. stated 80% rule)~~ — **RESOLVED**: `bun run test:coverage` enforces an 80% floor via `scripts/check-coverage.ts` (lcov-parsing; current ~81% lines / ~84% funcs). | RESOLVED | S |
 | 5 | Structured test-output parsing (pytest / go test) deferred — 4 TODOs | **MED** | M |
 | 6 | CLAUDE.md documents removed `src/agents/claude/` CLI adapter (ACP-only now) | **MED** | S |
 | 7 | ~~Duplicate logging subsystems: `src/logger/` **and** `src/logging/`~~ — **corrected: not duplicates** (see §4). `src/logging/` renamed → `src/log-format/` to fix the naming collision. | RESOLVED | M |
@@ -128,7 +128,7 @@ The "Known Violations (2026-04-18)" table in `.claude/rules/monorepo-awareness.m
 
 ## 7. Test Coverage Gaps
 
-**No coverage tooling exists.** `package.json` has no `--coverage` script and no threshold gate, despite the stated 80% requirement. This is the single highest-leverage fix: add `bun test --coverage` with a CI threshold so the rest of this section becomes measurable rather than estimated.
+**~~No coverage tooling exists.~~ RESOLVED.** `bun run test:coverage` now runs the unit suite with coverage and enforces an 80% line/function floor via `scripts/check-coverage.ts` (Bun's `bunfig` `coverageThreshold` computes but does not gate the exit code in 1.3.x, so the script parses `coverage/lcov.info` itself). Measured baseline: ~81% lines / ~84% functions. The remaining per-subsystem gaps below are now measurable from the per-file lcov report.
 
 Overall ratio ~1.28 tests:source. Well-covered: `execution/` (~2.1:1), `tdd/` (~3:1), `config/` (~1.9:1), `operations/` (~1.5:1).
 
@@ -145,7 +145,7 @@ Thin or zero **isolated** coverage:
 
 ## 8. Quick Wins (recommended order)
 
-1. **Add coverage tooling** + CI threshold (`bun test --coverage`). Small, unblocks everything else. *(§7)*
+1. ~~**Add coverage tooling** + CI threshold~~ — **done**: `bun run test:coverage` enforces an 80% floor via `scripts/check-coverage.ts`. *(§7)*
 2. **Fix or reject scoped permissions** so it can't silently degrade to `safe`. *(§2.1)*
 3. **Update CLAUDE.md** — remove CLI-adapter / `src/agents/claude/` references. Cheap, prevents agent confusion (it's loaded into every session). *(§5)*
 4. ~~Resolve the duplicate logging dir~~ — **done**: not a duplicate; `src/logging/` renamed → `src/log-format/` to fix the naming collision. *(§4)*

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "test:integration": "bun test ./test/integration/ --timeout=60000",
     "test:ui": "bun test ./test/ui/ --timeout=60000",
     "test:e2e": "timeout -k 5s 180s bun test test/e2e/ --timeout=60000",
+    "test:coverage": "bun run scripts/check-coverage.ts",
+    "test:coverage:report": "bun run scripts/check-coverage.ts --report",
     "check-test-overlap": "bun run scripts/check-test-overlap.ts",
     "check-dead-tests": "bun run scripts/check-dead-tests.ts",
     "check:test-sizes": "bun run scripts/check-test-sizes.ts",

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+/**
+ * Coverage gate: runs the unit suite with coverage, parses coverage/lcov.info,
+ * and fails if overall line or function coverage drops below the floor.
+ *
+ * Why a custom script: Bun 1.3.x collects coverage and accepts a
+ * `coverageThreshold` in bunfig.toml, but does NOT enforce it via exit code
+ * (verified: 33% coverage vs a 0.99 threshold still exits 0). So the floor is
+ * enforced here by parsing the lcov report.
+ *
+ * Scope: the unit suite (`test/unit/`) — the bulk of the tests, fast (~20s) and
+ * reliable. Integration/UI/e2e are excluded because Bun cannot merge coverage
+ * across the separate process-group invocations the wrapper uses, and they add
+ * little source coverage over the unit suite.
+ *
+ * Usage:
+ *   bun scripts/check-coverage.ts            # run + enforce floor (CI mode)
+ *   bun scripts/check-coverage.ts --report   # run + print summary, never fail
+ *
+ * Exit codes:
+ *   0 — coverage at/above floor (or --report)
+ *   1 — below floor, the test run failed, or lcov.info was not produced
+ */
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const LCOV_PATH = join(ROOT, "coverage", "lcov.info");
+
+/** Enforced floor. Matches the documented 80% rule (.claude/rules/common/testing.md). */
+const FLOOR = { lines: 0.8, functions: 0.8 };
+
+/** Wall-clock cap for the coverage run, in ms. */
+const RUN_TIMEOUT_MS = 300_000;
+
+interface Totals {
+  linesFound: number;
+  linesHit: number;
+  fnFound: number;
+  fnHit: number;
+}
+
+/**
+ * Run the unit suite with coverage in a detached process group so a hang or
+ * SIGABRT is reaped along with any descendants (mirrors scripts/run-tests.ts).
+ */
+async function runCoverage(): Promise<number> {
+  const child = Bun.spawn(
+    [
+      "bun",
+      "test",
+      "test/unit/",
+      "--coverage",
+      "--coverage-reporter=lcov",
+      "--coverage-reporter=text",
+      "--timeout=5000",
+    ],
+    {
+      cwd: ROOT,
+      env: { ...process.env, AGENT: "1" },
+      stdout: "inherit",
+      stderr: "inherit",
+      // Leader of its own process group so the timeout kill reaches descendants.
+      detached: true,
+    },
+  );
+
+  const pgid = child.pid;
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try {
+      process.kill(-pgid, "SIGKILL");
+    } catch {
+      child.kill("SIGKILL");
+    }
+  }, RUN_TIMEOUT_MS);
+
+  const exitCode = await child.exited;
+  clearTimeout(timer);
+
+  if (timedOut) {
+    console.error(`\n[coverage] unit suite exceeded ${RUN_TIMEOUT_MS / 1000}s — killed.`);
+    return 124;
+  }
+  return exitCode;
+}
+
+function parseLcov(text: string): Totals {
+  const totals: Totals = { linesFound: 0, linesHit: 0, fnFound: 0, fnHit: 0 };
+  for (const line of text.split("\n")) {
+    const colon = line.indexOf(":");
+    if (colon === -1) continue;
+    const tag = line.slice(0, colon);
+    const value = Number.parseInt(line.slice(colon + 1), 10);
+    if (Number.isNaN(value)) continue;
+    switch (tag) {
+      case "LF":
+        totals.linesFound += value;
+        break;
+      case "LH":
+        totals.linesHit += value;
+        break;
+      case "FNF":
+        totals.fnFound += value;
+        break;
+      case "FNH":
+        totals.fnHit += value;
+        break;
+    }
+  }
+  return totals;
+}
+
+function pct(hit: number, found: number): number {
+  return found === 0 ? 1 : hit / found;
+}
+
+async function main() {
+  const reportOnly = process.argv.includes("--report");
+
+  const runExit = await runCoverage();
+  if (runExit !== 0) {
+    console.error(`\n[coverage] test run failed (exit ${runExit}) — not evaluating coverage.`);
+    process.exit(1);
+  }
+
+  const lcovFile = Bun.file(LCOV_PATH);
+  if (!(await lcovFile.exists())) {
+    console.error(`\n[coverage] expected lcov report at ${LCOV_PATH} but none was produced.`);
+    process.exit(1);
+  }
+
+  const totals = parseLcov(await lcovFile.text());
+  const lines = pct(totals.linesHit, totals.linesFound);
+  const functions = pct(totals.fnHit, totals.fnFound);
+
+  const fmt = (n: number) => `${(n * 100).toFixed(2)}%`;
+  console.log("\n── coverage gate (test/unit) ──");
+  console.log(`  lines:     ${fmt(lines)}  (${totals.linesHit}/${totals.linesFound}, floor ${fmt(FLOOR.lines)})`);
+  console.log(`  functions: ${fmt(functions)}  (${totals.fnHit}/${totals.fnFound}, floor ${fmt(FLOOR.functions)})`);
+
+  if (reportOnly) return;
+
+  const failures: string[] = [];
+  if (lines < FLOOR.lines) failures.push(`line coverage ${fmt(lines)} < floor ${fmt(FLOOR.lines)}`);
+  if (functions < FLOOR.functions)
+    failures.push(`function coverage ${fmt(functions)} < floor ${fmt(FLOOR.functions)}`);
+
+  if (failures.length > 0) {
+    console.error(`\n[coverage] FAIL — ${failures.join("; ")}`);
+    console.error("Add tests for the uncovered code (see the per-file report above), or");
+    console.error("if the floor is genuinely too high, adjust FLOOR in scripts/check-coverage.ts.");
+    process.exit(1);
+  }
+
+  console.log("\n[coverage] OK — at or above floor.");
+}
+
+await main();


### PR DESCRIPTION
## Summary

The project documents an 80% coverage requirement (`common/testing.md`) but had **no coverage tooling at all** (gap report §4 / item #4). This adds `bun run test:coverage`, which runs the unit suite with coverage and **fails if overall line or function coverage drops below 80%**.

## Why a custom script instead of bunfig `coverageThreshold`
Bun 1.3.x collects coverage and accepts `coverageThreshold` in `bunfig.toml`, but **does not enforce it via exit code** — verified with a minimal repro: 33% coverage against a 0.99 threshold still exits 0. So `scripts/check-coverage.ts` parses `coverage/lcov.info` and enforces the floor itself.

## Changes
- **`scripts/check-coverage.ts`** — runs `test/unit/` with `--coverage` in a detached process group with a wall-clock cap (mirrors `scripts/run-tests.ts` so a hang/SIGABRT is reaped), parses lcov, enforces an 80% floor. `--report` prints the summary without failing.
- **`bunfig.toml`** — coverage reporters (`text`, `lcov`) + `coverageSkipTestFiles`; dropped the non-functional `coverageThreshold`.
- **`package.json`** — `test:coverage` (gate) and `test:coverage:report` (no-fail).
- **`testing-commands.md`** — documents the gate.

## Scope
Unit suite (`test/unit/`) — the bulk, ~20s, reliable. Integration/UI/e2e are excluded because Bun can't merge coverage across the separate process-group invocations the wrapper uses.

## Verification
- [x] `bun run test:coverage` — **81.20% lines / 84.42% functions**, ≥ 80% floor → PASS (exit 0)
- [x] Negative test: floor temporarily raised to 0.95 → **FAIL with clear message** (exit 1)
- [x] `bun x tsc --noEmit` — exit 0
- [x] `bun run lint` — green