### PR TITLE
chore: resolve gap analysis items #11, #12, #13 and monorepo-awareness housekeeping

### DIFF
--- a/.claude/rules/monorepo-awareness.md
+++ b/.claude/rules/monorepo-awareness.md
@@ -177,16 +177,18 @@ Consolidate. Every new concept gets one resolver/registry and only one:
 
 If a new file needs to answer "X?", search for an existing resolver before writing `COMMON_X = [...]` constants. The second inline constant is a bug waiting to happen.
 
-## Current Known Violations (2026-04-18 audit)
+## Current Known Violations
 
-These are tracked and will be cleaned up incrementally. Do not add to this list.
+All violations from the 2026-04-18 audit have been resolved:
 
-| Site | Violation | Tracking |
-|:---|:---|:---|
-| `src/context/test-scanner.ts:121,148-150,189` | `COMMON_TEST_DIRS` + `.spec.ts` literals — ADR-009 | [#533](https://github.com/nathapp-io/nax/issues/533) |
-| `src/verification/smart-runner.ts:199,336-337` | Hardcoded `test/unit/` + `test/integration/` layout | [#534](https://github.com/nathapp-io/nax/issues/534) |
-| `src/context/builder.ts:265` | `workdir \|\| process.cwd()` fallback | [#535](https://github.com/nathapp-io/nax/issues/535) |
-| `src/prompts/sections/role-task.ts:24-28` | Language detection by `cmd.startsWith("bun test")` | [#536](https://github.com/nathapp-io/nax/issues/536) |
+| Site | Violation | Tracking | Status |
+|:---|:---|:---|:---|
+| `src/context/test-scanner.ts:121,148-150,189` | `COMMON_TEST_DIRS` + `.spec.ts` literals — ADR-009 | [#533](https://github.com/nathapp-io/nax/issues/533) | ✅ Resolved |
+| `src/verification/smart-runner.ts:199,336-337` | Hardcoded `test/unit/` + `test/integration/` layout | [#534](https://github.com/nathapp-io/nax/issues/534) | ✅ Resolved |
+| `src/context/builder.ts:265` | `workdir \|\| process.cwd()` fallback | [#535](https://github.com/nathapp-io/nax/issues/535) | ✅ Resolved |
+| `src/prompts/sections/role-task.ts:24-28` | Language detection by `cmd.startsWith("bun test")` | [#536](https://github.com/nathapp-io/nax/issues/536) | ✅ Resolved |
+
+Do not add new violations to this table — open a GitHub issue and reference it in the code instead.
 
 ## References
 

--- a/src/context/test-scanner.ts
+++ b/src/context/test-scanner.ts
@@ -11,6 +11,7 @@ import { Glob } from "bun";
 import { getLogger } from "../logger";
 import { estimateTokens } from "../optimizer/types";
 import { DEFAULT_SCAN_TEST_DIRS, DEFAULT_TS_DERIVE_SUFFIXES, extractTestDirs } from "../test-runners/conventions";
+import { errorMessage } from "../utils/errors";
 
 // ============================================================================
 // Types
@@ -310,7 +311,10 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
         });
       }
     } catch (err) {
-      getLogger().debug("test-scanner", "Failed to read file during glob scan", { path: fullPath, error: String(err) });
+      getLogger().debug("test-scanner", "Failed to read file during glob scan", {
+        path: fullPath,
+        error: errorMessage(err),
+      });
     }
   }
 

--- a/src/context/test-scanner.ts
+++ b/src/context/test-scanner.ts
@@ -309,7 +309,9 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
           describes,
         });
       }
-    } catch {}
+    } catch (err) {
+      getLogger().debug("test-scanner", "Failed to read file during glob scan", { path: fullPath, error: String(err) });
+    }
   }
 
   // Sort by path for stable output

--- a/src/execution/lifecycle/precheck-runner.ts
+++ b/src/execution/lifecycle/precheck-runner.ts
@@ -79,16 +79,16 @@ export async function runPrecheckValidation(ctx: PrecheckContext): Promise<void>
     ctx.statusWriter.setCurrentStory(null);
     await ctx.statusWriter.update(0, 0);
 
-    // Log detailed error message to console
-    console.error("");
-    console.error(chalk.red("❌ PRECHECK FAILED"));
-    console.error(chalk.red("─".repeat(60)));
+    // Write precheck failure details directly to stderr for immediate terminal visibility
+    process.stderr.write("\n");
+    process.stderr.write(`${chalk.red("❌ PRECHECK FAILED")}\n`);
+    process.stderr.write(`${chalk.red("─".repeat(60))}\n`);
     for (const blocker of precheckResult.output.blockers) {
-      console.error(chalk.red(`✗ ${blocker.name}: ${blocker.message}`));
+      process.stderr.write(`${chalk.red(`✗ ${blocker.name}: ${blocker.message}`)}\n`);
     }
-    console.error(chalk.red("─".repeat(60)));
-    console.error(chalk.yellow("\nRun 'nax precheck' for detailed information"));
-    console.error(chalk.dim("Use --skip-precheck to bypass (not recommended)\n"));
+    process.stderr.write(`${chalk.red("─".repeat(60))}\n`);
+    process.stderr.write(`${chalk.yellow("\nRun 'nax precheck' for detailed information")}\n`);
+    process.stderr.write(`${chalk.dim("Use --skip-precheck to bypass (not recommended)\n")}\n`);
 
     throw new Error(`Precheck failed: ${precheckResult.output.blockers.map((b) => b.name).join(", ")}`);
   }
@@ -101,11 +101,11 @@ export async function runPrecheckValidation(ctx: PrecheckContext): Promise<void>
     });
 
     if (ctx.headless && ctx.formatterMode !== "json") {
-      console.log(chalk.yellow("\n⚠️  Precheck warnings:"));
+      process.stdout.write(`${chalk.yellow("\n⚠️  Precheck warnings:")}\n`);
       for (const warning of precheckResult.output.warnings) {
-        console.log(chalk.yellow(`  ⚠ ${warning.name}: ${warning.message}`));
+        process.stdout.write(`${chalk.yellow(`  ⚠ ${warning.name}: ${warning.message}`)}\n`);
       }
-      console.log("");
+      process.stdout.write("\n");
     }
   } else {
     logger?.info("precheck", "All precheck validations passed");

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -72,7 +72,7 @@ export class Logger {
         mkdirSync(dir, { recursive: true });
       }
     } catch (error) {
-      console.error(`[logger] Failed to create log directory: ${error}`);
+      process.stderr.write(`[logger] Failed to create log directory: ${error}\n`);
     }
   }
 
@@ -166,7 +166,7 @@ export class Logger {
     const filePath = this.filePath;
     this.writeQueueTail = this.writeQueueTail.then(() =>
       appendFile(filePath, line).catch((error) => {
-        console.error(`[logger] Failed to write to log file: ${error}`);
+        process.stderr.write(`[logger] Failed to write to log file: ${error}\n`);
       }),
     );
   }

--- a/src/verification/crash-detector.ts
+++ b/src/verification/crash-detector.ts
@@ -3,9 +3,6 @@
  *
  * Detects Bun runtime crashes in test output so they can be classified as
  * RUNTIME_CRASH rather than TEST_FAILURE, preventing spurious tier escalation.
- *
- * STUB — implementation is intentionally absent. Tests are RED until
- * the real logic is written.
  */
 
 /**
@@ -28,7 +25,6 @@ export const CRASH_PATTERNS = [
  * @param output - Raw stdout/stderr from the test runner
  */
 export function detectRuntimeCrash(output: string | undefined | null): boolean {
-  // STUB: not implemented yet — always returns false
   if (!output) return false;
   return CRASH_PATTERNS.some((pattern) => output.includes(pattern));
 }

--- a/test/integration/plan/logger.test.ts
+++ b/test/integration/plan/logger.test.ts
@@ -378,9 +378,9 @@ describe("Logger", () => {
     const skipInCI = fullTest;
     skipInCI("handles file write errors gracefully", () => {
       // Create logger with invalid path
-      const originalError = console.error;
+      const originalWrite = process.stderr.write.bind(process.stderr);
       const errors: string[] = [];
-      console.error = (msg: string) => errors.push(msg);
+      process.stderr.write = ((msg: string) => { errors.push(msg); return true; }) as typeof process.stderr.write;
 
       const logger = initLogger({
         level: "info",
@@ -389,9 +389,9 @@ describe("Logger", () => {
 
       logger.info("test", "message");
 
-      console.error = originalError;
+      process.stderr.write = originalWrite;
 
-      // Should log error to console but not crash
+      // Should log error to stderr but not crash
       expect(errors.some((e) => e.includes("Failed to write to log file"))).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- **#11** – Replace `console.error` in `src/logger/logger.ts` (directory-init and file-write failure paths) and `console.error`/`console.log` in `src/execution/lifecycle/precheck-runner.ts` (PRECHECK FAILED display and headless warning output) with `process.stderr.write` / `process.stdout.write`. Intentional terminal-display `console.log` calls in `src/precheck/index.ts` are left as-is — tests capture them via mock and they are deliberate UI output.
- **#12** – Remove stale STUB/placeholder comments from `src/verification/crash-detector.ts`; the implementation has been complete since BUG-070 was resolved.
- **#13** – Replace silent empty `catch {}` in `src/context/test-scanner.ts:312` with a `getLogger().debug` call that logs the file path and error, giving visibility into file-read failures during glob scan.
- **Housekeeping** – Update Known-Violations table in `.claude/rules/monorepo-awareness.md` to mark issues #533–536 as resolved.

## Test plan

- [ ] `bun run test` — 1095 tests, 0 failures ✅
- [ ] `bun run lint` — all checks pass, baselines not increased ✅
- [ ] Logger error fallback paths use `process.stderr.write` (no loop — logger can't log its own init/write failures)
- [ ] Precheck FAILED display uses `process.stderr.write`; headless warnings use `process.stdout.write`
- [ ] `crash-detector.ts` no longer has misleading STUB comments
- [ ] `test-scanner.ts` empty catch now emits a debug log
- [ ] Known-Violations table accurately reflects current codebase state