### PR TITLE
fix(execution): render advisory findings in non-blocking fix prompts

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -277,6 +277,10 @@ export async function buildPlanForStrategy(
       );
     }
     // Always: recover from a test regression that the best-effort fix introduces.
+    // No `promptSeverityFloor` here on purpose: this strategy only claims
+    // `source: "test-runner"` regression findings (never advisory adversarial
+    // findings), and its prompt renders failing tests without a severity filter,
+    // so a floor would be inert.
     nbStrategies.push(
       makeFullSuiteRectifyStrategy(story, config, nbSink) as FixStrategy<Finding, unknown, unknown, unknown>,
     );

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -236,11 +236,19 @@ export async function buildPlanForStrategy(
   if (nbf?.enabled && inputs.adversarialReview) {
     const nbSink = makeDeclarationSink();
 
+    // The non-blocking fix is seeded exclusively with advisory findings BELOW the
+    // run's blocking threshold (adversarial.ts advisory filter). The rectifier
+    // prompt builder filters by the same threshold, so without an explicit floor
+    // every seeded finding is stripped back out and the agent gets an empty
+    // findings list (then stalls asking the human for them). Pin the floor to
+    // "info" so all advisory findings render. Blocking-cycle strategies above
+    // are unaffected — they don't pass this option.
     if (nbf.scope === "source") {
       // implementer claims adversarial findings in SOURCE scope (both session modes)
       nbStrategies.push(
         makeAutofixImplementerStrategy(story, config, nbSink, {
           includeAdversarialReview: true,
+          promptSeverityFloor: "info",
         }) as FixStrategy<Finding, unknown, unknown, unknown>,
       );
     } else if (nbf.scope === "triage") {
@@ -249,9 +257,11 @@ export async function buildPlanForStrategy(
       nbStrategies.push(
         makeAutofixImplementerStrategy(story, config, nbSink, {
           adversarialReviewByFixTarget: "source",
+          promptSeverityFloor: "info",
         }) as FixStrategy<Finding, unknown, unknown, unknown>,
         makeAutofixTestWriterStrategy(story, config, nbSink, {
           includeAdversarialReview: false,
+          promptSeverityFloor: "info",
         }) as FixStrategy<Finding, unknown, unknown, unknown>,
       );
     } else {
@@ -259,8 +269,11 @@ export async function buildPlanForStrategy(
       nbStrategies.push(
         makeAutofixImplementerStrategy(story, config, nbSink, {
           includeAdversarialReview: false,
+          promptSeverityFloor: "info",
         }) as FixStrategy<Finding, unknown, unknown, unknown>,
-        makeAutofixTestWriterStrategy(story, config, nbSink) as FixStrategy<Finding, unknown, unknown, unknown>,
+        makeAutofixTestWriterStrategy(story, config, nbSink, {
+          promptSeverityFloor: "info",
+        }) as FixStrategy<Finding, unknown, unknown, unknown>,
       );
     }
     // Always: recover from a test regression that the best-effort fix introduces.

--- a/src/operations/autofix-implementer-strategy.ts
+++ b/src/operations/autofix-implementer-strategy.ts
@@ -34,6 +34,16 @@ export interface AutofixImplementerStrategyOptions {
    * unless `includeAdversarialReview` is also true)
    */
   adversarialReviewByFixTarget?: "source" | "test";
+  /**
+   * Severity floor for findings rendered into the rectifier prompt. The prompt
+   * builder drops findings below this floor (default `"error"`). The
+   * non-blocking fix is seeded exclusively with advisory findings *below* the
+   * run's blocking threshold, so without an explicit `"info"` floor every
+   * seeded finding is filtered back out and the agent receives an empty
+   * findings list. The non-blocking strategy set passes `"info"`.
+   * (default: undefined → `config.review.blockingThreshold`)
+   */
+  promptSeverityFloor?: "error" | "warning" | "info";
 }
 
 export function makeAutofixImplementerStrategy(
@@ -44,6 +54,7 @@ export function makeAutofixImplementerStrategy(
 ): FixStrategy<Finding, AutofixImplementerInput, AutofixImplementerOutput, AutofixConfig> {
   const claimsAdversarial = opts.includeAdversarialReview === true;
   const adversarialReviewByFixTarget = opts.adversarialReviewByFixTarget;
+  const blockingThreshold = opts.promptSeverityFloor ?? config.review?.blockingThreshold;
   return {
     name: "autofix-implementer",
     appliesTo: (f) =>
@@ -64,6 +75,7 @@ export function makeAutofixImplementerStrategy(
       failedChecks: findingsToFailedChecks(findings),
       story,
       findings,
+      blockingThreshold,
     }),
     extractApplied: (output) => {
       // Accumulate test-edit declarations and mock handoffs into the shared sink

--- a/src/operations/autofix-test-writer-strategy.ts
+++ b/src/operations/autofix-test-writer-strategy.ts
@@ -23,6 +23,18 @@ export interface AutofixTestWriterStrategyOptions {
    * (default: true)
    */
   includeAdversarialReview?: boolean;
+  /**
+   * Severity floor for findings rendered into the rectifier prompt. The prompt
+   * builder drops findings below this floor. Defaults (when undefined) to the
+   * run's `review.blockingThreshold` (i.e. `"error"`), which is correct for the
+   * blocking cycle but WRONG for the non-blocking fix: that path is seeded
+   * exclusively with advisory findings *below* the blocking threshold
+   * (`adversarial.ts` advisory filter), so the run threshold would strip every
+   * finding back out and the agent receives an empty findings list. The
+   * non-blocking strategy set passes `"info"` here so all seeded advisory
+   * findings render. (default: undefined → `config.review.blockingThreshold`)
+   */
+  promptSeverityFloor?: "error" | "warning" | "info";
 }
 
 export function makeAutofixTestWriterStrategy(
@@ -32,6 +44,7 @@ export function makeAutofixTestWriterStrategy(
   opts: AutofixTestWriterStrategyOptions = {},
 ): FixStrategy<Finding, AutofixTestWriterInput, AutofixTestWriterOutput, AutofixConfig> {
   const includeAdversarial = opts.includeAdversarialReview !== false;
+  const blockingThreshold = opts.promptSeverityFloor ?? config.review?.blockingThreshold;
   return {
     name: "autofix-test-writer",
     appliesTo: (f) =>
@@ -59,7 +72,7 @@ export function makeAutofixTestWriterStrategy(
           failedChecks: findingsToFailedChecks(findings),
           story,
           mode: "mock-restructure",
-          blockingThreshold: config.review?.blockingThreshold,
+          blockingThreshold,
           handoffReason,
           handoffFiles,
         };
@@ -67,7 +80,7 @@ export function makeAutofixTestWriterStrategy(
       return {
         failedChecks: findingsToFailedChecks(findings),
         story,
-        blockingThreshold: config.review?.blockingThreshold,
+        blockingThreshold,
       };
     },
     maxAttempts: config.execution.rectification.maxAttemptsPerStrategy,

--- a/test/unit/execution/build-plan-for-strategy-triage-assembly.test.ts
+++ b/test/unit/execution/build-plan-for-strategy-triage-assembly.test.ts
@@ -30,6 +30,9 @@ function makeTddRetryInputs(story: UserStory, extra: Partial<PlanInputs> = {}): 
 
 describe("buildPlanForStrategy — AC1: triage scope NBF strategy assembly (US-006)", () => {
   let capturedStrategyNamesByCall: string[][] = [];
+  // Full strategy objects from each fix-cycle call, so tests can invoke
+  // buildInput and assert the prompt severity floor was wired (not just names).
+  let capturedStrategiesByCall: Array<Array<{ name: string; buildInput: (...args: never[]) => unknown }>> = [];
   let origRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
   let origCallOp: typeof _storyOrchestratorDeps.callOp;
   let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
@@ -39,6 +42,7 @@ describe("buildPlanForStrategy — AC1: triage scope NBF strategy assembly (US-0
 
   beforeEach(() => {
     capturedStrategyNamesByCall = [];
+    capturedStrategiesByCall = [];
     origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
     origCallOp = _storyOrchestratorDeps.callOp;
     origCaptureGitRef = _storyOrchestratorDeps.captureGitRef;
@@ -76,10 +80,13 @@ describe("buildPlanForStrategy — AC1: triage scope NBF strategy assembly (US-0
       }
       return { success: true };
     }) as typeof _storyOrchestratorDeps.callOp;
-    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: { strategies: Array<{ name: string }> }) => {
-      capturedStrategyNamesByCall.push(cycle.strategies.map((s) => s.name));
-      return { iterations: [], finalFindings: [], exitReason: "no-strategy" as const, costUsd: 0 };
-    }) as typeof _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.runFixCycle = mock(
+      async (cycle: { strategies: Array<{ name: string; buildInput: (...args: never[]) => unknown }> }) => {
+        capturedStrategyNamesByCall.push(cycle.strategies.map((s) => s.name));
+        capturedStrategiesByCall.push(cycle.strategies);
+        return { iterations: [], finalFindings: [], exitReason: "no-strategy" as const, costUsd: 0 };
+      },
+    ) as typeof _storyOrchestratorDeps.runFixCycle;
   });
 
   afterEach(async () => {
@@ -162,6 +169,59 @@ describe("buildPlanForStrategy — AC1: triage scope NBF strategy assembly (US-0
     expect(nbfNames).toContain("autofix-implementer");
     expect(nbfNames).toContain("autofix-test-writer");
     expect(nbfNames).toContain("full-suite-rectify");
+  });
+
+  test("NBF scope=triage wires promptSeverityFloor='info' so advisory findings render (not just names)", async () => {
+    // Green gate (every op except adversarial-review succeeds) so the story is
+    // green and the non-blocking fix cycle actually runs — that cycle is the
+    // captured set. (A failing gate would instead capture the main rectification
+    // cycle, which shares the same strategy names but carries the run threshold.)
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "adversarial-review") {
+        return {
+          success: true,
+          passed: true,
+          advisoryFindings: [
+            { source: "adversarial-review", severity: "info", category: "test-gap", message: "advisory gap", fixTarget: "test" },
+          ],
+        };
+      }
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const story = makeStory({ attempts: 1 });
+    const config = withNbfScope("triage");
+    const ctx = makeCtxWithRuntime(config);
+    const inputs = makeTddRetryInputs(story, {
+      adversarialReview: {
+        story,
+        adversarialConfig: config.review.adversarial!,
+        mode: config.review.adversarial!.diffMode,
+      },
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    await plan.run();
+
+    // Drive a sub-error (info) advisory finding through the assembled autofix
+    // strategies' buildInput and assert the "info" floor reached the op input.
+    // A dropped `promptSeverityFloor: "info"` in either non-blocking branch would
+    // surface here as "error" (the run threshold), reproducing the empty-prompt bug.
+    const advisory = {
+      source: "adversarial-review",
+      severity: "info",
+      category: "test-gap",
+      message: "advisory gap",
+      fixTarget: "test",
+    } as never;
+    const floorOf = (s?: { buildInput: (...args: never[]) => unknown }) =>
+      (s?.buildInput([advisory] as never, [] as never, {} as never) as { blockingThreshold?: string } | undefined)
+        ?.blockingThreshold;
+
+    const nbfSet = capturedStrategiesByCall[0] ?? [];
+    expect(nbfSet.length).toBeGreaterThan(0);
+    expect(floorOf(nbfSet.find((s) => s.name === "autofix-test-writer"))).toBe("info");
+    expect(floorOf(nbfSet.find((s) => s.name === "autofix-implementer"))).toBe("info");
   });
 
   test("AC1: NBF scope=triage does NOT regress — scope=both still assembles the same three", async () => {

--- a/test/unit/operations/autofix-implementer-strategy.test.ts
+++ b/test/unit/operations/autofix-implementer-strategy.test.ts
@@ -133,6 +133,22 @@ describe("makeAutofixImplementerStrategy", () => {
     expect(input.failedChecks[0]?.findings).toEqual([semanticFinding]);
   });
 
+  test("buildInput omits blockingThreshold by default (inherits run threshold)", () => {
+    const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), makeSink());
+    const input = strategy.buildInput([], [], {} as FixCycleContext);
+    // config.review.blockingThreshold defaults to "error".
+    expect(input.blockingThreshold).toBe("error");
+  });
+
+  test("promptSeverityFloor=info sets blockingThreshold so advisory findings render (non-blocking fix)", () => {
+    const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), makeSink(), {
+      adversarialReviewByFixTarget: "source",
+      promptSeverityFloor: "info",
+    });
+    const input = strategy.buildInput([], [], {} as FixCycleContext);
+    expect(input.blockingThreshold).toBe("info");
+  });
+
   describe("triage: adversarialReviewByFixTarget opt-in", () => {
     test("claims adversarial-review with fixTarget=source when adversarialReviewByFixTarget='source'", () => {
       const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink(), {

--- a/test/unit/operations/autofix-test-writer-strategy.test.ts
+++ b/test/unit/operations/autofix-test-writer-strategy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Finding } from "@/findings";
 import type { FixCycleContext } from "@/findings/cycle-types";
 import { makeAutofixTestWriterStrategy, makeDeclarationSink } from "@/operations";
+import { RectifierPromptBuilder } from "@/prompts";
 import { makeNaxConfig, makeStory } from "@test/helpers";
 
 const mockCtx = {} as any;
@@ -100,6 +101,42 @@ describe("makeAutofixTestWriterStrategy", () => {
     expect(input.failedChecks).toHaveLength(1);
     expect(input.failedChecks[0]?.check).toBe("adversarial");
     expect(input.failedChecks[0]?.findings).toEqual([adversarialFinding]);
+  });
+
+  describe("promptSeverityFloor: advisory findings render into the prompt", () => {
+    const advisoryFinding: Finding = {
+      source: "adversarial-review",
+      severity: "info",
+      category: "test-gap",
+      message: "Tautological test never asserts on populate_indicators output",
+      file: "tests/unit/strategies/test_convergence.py",
+      line: 297,
+      fixTarget: "test",
+    };
+
+    test("default (no floor) drops sub-error advisory findings — the original bug", () => {
+      const strategy = makeAutofixTestWriterStrategy(makeStory(), makeNaxConfig(), makeSink());
+      const input = strategy.buildInput([advisoryFinding], [], {} as FixCycleContext);
+      // blockingThreshold defaults to config.review.blockingThreshold ("error").
+      const prompt = RectifierPromptBuilder.testWriterRectification(input.failedChecks, makeStory(), {
+        blockingThreshold: input.blockingThreshold,
+      });
+      expect(prompt).not.toContain("test_convergence.py");
+    });
+
+    test("promptSeverityFloor=info renders sub-error advisory findings", () => {
+      const strategy = makeAutofixTestWriterStrategy(makeStory(), makeNaxConfig(), makeSink(), {
+        includeAdversarialReview: false,
+        promptSeverityFloor: "info",
+      });
+      const input = strategy.buildInput([advisoryFinding], [], {} as FixCycleContext);
+      expect(input.blockingThreshold).toBe("info");
+      const prompt = RectifierPromptBuilder.testWriterRectification(input.failedChecks, makeStory(), {
+        blockingThreshold: input.blockingThreshold,
+      });
+      expect(prompt).toContain("test_convergence.py");
+      expect(prompt).toContain("Tautological test");
+    });
   });
 
   describe("triage: includeAdversarialReview opt-out", () => {


### PR DESCRIPTION
## What

The non-blocking adversarial fix (ADR-024) handed the autofix agent an **empty findings list**, causing it to stall and ask the user — over the Telegram interaction plugin — to paste the adversarial reviewer's findings.

## Why

The non-blocking fix is seeded **exclusively** with advisory findings — those strictly *below* the run's blocking threshold (`src/review/adversarial.ts`):

```ts
const advisoryFindings = allFindings.filter((f) => !isBlockingSeverity(f.severity, threshold));
```

But the rectifier prompt builder (`src/prompts/builders/rectifier-builder.ts`) re-applies the same threshold (`blockingThreshold ?? "error"`) before rendering findings. Since `review.blockingThreshold` defaults to `"error"`, every advisory `info`/`warning` finding was filtered straight back out → empty "Test File Findings" section → the agent asks the human for the findings it was never given.

`scope: "triage"` (#1248) exposed this on every run: it routes a pure advisory test-subset to the test-writer, firing the empty-prompt path. The same latent defect affected the `source` and `both` lanes too — the implementer strategy's `buildInput` set no `blockingThreshold` at all (defaulting downstream to `"error"`).

Reproduction confirmed the rendered section was pure whitespace: `" (adversarial review)\n\n\n"`.

## How

- Add a `promptSeverityFloor?: "error" | "warning" | "info"` option to `makeAutofixTestWriterStrategy` and `makeAutofixImplementerStrategy`. Each computes `blockingThreshold = opts.promptSeverityFloor ?? config.review?.blockingThreshold` and threads it into its op input.
- `src/execution/build-plan-for-strategy.ts` passes `promptSeverityFloor: "info"` in all three non-blocking branches (`source`, `triage`, `both`) so advisory findings render.
- The implementer's `buildInput` now sets `blockingThreshold` explicitly (previously unset).
- The **blocking cycle is untouched** — it never passes the option and still inherits `review.blockingThreshold`.
- `full-suite-rectify` intentionally omits the floor (claims only `test-runner` regressions; its prompt applies no severity filter) — documented at the call site.

## Testing

- [x] Factory-level regression tests in both strategy test files (incl. one reproducing the original empty-prompt bug).
- [x] Integration assertion in the triage assembly test driving a live non-blocking fix cycle (green gate) — asserts both autofix strategies carry `blockingThreshold: "info"`. A dropped floor line now fails a test.
- [x] Affected suites: 90 pass / 0 fail.
- [x] `bun run typecheck` passes.
- [x] `bun run lint` passes.

## Notes

Code-reviewed (APPROVE, no CRITICAL/HIGH); the MEDIUM test-gap and LOW comment from review are addressed in the second commit.