### PR TITLE
feat(test-runners): structured error/stack extraction for pytest and go test

### DIFF
--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -7,8 +7,8 @@
  * Supported:
  *   - Bun test
  *   - Jest / Vitest
- *   - pytest        (common-parser fallback — structured extraction TODO)
- *   - go test       (common-parser fallback — structured extraction TODO)
+ *   - pytest        (FAILED lines + file:line stackTrace from verbose FAILURES block)
+ *   - go test       (--- FAIL: lines + file:line:msg from indented error lines)
  *   - Unknown       (common-parser fallback via broad regexes)
  */
 
@@ -258,8 +258,17 @@ function parseJestOutput(output: string): TestSummary {
  * ====== 2 failed, 5 passed in 0.42s ======
  * ```
  *
- * TODO: Add structured error/stack extraction from the verbose block.
- * Currently falls back to common parser for counts and extracts FAILED lines for names.
+ * Verbose format adds a FAILURES block with per-test sections:
+ * ```
+ * ================================= FAILURES =================================
+ * ________________________________ test_bar __________________________________
+ *     def test_bar():
+ * >       assert 1 == 2
+ * E       AssertionError: assert 1 == 2
+ *
+ * tests/test_foo.py:5: AssertionError
+ * ```
+ * The file:line reference at the end of each section is extracted into stackTrace.
  */
 function parsePytestOutput(output: string): TestSummary {
   const common = parseCommonOutput(output);
@@ -280,11 +289,64 @@ function parsePytestOutput(output: string): TestSummary {
     }
   }
 
+  // Merge file:line stackTrace entries from the verbose FAILURES block
+  const verboseStacks = parsePytestVerboseStacks(output);
+  for (const failure of failures) {
+    const leafName = failure.testName.split(" > ").pop() ?? failure.testName;
+    // Class-based tests: FAILED line yields "TestClass > test_method" but the verbose
+    // block header uses "TestClass.test_method" (dot separator). Try both forms.
+    const stack =
+      verboseStacks.get(leafName) ??
+      verboseStacks.get(failure.testName) ??
+      verboseStacks.get(failure.testName.replace(/ > /g, "."));
+    if (stack && stack.length > 0) {
+      failure.stackTrace = stack;
+    }
+  }
+
   return {
     passed: common.passed,
     failed: common.failed,
     failures: failures.length > 0 ? failures : common.failures,
   };
+}
+
+/**
+ * Extract a map of testName → stackTrace entries from the pytest verbose FAILURES block.
+ *
+ * Block headers look like: "____ test_name ____" (4+ underscores padding each side).
+ * Class-based test headers use dot notation: "____ TestClass.test_method ____".
+ * File:line references look like: "tests/foo.py:10: AssertionError" (bare, unindented).
+ *
+ * Known limitation: if two test files both define a function with the same name (e.g.
+ * both define `test_foo`), the map key collides and the last block wins. The wrong
+ * stackTrace may be assigned to one of the failures. This is a minor edge case that
+ * would require full file-path correlation to resolve.
+ */
+function parsePytestVerboseStacks(output: string): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  const failuresIdx = output.indexOf("FAILURES");
+  if (failuresIdx === -1) return result;
+
+  let currentTest: string | null = null;
+  for (const line of output.slice(failuresIdx).split("\n")) {
+    const headerMatch = line.match(/^_{4,}\s+(.+?)\s+_{4,}$/);
+    if (headerMatch) {
+      currentTest = headerMatch[1].trim();
+      continue;
+    }
+    if (currentTest) {
+      // "tests/test_foo.py:10: AssertionError" — bare (unindented) file:line reference
+      const fileLineMatch = line.match(/^(\S+\.py):(\d+):/);
+      if (fileLineMatch) {
+        const entry = `${fileLineMatch[1]}:${fileLineMatch[2]}`;
+        const existing = result.get(currentTest) ?? [];
+        result.set(currentTest, [...existing, entry]);
+      }
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -294,28 +356,54 @@ function parsePytestOutput(output: string): TestSummary {
  * ```
  * --- FAIL: TestFoo (0.00s)
  *     foo_test.go:12: Error message
+ *     foo_test.go:13: additional context
  * ok  	example.com/pkg	0.042s
  * FAIL	example.com/pkg	0.001s
  * ```
  *
- * TODO: Add structured error extraction from indented lines after "--- FAIL:".
- * Currently falls back to common parser for counts and extracts FAIL lines for names.
+ * Indented lines directly following "--- FAIL:" carry the file:line:message details.
+ * The first such line populates `file` and `error`; all lines populate `stackTrace`.
+ * Subtests (e.g. "TestSuite/SubTest_one") are preserved verbatim as testName.
  */
 function parseGoTestOutput(output: string): TestSummary {
   const common = parseCommonOutput(output);
 
-  // Structured failure names from "--- FAIL: TestName (Xs)" lines
   const failures: TestFailure[] = [];
-  for (const line of output.split("\n")) {
-    const m = line.match(/^--- FAIL:\s+(\S+)\s+\([\d.]+s\)/);
-    if (m) {
+  const lines = output.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    const failMatch = lines[i].match(/^--- FAIL:\s+(\S+)\s+\([\d.]+s\)/);
+    if (failMatch) {
+      const testName = failMatch[1];
+      i++;
+
+      const errorLines: Array<{ file: string; lineNum: string; msg: string }> = [];
+      while (i < lines.length) {
+        const line = lines[i];
+        if (!line.trim()) {
+          i++;
+          continue;
+        }
+        // Indented error line: "    foo_test.go:12: message" (4+ spaces)
+        const errMatch = line.match(/^\s{4,}(\S+\.go):(\d+):\s+(.+)$/);
+        if (errMatch) {
+          errorLines.push({ file: errMatch[1], lineNum: errMatch[2], msg: errMatch[3] });
+          i++;
+        } else {
+          break;
+        }
+      }
+
       failures.push({
-        file: "unknown",
-        testName: m[1],
-        error: "Unknown error",
-        stackTrace: [],
+        file: errorLines[0]?.file ?? "unknown",
+        testName,
+        error: errorLines[0]?.msg ?? "Unknown error",
+        stackTrace: errorLines.map((e) => `${e.file}:${e.lineNum}: ${e.msg}`),
       });
+      continue;
     }
+    i++;
   }
 
   return {

--- a/test/unit/test-runners/parser.test.ts
+++ b/test/unit/test-runners/parser.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import { parseTestOutput } from "../../../src/test-runners";
+
+describe("pytest output — structured error/stack extraction", () => {
+  test("extracts stackTrace file:line reference from verbose FAILURES block", () => {
+    const output = `
+================================= FAILURES =================================
+________________________________ test_subtract _____________________________
+
+    def test_subtract():
+>       assert subtract(5, 3) == 1
+E       AssertionError: assert 2 == 1
+E       assert 2 == 1
+
+tests/test_calculator.py:10: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_calculator.py::test_subtract - AssertionError: assert 2 == 1
+========================= 1 failed, 1 passed in 0.05s =========================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].file).toBe("tests/test_calculator.py");
+    expect(result.failures[0].testName).toBe("test_subtract");
+    expect(result.failures[0].error).toBe("AssertionError: assert 2 == 1");
+    expect(result.failures[0].stackTrace).toContain("tests/test_calculator.py:10");
+  });
+
+  test("extracts stackTrace for multiple pytest failures in a single verbose block", () => {
+    const output = `
+================================= FAILURES =================================
+_________________________________ test_a ___________________________________
+
+    def test_a():
+>       assert 1 == 2
+E       AssertionError: assert 1 == 2
+
+tests/test_foo.py:5: AssertionError
+
+_________________________________ test_b ___________________________________
+
+    def test_b():
+>       assert "hello" == "world"
+E       AssertionError: assert 'hello' == 'world'
+E         - world
+E         + hello
+
+tests/test_foo.py:9: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_a - AssertionError: assert 1 == 2
+FAILED tests/test_foo.py::test_b - AssertionError: assert 'hello' == 'world'
+========================= 2 failed in 0.03s ================================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0].stackTrace).toContain("tests/test_foo.py:5");
+    expect(result.failures[1].stackTrace).toContain("tests/test_foo.py:9");
+  });
+
+  test("extracts stackTrace for class-based test methods (dot notation in verbose header)", () => {
+    const output = `
+================================= FAILURES =================================
+___________________ TestCalculator.test_subtract ___________________________
+
+    def test_subtract(self):
+>       assert self.calc.subtract(5, 3) == 1
+E       AssertionError: assert 2 == 1
+
+tests/test_calculator.py:18: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_calculator.py::TestCalculator::test_subtract - AssertionError: assert 2 == 1
+========================= 1 failed in 0.05s =========================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].testName).toBe("TestCalculator > test_subtract");
+    expect(result.failures[0].stackTrace).toContain("tests/test_calculator.py:18");
+  });
+
+  test("preserves existing behavior when no verbose FAILURES block is present", () => {
+    const output = `
+FAILED tests/test_foo.py::test_bar - AssertionError: assert 1 == 2
+====== 1 failed, 3 passed in 0.42s ======
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].file).toBe("tests/test_foo.py");
+    expect(result.failures[0].testName).toBe("test_bar");
+    expect(result.failures[0].error).toBe("AssertionError: assert 1 == 2");
+  });
+});
+
+describe("go test output — structured error/file/stack extraction", () => {
+  test("extracts file and error message from indented lines after --- FAIL:", () => {
+    const output = `
+--- FAIL: TestAdd (0.00s)
+    calculator_test.go:12: Expected 4 but got 3
+ok  	example.com/calc	0.001s
+FAIL	example.com/calc	0.001s
+FAIL
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].testName).toBe("TestAdd");
+    expect(result.failures[0].file).toBe("calculator_test.go");
+    expect(result.failures[0].error).toBe("Expected 4 but got 3");
+    expect(result.failures[0].stackTrace).toContain("calculator_test.go:12: Expected 4 but got 3");
+  });
+
+  test("extracts multiple error lines per failure into stackTrace", () => {
+    const output = `
+--- FAIL: TestFoo (0.00s)
+    foo_test.go:20: first error
+    foo_test.go:21: second error
+--- FAIL: TestBar (0.00s)
+    bar_test.go:8: nil pointer dereference
+FAIL	example.com/pkg	0.002s
+FAIL
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0].testName).toBe("TestFoo");
+    expect(result.failures[0].error).toBe("first error");
+    expect(result.failures[0].stackTrace).toHaveLength(2);
+    expect(result.failures[0].stackTrace[0]).toBe("foo_test.go:20: first error");
+    expect(result.failures[0].stackTrace[1]).toBe("foo_test.go:21: second error");
+
+    expect(result.failures[1].testName).toBe("TestBar");
+    expect(result.failures[1].file).toBe("bar_test.go");
+    expect(result.failures[1].error).toBe("nil pointer dereference");
+  });
+
+  test("extracts subtest names and preserves existing test count behavior", () => {
+    const output = `
+--- FAIL: TestSuite/SubTest_one (0.00s)
+    suite_test.go:45: unexpected value
+ok  	example.com/pkg	0.000s
+FAIL	example.com/pkg	0.001s
+1 fail
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].testName).toBe("TestSuite/SubTest_one");
+    expect(result.failures[0].file).toBe("suite_test.go");
+    expect(result.failures[0].error).toBe("unexpected value");
+    expect(result.failed).toBe(1);
+  });
+
+  test("falls back to unknown/Unknown error when no indented error lines are present", () => {
+    const output = `
+--- FAIL: TestMissingDetail (0.00s)
+FAIL	example.com/pkg	0.001s
+FAIL
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].testName).toBe("TestMissingDetail");
+    expect(result.failures[0].file).toBe("unknown");
+    expect(result.failures[0].error).toBe("Unknown error");
+    expect(result.failures[0].stackTrace).toHaveLength(0);
+  });
+});

--- a/test/unit/test-runners/parser.test.ts
+++ b/test/unit/test-runners/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseTestOutput } from "../../../src/test-runners";
+import { parseTestOutput } from "@/test-runners";
 
 describe("pytest output — structured error/stack extraction", () => {
   test("extracts stackTrace file:line reference from verbose FAILURES block", () => {


### PR DESCRIPTION
## Summary

Implements the two structured-parsing TODOs from the codebase gap analysis (item #5).

**pytest** — `parsePytestVerboseStacks()` parses the verbose `FAILURES` block, extracting the bare `file.py:line` reference at the end of each per-test section and populating `TestFailure.stackTrace` (was always `[]`). Matching handles module-level functions, class-based methods (`TestClass.test_method` dot notation in verbose headers), and nested test names.

**go test** — Replaces the single-pass for-loop with an indexed while-loop that collects indented `    file.go:line: message` lines immediately following each `--- FAIL:` marker. Populates `TestFailure.file`, `.error`, and `.stackTrace` (were always `"unknown"`, `"Unknown error"`, and `[]`). Subtests (`TestSuite/SubTest_one`) are preserved verbatim as `testName`.

Both changes fall back gracefully to existing behavior when verbose output is absent.

## Test plan

- [ ] `test/unit/test-runners/parser.test.ts` (new, mirrors `src/test-runners/parser.ts`): 8 tests covering pytest verbose stackTrace, multi-failure blocks, class-based method matching, no-verbose-block regression guard, go test file/error/stack extraction, multi-line stackTrace, subtest names, and no-error-lines fallback
- [ ] Full suite: `bun run test` — 1095 tests across 110 files, all pass
- [ ] `bun run lint` — no file-size or alias violations