### PR TITLE
fix(config): reject unimplemented scoped permission profile at load

### DIFF
--- a/docs/reviews/CODEBASE-GAP-ANALYSIS-2026-06-19.md
+++ b/docs/reviews/CODEBASE-GAP-ANALYSIS-2026-06-19.md
@@ -13,7 +13,7 @@
 | # | Finding | Severity | Effort |
 |:--|:--------|:--------:|:------:|
 | 1 | `story-orchestrator.ts` (1462 LOC) + its test (1734 LOC) — 2.4×/2.2× over hard limit | **HIGH** | L |
-| 2 | Scoped permission profile is a non-functional Phase-2 stub | **HIGH** | M |
+| 2 | Scoped permission profile is a non-functional Phase-2 stub | **MITIGATED** | M |
 | 3 | `setup-write.ts` `writeSetupConfig()` throws "not implemented", no callers | **HIGH** | M |
 | 4 | ~~No test coverage tooling at all (vs. stated 80% rule)~~ — **RESOLVED**: `bun run test:coverage` enforces an 80% floor via `scripts/check-coverage.ts` (lcov-parsing; current ~81% lines / ~84% funcs). | RESOLVED | S |
 | 5 | Structured test-output parsing (pytest / go test) deferred — 4 TODOs | **MED** | M |
@@ -33,7 +33,9 @@
 ### 2.1 Scoped permission profile — HIGH
 `src/config/permissions.ts` — `resolveScopedPermissions()` is a Phase-2 stub returning `{ mode: "approve-reads", skipPermissions: false }` (identical to `safe`). The `allowedTools?: string[]` field is declared but never populated.
 
-**Impact:** `execution.permissionProfile: "scoped"` silently behaves like `safe`. A user who sets it believes they have tool-scoped permissions but does not. Either implement Phase 2 or reject the value at config-parse time until it lands.
+**Impact:** `execution.permissionProfile: "scoped"` silently behaves like `safe`. A user who sets it believes they have tool-scoped permissions but does not.
+
+**MITIGATED (interim):** the full Phase-2 feature is deferred and tracked by **GitHub #374** (note: its stated acpx `--allowed-tools` blocker is already cleared in the acpx fork, and the CLI-adapter subtask P2-002 is obsolete since the CLI adapter was removed). Until it lands, `permissionProfile: "scoped"` is now **rejected at config-load** with a `CONFIG_SCOPED_PROFILE_UNIMPLEMENTED` error pointing to #374 (`rejectUnimplementedScopedProfile` in `src/config/loader.ts`) — so the silent downgrade can no longer happen.
 
 ### 2.2 `setup-write.ts` — HIGH
 `src/cli/setup-write.ts:14` — `writeSetupConfig()` is `throw new Error("not implemented")` and has **no callers anywhere in `src/`**. Dead orphan stub: either wire it up or remove it.
@@ -146,7 +148,7 @@ Thin or zero **isolated** coverage:
 ## 8. Quick Wins (recommended order)
 
 1. ~~**Add coverage tooling** + CI threshold~~ — **done**: `bun run test:coverage` enforces an 80% floor via `scripts/check-coverage.ts`. *(§7)*
-2. **Fix or reject scoped permissions** so it can't silently degrade to `safe`. *(§2.1)*
+2. ~~**Fix or reject scoped permissions** so it can't silently degrade to `safe`.~~ — **done (rejected at load)**; full feature deferred to #374. *(§2.1)*
 3. **Update CLAUDE.md** — remove CLI-adapter / `src/agents/claude/` references. Cheap, prevents agent confusion (it's loaded into every session). *(§5)*
 4. ~~Resolve the duplicate logging dir~~ — **done**: not a duplicate; `src/logging/` renamed → `src/log-format/` to fix the naming collision. *(§4)*
 5. **Add a file-size lint gate** and split `story-orchestrator.ts`. *(§3)*

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -171,6 +171,30 @@ function rejectLegacyRectificationKeys(conf: Record<string, unknown>): void {
   throw new NaxError(message, "CONFIG_LEGACY_RECTIFICATION_KEYS", { stage: "config", legacyKeys });
 }
 
+/**
+ * @internal Reject `execution.permissionProfile: "scoped"` until Phase 2 lands.
+ *
+ * The scoped profile is a valid enum value (Zod accepts it), but its resolver
+ * (`resolveScopedPermissions`) is still a stub that silently returns "safe"
+ * defaults. A user who sets `"scoped"` would believe they have per-stage tool
+ * allowlists while actually running in the weaker `safe` mode — a silent
+ * downgrade. Fail fast with a pointer to the tracking issue instead.
+ *
+ * Remove this guard when scoped permissions are implemented (GitHub #374).
+ */
+function rejectUnimplementedScopedProfile(conf: Record<string, unknown>): void {
+  const execution = conf.execution as Record<string, unknown> | undefined;
+  if (execution?.permissionProfile !== "scoped") return;
+
+  const message = [
+    'Invalid configuration — execution.permissionProfile: "scoped" is not yet implemented.',
+    "The scoped (per-stage tool allowlist) profile is tracked by GitHub #374 and would",
+    'otherwise silently run as "safe", giving you weaker permissions than intended.',
+    'Use "unrestricted" or "safe" for now.',
+  ].join("\n");
+  throw new NaxError(message, "CONFIG_SCOPED_PROFILE_UNIMPLEMENTED", { stage: "config" });
+}
+
 /** @internal Backward compat: map deprecated routing.llm.batchMode to routing.llm.mode.
  * Returns a new object (immutable -- does not mutate the input). */
 function applyBatchModeCompat(conf: Record<string, unknown>): Record<string, unknown> {
@@ -418,6 +442,9 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   // that were split across quality.autofix and execution.rectification before
   // unification. Same Zod-strip rationale.
   rejectLegacyRectificationKeys(rawConfig);
+  // Fail fast on the not-yet-implemented scoped permission profile (GitHub #374)
+  // rather than letting it silently degrade to "safe".
+  rejectUnimplementedScopedProfile(rawConfig);
 
   const result = NaxConfigSchema.safeParse(rawConfig);
   if (!result.success) {
@@ -544,6 +571,7 @@ export async function loadConfigForWorkdir(
     // ADR-012 Phase 6 — legacy-key guard applies to per-package overlays too.
     rejectLegacyAgentKeys(rawMerged);
     rejectLegacyRectificationKeys(rawMerged);
+    rejectUnimplementedScopedProfile(rawMerged);
     const result = NaxConfigSchema.safeParse(rawMerged);
     if (!result.success) {
       // Fail-fast — consistent with root-chain resolution (a missing profile file

--- a/src/config/permissions.ts
+++ b/src/config/permissions.ts
@@ -53,9 +53,14 @@ export function resolvePermissions(config: AgentManagerConfig | undefined, _stag
 
 /**
  * Phase 2 stub — resolves per-stage permissions from config block.
- * Returns safe defaults until Phase 2 is implemented.
+ *
+ * NOT YET IMPLEMENTED (tracked by GitHub #374). Currently unreachable in normal
+ * flow: `rejectUnimplementedScopedProfile` in src/config/loader.ts rejects
+ * `permissionProfile: "scoped"` at config-load time so it can't silently degrade
+ * here. Kept as a defensive fallback for any path that bypasses the loader guard.
+ * When #374 lands, implement per docs/specs/scoped-permissions.md §2.4 and remove
+ * the loader guard.
  */
 function resolveScopedPermissions(_config: AgentManagerConfig | undefined, _stage: PipelineStage): ResolvedPermissions {
-  // Phase 2 implementation goes here
   return { mode: "approve-reads", skipPermissions: false };
 }

--- a/test/unit/config/scoped-profile-guard.test.ts
+++ b/test/unit/config/scoped-profile-guard.test.ts
@@ -1,0 +1,70 @@
+// test/unit/config/scoped-profile-guard.test.ts
+//
+// Regression guard for the not-yet-implemented "scoped" permission profile
+// (GitHub #374). The scoped resolver is still a stub that returns "safe"
+// defaults, so loading a config with `permissionProfile: "scoped"` must throw
+// fast rather than silently downgrading the user to weaker permissions.
+//
+// Remove this guard (and these tests) when scoped permissions are implemented.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { loadConfig } from "@/config";
+import { NaxError } from "@/errors";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+const tempDirs: string[] = [];
+
+async function writeProjectConfig(contents: object): Promise<string> {
+  const root = makeTempDir("nax-scoped-guard-");
+  tempDirs.push(root);
+  const naxDir = join(root, ".nax");
+  await mkdir(naxDir, { recursive: true });
+  await Bun.write(join(naxDir, "config.json"), JSON.stringify(contents, null, 2));
+  return root;
+}
+
+describe("scoped permission profile — unimplemented guard (#374)", () => {
+  beforeEach(() => {
+    tempDirs.splice(0, tempDirs.length);
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      cleanupTempDir(dir);
+    }
+  });
+
+  test('rejects execution.permissionProfile: "scoped" with a pointer to #374', async () => {
+    const root = await writeProjectConfig({
+      execution: { permissionProfile: "scoped" },
+    });
+    try {
+      await loadConfig(root);
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      const e = err as NaxError;
+      expect(e.code).toBe("CONFIG_SCOPED_PROFILE_UNIMPLEMENTED");
+      expect(e.message).toContain("#374");
+      expect(e.message).toContain("not yet implemented");
+    }
+  });
+
+  test('accepts execution.permissionProfile: "unrestricted"', async () => {
+    const root = await writeProjectConfig({
+      execution: { permissionProfile: "unrestricted" },
+    });
+    const config = await loadConfig(root);
+    expect(config.execution.permissionProfile).toBe("unrestricted");
+  });
+
+  test('accepts execution.permissionProfile: "safe"', async () => {
+    const root = await writeProjectConfig({
+      execution: { permissionProfile: "safe" },
+    });
+    const config = await loadConfig(root);
+    expect(config.execution.permissionProfile).toBe("safe");
+  });
+});


### PR DESCRIPTION
## Summary

`execution.permissionProfile: "scoped"` is a valid enum value, but its resolver (`resolveScopedPermissions`) is a stub that silently returns `safe` defaults. A user who sets `"scoped"` believes they have per-stage tool scoping while actually running in the weaker `safe` mode — a **silent permission downgrade** (gap report §2.1 / issue #374).

The full scoped-permissions feature (issue #374) is **deferred**. This PR is the interim safety guard: fail fast at config-load instead of silently degrading.

## Change
- **`rejectUnimplementedScopedProfile`** in `src/config/loader.ts` — throws `NaxError("CONFIG_SCOPED_PROFILE_UNIMPLEMENTED")` with a pointer to #374 when `permissionProfile: "scoped"` is set. Wired at both guard call sites (root config + per-package overlay), mirroring the existing `rejectLegacyAgentKeys` pattern.
- **`src/config/permissions.ts`** — documents that the resolver stub is now guarded/unreachable in normal flow.
- **`test/unit/config/scoped-profile-guard.test.ts`** — rejects `scoped`; accepts `unrestricted`/`safe`.

## Note on #374
While investigating, I found the issue's stated blocker is already resolved: **acpx supports `--allowed-tools`** (confirmed in the fork), and nax invokes acpx per-prompt-per-session, so per-stage enforcement is achievable with no acpx changes. P2-002 (CLI mapping) is obsolete (CLI adapter removed). Captured in the gap report for when #374 is picked up.

## Verification
- [x] `bun x tsc --noEmit` — exit 0
- [x] `bun test test/unit/config/scoped-profile-guard.test.ts` — 3 pass
- [x] `bun test test/unit/config/` — 632 pass, 0 fail
- [x] End-to-end: a `{permissionProfile:"scoped"}` config throws `CONFIG_SCOPED_PROFILE_UNIMPLEMENTED` at load
- [x] `bun run lint` — green (aliases used; deep-relatives + alias-internals satisfied)