### PR TITLE
test(execution): close StoryOrchestrator e2e coverage gaps

### DIFF
--- a/test/e2e/agent-fix.e2e.test.ts
+++ b/test/e2e/agent-fix.e2e.test.ts
@@ -74,6 +74,59 @@ describe("E2E: agent-fix", () => {
     ]);
   });
 
+  test("three-session: typecheck fail -> autofix-implementer re-runs full-suite-gate, NOT verifier", async () => {
+    // Strategy parity for autofix-implementer. In three-session the full-suite-gate IS
+    // present, so the revalidation set [lint, typecheck, full-suite-gate, semantic, adversarial]
+    // re-runs it (it was absent in the test-after variant above). The verifier is the
+    // TDD-isolation judge — a once-per-story phase NOT in the revalidation set — so it
+    // must run exactly once despite the source-code fix.
+    const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+    const verifier = () => ({ output: PASSING_VERDICT });
+    let tcCall = 0;
+    const { result, phaseLog, strategiesFired } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+      gates: {
+        typecheck: () => (tcCall++ === 0 ? FAIL_TC : PASS_TC),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(strategiesFired).toContain("autofix-implementer");
+    // full-suite-gate re-run by revalidation (present in three-session): runs twice.
+    expect(phaseLog.filter((p) => p === "full-suite-gate").length).toBe(2);
+    expect(phaseLog.filter((p) => p === "typecheck-check").length).toBe(2);
+    expect(phaseLog.filter((p) => p === "lint-check").length).toBe(2);
+    // SOUNDNESS: verifier NOT re-run by autofix-implementer (excluded from its set).
+    expect(phaseLog.filter((p) => p === "verifier").length).toBe(1);
+    expect(phaseLog.filter((p) => p === "semantic-review").length).toBe(1);
+    expect(phaseLog.filter((p) => p === "adversarial-review").length).toBe(1);
+
+    // Main loop short-circuits at typecheck-check (pos 8) → autofix-implementer →
+    // revalidation in canonical order: full-suite-gate(4), lint(7), typecheck(8),
+    // semantic(9), adversarial(10).
+    expect(phaseLog).toEqual([
+      "test-writer",
+      "greenfield-gate",
+      "implementer",
+      "full-suite-gate",
+      "verifier",
+      "lint-check",
+      "typecheck-check",
+      "full-suite-gate",
+      "lint-check",
+      "typecheck-check",
+      "semantic-review",
+      "adversarial-review",
+    ]);
+  });
+
   test("adversarial(test-gap) -> autofix-test-writer -> revalidation set", async () => {
     const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
     const verifier = () => ({ output: PASSING_VERDICT });

--- a/test/e2e/exhaustion-edge.e2e.test.ts
+++ b/test/e2e/exhaustion-edge.e2e.test.ts
@@ -43,6 +43,103 @@ describe("E2E: exhaustion + edge", () => {
     expect(result.rectificationExhausted).toBe(true);
   });
 
+  test("greenfield-gate pauses with greenfield-no-tests when no tests exist (seed disabled)", async () => {
+    // With the placeholder seed disabled, the scripted test-writer does not write real
+    // files, so greenfield-gate finds no pre-existing tests and short-circuits the run
+    // with pauseReason "greenfield-no-tests" (BUG-010). The implementer never runs.
+    const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+    const verifier = () => ({ output: PASSING_VERDICT });
+    const { result, phaseLog } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      seedPlaceholderTest: false,
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    const gateOut = result.phaseOutputs["greenfield-gate"] as { pauseReason?: string } | undefined;
+    expect(gateOut?.pauseReason).toBe("greenfield-no-tests");
+    // Short-circuit at the gate: implementer (canonical pos 3) never runs.
+    expect(phaseLog).not.toContain("implementer");
+  });
+
+  test("no-strategy: a finding no loaded strategy matches exhausts with zero fix attempts", async () => {
+    // With autofix disabled, the only loaded strategies are mechanical-lintfix (lintFix
+    // present) and full-suite-rectify (verify-scoped present): one claims lint findings,
+    // the other claims test-runner findings. A blocking adversarial finding (source
+    // "adversarial") matches NEITHER, so the cycle exits "no-strategy" at iteration 0 —
+    // rectification is exhausted and no fix op is ever dispatched. (Adversarial findings
+    // survive substantiation without an AC index, unlike semantic findings — so this is
+    // the clean way to land a surviving-but-unmatched finding.)
+    const failingAdversarial = () => ({
+      output: JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "warning",
+            category: "test-gap",
+            file: "test/a.test.ts",
+            line: 1,
+            issue: "missing edge-case coverage",
+            suggestion: "add the missing test",
+            verifiedBy: { file: "test/a.test.ts", observed: "expect(fn(null))" },
+          },
+        ],
+      }),
+    });
+    const { result, strategiesFired } = await runOrchestratorE2E({
+      strategy: "test-after",
+      // autofix off → no autofix-* strategies; blockingThreshold "warning" → the finding blocks.
+      config: {
+        quality: { autofix: { enabled: false } },
+        review: { blockingThreshold: "warning" },
+      } as unknown as Parameters<typeof runOrchestratorE2E>[0]["config"],
+      agent: { implementer: impl, "reviewer-semantic": PASS_REVIEW, "reviewer-adversarial": failingAdversarial },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.rectificationExhausted).toBe(true);
+    // No fix op was dispatched — no loaded strategy matched the adversarial finding.
+    expect(strategiesFired).toEqual([]);
+  });
+
+  test("bail-when: increasing typecheck failures abort before maxAttempts", async () => {
+    // typecheck regresses (1 error → 2 errors) after the autofix-implementer fix. With
+    // abortOnIncreasingFailures enabled and consecutiveIncreasesToBail=1, the cycle bails
+    // on the first increase rather than burning all maxAttempts. Exhausted=true, but the
+    // typecheck phase ran fewer times than the always-fail exhaustion case (3 attempts).
+    let tcCall = 0;
+    const tc = () => {
+      const n = tcCall++;
+      return {
+        commandName: "typecheck",
+        command: "tc",
+        success: false,
+        exitCode: 1,
+        // attempt 0: one error; attempt 1+: two errors (increasing finding count).
+        output: n === 0 ? "TS2304: Cannot find name 'a'" : "TS2304: name 'a'\nTS2305: name 'b'",
+        durationMs: 1,
+        timedOut: false,
+      };
+    };
+    const { result, phaseLog } = await runOrchestratorE2E({
+      strategy: "test-after",
+      rectification: { maxAttempts: 5, abortOnIncreasingFailures: true, consecutiveIncreasesToBail: 1 },
+      agent: { implementer: impl, "reviewer-semantic": PASS_REVIEW, "reviewer-adversarial": PASS_REVIEW },
+      gates: { typecheck: tc },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.rectificationExhausted).toBe(true);
+    // Bailed early: typecheck ran far fewer than maxAttempts (5) times.
+    expect(phaseLog.filter((p) => p === "typecheck-check").length).toBeLessThan(5);
+  });
+
   test("greenfield-gate runs and does not prevent three-session completion", async () => {
     // The harness seeds a placeholder test file (test/placeholder.test.ts) so
     // greenfield-gate detects pre-existing tests and proceeds normally (does not pause

--- a/test/e2e/full-suite-rectify.e2e.test.ts
+++ b/test/e2e/full-suite-rectify.e2e.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { runOrchestratorE2E } from "@test/helpers";
+import type { NaxConfig } from "@/config";
+
+const PASS_REVIEW = () => ({ output: JSON.stringify({ passed: true, findings: [] }) });
+const impl = () => ({ output: JSON.stringify({ filesChanged: ["src/a.ts"] }) });
+const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+
+const PASSING_VERDICT = JSON.stringify({
+  version: 1,
+  approved: true,
+  tests: { allPassing: true, passCount: 3, failCount: 0 },
+  testModifications: { detected: false, files: [], legitimate: true, reasoning: "no modifications" },
+  acceptanceCriteria: { allMet: true, criteria: [] },
+  quality: { rating: "good", issues: [] },
+  fixes: [],
+  reasoning: "All tests pass",
+});
+
+describe("E2E: full-suite-rectify (success path)", () => {
+  test("three-session: failing gate -> full-suite-rectify edits tests -> verifier IS re-judged -> success", async () => {
+    // full-suite-rectify is the ONLY strategy whose appliesTo matches a structured
+    // test-runner finding, and the ONLY one whose revalidation set re-runs the
+    // verifier (because it edits TEST code, which legitimately changes the verifier's
+    // verdict). This locks both: (1) the strategy fires on a failing-test finding,
+    // (2) the verifier runs after the test edit. The gate short-circuits the main loop
+    // at canonical pos 4 — BEFORE the verifier (pos 5) — so the verifier running at all
+    // proves it was pulled in by full-suite-rectify's revalidation set.
+    const verifier = () => ({ output: PASSING_VERDICT });
+
+    const { result, phaseLog, strategiesFired } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+      gates: {
+        // attempt 0 (main loop): structured failing-test finding → full-suite-rectify matches.
+        // attempt 1+ (revalidation): tests now pass after the test edit.
+        fullSuite: (attempt) =>
+          attempt === 0
+            ? {
+                passed: false,
+                failed: 1,
+                output: "1 failing",
+                failures: [{ testName: "edge case", file: "test/a.test.ts", error: "expected 2, got 1" }],
+              }
+            : { passed: true, failed: 0 },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rectificationExhausted).toBeFalsy();
+    expect(strategiesFired).toContain("full-suite-rectify");
+
+    // gate runs twice: main loop (fail) + revalidation (pass).
+    expect(phaseLog.filter((p) => p === "full-suite-gate").length).toBe(2);
+    // The verifier — never reached in the main loop (gate short-circuited at pos 4) —
+    // is re-judged by full-suite-rectify's revalidation set. This is the property that
+    // distinguishes full-suite-rectify from autofix-implementer/autofix-test-writer,
+    // both of which exclude the verifier.
+    expect(phaseLog.filter((p) => p === "verifier").length).toBe(1);
+    // Reviews still run (revalidation runs semantic; resume backfills adversarial).
+    expect(phaseLog.filter((p) => p === "semantic-review").length).toBe(1);
+    expect(phaseLog.filter((p) => p === "adversarial-review").length).toBe(1);
+
+    expect(phaseLog).toEqual([
+      "test-writer",
+      "greenfield-gate",
+      "implementer",
+      "full-suite-gate",
+      "full-suite-gate",
+      "verifier",
+      "lint-check",
+      "typecheck-check",
+      "semantic-review",
+      "adversarial-review",
+    ]);
+  });
+
+  test("single-session: failing verify-scoped is matched by full-suite-rectify (NOT no-strategy)", async () => {
+    // Regression guard (build-plan-for-strategy.ts §"Without the verify-scoped arm").
+    // In single-session there is no full-suite-gate; the scoped verify phase is the test
+    // gate. A scoped test failure must still load full-suite-rectify — otherwise the cycle
+    // exits "no-strategy" at iteration 0 and the story fails without a single fix attempt.
+    // We drive verify-scoped to fail via a static failing test command (commands.test:"false");
+    // because the command can't be made attempt-aware, the story ultimately exhausts — but
+    // the point is that full-suite-rectify FIRED (was matched), not that it resolved.
+    const { result, strategiesFired } = await runOrchestratorE2E({
+      strategy: "test-after",
+      config: { quality: { commands: { test: "false" } } } as unknown as Partial<NaxConfig>,
+      agent: { implementer: impl, "reviewer-semantic": PASS_REVIEW, "reviewer-adversarial": PASS_REVIEW },
+    });
+
+    // The matching strategy is loaded and attempted — the no-strategy regression is guarded.
+    expect(strategiesFired).toContain("full-suite-rectify");
+    // Static failing command can't be fixed → story exhausts and fails (expected).
+    expect(result.success).toBe(false);
+    expect(result.rectificationExhausted).toBe(true);
+  });
+});

--- a/test/e2e/mechanical-fix.e2e.test.ts
+++ b/test/e2e/mechanical-fix.e2e.test.ts
@@ -33,4 +33,61 @@ describe("E2E: mechanical lint-fix", () => {
     // SOUNDNESS: verify-scoped (the test gate in test-after) runs exactly once — NOT re-run after lint-fix
     expect(phaseLog.filter((p) => p === "verify-scoped").length).toBe(1);
   });
+
+  test("three-session: lint-fix re-runs ONLY lint-check; full-suite-gate + verifier NOT re-run", async () => {
+    // Strategy parity for mechanical-lintfix: in three-session the test gate is the
+    // full-suite-gate (not verify-scoped) and a verifier phase exists. mechanical-lintfix's
+    // revalidation set is ["lint-check"] only (AST-preserving fixes can't regress tests),
+    // so neither the full-suite-gate nor the verifier may be re-run by the fix.
+    const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+    const verifier = () => ({
+      output: JSON.stringify({
+        version: 1,
+        approved: true,
+        tests: { allPassing: true, passCount: 3, failCount: 0 },
+        testModifications: { detected: false, files: [], legitimate: true, reasoning: "no modifications" },
+        acceptanceCriteria: { allMet: true, criteria: [] },
+        quality: { rating: "good", issues: [] },
+        fixes: [],
+        reasoning: "All tests pass",
+      }),
+    });
+    let lintCalls = 0;
+    const { result, phaseLog, strategiesFired } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+      gates: {
+        lint: () => (lintCalls++ === 0 ? FAIL_LINT : PASS_LINT),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(strategiesFired).toContain("mechanical-lintfix");
+    expect(phaseLog.filter((p) => p === "lint-check").length).toBe(2);
+    // SOUNDNESS: the test gate (full-suite-gate) and the verifier each run exactly once —
+    // mechanical-lintfix's revalidation set is lint-check only.
+    expect(phaseLog.filter((p) => p === "full-suite-gate").length).toBe(1);
+    expect(phaseLog.filter((p) => p === "verifier").length).toBe(1);
+
+    // Main loop short-circuits at lint-check (canonical pos 7) → mechanical-lintfix →
+    // lint-check passes → post-rectification resume runs typecheck/semantic/adversarial.
+    expect(phaseLog).toEqual([
+      "test-writer",
+      "greenfield-gate",
+      "implementer",
+      "full-suite-gate",
+      "verifier",
+      "lint-check",
+      "lint-check",
+      "typecheck-check",
+      "semantic-review",
+      "adversarial-review",
+    ]);
+  });
 });

--- a/test/e2e/non-blocking-fix.e2e.test.ts
+++ b/test/e2e/non-blocking-fix.e2e.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { runOrchestratorE2E } from "@test/helpers";
+import type { NaxConfig } from "@/config";
+
+const PASS_SEMANTIC = () => ({ output: JSON.stringify({ passed: true, findings: [] }) });
+
+// Adversarial PASSES (no blocking findings) but surfaces one advisory finding below the
+// default "error" blocking threshold. The advisory finding seeds the ADR-024 non-blocking
+// best-effort fix. `verifiedBy.observed` keeps it from being downgraded/dropped during
+// substantiation (same technique as agent-fix.e2e.test.ts), and "warning" < "error" so it
+// lands in advisoryFindings rather than the blocking set.
+const ADVISORY_ADVERSARIAL = () => ({
+  output: JSON.stringify({
+    passed: true,
+    findings: [
+      {
+        severity: "warning",
+        category: "maintainability",
+        file: "src/a.ts",
+        line: 1,
+        issue: "helper could be extracted for clarity",
+        suggestion: "extract a named function",
+        verifiedBy: { file: "src/a.ts", observed: "const x = 1" },
+      },
+    ],
+  }),
+});
+
+const impl = () => ({ output: JSON.stringify({ filesChanged: ["src/a.ts"] }) });
+
+// Enable nbf in "source" scope (autofix-implementer only — no test edits, no verifier needed).
+// Every field is set explicitly: makeNaxConfig deep-merges raw objects against DEFAULT_CONFIG,
+// and nonBlockingFix is schema-`.optional()` (undefined by default), so zod defaults are NOT
+// re-applied to a freshly-introduced object — omitted fields (e.g. sourceDiffCap) would be
+// undefined and silently skip the cap check.
+const NBF_CONFIG = {
+  review: {
+    adversarial: {
+      nonBlockingFix: {
+        enabled: true,
+        scope: "source",
+        regressionAttempts: 1,
+        verifierGuard: true,
+        sourceDiffCap: { maxFiles: 10, maxLines: 500 },
+      },
+    },
+  },
+} as unknown as Partial<NaxConfig>;
+
+describe("E2E: non-blocking fix (ADR-024)", () => {
+  test("advisory findings + clean best-effort fix -> ran + kept", async () => {
+    // The story is already green (adversarial passed). nbf runs over the advisory finding,
+    // the implementer "fixes" it cleanly, the post-pass source diff is within sourceDiffCap
+    // (empty in the scripted workdir), so the result is kept.
+    const { result, nonBlockingFix } = await runOrchestratorE2E({
+      strategy: "test-after",
+      config: NBF_CONFIG,
+      agent: {
+        implementer: impl,
+        "reviewer-semantic": PASS_SEMANTIC,
+        "reviewer-adversarial": ADVISORY_ADVERSARIAL,
+      },
+    });
+
+    // The main story passes regardless of nbf (nbf is non-blocking by construction).
+    expect(result.success).toBe(true);
+    expect(nonBlockingFix).toBeDefined();
+    expect(nonBlockingFix?.ran).toBe(true);
+    expect(nonBlockingFix?.kept).toBe(true);
+    expect(nonBlockingFix?.restored).toBe(false);
+  });
+
+  test("advisory findings + best-effort fix exceeds sourceDiffCap -> ran + restored (fail-safe)", async () => {
+    // Same setup and a clean fix, but the post-pass source diff exceeds sourceDiffCap
+    // (default maxFiles: 10, maxLines: 500). nbf treats an over-cap pass as exhausted and
+    // rolls back to the adversarial-passed snapshot → restored. This exercises the
+    // un-reviewed-source-edit safety rail. The story still passes (nbf never blocks).
+    const { result, nonBlockingFix } = await runOrchestratorE2E({
+      strategy: "test-after",
+      config: NBF_CONFIG,
+      // Over the default cap (maxFiles 10 / maxLines 500) → restore.
+      nonBlockingFixDiff: { fileCount: 42, sourceLineCount: 9000 },
+      agent: {
+        implementer: impl,
+        "reviewer-semantic": PASS_SEMANTIC,
+        "reviewer-adversarial": ADVISORY_ADVERSARIAL,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(nonBlockingFix).toBeDefined();
+    expect(nonBlockingFix?.ran).toBe(true);
+    expect(nonBlockingFix?.restored).toBe(true);
+    expect(nonBlockingFix?.kept).toBe(false);
+  });
+});

--- a/test/e2e/resume.e2e.test.ts
+++ b/test/e2e/resume.e2e.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { runOrchestratorE2E } from "@test/helpers";
+import type { QualityCommandResult } from "@/quality/runner";
+
+const PASS_REVIEW = () => ({ output: JSON.stringify({ passed: true, findings: [] }) });
+const impl = () => ({ output: JSON.stringify({ filesChanged: ["src/a.ts"] }) });
+const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+
+const PASSING_VERDICT = JSON.stringify({
+  version: 1,
+  approved: true,
+  tests: { allPassing: true, passCount: 3, failCount: 0 },
+  testModifications: { detected: false, files: [], legitimate: true, reasoning: "no modifications" },
+  acceptanceCriteria: { allMet: true, criteria: [] },
+  quality: { rating: "good", issues: [] },
+  fixes: [],
+  reasoning: "All tests pass",
+});
+
+const FAIL_LINT: QualityCommandResult = {
+  commandName: "lint", command: "lint", success: false, exitCode: 1,
+  output: "E501 line too long", durationMs: 1, timedOut: false,
+};
+
+describe("E2E: post-rectification resume", () => {
+  test("review-incomplete: carve-out cannot launder a story whose adversarial-review never ran (US-002)", async () => {
+    // The full-suite-gate (canonical pos 4) fails persistently. full-suite-rectify
+    // re-judges the verifier, which PASSES — so the verifier-SSOT carve-out exempts the
+    // (still-red) gate from success aggregation. The resume then walks the canonical order
+    // and reaches semantic-review (pos 9), but breaks again at the still-red gate before
+    // adversarial-review (pos 10) can run. The completeness guard (US-002) refuses to let
+    // the carve-out pass a story that was never adversarially reviewed: it forces
+    // success=false and surfaces the never-run review for escalation routing.
+    const verifier = () => ({ output: PASSING_VERDICT });
+    const { result, phaseLog } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+      gates: {
+        fullSuite: () => ({
+          passed: false,
+          failed: 1,
+          output: "persistent failure",
+          failures: [{ testName: "broken", file: "test/a.test.ts", error: "boom" }],
+        }),
+      },
+    });
+
+    // Despite the verifier-SSOT carve-out exempting the red gate, the story cannot pass.
+    expect(result.success).toBe(false);
+    expect(result.missingRequiredReviewPhases).toBeDefined();
+    expect(result.missingRequiredReviewPhases).toContain("adversarial-review");
+    // The resume reached semantic-review (it ran) but never adversarial-review — that gap
+    // is precisely what the US-002 guard catches.
+    expect(phaseLog).toContain("semantic-review");
+    expect(phaseLog).not.toContain("adversarial-review");
+  });
+
+  test("mechanical-only resume: exhausted lint-only findings still run the reviews", async () => {
+    // lint-check (pos 7) fails persistently. The main loop short-circuits before
+    // typecheck/semantic/adversarial. mechanical-lintfix exhausts (a hard lint error it
+    // can't fix). Lint-style errors do not invalidate LLM analysis, so the mechanical-only
+    // resume runs every phase that never executed — including the reviews — even though
+    // the gate never greened. The story still fails (lint stays red), but the reviews ran.
+    const { result, phaseLog } = await runOrchestratorE2E({
+      strategy: "test-after",
+      agent: { implementer: impl, "reviewer-semantic": PASS_REVIEW, "reviewer-adversarial": PASS_REVIEW },
+      gates: {
+        lint: () => FAIL_LINT,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.rectificationExhausted).toBe(true);
+    // mechanical-only resume backfilled the reviews despite the unresolved lint error.
+    expect(phaseLog).toContain("semantic-review");
+    expect(phaseLog).toContain("adversarial-review");
+  });
+});

--- a/test/helpers/e2e/orchestrator-harness.ts
+++ b/test/helpers/e2e/orchestrator-harness.ts
@@ -59,6 +59,39 @@ export interface E2EOptions {
   gates?: E2EGates;
   story?: Partial<UserStory>;
   config?: Partial<NaxConfig>;
+  /**
+   * Seed `test/placeholder.test.ts` so greenfield-gate detects pre-existing tests
+   * and does NOT pause with "greenfield-no-tests". Defaults to `true`. Set to
+   * `false` to drive the greenfield-no-tests pause branch (three-session only).
+   */
+  seedPlaceholderTest?: boolean;
+  /**
+   * Source-diff metrics the spied `runNonBlockingFix` reports for the ADR-024
+   * best-effort pass. Defaults to `{ fileCount: 0, sourceLineCount: 0 }` (within
+   * any cap → kept). Set above the configured `sourceDiffCap` to drive the
+   * cap-exceeded → restored fail-safe branch. The harness always stubs the
+   * git-backed snapshot/rollback deps so nbf works in the non-git temp workdir.
+   */
+  nonBlockingFixDiff?: { fileCount: number; sourceLineCount: number };
+  /**
+   * Overrides for the rectification phase options. Defaults: maxAttempts 3,
+   * abortOnIncreasingFailures false. Set `abortOnIncreasingFailures: true` (with an
+   * optional `consecutiveIncreasesToBail`) to drive the increasing-failures bail-when path.
+   */
+  rectification?: {
+    maxAttempts?: number;
+    abortOnIncreasingFailures?: boolean;
+    consecutiveIncreasesToBail?: number;
+  };
+}
+
+/** Surfaced non-blocking-fix outcome (ADR-024). Captured by spying
+ * `_storyOrchestratorDeps.runNonBlockingFix`, whose return value is otherwise
+ * discarded by ExecutionPlan. `undefined` when the nbf path never invoked it. */
+export interface E2ENonBlockingFix {
+  ran: boolean;
+  kept: boolean;
+  restored: boolean;
 }
 
 export interface E2EResult {
@@ -68,9 +101,14 @@ export interface E2EResult {
     rectificationExhausted?: boolean;
     gateRegressedDuringRect?: boolean;
     unresolvedDetail?: string;
+    liteScopeIncomplete?: boolean;
+    missingRequiredReviewPhases?: readonly string[];
+    unfixedFindings?: readonly unknown[];
   };
   phaseLog: string[];
   strategiesFired: string[];
+  /** nbf outcome when the non-blocking-fix path ran; undefined otherwise. */
+  nonBlockingFix?: E2ENonBlockingFix;
 }
 
 function makeE2EConfig(overrides?: Partial<NaxConfig>): NaxConfig {
@@ -79,6 +117,9 @@ function makeE2EConfig(overrides?: Partial<NaxConfig>): NaxConfig {
   // mechanical-lintfix, or `enabled/checks` for review). Other top-level overrides
   // pass through directly.
   const { quality: qualityOverride, review: reviewOverride, ...topLevelRest } = overrides ?? {};
+  // `makeNaxConfig` deep-merges against DEFAULT_CONFIG, so a partial `review.adversarial`
+  // override (e.g. `{ nonBlockingFix: { enabled: true } }`) merges into — rather than
+  // wipes — the default adversarial config (diffMode etc. survive for makeMockPlanInputs).
   return makeNaxConfig({
     quality: {
       commands: { lint: "lint", typecheck: "tc", test: "true", lintFix: "lint --fix" },
@@ -101,13 +142,17 @@ export async function runOrchestratorE2E(opts: E2EOptions): Promise<E2EResult> {
   // Seed a placeholder test file so the greenfield-gate detects pre-existing tests
   // and does not pause with "greenfield-no-tests". The gate uses Bun.Glob for
   // non-git workdirs (temp dirs created by makeTempDir are not git repos).
-  await Bun.write(`${workdir}/test/placeholder.test.ts`, "// E2E seed\n");
+  // Opt out (seedPlaceholderTest: false) to drive the greenfield-no-tests pause branch.
+  if (opts.seedPlaceholderTest !== false) {
+    await Bun.write(`${workdir}/test/placeholder.test.ts`, "// E2E seed\n");
+  }
   const story = makeStory({ id: "US-001", ...opts.story });
 
   const { runtime } = makeRuntimeWithFakeAgent(makeScriptedAgent(opts.agent), { config, workdir });
 
   // --- save originals ---
   const origCallOp = _storyOrchestratorDeps.callOp;
+  const origRunNbf = _storyOrchestratorDeps.runNonBlockingFix;
   const origLint = _lintCheckDeps.runQualityCommand;
   const origTc = _typecheckCheckDeps.runQualityCommand;
   const origRunTests = _fullSuiteGateDeps.runTests;
@@ -146,6 +191,30 @@ export async function runOrchestratorE2E(opts: E2EOptions): Promise<E2EResult> {
       op as Parameters<typeof origCallOp>[1],
       input as Parameters<typeof origCallOp>[2],
     );
+  };
+
+  // ExecutionPlan discards runNonBlockingFix's return — spy it so the nbf outcome
+  // ({ ran, kept, restored }) is observable. Delegates to the real implementation.
+  let nonBlockingFix: E2ENonBlockingFix | undefined;
+  // biome-ignore lint/suspicious/noExplicitAny: E2E instrumentation wrapper — passes through to origRunNbf
+  (_storyOrchestratorDeps as { runNonBlockingFix: (...args: any[]) => any }).runNonBlockingFix = async (
+    nbfArgs: unknown,
+    nbfDeps: unknown,
+  ) => {
+    // Stub the git-backed snapshot/rollback/diff deps so nbf works in the non-git
+    // temp workdir and the source-diff cap path is deterministic. Merged AFTER the
+    // execution-plan's deps so these wins (the plan only supplies measureSourceDiff).
+    const stubDeps = {
+      captureSnapshotRef: async () => "e2e-nbf-snapshot",
+      rollbackToRef: async () => {},
+      measureSourceDiff: async () => opts.nonBlockingFixDiff ?? { fileCount: 0, sourceLineCount: 0 },
+    };
+    const out = await origRunNbf(nbfArgs as Parameters<typeof origRunNbf>[0], {
+      ...(nbfDeps as object),
+      ...stubDeps,
+    } as Parameters<typeof origRunNbf>[1]);
+    nonBlockingFix = { ran: out.ran, kept: out.kept, restored: out.restored };
+    return out;
   };
 
   const lintAttempts = { n: 0 };
@@ -243,9 +312,12 @@ export async function runOrchestratorE2E(opts: E2EOptions): Promise<E2EResult> {
         }
       : {}),
     rectification: {
-      maxAttempts: 3,
+      maxAttempts: opts.rectification?.maxAttempts ?? 3,
       strategies: [],
-      abortOnIncreasingFailures: false,
+      abortOnIncreasingFailures: opts.rectification?.abortOnIncreasingFailures ?? false,
+      ...(opts.rectification?.consecutiveIncreasesToBail !== undefined
+        ? { consecutiveIncreasesToBail: opts.rectification.consecutiveIncreasesToBail }
+        : {}),
     },
   });
 
@@ -254,9 +326,10 @@ export async function runOrchestratorE2E(opts: E2EOptions): Promise<E2EResult> {
   try {
     const plan = await buildPlanForStrategy(ctx, story, config, opts.strategy, inputs);
     const result = await plan.run();
-    return { result: result as E2EResult["result"], phaseLog, strategiesFired };
+    return { result: result as E2EResult["result"], phaseLog, strategiesFired, nonBlockingFix };
   } finally {
     _storyOrchestratorDeps.callOp = origCallOp;
+    _storyOrchestratorDeps.runNonBlockingFix = origRunNbf;
     _lintCheckDeps.runQualityCommand = origLint;
     _typecheckCheckDeps.runQualityCommand = origTc;
     _fullSuiteGateDeps.runTests = origRunTests;


### PR DESCRIPTION
## Summary

Closes the in-flow **StoryOrchestrator** end-to-end coverage gaps surfaced by a flow-vs-e2e audit. The independent e2e suite grows from **12 → 23 tests** (9 files). **No production/source changes — test + harness only.** `typecheck` clean; full `bun run test:e2e` green.

## Why

The e2e suite covered the happy single-story path and the three common rectification strategies well, but several in-flow branches had **no end-to-end exercise** — including the only strategy that edits test code (and re-judges the verifier), the post-pass source-mutation fail-safe, and the US-002 "passed without review" guard.

## Harness extensions (`test/helpers/e2e/orchestrator-harness.ts`)

- Widen `E2EResult` to surface `liteScopeIncomplete`, `missingRequiredReviewPhases`, `unfixedFindings` (already returned via the result spread — type-only).
- Spy `runNonBlockingFix` to observe `{ran,kept,restored}` (otherwise discarded by `ExecutionPlan`), and stub the git-backed snapshot/rollback/diff deps so nbf works in the non-git temp workdir **and** the `sourceDiffCap` path is deterministic (`nonBlockingFixDiff` option).
- `seedPlaceholderTest` opt-out → drives the `greenfield-no-tests` pause branch.
- `rectification` override (`abortOnIncreasingFailures`, `consecutiveIncreasesToBail`) → drives the increasing-failures bail.

## New / extended scenarios

| Scenario | File |
|:--|:--|
| mechanical-lintfix **three-session** (gate + verifier NOT re-run) | `mechanical-fix` |
| autofix-implementer **three-session** (gate re-run, verifier NOT) | `agent-fix` |
| **full-suite-rectify success** — verifier IS re-judged (its unique property) | `full-suite-rectify` (new) |
| full-suite-rectify single-session verify-scoped match (no-strategy regression guard) | `full-suite-rectify` (new) |
| **non-blocking-fix** ran+kept / ran+restored (`sourceDiffCap` fail-safe) | `non-blocking-fix` (new) |
| **review-incomplete** (US-002): carve-out can't launder a story whose adversarial-review never ran | `resume` (new) |
| **mechanical-only resume** runs reviews despite unresolved lint | `resume` (new) |
| **no-strategy**, **bail-when**, **greenfield pause** | `exhaustion-edge` |

## Deliberately documented as covered elsewhere (not forced into brittle e2e)

- **Verifier-SSOT carve-out PASS path** — unreachable in the simple main loop (gate short-circuits at canonical pos 4, before the verifier at pos 5); thoroughly unit-covered (`story-orchestrator-carveout-staleness.test.ts`, `story-orchestrator-revalidation.test.ts`). The FAIL/staleness side already had e2e.
- **`liteScopeIncomplete`** — narrow lite-validate flag, unit-covered (`findings/cycle.test.ts`, `story-orchestrator-revalidation.test.ts`).
- **Isolation violations** — left at integration (scripted agents don't touch disk; would need a separate git-backed harness).

## Test plan

- [x] `bun run test:e2e` — 23 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (`src/`+`bin/`; `test/` is outside the lint gate, new files follow existing e2e conventions)
- [x] Code review (code-reviewer agent) — **Approve**, no CRITICAL/HIGH

🤖 Generated with [Claude Code](https://claude.com/claude-code)
