### PR TITLE
fix(execution): fail story when a configured review phase never ran

### DIFF
--- a/scripts/baselines/file-sizes-baseline.json
+++ b/scripts/baselines/file-sizes-baseline.json
@@ -1,12 +1,11 @@
 {
-  "updatedAt": "2026-06-19T03:19:35.176Z",
+  "updatedAt": "2026-06-19T05:09:25.051Z",
   "byFile": {
     "src/agents/acp/adapter.ts": 629,
     "src/agents/acp/spawn-client.ts": 737,
     "src/agents/manager.ts": 820,
     "src/config/runtime-types.ts": 626,
     "src/context/engine/providers/code-neighbor.ts": 613,
-    "src/execution/post-run.ts": 607,
     "src/execution/unified-executor.ts": 689,
     "src/operations/call.ts": 631,
     "src/prompts/builders/rectifier-builder.ts": 902,

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -95,6 +95,11 @@ export function resolveMaxAttemptsOutcome(failureCategory?: FailureCategory): "p
       return "pause";
     case "runtime-crash":
       return "pause";
+    // Exhausted all tiers without ever running the configured review — the gate
+    // stayed red and the story never got semantic/adversarial judgment. Needs a
+    // human, same as verifier-rejected.
+    case "review-incomplete":
+      return "pause";
     case "session-failure":
     case "tests-failing":
     case "full-suite-gate-exhausted":

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -3,7 +3,7 @@ export { run } from "./runner";
 export type { FailureCategory } from "../tdd/types";
 export { appendProgress } from "./progress";
 export { groupStoriesIntoBatches, type StoryBatch } from "./batching";
-export { escalateTier, getTierConfig, calculateMaxIterations } from "./escalation";
+export { escalateTier, getTierConfig, calculateMaxIterations, resolveMaxAttemptsOutcome } from "./escalation";
 export { readQueueFile, clearQueueFile } from "./queue-handler";
 export {
   hookCtx,

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -15,14 +15,7 @@ import type { AgentResult } from "../agents/types";
 import type { Finding } from "../findings/types";
 import { checkMergeConflict, isTriggerEnabled } from "../interaction/triggers";
 import { getLogger } from "../logger";
-import {
-  fullSuiteGateOp,
-  greenfieldGateOp,
-  implementerOp,
-  testWriterOp,
-  verifierOp,
-  verifyScopedOp,
-} from "../operations";
+import { fullSuiteGateOp, implementerOp, testWriterOp, verifierOp, verifyScopedOp } from "../operations";
 import { routeTddFailure } from "../pipeline/stages/execution-helpers";
 import type { PipelineContext, StageResult } from "../pipeline/types";
 import { parseSelfVerificationMarker } from "../quality";
@@ -31,8 +24,8 @@ import { rollbackToRef } from "../tdd/rollback";
 import { errorMessage } from "../utils/errors";
 import { autoCommitIfDirty, detectMergeConflict } from "../utils/git";
 import { failAndClose } from "./session-manager-runtime";
-import { EXHAUSTED_EXIT_REASONS } from "./story-orchestrator";
 import type { StoryOrchestratorResult } from "./story-orchestrator";
+import { deriveTddFailureCategory } from "./tdd-failure-category";
 import type { FailureCategory } from "./types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -95,91 +88,7 @@ export function extractPauseReason(phaseOutputs: Record<string, unknown>): strin
   return undefined;
 }
 
-/** Derive TDD failure category from phase outputs after plan.run(). */
-export function deriveTddFailureCategory(
-  phaseOutputs: Record<string, unknown>,
-  unfixedFindings?: readonly Finding[],
-  gateRegressedDuringRect?: boolean,
-): FailureCategory | undefined {
-  // Test-writer failure → session-failure
-  const testWriterOutput = phaseOutputs[testWriterOp.name] as { success?: boolean } | undefined;
-  if (testWriterOutput?.success === false) {
-    return "session-failure";
-  }
-
-  // Greenfield gate: when success=false + pauseReason="greenfield-no-tests", the pause
-  // handler in extractPauseReason fires first. deriveTddFailureCategory also checks it so
-  // the failureCategory is set correctly for non-pause paths (e.g. tests that bypass pause).
-  const greenfieldOutput = phaseOutputs[greenfieldGateOp.name] as
-    | { success?: boolean; pauseReason?: string }
-    | undefined;
-  if (greenfieldOutput?.success === false && greenfieldOutput?.pauseReason === "greenfield-no-tests") {
-    return "greenfield-no-tests";
-  }
-
-  // Verifier failure → derive from verifier output
-  const verifierOutput = phaseOutputs[verifierOp.name] as { success?: boolean; failureCategory?: string } | undefined;
-  if (verifierOutput?.success === false) {
-    if (verifierOutput.failureCategory) {
-      return verifierOutput.failureCategory as FailureCategory;
-    }
-    return "tests-failing";
-  }
-
-  // Verifier passed → it is the SSOT for the TDD verdict. Even if the gate flagged
-  // failures, the verifier has judged this story OK (e.g. unrelated regressions).
-  // Skip the gate-derived category in that case — UNLESS rectification introduced
-  // new gate failures after the verifier ran, which makes the verdict stale (the
-  // story is failed for exactly this reason; route it to escalation as a gate
-  // failure rather than dropping the category). Mirrors the success-aggregation
-  // staleness guard in ExecutionPlan.run.
-  const verifierPassed = verifierOutput?.success === true && !gateRegressedDuringRect;
-
-  // Full-suite gate exhausted: rectification ran out of retry budget AND at least
-  // one test-runner finding remains unfixed. Takes priority over the plain
-  // tests-failing branch below, but only fires when verifier did NOT pass (the
-  // verifierPassed guard above already short-circuits when verifier succeeded).
-  if (!verifierPassed && unfixedFindings && unfixedFindings.length > 0) {
-    const rectOutput = phaseOutputs.rectification as { exitReason?: string } | undefined;
-    if (
-      rectOutput?.exitReason &&
-      EXHAUSTED_EXIT_REASONS.has(rectOutput.exitReason) &&
-      unfixedFindings.some((f) => f.source === "test-runner")
-    ) {
-      return "full-suite-gate-exhausted";
-    }
-  }
-
-  // Mid-rectification crash: validator infrastructure threw during re-validation.
-  // runFixCycle sets exitReason "validator-error" when runPhase throws (story-orchestrator.ts:932).
-  // Distinct from EXHAUSTED_EXIT_REASONS — the crash, not budget exhaustion, is the root cause.
-  if (!verifierPassed) {
-    const rectOutputCrash = phaseOutputs.rectification as { exitReason?: string } | undefined;
-    if (rectOutputCrash?.exitReason === "validator-error") {
-      return "runtime-crash";
-    }
-  }
-
-  // Full-suite gate failure without an overriding verifier verdict → tests-failing.
-  // Reached only when verifier either failed-without-category-but-handled-above, did
-  // not run, or has no output. Routed by `routeTddFailure` as `escalate` (same
-  // handling as a verifier-derived tests-failing). Distinct from
-  // `full-suite-gate-exhausted`, which fires only after rectification retries spent.
-  if (!verifierPassed) {
-    const gateOutput = phaseOutputs[fullSuiteGateOp.name] as { success?: boolean; passed?: boolean } | undefined;
-    if (gateOutput && (gateOutput.success === false || gateOutput.passed === false)) {
-      return "tests-failing";
-    }
-  }
-
-  // Implementer failure → session-failure
-  const implOutput = phaseOutputs[implementerOp.name] as { success?: boolean } | undefined;
-  if (implOutput?.success === false) {
-    return "session-failure";
-  }
-
-  return undefined;
-}
+export { deriveTddFailureCategory };
 
 /**
  * Wrapper-level session teardown on failure.
@@ -334,6 +243,7 @@ export async function applyPostRunInspection(
           planResult.phaseOutputs,
           planResult.unfixedFindings,
           planResult.gateRegressedDuringRect,
+          planResult.missingRequiredReviewPhases,
         )
       : undefined;
 

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -237,6 +237,11 @@ export async function applyPostRunInspection(
   }
 
   const pauseReason = extractPauseReason(planResult.phaseOutputs);
+  // Non-TDD stories get no failureCategory and rely on the generic escalate path
+  // below (`!planResult.success` → escalate). A non-TDD missing-review failure
+  // (`missingRequiredReviewPhases`) therefore still escalates and re-runs the
+  // review, but on exhaustion resolves to `fail` rather than the `review-incomplete`
+  // `pause` the TDD path uses — the core bug (skipped review) is fixed for both.
   const failureCategory =
     isTdd && !planResult.success
       ? deriveTddFailureCategory(

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -291,21 +291,49 @@ export class ExecutionPlan {
         { storyId: this.ctx.storyId, packageDir: this.ctx.packageDir },
       );
     }
-    const success = Object.entries(phaseOutputs).every(([name, output]) => {
-      if (verifierPassedSsot && name === gateName) return true;
-      return phasePassed(name, output, this.ctx.storyId);
-    });
+
+    // Completeness guard (US-002): a configured review phase absent from
+    // phaseOutputs never ran — the post-rectification resume loop can break at a
+    // still-red full-suite-gate (canonical pos 4) before reaching the reviews
+    // (pos 9-10). The verifier-SSOT carve-out must NOT launder such a story into
+    // a pass: it cannot be certified without the semantic/adversarial judgment it
+    // was configured to require. Forcing success=false routes it to escalation
+    // (deriveTddFailureCategory → "review-incomplete") so a stronger tier can
+    // green the gate and actually run the review; the story becomes terminal only
+    // once escalation is exhausted.
+    const requiredReviewPhaseNames = [
+      this.state.semanticReview ? "semantic-review" : undefined,
+      this.state.adversarialReview ? "adversarial-review" : undefined,
+    ].filter((name): name is string => name !== undefined);
+    const missingRequiredReviewPhases = requiredReviewPhaseNames.filter((name) => !(name in phaseOutputs));
+    if (missingRequiredReviewPhases.length > 0) {
+      logger?.warn(
+        "story-orchestrator",
+        "Configured review phase(s) never ran — story cannot pass without review judgment, failing for escalation",
+        { storyId: this.ctx.storyId, packageDir: this.ctx.packageDir, missingRequiredReviewPhases },
+      );
+    }
+
+    const success =
+      missingRequiredReviewPhases.length === 0 &&
+      Object.entries(phaseOutputs).every(([name, output]) => {
+        if (verifierPassedSsot && name === gateName) return true;
+        return phasePassed(name, output, this.ctx.storyId);
+      });
     const totalCostUsd = Object.values(phaseCosts).reduce((sum, cost) => sum + cost, 0);
     const durationMs = Date.now() - startedAt;
 
     // Final aggregate log — single end-of-run summary so anyone reading the JSONL
     // can see the orchestrator's verdict without correlating per-phase lines.
-    const failedPhases = Object.entries(phaseOutputs)
-      .filter(([name, output]) => {
-        if (verifierPassedSsot && name === gateName) return false;
-        return !phasePassed(name, output, this.ctx.storyId);
-      })
-      .map(([name]) => name);
+    const failedPhases = [
+      ...Object.entries(phaseOutputs)
+        .filter(([name, output]) => {
+          if (verifierPassedSsot && name === gateName) return false;
+          return !phasePassed(name, output, this.ctx.storyId);
+        })
+        .map(([name]) => name),
+      ...missingRequiredReviewPhases.map((name) => `${name} (never ran)`),
+    ];
     const summary: Record<string, unknown> = {
       storyId: this.ctx.storyId,
       success,
@@ -316,6 +344,7 @@ export class ExecutionPlan {
     };
     if (rectResult.rectificationExhausted) summary.rectificationExhausted = true;
     if (rectResult.unfixedFindings) summary.unfixedFindingsCount = rectResult.unfixedFindings.length;
+    if (missingRequiredReviewPhases.length > 0) summary.missingRequiredReviewPhases = missingRequiredReviewPhases;
     if (success) {
       logger?.info("story-orchestrator", "Story orchestration complete", summary);
     } else {
@@ -330,6 +359,7 @@ export class ExecutionPlan {
       phaseOutputs,
       ...rectResult,
       gateRegressedDuringRect,
+      missingRequiredReviewPhases: missingRequiredReviewPhases.length > 0 ? missingRequiredReviewPhases : undefined,
     };
   }
 }

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -302,8 +302,8 @@ export class ExecutionPlan {
     // green the gate and actually run the review; the story becomes terminal only
     // once escalation is exhausted.
     const requiredReviewPhaseNames = [
-      this.state.semanticReview ? "semantic-review" : undefined,
-      this.state.adversarialReview ? "adversarial-review" : undefined,
+      this.state.semanticReview?.slot.op.name,
+      this.state.adversarialReview?.slot.op.name,
     ].filter((name): name is string => name !== undefined);
     const missingRequiredReviewPhases = requiredReviewPhaseNames.filter((name) => !(name in phaseOutputs));
     if (missingRequiredReviewPhases.length > 0) {

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -47,6 +47,16 @@ export interface StoryOrchestratorResult {
    * route the failure to escalation as `tests-failing`.
    */
   readonly gateRegressedDuringRect?: boolean;
+  /**
+   * Names of configured review phases (semantic-review / adversarial-review) that
+   * never executed before the verdict — e.g. the post-rectification resume loop
+   * broke at a still-red full-suite-gate (canonical pos 4) before reaching the
+   * review (pos 9-10). A non-empty list forces success=false and routes to
+   * escalation via `deriveTddFailureCategory` → `review-incomplete`, so the story
+   * cannot pass on the verifier-SSOT carve-out without semantic/adversarial
+   * judgment (US-002 regression).
+   */
+  readonly missingRequiredReviewPhases?: readonly string[];
 }
 
 export type PhaseKind =

--- a/src/execution/tdd-failure-category.ts
+++ b/src/execution/tdd-failure-category.ts
@@ -1,0 +1,100 @@
+import type { Finding } from "../findings/types";
+import { fullSuiteGateOp, greenfieldGateOp, implementerOp, testWriterOp, verifierOp } from "../operations";
+import { EXHAUSTED_EXIT_REASONS } from "./story-orchestrator";
+import type { FailureCategory } from "./types";
+
+/** Derive TDD failure category from phase outputs after plan.run(). */
+export function deriveTddFailureCategory(
+  phaseOutputs: Record<string, unknown>,
+  unfixedFindings?: readonly Finding[],
+  gateRegressedDuringRect?: boolean,
+  missingRequiredReviewPhases?: readonly string[],
+): FailureCategory | undefined {
+  // A configured review phase never ran (e.g. the resume loop broke at a red gate
+  // before reaching it). Checked FIRST so it outranks the verifier-SSOT carve-out
+  // below — an unreviewed story must not be exempted into a pass. Routed to
+  // escalation by `routeTddFailure` so a stronger tier can green the gate and run
+  // the review; terminal only after escalation is exhausted (US-002).
+  if (missingRequiredReviewPhases && missingRequiredReviewPhases.length > 0) {
+    return "review-incomplete";
+  }
+
+  // Test-writer failure → session-failure
+  const testWriterOutput = phaseOutputs[testWriterOp.name] as { success?: boolean } | undefined;
+  if (testWriterOutput?.success === false) {
+    return "session-failure";
+  }
+
+  // Greenfield gate: when success=false + pauseReason="greenfield-no-tests", the pause
+  // handler in extractPauseReason fires first. deriveTddFailureCategory also checks it so
+  // the failureCategory is set correctly for non-pause paths (e.g. tests that bypass pause).
+  const greenfieldOutput = phaseOutputs[greenfieldGateOp.name] as
+    | { success?: boolean; pauseReason?: string }
+    | undefined;
+  if (greenfieldOutput?.success === false && greenfieldOutput?.pauseReason === "greenfield-no-tests") {
+    return "greenfield-no-tests";
+  }
+
+  // Verifier failure → derive from verifier output
+  const verifierOutput = phaseOutputs[verifierOp.name] as { success?: boolean; failureCategory?: string } | undefined;
+  if (verifierOutput?.success === false) {
+    if (verifierOutput.failureCategory) {
+      return verifierOutput.failureCategory as FailureCategory;
+    }
+    return "tests-failing";
+  }
+
+  // Verifier passed → it is the SSOT for the TDD verdict. Even if the gate flagged
+  // failures, the verifier has judged this story OK (e.g. unrelated regressions).
+  // Skip the gate-derived category in that case — UNLESS rectification introduced
+  // new gate failures after the verifier ran, which makes the verdict stale (the
+  // story is failed for exactly this reason; route it to escalation as a gate
+  // failure rather than dropping the category). Mirrors the success-aggregation
+  // staleness guard in ExecutionPlan.run.
+  const verifierPassed = verifierOutput?.success === true && !gateRegressedDuringRect;
+
+  // Full-suite gate exhausted: rectification ran out of retry budget AND at least
+  // one test-runner finding remains unfixed. Takes priority over the plain
+  // tests-failing branch below, but only fires when verifier did NOT pass (the
+  // verifierPassed guard above already short-circuits when verifier succeeded).
+  if (!verifierPassed && unfixedFindings && unfixedFindings.length > 0) {
+    const rectOutput = phaseOutputs.rectification as { exitReason?: string } | undefined;
+    if (
+      rectOutput?.exitReason &&
+      EXHAUSTED_EXIT_REASONS.has(rectOutput.exitReason) &&
+      unfixedFindings.some((f) => f.source === "test-runner")
+    ) {
+      return "full-suite-gate-exhausted";
+    }
+  }
+
+  // Mid-rectification crash: validator infrastructure threw during re-validation.
+  // runFixCycle sets exitReason "validator-error" when runPhase throws (story-orchestrator.ts:932).
+  // Distinct from EXHAUSTED_EXIT_REASONS — the crash, not budget exhaustion, is the root cause.
+  if (!verifierPassed) {
+    const rectOutputCrash = phaseOutputs.rectification as { exitReason?: string } | undefined;
+    if (rectOutputCrash?.exitReason === "validator-error") {
+      return "runtime-crash";
+    }
+  }
+
+  // Full-suite gate failure without an overriding verifier verdict → tests-failing.
+  // Reached only when verifier either failed-without-category-but-handled-above, did
+  // not run, or has no output. Routed by `routeTddFailure` as `escalate` (same
+  // handling as a verifier-derived tests-failing). Distinct from
+  // `full-suite-gate-exhausted`, which fires only after rectification retries spent.
+  if (!verifierPassed) {
+    const gateOutput = phaseOutputs[fullSuiteGateOp.name] as { success?: boolean; passed?: boolean } | undefined;
+    if (gateOutput && (gateOutput.success === false || gateOutput.passed === false)) {
+      return "tests-failing";
+    }
+  }
+
+  // Implementer failure → session-failure
+  const implOutput = phaseOutputs[implementerOp.name] as { success?: boolean } | undefined;
+  if (implOutput?.success === false) {
+    return "session-failure";
+  }
+
+  return undefined;
+}

--- a/src/execution/tdd-failure-category.ts
+++ b/src/execution/tdd-failure-category.ts
@@ -10,15 +10,6 @@ export function deriveTddFailureCategory(
   gateRegressedDuringRect?: boolean,
   missingRequiredReviewPhases?: readonly string[],
 ): FailureCategory | undefined {
-  // A configured review phase never ran (e.g. the resume loop broke at a red gate
-  // before reaching it). Checked FIRST so it outranks the verifier-SSOT carve-out
-  // below — an unreviewed story must not be exempted into a pass. Routed to
-  // escalation by `routeTddFailure` so a stronger tier can green the gate and run
-  // the review; terminal only after escalation is exhausted (US-002).
-  if (missingRequiredReviewPhases && missingRequiredReviewPhases.length > 0) {
-    return "review-incomplete";
-  }
-
   // Test-writer failure → session-failure
   const testWriterOutput = phaseOutputs[testWriterOp.name] as { success?: boolean } | undefined;
   if (testWriterOutput?.success === false) {
@@ -94,6 +85,17 @@ export function deriveTddFailureCategory(
   const implOutput = phaseOutputs[implementerOp.name] as { success?: boolean } | undefined;
   if (implOutput?.success === false) {
     return "session-failure";
+  }
+
+  // A configured review phase never ran, and no more-specific category applied.
+  // This is the verifier-SSOT carve-out case: the verifier passed, so the
+  // gate-derived categories above were skipped, yet a red gate stopped the resume
+  // loop before reaching the reviews (semantic/adversarial). Checked LAST so a
+  // genuine gate/session/verifier failure keeps its specific category (no masking
+  // of `tests-failing`). Routes to escalation so a stronger tier can green the
+  // gate and run the review; terminal (pause) only after escalation exhausts (US-002).
+  if (missingRequiredReviewPhases && missingRequiredReviewPhases.length > 0) {
+    return "review-incomplete";
   }
 
   return undefined;

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -27,6 +27,8 @@ export type FailureCategory =
   | "verifier-rejected"
   /** Greenfield project with no test files — TDD not applicable (BUG-010) */
   | "greenfield-no-tests"
+  /** A configured review phase (semantic / adversarial) never ran before the verdict */
+  | "review-incomplete"
   /** Worktree dependency preparation failed before pipeline execution started */
   | "dependency-prep"
   | "runtime-crash";

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -88,7 +88,8 @@ export function routeTddFailure(
     failureCategory === "tests-failing" ||
     failureCategory === "full-suite-gate-exhausted" ||
     failureCategory === "verifier-rejected" ||
-    failureCategory === "runtime-crash"
+    failureCategory === "runtime-crash" ||
+    failureCategory === "review-incomplete"
   ) {
     return { action: "escalate", reason: buildReason(failureCategory) };
   }

--- a/test/unit/execution/escalation/tier-escalation.test.ts
+++ b/test/unit/execution/escalation/tier-escalation.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { makeLogger } from "@test/helpers";
+import { resolveMaxAttemptsOutcome } from "@/execution";
 import { pipelineEventBus } from "@/pipeline";
 
 // ---------------------------------------------------------------------------
@@ -72,36 +73,24 @@ describe("shouldRetrySameTier", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveMaxAttemptsOutcome — runtime-crash category", () => {
-  test("returns pause for runtime-crash failure category", async () => {
-    const { resolveMaxAttemptsOutcome } = await import(
-      "../../../../src/execution/escalation/tier-escalation"
-    );
-
+  test("returns pause for runtime-crash failure category", () => {
     expect(resolveMaxAttemptsOutcome("runtime-crash")).toBe("pause");
   });
 
-  test("still returns fail for tests-failing (regression guard)", async () => {
-    const { resolveMaxAttemptsOutcome } = await import(
-      "../../../../src/execution/escalation/tier-escalation"
-    );
-
+  test("still returns fail for tests-failing (regression guard)", () => {
     expect(resolveMaxAttemptsOutcome("tests-failing")).toBe("fail");
   });
 
-  test("returns fail for full-suite-gate-exhausted (regression guard)", async () => {
-    const { resolveMaxAttemptsOutcome } = await import(
-      "../../../../src/execution/escalation/tier-escalation"
-    );
-
+  test("returns fail for full-suite-gate-exhausted (regression guard)", () => {
     expect(resolveMaxAttemptsOutcome("full-suite-gate-exhausted")).toBe("fail");
   });
 
-  test("still returns pause for verifier-rejected (regression guard)", async () => {
-    const { resolveMaxAttemptsOutcome } = await import(
-      "../../../../src/execution/escalation/tier-escalation"
-    );
-
+  test("still returns pause for verifier-rejected (regression guard)", () => {
     expect(resolveMaxAttemptsOutcome("verifier-rejected")).toBe("pause");
+  });
+
+  test("returns pause for review-incomplete (US-002: exhausted without review judgment → human review)", () => {
+    expect(resolveMaxAttemptsOutcome("review-incomplete")).toBe("pause");
   });
 });
 

--- a/test/unit/execution/execution-stage.test.ts
+++ b/test/unit/execution/execution-stage.test.ts
@@ -80,6 +80,15 @@ describe("routeTddFailure", () => {
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
+  it("escalates on review-incomplete with category in reason (US-002)", () => {
+    const ctx: MockContext = {};
+    const result = routeTddFailure("review-incomplete", false, ctx);
+
+    expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD review-incomplete");
+    expect(ctx.retryAsLite).toBeUndefined();
+  });
+
   it("escalates on greenfield-no-tests with category in reason", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure("greenfield-no-tests", false, ctx);

--- a/test/unit/execution/post-run-inspection.test.ts
+++ b/test/unit/execution/post-run-inspection.test.ts
@@ -132,6 +132,47 @@ describe("deriveTddFailureCategory", () => {
     expect(result).toBeUndefined();
   });
 
+  // ─── US-002: review-incomplete (configured review never ran) ──────────────
+
+  test("returns review-incomplete in the carve-out case (verifier passed, gate red, review absent)", () => {
+    // Verifier passed → gate-derived categories skipped → the missing review is the
+    // real reason. Routes to escalation so a stronger tier can green the gate and run it.
+    const result = deriveTddFailureCategory(
+      {
+        [fullSuiteGateOp.name]: { success: false, passed: false, findings: [] },
+        [verifierOp.name]: { success: true },
+      },
+      undefined,
+      false,
+      ["adversarial-review"],
+    );
+    expect(result).toBe("review-incomplete");
+  });
+
+  test("a genuine red gate (verifier did NOT pass) keeps tests-failing even with a missing review (no masking)", () => {
+    // review-incomplete is checked LAST — a real gate failure must not be masked into
+    // review-incomplete (which would flip the max-attempts outcome from fail to pause).
+    const result = deriveTddFailureCategory(
+      {
+        [fullSuiteGateOp.name]: { success: false, passed: false, findings: [] },
+      },
+      undefined,
+      false,
+      ["adversarial-review"],
+    );
+    expect(result).toBe("tests-failing");
+  });
+
+  test("a session failure outranks a missing review", () => {
+    const result = deriveTddFailureCategory(
+      { [implementerOp.name]: { success: false } },
+      undefined,
+      false,
+      ["semantic-review", "adversarial-review"],
+    );
+    expect(result).toBe("session-failure");
+  });
+
   // ─── US-001: full-suite-gate-exhausted derivation ─────────────────────────
 
   test("returns full-suite-gate-exhausted when rectification exhausted with max-attempts-total and test-runner finding", () => {

--- a/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
+++ b/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
@@ -284,3 +284,108 @@ describe("ExecutionPlan.run — carve-out staleness", () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ExecutionPlan.run — completeness guard: carve-out must NOT pass a story when a
+// configured review phase never ran (US-002 regression).
+//
+// Repro: full-suite-gate stays red with the SAME finding through rectification
+// (subset of baseline → NOT regressed → carve-out would normally exempt it).
+// verifier + semantic-review pass during the lite revalidation (full-suite-rectify
+// scope excludes adversarial-review). The post-rectification resume loop breaks at
+// the still-red gate (canonical pos 4) before reaching adversarial-review (pos 10),
+// so adversarial-review never runs — yet the verifier-SSOT carve-out exempts the
+// gate and the story passes WITHOUT adversarial judgment.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ExecutionPlan.run — completeness guard (configured review must run)", () => {
+  let rt: NaxRuntime | undefined;
+  afterEach(async () => {
+    await rt?.close();
+  });
+
+  test("carve-out exempts red gate but adversarial-review never ran → story fails (not silent pass)", async () => {
+    const config = makeNaxConfig({
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2, abortOnIncreasingFailures: false } },
+    });
+    rt = makeTestRuntime({ config });
+
+    // Gate: red with the SAME finding on every run (main loop + every re-run).
+    // Identical finding → post-rect keys ⊆ baseline → gateRegressedDuringRect=false.
+    const gateOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "full-suite-gate",
+      stage: "verify",
+      config: testSel,
+      execute: async () => ({
+        success: false,
+        passed: false,
+        estimatedCostUsd: 0,
+        findings: [testFinding("foo.test.ts", "persistent")],
+      }),
+    };
+    const semanticOp = makeDeterministicOp("semantic-review", { success: true });
+
+    let adversarialRuns = 0;
+    const adversarialOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "adversarial-review",
+      stage: "verify",
+      config: testSel,
+      execute: async () => {
+        adversarialRuns++;
+        return { success: true, passed: true, estimatedCostUsd: 0, findings: [] };
+      },
+    };
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = (async (
+      _ctx: unknown,
+      op: { kind?: string; execute?: (i: unknown, c: unknown) => unknown },
+      input: unknown,
+    ) => {
+      if (op.kind === "deterministic" && op.execute) return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    }) as typeof _storyOrchestratorDeps.callOp;
+    // Lite revalidation in full-suite-rectify scope: gate-last (carve-out discards
+    // it after verifier passes), excludes adversarial-review. Exit "resolved".
+    _storyOrchestratorDeps.runFixCycle = (async (cycle: {
+      validate: (c: unknown, o: unknown) => Promise<unknown>;
+    }) => {
+      await cycle.validate({}, { mode: "lite", strategiesRun: ["full-suite-rectify"] });
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    try {
+      const ctx = {
+        runtime: rt,
+        packageView: rt.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-adv",
+      } as unknown as CallContext;
+
+      const result = await new StoryOrchestratorBuilder()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-adv" } as never, workdir: "/tmp" } })
+        .addVerifier({ op: makeDeterministicOp("verifier", { success: true }), input: {} })
+        .addSemanticReview({ op: semanticOp, input: {} })
+        .addAdversarialReview({ op: adversarialOp, input: {} })
+        .addRectification({ maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false })
+        .build(ctx)
+        .run();
+
+      // Precondition: this is the carve-out path, not the staleness path.
+      expect(result.gateRegressedDuringRect).toBe(false);
+      // The bug: adversarial-review never executed (resume broke at the red gate).
+      expect(adversarialRuns).toBe(0);
+      expect("adversarial-review" in result.phaseOutputs).toBe(false);
+      // The fix: a configured review that never ran must NOT yield a passing story.
+      expect(result.success).toBe(false);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+});


### PR DESCRIPTION
## Problem

A story could be marked `success: true` while a configured `adversarial-review` phase **never executed** — observed in a real run (US-002): semantic review passed, then the story jumped straight to the full-suite gate and completed successfully, with no adversarial review anywhere in the log.

### Root cause (two compounding defects)

1. **The success verdict only checked phases that ran.** `ExecutionPlan.run` computed `success` over `Object.entries(phaseOutputs)` — phases that actually produced output. A phase that never ran has no key, so it was invisible to the verdict and could not fail the story.

2. **The verifier-SSOT carve-out laundered a red gate into a pass, bypassing escalation.** When the verifier passed, a still-red `full-suite-gate` was exempted (treated as an unrelated regression) → `success: true`. Per `iteration-runner.ts`, `success: true` routes to `handlePipelineSuccess` and **never reaches the fast→balanced→powerful escalation ladder**. The post-rectification resume loop broke at the red gate (canonical pos 4) before reaching `adversarial-review` (pos 10), so the review never ran — yet the story passed.

The other stories in the run *did* get adversarial review because their gate was green on the first pass, so the canonical sequence ran through uninterrupted.

## Fix

- **Completeness guard** (`execution-plan.ts`): a configured `semantic-review`/`adversarial-review` absent from `phaseOutputs` forces `success: false`, surfaced via a new `missingRequiredReviewPhases` result field. The carve-out can no longer certify an unreviewed story.
- **New `review-incomplete` `FailureCategory`**: routes to **escalate** (`routeTddFailure`) so a stronger tier can green the gate and actually run the review, and to **pause** for human review once tiers are exhausted (`resolveMaxAttemptsOutcome`). It is checked **last** in `deriveTddFailureCategory`, so it fires only in the carve-out case and never masks a genuine `tests-failing`/`session-failure`.
- Extracted `deriveTddFailureCategory` into `src/execution/tdd-failure-category.ts` (a concern-split that drops `post-run.ts` back under the 600-line limit).

Net effect: a story can no longer pass without the review judgment it was configured to require; it escalates first and is terminal (human review) only after escalation is exhausted.

## Behavior change to note

For a story whose gate never greens across all tiers (e.g. a genuinely persistent unrelated regression), the outcome changes from a silent pass to **pause for human review**. The deferred regression sweep still attributes truly-unrelated failures separately. This is the intended "guard-in-place" trade-off.

## Code review

A `code-reviewer` agent reviewed the diff. It confirmed the guard cannot false-positive on empty-diff/skipped reviews (`runPhase` always writes `phaseOutputs[opName]`), that review inputs are populated only when genuinely enabled, and that the extraction is faithful with no circular imports. Findings addressed: M1 (category masking — moved the check last), H1 (added routing-chain unit tests), L1 (derive phase names from `slot.op.name`), L2 (documented non-TDD escalate-then-fail vs TDD escalate-then-pause).

## Testing

- New TDD test reproducing the US-002 carve-out path (confirmed RED before the fix, GREEN after).
- Routing-chain unit tests: `deriveTddFailureCategory` (carve-out → `review-incomplete`, red-gate no-masking, session-failure outranks), `routeTddFailure` → escalate, `resolveMaxAttemptsOutcome` → pause.
- `bun run typecheck`, `bun run lint` (all gates), and full suite (unit + integration + ui) — all green, 0 failures.

## Test plan

- [ ] CI green
- [ ] Confirm the widened "red gate never greens → pause" semantics is desired vs the prior silent pass