### PR TITLE
fix(execution): surface implementer UNRESOLVED in full-suite rectification escalation

### DIFF
--- a/docs/architecture/story-orchestrator-flow.md
+++ b/docs/architecture/story-orchestrator-flow.md
@@ -265,6 +265,14 @@ over a safe default.
 - Exit reasons (`src/execution/story-orchestrator.ts:61`, `EXHAUSTED_EXIT_REASONS`):
   `max-attempts-total`, `max-attempts-per-strategy`, `no-strategy`, `agent-gave-up`,
   `validate-short-circuit`, `bail-when`.
+- **`agent-gave-up`** fires when a fix-op emits the `UNRESOLVED:` sentinel (the implementer
+  signalling a contradiction it cannot resolve — e.g. `full-suite-rectify` and
+  `autofix-implementer` both parse it). The sentinel's reason text is carried as
+  `unresolvedDetail` through `RectificationResult` → `StoryOrchestratorResult` →
+  `decideStageAction`, which surfaces it in the escalation reason
+  (`"Rectification exhausted: <detail>"`) so the next tier's `priorErrors` carries the
+  diagnosis. When a fix-op emits both `UNRESOLVED:` and a test-edit declaration, the
+  declaration wins (the test-writer handoff runs instead of giving up).
 - **Terminal lite-validate**: when a strategy exhausts its attempts, a final "lite"
   validate re-orders phases so `full-suite-gate` runs **last** (`orderGateLast()`, `:552`).
 

--- a/docs/findings/us-002-rectification-debug-2026-06-19.md
+++ b/docs/findings/us-002-rectification-debug-2026-06-19.md
@@ -231,6 +231,8 @@ The only unfixed item is the test itself: `test/oauth/admin-client.guard.route.s
 
 2. (Optional) Consider logging a structured "rectification narrative" when `gateRegressedDuringRect` fires — even with the current fixes, a future case where the cycle exits "resolved" via verifier-SSOT but the resume gate regresses would still get a generic escalation reason. Capturing "last round changed files X,Y via approach Z" would give the powerful-tier agent more context in that scenario.
 
+3. (Optional — code review MEDIUM) The **regression** rectification path (`run-regression.ts:422`) uses the *non-sink* variant of `makeFullSuiteRectifyStrategy`, whose `fixOp` is `implementerOp` (not `fullSuiteRectifyOp`) with a static `extractApplied`. `implementerOp` never parses `UNRESOLVED:`, so an agent giving up during *deferred-regression* rectification still drops the diagnosis. Out of scope for US-002 (the per-story full-suite findings cycle, sink variant), and arguably a pre-existing limitation rather than a regression — but the bug class is only half-fixed. Fixing it means switching the non-sink variant to `fullSuiteRectifyOp` (or teaching `implementerOp` to surface UNRESOLVED), which has its own blast radius and deserves its own change.
+
 ---
 
 ## 8. Files Changed (This Session)

--- a/docs/findings/us-002-rectification-debug-2026-06-19.md
+++ b/docs/findings/us-002-rectification-debug-2026-06-19.md
@@ -1,0 +1,249 @@
+# US-002 Rectification Debug Report — 2026-06-19
+
+**Run log:** `logs/2026-06-19T07-01-45.jsonl`  
+**Story:** US-002 (feature: b2b2b-oauth-protection)  
+**Outcome:** Escalated to powerful tier after 3 rectification rounds
+
+---
+
+## 1. What Happened (Timeline)
+
+```
+test-writer (288s)
+  → implementer (1010s) — committed guard, wired AppModule
+  → full-suite-gate FAILED (2 findings: AC5, AC6)
+  → rectification round 1 (1161s)
+      implementer: declared UNRESOLVED mid-session (line 1401 of audit log)
+      changed mind → tried Exception 4(b) instead
+      changed mind again → tried jest.setup.js seam stubs
+      validate: 3 findings (REGRESSED from 2)
+  → rectification round 2 (248KB log): partial progress
+  → rectification round 3 (124KB log):
+      seam stubs fixed AC5/AC6 (absolute URL rewrite in jest.setup.js)
+      cycle validate: scoped verifier PASSED 6 ACs
+      full-suite-gate: 1 finding (AppModule regression caused by seam stubs)
+      verifier-SSOT carve-out: gate finding EXCLUDED → exitReason = "resolved"
+  → post-rectification resume: gate re-ran → AppModule still failing
+  → nax: "Gate regressed during rectification after verifier passed — verifier verdict is stale"
+  → planResult.success = false, gateRegressedDuringRect = true
+  → failureCategory = "tests-failing"
+  → routeTddFailure("tests-failing", false, ctx)  [no failureDetail!]
+  → action: escalate to powerful tier
+```
+
+---
+
+## 2. Root Causes
+
+### Root Cause 1 — Bad AC5/AC6 tests (in koda project)
+
+`test/oauth/admin-client.guard.route.spec.ts` passes `loginUrl: '/login'` and `consentUrl: '/consent'` to `OAuthModule.registerAsync` directly. The library's `assertAuthorizeConfig` calls `new URL(value)` which throws for relative URLs. The existing project test `test/oauth-integration/oauth-integration.wiring.spec.ts:40-44` explicitly documents this library contract.
+
+**Fix needed:** In the koda project, update AC5/AC6 tests to use absolute URLs (e.g. `https://auth.example.com/login`). This is not a nax bug.
+
+### Root Cause 2 — `fullSuiteRectifyOp.parse()` silently dropped UNRESOLVED sentinel
+
+The implementer correctly identified the problem in round 1 and emitted:
+```
+UNRESOLVED: AC5 and AC6 in test/oauth/admin-client.guard.route.spec.ts pass
+loginUrl: '/login' and consentUrl: '/consent' to OAuthModule.registerAsync
+directly (bypassing AppModule). The library's assertAuthorizeConfig rejects
+relative URLs (new URL('/login') throws)...
+```
+
+But `fullSuiteRectifyOp.parse()` had no code to extract `UNRESOLVED:` — unlike `autofixImplementerOp` which does. So `agent-gave-up` never fired, the cycle ran 2 more useless rounds, and the implementer resorted to a seam stub workaround that introduced an AppModule regression.
+
+### Root Cause 3 — Escalation context carries no diagnosis
+
+The powerful-tier run's `priorErrors` received a generic `"TDD tests-failing"` reason — no information about WHY rectification failed. The escalation path taken was `routeTddFailure` at `post-run.ts:459`, which was never extended to carry diagnostic detail from the rectification cycle.
+
+---
+
+## 3. Changes Made
+
+### Change A — `src/operations/full-suite-rectify-op.ts` `parse()` ✅
+Added `UNRESOLVED:` extraction:
+```typescript
+const unresolvedMatch = output.match(/^UNRESOLVED:\s*(.+)$/m);
+return {
+  applied: true,
+  testEditDeclarations: declarations,
+  ...(unresolvedMatch ? { unresolvedReason: unresolvedMatch[1]?.trim() } : {}),
+};
+```
+Added `unresolvedReason?: string` to `FullSuiteRectifyOutput`.  
+**Tests:** AC-5 describe block in `test/unit/operations/full-suite-rectify-op.test.ts` (3 tests).
+
+### Change B — `src/operations/full-suite-rectify.ts` `extractApplied` ✅
+Only propagate `unresolved` (triggering `agent-gave-up` exit) when there are **no** `testEditDeclarations`. If the agent emits both UNRESOLVED and an Exception 4(b) `TEST_EDIT_REASON:` block (confused implementer), declarations take priority so `postValidate` can invoke the test-writer handoff instead of dead-ending.
+```typescript
+const hasDeclarations = output.testEditDeclarations.length > 0;
+return {
+  targetFiles: [],
+  summary: output.unresolvedReason ?? "Fixed failing tests",
+  ...(output.unresolvedReason && !hasDeclarations ? { unresolved: output.unresolvedReason } : {}),
+};
+```
+**Tests:** AC8 priority test in `test/unit/operations/full-suite-rectify.test.ts`.
+
+### Change C — `unresolvedDetail` threading ✅ (partial fix)
+- Added `unresolvedDetail?: string` to `RectificationResult` and `StoryOrchestratorResult` in `types.ts`
+- `rectification.ts`: spreads `cycleResult.unresolvedDetail` into the exhausted-exit return
+- `execution-plan.ts`: `...rectResult` spread already carries it through (no change needed)
+- `post-run.ts`: enriches escalation reason when on the `rectificationExhausted` path:
+  ```typescript
+  const exhaustedReason = planResult.unresolvedDetail
+    ? `Rectification exhausted: ${planResult.unresolvedDetail}`
+    : "Rectification exhausted with unfixed findings";
+  ```
+
+---
+
+## 4. Reconciling §4-vs-§5 — Which Escalation Path Fires?
+
+**This section previously claimed Change C does not cover this run. That claim describes
+the ORIGINAL broken behaviour, not the behaviour after the fixes are applied. The
+re-analysis below (2026-06-19, verified against current source) supersedes it.**
+
+Two distinct escalation paths exist in `decideStageAction` (`post-run.ts`):
+
+| Path | Trigger | Site | Carries detail? |
+|---|---|---|---|
+| `rectificationExhausted` | `planResult.rectificationExhausted && unfixedFindings.length > 0` (non-mechanical) | lines 355-379 | **Yes** — `"Rectification exhausted: ${unresolvedDetail}"` |
+| `routeTddFailure` | `isTdd && !planResult.success`, reached only if the block above didn't return | line 459 | **No** — generic category, no detail |
+
+**The key insight: the path taken depends on whether Change A fires.**
+
+- **ORIGINAL run (no UNRESOLVED parsing):** the cycle never bailed in round 1. It ran 3
+  rounds, the seam-stub workaround greened the verifier, the post-resume gate then
+  regressed → `gateRegressedDuringRect = true` → `routeTddFailure` (line 459) → generic
+  reason. This is the path the old §4 described.
+
+- **WITH Change A applied:** the implementer's round-1 `UNRESOLVED:` is now parsed →
+  `extractApplied` returns `{ unresolved }` (no test-edit declarations present, so Change B
+  does not suppress it) → cycle exits `agent-gave-up` in round 1 (`cycle.ts:274-301`),
+  carrying `finalFindings = [AC5, AC6]` and `unresolvedDetail`. `agent-gave-up` ∈
+  `EXHAUSTED_EXIT_REASONS`, so `rectification.ts:228` returns
+  `{ rectificationExhausted: true, unfixedFindings: [AC5,AC6], unresolvedDetail }`.
+
+  The rounds 2+3, the seam-stub workaround, and the AppModule regression **never happen**.
+  The resume block (`execution-plan.ts:111`) is skipped (`!rectificationExhausted` is
+  false), so `gateRegressedDuringRect` stays `false`. The run takes the
+  **`rectificationExhausted` path**, which DOES carry `unresolvedDetail`.
+
+**Verified call chain (current source):**
+```
+fullSuiteRectifyOp.parse (op:36)              → unresolvedReason = "AC5/AC6…"
+extractApplied (full-suite-rectify.ts:62-67)  → { unresolved } (hasDeclarations === false)
+cycle.ts:274-301                              → exitReason "agent-gave-up", unresolvedDetail set
+rectification.ts:228-234                      → { rectificationExhausted, unfixedFindings, unresolvedDetail }
+execution-plan.ts:360 (...rectResult)         → spread into StoryOrchestratorResult; success=false
+post-run.ts:355-377                           → escalate, reason "Rectification exhausted: AC5/AC6…"
+```
+Sink variant (where Change A lives) is the one wired for three-session TDD — confirmed at
+`build-plan-for-strategy.ts:174`. US-002 is three-session, so this is its path.
+
+### Genuine Remaining Gap (unchanged): the `gateRegressedDuringRect` path has no detail
+
+Change C only enriches the `rectificationExhausted` path. A FUTURE case where the agent does
+NOT emit UNRESOLVED, the cycle exits `"resolved"` via the verifier-SSOT carve-out, and the
+post-resume gate then regresses would still hit `routeTddFailure` (line 459) with a generic
+reason. This run no longer reaches that path (Change A reroutes it), but the path itself is
+still undiagnosed. Tracked as the optional item in §7.
+
+---
+
+## 5. Effectiveness of Changes — Confirmed by Independent Trace
+
+A follow-up agent traced the ACP session output contract and confirmed the full chain works:
+
+### What `parse()` actually receives
+
+`adapter.ts:602` calls `extractOutput(lastResponse)` where `lastResponse` is the final ACP turn's `AcpSessionResponse`. `extractOutput` joins **all `assistant` messages** from that response with `\n`. For a warm session, one `sendTurn()` is dispatched per round; the response contains the agent's complete output. The full 1511-line transcript IS passed to `parse()`.
+
+### Change A — Fires ✅
+
+The audit log shows UNRESOLVED in the text at **two** places:
+- Line 1401: `UNRESOLVED: AC5 and AC6 in test/oauth/admin-client.guard.route.spec.ts pass loginUrl: '/login'...`
+- Line 1512: `UNRESOLVED: AC5/AC6 in test/oauth/admin-client.guard.route.spec.ts fail at OAuthModule bootstrap...`
+
+The regex `/^UNRESOLVED:\s*(.+)$/m` matches line 1401 (first hit). `unresolvedReason` is populated. `agent-gave-up` would fire in round 1, skipping rounds 2+3 entirely.
+
+### Change B — Correct ✅
+
+The agent debated Exception 4(b) at lines 1407-1438 but ultimately did NOT emit `TEST_EDIT_REASON:`. So `output.testEditDeclarations.length === 0`, and `unresolved: output.unresolvedReason` IS set — the priority logic correctly doesn't interfere.
+
+### Change C — Full chain intact ✅
+
+`FixCycleResult` already declares `unresolvedDetail?: string` at `src/findings/cycle-types.ts:82`, and `cycle.ts:292,298` already sets it from `unresolvedFa.unresolved`. The full thread:
+
+```
+extractApplied returns { unresolved: "AC5/AC6..." }
+→ cycle.ts:292 sets cycleResult.unresolvedDetail
+→ rectification.ts:232 spreads it into RectificationResult
+→ execution-plan.ts:360 ...rectResult spreads it into StoryOrchestratorResult
+→ post-run.ts:374-376 builds escalation reason:
+    "Rectification exhausted: AC5/AC6 in test/oauth/... OAuthModule: config.loginUrl
+     must be an absolute URL (got '/login')..."
+→ priorErrors on PRD story → powerful-tier test-writer context bundle
+```
+
+### Summary
+
+| Change | Would fire in this run? | Effect |
+|---|---|---|
+| A — UNRESOLVED parsing | **Yes** | `agent-gave-up` after round 1; rounds 2+3 (and AppModule regression) never happen |
+| B — testEditDeclarations priority | Correct (no declarations present, so doesn't interfere) | Handles the confused-implementer case for future runs |
+| C — `unresolvedDetail` threading | **Yes** (once A fires) | Powerful-tier agent receives the AC5/AC6 relative URL diagnosis in priorErrors |
+
+---
+
+## 5b. Gap Found in Re-Analysis — Change C Had No Test Coverage (now closed)
+
+The re-analysis grepped `unresolvedDetail` across `test/` and found it only in
+`test/unit/findings/cycle.test.ts` (which proves the *cycle* sets it). Neither threading hop
+that constitutes Point 2's fix was covered:
+
+- `rectification.ts:232` — spreading `unresolvedDetail` into `RectificationResult`
+- `post-run.ts:374-376` — building `"Rectification exhausted: ${unresolvedDetail}"`
+
+The existing `post-run-inspection.test.ts` test only asserted the **fallback** reason
+(`"Rectification exhausted with unfixed findings"`), exercising the `else` branch. The
+enrichment branch — the entire reason Change C exists — could have regressed silently.
+
+**Closed:** added `"rectificationExhausted + unresolvedDetail → escalation reason carries the
+agent's diagnosis"` to `test/unit/execution/post-run-inspection.test.ts`. It sets
+`unresolvedDetail` on the plan result and asserts the escalation reason is
+`"Rectification exhausted: <detail>"`. The middle hop (the one-line conditional spread in
+`rectification.ts`) is left to inspection — both its producer (`cycle.test.ts`) and consumer
+(the new test) are now covered, and a dedicated `runRectification` harness test would add
+brittleness for marginal value.
+
+## 6. One Remaining Item — Root Cause 1 (koda project)
+
+The only unfixed item is the test itself: `test/oauth/admin-client.guard.route.spec.ts` must use absolute URLs for `loginUrl`/`consentUrl`. This is in the koda project, not nax.
+
+---
+
+## 7. Next Session TODO
+
+1. **Fix Root Cause 1** (koda project): update AC5/AC6 tests in `test/oauth/admin-client.guard.route.spec.ts` to use absolute URLs (e.g. `https://auth.example.com/login`).
+
+2. (Optional) Consider logging a structured "rectification narrative" when `gateRegressedDuringRect` fires — even with the current fixes, a future case where the cycle exits "resolved" via verifier-SSOT but the resume gate regresses would still get a generic escalation reason. Capturing "last round changed files X,Y via approach Z" would give the powerful-tier agent more context in that scenario.
+
+---
+
+## 8. Files Changed (This Session)
+
+| File | Change |
+|---|---|
+| `src/operations/full-suite-rectify-op.ts` | Added `unresolvedReason?` to output type; extract in `parse()` |
+| `src/operations/full-suite-rectify.ts` | `extractApplied`: priority logic for testEditDeclarations vs UNRESOLVED |
+| `src/execution/story-orchestrator/types.ts` | `unresolvedDetail?` on `RectificationResult` and `StoryOrchestratorResult` |
+| `src/execution/story-orchestrator/rectification.ts` | Spread `cycleResult.unresolvedDetail` into exhausted-exit return |
+| `src/execution/post-run.ts` | Enrich escalation reason with `unresolvedDetail` on the exhausted path |
+| `test/unit/operations/full-suite-rectify-op.test.ts` | AC-5 describe block (3 tests) |
+| `test/unit/operations/full-suite-rectify.test.ts` | AC8 + AC8 boundary + AC8 priority tests |
+| `test/unit/execution/post-run-inspection.test.ts` | **Re-analysis:** test for the `unresolvedDetail` → escalation-reason enrichment (Change C / Point 2) |
+
+Tests pass: operations 30, post-run-inspection 46, story-orchestrator + post-run suites 47. Typecheck clean.

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -368,9 +368,13 @@ export async function decideStageAction(
         storyId: ctx.story.id,
         findingsCount: planResult.unfixedFindings.length,
         findingSources,
+        ...(planResult.unresolvedDetail ? { unresolvedDetail: planResult.unresolvedDetail } : {}),
       });
       await cleanupSessionOnFailure(ctx);
-      return { action: "escalate", reason: "Rectification exhausted with unfixed findings" };
+      const exhaustedReason = planResult.unresolvedDetail
+        ? `Rectification exhausted: ${planResult.unresolvedDetail}`
+        : "Rectification exhausted with unfixed findings";
+      return { action: "escalate", reason: exhaustedReason };
     }
   }
 

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -226,7 +226,11 @@ export async function runRectification(
   }
 
   if (EXHAUSTED_EXIT_REASONS.has(cycleResult.exitReason) && cycleResult.finalFindings.length > 0) {
-    return { rectificationExhausted: true, unfixedFindings: cycleResult.finalFindings };
+    return {
+      rectificationExhausted: true,
+      unfixedFindings: cycleResult.finalFindings,
+      ...(cycleResult.unresolvedDetail ? { unresolvedDetail: cycleResult.unresolvedDetail } : {}),
+    };
   }
   if (cycleResult.exitReason === "validate-short-circuit") {
     // Empty findings — surface the lite-scope-backfill flag so resume can still run.

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -57,6 +57,9 @@ export interface StoryOrchestratorResult {
    * judgment (US-002 regression).
    */
   readonly missingRequiredReviewPhases?: readonly string[];
+  /** When rectification exited via agent-gave-up, the implementer's UNRESOLVED: reason text.
+   *  Surfaced into the escalation reason so the next tier's priorErrors carries the diagnosis. */
+  readonly unresolvedDetail?: string;
 }
 
 export type PhaseKind =
@@ -203,6 +206,8 @@ export interface RectificationResult {
   unfixedFindings?: readonly Finding[];
   /** Validate short-circuited with empty findings — resume must still run scope-backfill phases. */
   liteScopeIncomplete?: boolean;
+  /** Populated when exitReason is "agent-gave-up" — the implementer's UNRESOLVED: reason text. */
+  unresolvedDetail?: string;
 }
 
 export const STRICT_VERDICT_PHASE_NAMES = new Set<string>([

--- a/src/operations/full-suite-rectify-op.ts
+++ b/src/operations/full-suite-rectify-op.ts
@@ -14,6 +14,8 @@ export interface FullSuiteRectifyInput {
 export interface FullSuiteRectifyOutput {
   applied: true;
   testEditDeclarations: TestEditDeclaration[];
+  /** Populated when the agent emits UNRESOLVED: — triggers agent-gave-up exit in the findings cycle. */
+  unresolvedReason?: string;
 }
 
 export const fullSuiteRectifyOp: RunOperation<FullSuiteRectifyInput, FullSuiteRectifyOutput, AutofixConfig> = {
@@ -31,6 +33,11 @@ export const fullSuiteRectifyOp: RunOperation<FullSuiteRectifyInput, FullSuiteRe
   },
   parse(output, _input, _ctx) {
     const declarations = parseTestEditDeclarations(output);
-    return { applied: true, testEditDeclarations: declarations };
+    const unresolvedMatch = output.match(/^UNRESOLVED:\s*(.+)$/m);
+    return {
+      applied: true,
+      testEditDeclarations: declarations,
+      ...(unresolvedMatch ? { unresolvedReason: unresolvedMatch[1]?.trim() } : {}),
+    };
   },
 };

--- a/src/operations/full-suite-rectify.ts
+++ b/src/operations/full-suite-rectify.ts
@@ -55,7 +55,16 @@ export function makeFullSuiteRectifyStrategy(
             sink.testEdits.push(d);
           }
         }
-        return { targetFiles: [], summary: "Fixed failing tests" };
+        // Only propagate `unresolved` (triggering agent-gave-up exit) when there
+        // are no testEditDeclarations. If the agent emitted UNRESOLVED alongside an
+        // Exception 4(b) declaration, the declaration takes priority so postValidate
+        // can still invoke the test-writer handoff to fix the broken test.
+        const hasDeclarations = output.testEditDeclarations.length > 0;
+        return {
+          targetFiles: [],
+          summary: output.unresolvedReason ?? "Fixed failing tests",
+          ...(output.unresolvedReason && !hasDeclarations ? { unresolved: output.unresolvedReason } : {}),
+        };
       },
       maxAttempts: config.execution.rectification.maxAttemptsPerStrategy,
       coRun: "exclusive",

--- a/src/operations/full-suite-rectify.ts
+++ b/src/operations/full-suite-rectify.ts
@@ -60,10 +60,13 @@ export function makeFullSuiteRectifyStrategy(
         // Exception 4(b) declaration, the declaration takes priority so postValidate
         // can still invoke the test-writer handoff to fix the broken test.
         const hasDeclarations = output.testEditDeclarations.length > 0;
+        const unresolved = output.unresolvedReason && !hasDeclarations ? output.unresolvedReason : undefined;
         return {
           targetFiles: [],
-          summary: output.unresolvedReason ?? "Fixed failing tests",
-          ...(output.unresolvedReason && !hasDeclarations ? { unresolved: output.unresolvedReason } : {}),
+          // Mirror `unresolved`: when a declaration suppresses the give-up, the iteration
+          // is a handoff, not a give-up — don't label the summary with the UNRESOLVED text.
+          summary: unresolved ?? "Fixed failing tests",
+          ...(unresolved ? { unresolved } : {}),
         };
       },
       maxAttempts: config.execution.rectification.maxAttemptsPerStrategy,

--- a/test/e2e/exhaustion-edge.e2e.test.ts
+++ b/test/e2e/exhaustion-edge.e2e.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { runOrchestratorE2E } from "@test/helpers";
 import type { QualityCommandResult } from "@/quality/runner";
+import { runOrchestratorE2E } from "@test/helpers";
 
 const PASS_REVIEW = () => ({ output: JSON.stringify({ passed: true, findings: [] }) });
 const impl = () => ({ output: JSON.stringify({ filesChanged: ["src/a.ts"] }) });
 
 const ALWAYS_FAIL_TC: QualityCommandResult = {
-  commandName: "typecheck", command: "tc", success: false, exitCode: 1,
-  output: "TS2304: Cannot find name 'x'", durationMs: 1, timedOut: false,
+  commandName: "typecheck",
+  command: "tc",
+  success: false,
+  exitCode: 1,
+  output: "TS2304: Cannot find name 'x'",
+  durationMs: 1,
+  timedOut: false,
 };
 
 const PASSING_VERDICT = JSON.stringify({
@@ -46,8 +51,13 @@ describe("E2E: exhaustion + edge", () => {
     const verifier = () => ({ output: PASSING_VERDICT });
     const { result, phaseLog } = await runOrchestratorE2E({
       strategy: "three-session-tdd",
-      agent: { "test-writer": tw, implementer: impl, verifier,
-        "reviewer-semantic": PASS_REVIEW, "reviewer-adversarial": PASS_REVIEW },
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
     });
     // greenfield-gate must appear in the log (it always runs in three-session-tdd)
     expect(phaseLog).toContain("greenfield-gate");
@@ -78,15 +88,36 @@ describe("E2E: exhaustion + edge", () => {
 
     const { result, phaseLog } = await runOrchestratorE2E({
       strategy: "three-session-tdd",
-      agent: { "test-writer": tw, implementer: impl, verifier,
-        "reviewer-semantic": PASS_REVIEW, "reviewer-adversarial": PASS_REVIEW },
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
       gates: {
-        typecheck: () => tcCall++ === 0
-          ? { commandName: "typecheck", command: "tc", success: false, exitCode: 1, output: "TS2304", durationMs: 1, timedOut: false }
-          : { commandName: "typecheck", command: "tc", success: true, exitCode: 0, output: "", durationMs: 1, timedOut: false },
-        fullSuite: () => fsCall++ === 0
-          ? { passed: true, failed: 0 }
-          : { passed: false, failed: 1, output: "new failure" },
+        typecheck: () =>
+          tcCall++ === 0
+            ? {
+                commandName: "typecheck",
+                command: "tc",
+                success: false,
+                exitCode: 1,
+                output: "TS2304",
+                durationMs: 1,
+                timedOut: false,
+              }
+            : {
+                commandName: "typecheck",
+                command: "tc",
+                success: true,
+                exitCode: 0,
+                output: "",
+                durationMs: 1,
+                timedOut: false,
+              },
+        fullSuite: () =>
+          fsCall++ === 0 ? { passed: true, failed: 0 } : { passed: false, failed: 1, output: "new failure" },
       },
     });
 
@@ -99,5 +130,55 @@ describe("E2E: exhaustion + edge", () => {
     // full-suite-gate appears 3 times: once in the main loop (passes), twice in
     // revalidation attempts (both fail because fsCall >= 1 always returns failed).
     expect(phaseLog.filter((p) => p === "full-suite-gate").length).toBe(3);
+  });
+
+  test("implementer UNRESOLVED on full-suite-rectify → agent-gave-up exhaustion carries unresolvedDetail (US-002)", async () => {
+    // The full-suite gate fails with a test-runner finding → full-suite-rectify is the
+    // sole matching strategy. On the rectification turn the implementer emits an
+    // `UNRESOLVED:` sentinel (the AC5/AC6 relative-URL contradiction). fullSuiteRectifyOp
+    // parses it → extractApplied returns { unresolved } (no test-edit declarations, so the
+    // declaration-priority guard does not suppress it) → the cycle exits "agent-gave-up"
+    // in round 1, threading unresolvedDetail through to StoryOrchestratorResult.
+    //
+    // This exercises the REAL producer→result chain (parse → extractApplied → cycle →
+    // rectification spread → execution-plan), complementing the post-run unit test which
+    // covers result→escalation-reason. Without the fix the sentinel was dropped, the cycle
+    // ran extra rounds, and the diagnosis never surfaced.
+    const UNRESOLVED_REASON =
+      "AC5/AC6 pass relative loginUrl '/login' to OAuthModule.registerAsync; the library rejects relative URLs (new URL('/login') throws)";
+    const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+    const verifier = () => ({ output: PASSING_VERDICT });
+    // Per-role attempt counter: attempt 0 = main implementer phase (normal output);
+    // attempt 1+ = full-suite-rectify fix-op turns (emit the UNRESOLVED sentinel).
+    const implementer = (attempt: number) =>
+      attempt === 0
+        ? { output: JSON.stringify({ filesChanged: ["src/a.ts"] }) }
+        : { output: `Tried to fix the failing tests but cannot.\nUNRESOLVED: ${UNRESOLVED_REASON}` };
+
+    const { result } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      agent: {
+        "test-writer": tw,
+        implementer,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+      gates: {
+        fullSuite: () => ({
+          passed: false,
+          failed: 1,
+          output: "AC5/AC6 relative URL failure",
+          // Structured failure → source:"test-runner", category:"failed-test" finding,
+          // which is what full-suite-rectify.appliesTo matches.
+          failures: [{ testName: "AC5 redirects to login", file: "test/oauth/admin.spec.ts", error: "Invalid URL" }],
+        }),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.rectificationExhausted).toBe(true);
+    // The implementer's diagnosis is threaded through verbatim so the escalated tier knows why.
+    expect(result.unresolvedDetail).toBe(UNRESOLVED_REASON);
   });
 });

--- a/test/helpers/e2e/orchestrator-harness.ts
+++ b/test/helpers/e2e/orchestrator-harness.ts
@@ -1,3 +1,5 @@
+import type { NaxConfig } from "@/config";
+import type { TestStrategy } from "@/config/schema-types";
 /**
  * E2E-only: drives the REAL Story Orchestrator end-to-end with scripted agents +
  * attempt-aware gate _deps. Records an ordered phase log by wrapping the single
@@ -7,21 +9,19 @@
  * The runtime is closed in finally to prevent idle-watchdog timer leaks.
  */
 import { _storyOrchestratorDeps, buildPlanForStrategy } from "@/execution";
-import { _lintCheckDeps, _typecheckCheckDeps, _fullSuiteGateDeps } from "@/operations";
-import type { NaxConfig } from "@/config";
-import type { TestStrategy } from "@/config/schema-types";
+import { _fullSuiteGateDeps, _lintCheckDeps, _typecheckCheckDeps } from "@/operations";
 import type { UserStory } from "@/prd/types";
 import type { QualityCommandResult } from "@/quality/runner";
 import {
+  cleanupTempDir,
   makeMockCallContext,
   makeMockPlanInputs,
   makeNaxConfig,
   makeRuntimeWithFakeAgent,
   makeStory,
   makeTempDir,
-  cleanupTempDir,
 } from "../index";
-import { makeScriptedAgent, type ScriptedAgentSpec } from "./scripted-agent";
+import { type ScriptedAgentSpec, makeScriptedAgent } from "./scripted-agent";
 
 type GateFn<T> = (attempt: number) => T;
 
@@ -38,7 +38,19 @@ const PASS_QC = (name: string): QualityCommandResult => ({
 export interface E2EGates {
   lint?: GateFn<QualityCommandResult>;
   typecheck?: GateFn<QualityCommandResult>;
-  fullSuite?: GateFn<{ passed: boolean; failed: number; output?: string }>;
+  /**
+   * `failures` is optional. When omitted, `parsedSummary.failures` is left undefined
+   * (preserving the legacy behavior where a `failed > 0` gate crashes the gate parse and
+   * is swallowed as `validator-error`). Provide structured failures to drive the gate's
+   * real finding path (`source: "test-runner"`, `category: "failed-test"`) — e.g. to
+   * exercise the full-suite-rectify strategy.
+   */
+  fullSuite?: GateFn<{
+    passed: boolean;
+    failed: number;
+    output?: string;
+    failures?: Array<{ testName: string; file?: string; error: string }>;
+  }>;
 }
 
 export interface E2EOptions {
@@ -55,6 +67,7 @@ export interface E2EResult {
     phaseOutputs: Record<string, unknown>;
     rectificationExhausted?: boolean;
     gateRegressedDuringRect?: boolean;
+    unresolvedDetail?: string;
   };
   phaseLog: string[];
   strategiesFired: string[];
@@ -128,17 +141,19 @@ export async function runOrchestratorE2E(opts: E2EOptions): Promise<E2EResult> {
     } else if (opName) {
       strategiesFired.push(opName);
     }
-    return origCallOp(ctx as Parameters<typeof origCallOp>[0], op as Parameters<typeof origCallOp>[1], input as Parameters<typeof origCallOp>[2]);
+    return origCallOp(
+      ctx as Parameters<typeof origCallOp>[0],
+      op as Parameters<typeof origCallOp>[1],
+      input as Parameters<typeof origCallOp>[2],
+    );
   };
 
   const lintAttempts = { n: 0 };
   const tcAttempts = { n: 0 };
   const fsAttempts = { n: 0 };
 
-  _lintCheckDeps.runQualityCommand = async () =>
-    opts.gates?.lint?.(lintAttempts.n++) ?? PASS_QC("lint");
-  _typecheckCheckDeps.runQualityCommand = async () =>
-    opts.gates?.typecheck?.(tcAttempts.n++) ?? PASS_QC("typecheck");
+  _lintCheckDeps.runQualityCommand = async () => opts.gates?.lint?.(lintAttempts.n++) ?? PASS_QC("lint");
+  _typecheckCheckDeps.runQualityCommand = async () => opts.gates?.typecheck?.(tcAttempts.n++) ?? PASS_QC("typecheck");
   _fullSuiteGateDeps.runTests = async (_input, _gateCtx) => {
     const g = opts.gates?.fullSuite?.(fsAttempts.n++) ?? { passed: true, failed: 0 };
     return {
@@ -146,8 +161,16 @@ export async function runOrchestratorE2E(opts: E2EOptions): Promise<E2EResult> {
       failed: g.failed,
       output: g.output ?? "",
       // TestSummary has a complex shape; cast via unknown to avoid importing its full type.
+      // `failures` is only set when the caller supplies it — otherwise it stays undefined
+      // to preserve the legacy gate-parse-crash → validator-error behavior some tests rely on.
       // biome-ignore lint/suspicious/noExplicitAny: minimal test summary for gate mock
-      parsedSummary: { passed: g.passed ? 1 : 0, failed: g.failed, skipped: 0 } as any,
+      parsedSummary: {
+        passed: g.passed ? 1 : 0,
+        failed: g.failed,
+        skipped: 0,
+        ...(g.failures ? { failures: g.failures } : {}),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal test summary for gate mock
+      } as any,
       timedOut: false,
     };
   };

--- a/test/unit/execution/post-run-inspection.test.ts
+++ b/test/unit/execution/post-run-inspection.test.ts
@@ -5,13 +5,13 @@
  * decideStageAction from src/execution/post-run.ts.
  */
 
-import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
-  deriveTddFailureCategory,
-  extractPauseReason,
+  _postRunDeps,
   applyPostRunInspection,
   decideStageAction,
-  _postRunDeps,
+  deriveTddFailureCategory,
+  extractPauseReason,
 } from "../../../src/execution/post-run";
 import type { InspectionOptions } from "../../../src/execution/post-run";
 import { EXHAUSTED_EXIT_REASONS } from "../../../src/execution/story-orchestrator";
@@ -164,12 +164,10 @@ describe("deriveTddFailureCategory", () => {
   });
 
   test("a session failure outranks a missing review", () => {
-    const result = deriveTddFailureCategory(
-      { [implementerOp.name]: { success: false } },
-      undefined,
-      false,
-      ["semantic-review", "adversarial-review"],
-    );
+    const result = deriveTddFailureCategory({ [implementerOp.name]: { success: false } }, undefined, false, [
+      "semantic-review",
+      "adversarial-review",
+    ]);
     expect(result).toBe("session-failure");
   });
 
@@ -193,10 +191,7 @@ describe("deriveTddFailureCategory", () => {
       const unfixedFindings: Finding[] = [
         { source: "test-runner", severity: "error", category: "test-failure", message: "failing" },
       ];
-      const result = deriveTddFailureCategory(
-        { rectification: { exitReason, success: false } },
-        unfixedFindings,
-      );
+      const result = deriveTddFailureCategory({ rectification: { exitReason, success: false } }, unfixedFindings);
       expect(result).toBe("full-suite-gate-exhausted");
     }
   });
@@ -312,7 +307,12 @@ function makeInspectionOpts(overrides: Partial<InspectionOptions> = {}): Inspect
 
 const LINT_FINDING: Finding = { source: "lint", severity: "error", message: "unused var", category: "lint" };
 const TYPECHECK_FINDING: Finding = { source: "typecheck", severity: "error", message: "type error", category: "type" };
-const TEST_RUNNER_FINDING: Finding = { source: "test-runner", severity: "error", message: "test failed", category: "test" };
+const TEST_RUNNER_FINDING: Finding = {
+  source: "test-runner",
+  severity: "error",
+  message: "test failed",
+  category: "test",
+};
 const SEMANTIC_REVIEW_FINDING: Finding = {
   source: "semantic-review",
   severity: "error",
@@ -442,6 +442,30 @@ describe("AC8: mechanicalFailedOnly — non-mechanical source present → escala
       throw new Error(`Expected escalate action, got ${result.action}`);
     }
     expect(result.reason).toBe("Rectification exhausted with unfixed findings");
+  });
+
+  test("rectificationExhausted + unresolvedDetail → escalation reason carries the agent's diagnosis", async () => {
+    // Point 2 (US-002): when the implementer signals UNRESOLVED, the cycle exits
+    // agent-gave-up and threads unresolvedDetail through to the escalation reason so
+    // the powerful-tier agent's priorErrors explains WHY rectification gave up — not a
+    // generic "exhausted" line. Guards post-run.ts:374-376 against regression.
+    const ctx = makeTestContext();
+    const detail =
+      "AC5/AC6 pass relative loginUrl '/login' to OAuthModule.registerAsync; assertAuthorizeConfig rejects relative URLs (new URL('/login') throws)";
+    const planResult = makePlanResult({
+      success: false,
+      rectificationExhausted: true,
+      unfixedFindings: [TEST_RUNNER_FINDING],
+      unresolvedDetail: detail,
+    });
+    const opts = makeInspectionOpts();
+    const inspection = await applyPostRunInspection(ctx, planResult, opts);
+    const result = await decideStageAction(ctx, planResult, inspection, opts);
+
+    if (result.action !== "escalate") {
+      throw new Error(`Expected escalate action, got ${result.action}`);
+    }
+    expect(result.reason).toBe(`Rectification exhausted: ${detail}`);
   });
 
   test("rectificationExhausted + semantic-review finding in TDD mode bypasses pause routing", async () => {

--- a/test/unit/operations/full-suite-rectify-op.test.ts
+++ b/test/unit/operations/full-suite-rectify-op.test.ts
@@ -79,3 +79,33 @@ describe("fullSuiteRectifyOp.parse (AC-4)", () => {
     expect(result.testEditDeclarations).toEqual([]);
   });
 });
+
+describe("fullSuiteRectifyOp.parse — UNRESOLVED sentinel (AC-5)", () => {
+  const input = { story, findings: [finding] };
+
+  test("UNRESOLVED: line sets unresolvedReason", () => {
+    const output =
+      "Tried several approaches.\n\nUNRESOLVED: The test passes relative URLs that the library rejects — cannot satisfy without modifying the test.";
+    const result = fullSuiteRectifyOp.parse(output, input, ctx);
+    expect(result.unresolvedReason).toBe(
+      "The test passes relative URLs that the library rejects — cannot satisfy without modifying the test.",
+    );
+  });
+
+  test("output without UNRESOLVED: leaves unresolvedReason undefined", () => {
+    const result = fullSuiteRectifyOp.parse("Fixed everything.", input, ctx);
+    expect(result.unresolvedReason).toBeUndefined();
+  });
+
+  test("UNRESOLVED: coexists with test-edit declarations", () => {
+    const output = `TEST_EDIT_REASON: lint_only
+FILE: test/unit/foo.test.ts
+FINDING: no-unused-vars
+CHANGE: const x = 1; → // removed
+
+UNRESOLVED: AC6 cannot be satisfied without changing the assertion.`;
+    const result = fullSuiteRectifyOp.parse(output, input, ctx);
+    expect(result.testEditDeclarations).toHaveLength(1);
+    expect(result.unresolvedReason).toBe("AC6 cannot be satisfied without changing the assertion.");
+  });
+});

--- a/test/unit/operations/full-suite-rectify.test.ts
+++ b/test/unit/operations/full-suite-rectify.test.ts
@@ -220,5 +220,7 @@ describe("makeFullSuiteRectifyStrategy — with DeclarationSink", () => {
     expect(sink.testEdits).toHaveLength(1);
     // unresolved is suppressed — agent-gave-up must NOT fire when a handoff can still run
     expect(result.unresolved).toBeUndefined();
+    // summary must not echo the UNRESOLVED text either: this iteration is a handoff, not a give-up
+    expect(result.summary).toBe("Fixed failing tests");
   });
 });

--- a/test/unit/operations/full-suite-rectify.test.ts
+++ b/test/unit/operations/full-suite-rectify.test.ts
@@ -177,4 +177,48 @@ describe("makeFullSuiteRectifyStrategy — with DeclarationSink", () => {
     expect(sink.testEdits).toHaveLength(0);
     expect(sink.mockHandoffs).toHaveLength(0);
   });
+
+  test("AC8: extractApplied forwards unresolvedReason as unresolved when no testEditDeclarations", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink);
+    const output: FullSuiteRectifyOutput = {
+      applied: true,
+      testEditDeclarations: [],
+      unresolvedReason: "Test uses relative URLs that the library rejects",
+    };
+    const input: FullSuiteRectifyInput = { story: makeTestStory(), findings: [] };
+    const result = strategy.extractApplied!(output, input);
+    expect(result.unresolved).toBe("Test uses relative URLs that the library rejects");
+    expect(result.summary).toBe("Test uses relative URLs that the library rejects");
+  });
+
+  test("AC8 boundary: extractApplied without unresolvedReason leaves unresolved undefined", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink);
+    const output: FullSuiteRectifyOutput = { applied: true, testEditDeclarations: [] };
+    const input: FullSuiteRectifyInput = { story: makeTestStory(), findings: [] };
+    const result = strategy.extractApplied!(output, input);
+    expect(result.unresolved).toBeUndefined();
+    expect(result.summary).toBe("Fixed failing tests");
+  });
+
+  test("AC8 priority: UNRESOLVED + testEditDeclarations → testEditDeclarations win, unresolved suppressed", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink);
+    const decl: TestEditDeclaration = {
+      reason: "required_infrastructure_missing",
+      file: "test/oauth/admin-client.guard.route.spec.ts",
+    };
+    const output: FullSuiteRectifyOutput = {
+      applied: true,
+      testEditDeclarations: [decl],
+      unresolvedReason: "Test uses relative URLs",
+    };
+    const input: FullSuiteRectifyInput = { story: makeTestStory(), findings: [] };
+    const result = strategy.extractApplied!(output, input);
+    // Declaration flows through to sink so test-writer handoff can fire via postValidate
+    expect(sink.testEdits).toHaveLength(1);
+    // unresolved is suppressed — agent-gave-up must NOT fire when a handoff can still run
+    expect(result.unresolved).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a US-002 rectification failure where `fullSuiteRectifyOp` silently dropped the implementer's `UNRESOLVED:` sentinel. Because the sentinel was never parsed, the findings cycle never exited `agent-gave-up` — it ran extra rectification rounds (eventually a seam-stub workaround that regressed the gate) and the escalated tier received a generic `tests-failing` reason with **no diagnosis**.

Now the sentinel is parsed, the cycle exits in round 1, and the implementer's diagnosis is threaded all the way to the escalation reason so the next tier's `priorErrors` explains *why* rectification gave up.

## Changes

- **`full-suite-rectify-op.ts`** — parse `UNRESOLVED:` into `unresolvedReason` (consistent with the existing `autofix-implementer` op).
- **`full-suite-rectify.ts`** — propagate `unresolved` only when there are **no** `testEditDeclarations`; when both are present the declaration wins (the test-writer handoff runs instead of giving up). The iteration `summary` mirrors this so a handoff isn't mislabelled with the UNRESOLVED text.
- **`story-orchestrator/{types,rectification}.ts`** — thread `unresolvedDetail` from the cycle result → `RectificationResult` → `StoryOrchestratorResult`.
- **`post-run.ts`** — enrich the escalation reason with `unresolvedDetail` on the `rectificationExhausted` path: `"Rectification exhausted: <detail>"`.

## Verified chain

```
fullSuiteRectifyOp.parse → unresolvedReason
extractApplied → { unresolved }  (no test-edit decls)
cycle.ts → exitReason "agent-gave-up", unresolvedDetail set  (agent-gave-up ∈ EXHAUSTED_EXIT_REASONS)
rectification.ts → { rectificationExhausted, unfixedFindings, unresolvedDetail }
execution-plan.ts (...rectResult) → StoryOrchestratorResult; success=false
post-run.ts → escalate, reason "Rectification exhausted: <detail>"
```

## Tests

- Unit: UNRESOLVED parsing (3), declaration-priority trio incl. summary assertion, and the escalation-reason enrichment branch (previously untested — the whole point of the threading).
- **e2e** (`exhaustion-edge.e2e`): drives the **real orchestrator** end-to-end — implementer emits `UNRESOLVED:` on the rectify turn, asserts `rectificationExhausted` + `unresolvedDetail` carries the diagnosis. Harness gains an optional `failures` field on the gate mock (omitted = legacy crash→`validator-error`, preserving existing tests).
- Full e2e suite (12) + affected unit suites (76) green; typecheck + lint clean.

## Review notes

Code-reviewed (APPROVE, no CRITICAL/HIGH). One documented scope limitation: the **deferred-regression** rectification path (`run-regression.ts`) uses the non-sink variant (`implementerOp`), which doesn't parse UNRESOLVED — tracked in the findings report, out of scope for US-002.

## Not included

Root Cause 1 lives in the **koda** project, not nax: `test/oauth/admin-client.guard.route.spec.ts` passes relative URLs (`/login`) to `OAuthModule.registerAsync`, which the library rejects. That bad test is the original trigger and needs fixing separately.

See `docs/findings/us-002-rectification-debug-2026-06-19.md` for the full investigation.