### PR TITLE
fix(execution): resolve should-fix StoryOrchestrator audit items (#5, #4)

### DIFF
--- a/docs/reports/20260620-story-orchestrator-correctness-audit.md
+++ b/docs/reports/20260620-story-orchestrator-correctness-audit.md
@@ -1,0 +1,266 @@
+# StoryOrchestrator Correctness Audit — 2026-06-20
+
+> **Update (2026-06-20):** the two safe "should-fix" robustness items have landed on
+> `fix/story-orchestrator-should-fix` — **#5** (`routeTddFailure` exhaustiveness guard) and **#4**
+> (`phaseCosts` restored on nbf rollback), each with regression tests. **#7** was re-examined during
+> implementation and intentionally left unchanged (the `undefined → pause` fallback is correct; see §7).
+> The must-fix items **#1, #2, #3** remain open.
+
+> Scope: behavioral correctness of the per-story execution flow (`src/execution/story-orchestrator/`)
+> and its collaborators — rectification, resume loops, the verifier-SSOT carve-out + staleness guard,
+> the ADR-024 non-blocking fix, and failure categorization + tier escalation.
+>
+> Method: four independent audits, each reading the production code (not tests) and reasoning about
+> edge cases, followed by direct source verification of the high-severity claims. This is a
+> correctness review, **not** a test-coverage review.
+
+## Verdict
+
+The architecture is **sound and well-guarded** — the short-circuit RED→GREEN contract, loop bounds,
+immutability, escalation budget/termination, and prior-failure threading are all correct. **No CRITICAL
+defect.** The real issues cluster in two areas: **non-blocking-fix robustness** and the **staleness
+guard's representational assumptions**. The highest-value fixes are #1, #2, and #3.
+
+## Findings at a glance
+
+| # | Severity | Type | Location | Status |
+|---|----------|------|----------|--------|
+| 1 | MEDIUM–HIGH | Confirmed bug | `non-blocking-fix.ts:148` | **Open** — nbf snapshot capture throws into the verdict path (violates documented contract); reproduced empirically |
+| 2 | MEDIUM | Confirmed bug | `story-orchestrator/types.ts:174-181` | **Open** — `full-suite-rectify` edits tests but never re-runs `adversarial-review` → stale verdict |
+| 3 | HIGH impact / conditional reach | Design weakness | `phase-eval.ts:110`, `full-suite-gate.ts` (timeout/exec-fail) | **Open** — staleness guard blind to keyless gate failures → a red suite *can* be exempted |
+| 4 | LOW–MEDIUM | Confirmed bug (metrics) | `non-blocking-fix.ts:195-217` | ✅ **Fixed** (`fix/story-orchestrator-should-fix`) — `phaseCosts` snapshotted at entry, restored on rollback |
+| 5 | MEDIUM | Design gap | `pipeline/stages/execution-helpers.ts:64` | ✅ **Fixed** (`fix/story-orchestrator-should-fix`) — `routeTddFailure` now exhaustive (`satisfies never`) |
+| 6 | LOW–MEDIUM | Design gap | `non-blocking-fix.ts:120-125` | **Open** — `sourceDiffCap` counts only *added* lines; a large *deleting* edit bypasses the cap |
+| 7 | MEDIUM → LOW | Re-examined | `tdd-failure-category.ts:101` | ⏸️ **No change** — on inspection the `undefined → pause` fallback is correct; a richer category needs a design change (see below) |
+| 8 | LOW | Design gap | `tdd-failure-category.ts:32` | **Open** — `isolation-violation` handling appears dead for the verifier path |
+| 9 | LOW | Intentional asymmetry | `post-run.ts:245` | **Open** (by design) — TDD pauses vs non-TDD hard-fails for the same "review never ran" root cause |
+
+Gating note: #1, #4, #6 only bite when the **non-blocking fix is enabled** (`review.adversarial.nonBlockingFix.enabled`, default `false`).
+
+---
+
+## Detailed findings
+
+### 1. nbf `captureSnapshotRef` throws into the verdict path — Confirmed bug
+
+`runNonBlockingFix` captures the rollback snapshot **before** its try/catch:
+
+```ts
+// non-blocking-fix.ts
+const restoreRef = await _deps.captureSnapshotRef(args.workdir, args.storyId); // line 148 — OUTSIDE try
+const maxAttempts = 1 + args.cfg.regressionAttempts;
+let exhausted = false;
+try {                                                                          // line 152
+  const result = await args.runRectify(maxAttempts);
+  ...
+```
+
+The module docstring (lines 131-134) promises the pass *"never throws into the caller's verdict path."*
+But `captureSnapshotRef` runs `git rev-parse HEAD` and throws `NaxError(SNAPSHOT_REF_FAILED)` in a
+non-git workdir or on a transient git failure. That throw propagates through
+`_storyOrchestratorDeps.runNonBlockingFix` (`execution-plan.ts:226`) into `run()`, which has no
+try/catch around the call — converting an **advisory best-effort pass into a hard story crash**.
+
+Reproduced empirically: the e2e harness hit `SNAPSHOT_REF_FAILED` the first time nbf ran in a
+non-git temp workdir (the e2e PR works around it by stubbing the git deps).
+
+**Fix:** move the capture inside the try; on failure, log a warning and return
+`{ ran: false, kept: false, restored: false }` (treat an unsnapshottable tree as "cannot run nbf",
+never as a story failure).
+
+### 2. `full-suite-rectify` edits tests but never re-runs adversarial-review — Confirmed bug
+
+```ts
+// story-orchestrator/types.ts — STRATEGY_TO_REVALIDATION_PHASES
+"full-suite-rectify": ["lint-check", "typecheck-check", "full-suite-gate", "verifier", "verify-scoped", "semantic-review"],
+//                      ^ no "adversarial-review"
+```
+
+`full-suite-rectify` is the strategy that **edits test code**. `adversarial-review` is the phase that
+judges test quality/coverage. After this strategy rewrites tests, the post-rectification resume sees
+`adversarial-review` already passing in `phaseOutputs` (`execution-plan.ts:123`) and **skips it**, so
+the pre-rectification adversarial verdict is read as current against rewritten tests.
+
+**Fix:** add `"adversarial-review"` to the `full-suite-rectify` revalidation set. (Alternative:
+force-rerun reviews in the resume whenever rectification edited tests, instead of trusting a prior pass.)
+
+### 3. Staleness guard is blind to keyless gate failures — Design weakness (high impact)
+
+The verifier-SSOT carve-out exempts a still-red full-suite-gate when the verifier passed, *unless*
+rectification introduced a **new** gate failure. "New" is computed by diffing failing-test identity keys:
+
+```ts
+// phase-eval.ts
+keys.add(`${f.file ?? ""}::${f.rule ?? ""}`);  // only for source === "test-runner"
+
+// execution-plan.ts
+const gateRegressedDuringRect =
+  gateName !== undefined &&
+  [...gateFailureKeys(phaseOutputs[gateName])].some((k) => !preRectGateFailureKeys.has(k));
+```
+
+But gate failures legitimately change *representation* between runs:
+
+- **Timeout** → `findings: []` → empty key set → `[].some(...)` is **always `false`**.
+- **Execution-failure** (non-zero exit, no structured failures) → one synth finding with **no `file`/`rule`**
+  (`findings/adapters/test-runner.ts:42-54`) → key `"::"`.
+
+So a gate that regresses into a *keyless* form (timeout/exec-fail) produces no "new" key, the staleness
+guard reads `false`, and with the verifier passed the carve-out exempts a **genuinely red full suite**
+→ `success = true`. Two distinct execution-failures also collide to `"::"`.
+
+**Reachability caveat (honest):** the gate-before-verifier canonical ordering + short-circuit +
+nbf-restore semantics block most paths, so a complete *live* trigger was not proven without nbf
+enabled. Classified as a real **latent fragility to harden**, not a proven live exploit. The blind
+spot itself is verified.
+
+**Fix:** compare gate **pass/fail status**, not just key identity. If the baseline gate was
+green/passing and the final gate is failing in *any* representation, treat the verdict as stale
+(revoke the exemption). Fold timeout / execution-failure / `failed>0-but-empty-findings` into the
+regression signal explicitly rather than relying on extractable keys.
+
+### 4. phaseCosts not restored on nbf rollback — Confirmed bug (metrics only)
+
+`restoreToSnapshot` (`non-blocking-fix.ts:195-213`) reverts the git tree and `phaseOutputs` in place
+but never touches `phaseCosts`. The nbf rectify pass accrues cost under the same op names
+(`run-phase.ts` accumulates `phaseCosts[opName] += ...`), so a *rolled-back* pass still inflates
+`totalCostUsd` and the returned `phaseCosts` — asymmetric with the restored outputs. Verdict is
+unaffected; only metrics are wrong.
+
+**Fix:** snapshot `phaseCosts` at nbf entry and restore it alongside `phaseOutputs` on rollback — or,
+since the runtime discards nbf's `{ran,kept,restored}` return, surface that outcome and subtract the
+wasted cost / emit an nbf-attribution metric.
+
+> ✅ **Resolved** (`fix/story-orchestrator-should-fix`). `NonBlockingFixArgs` now carries `phaseCosts`;
+> `runNonBlockingFix` snapshots it at entry (`{ ...args.phaseCosts }`) and `restoreToSnapshot` reverts
+> it in place alongside `phaseOutputs`, so a discarded pass leaves the result's per-phase cost
+> breakdown symmetric with its outputs. True total spend is unaffected — it lives in the cost
+> middleware / `CostAggregator` (the SSOT); this only corrects the diagnostic per-phase split.
+> Regression tests: `non-blocking-fix.test.ts` — "restored → phaseCosts rolled back…" and
+> "kept → phaseCosts retains…".
+
+### 5. `routeTddFailure` lacks an exhaustiveness guard — Design gap
+
+`resolveMaxAttemptsOutcome` ends with a `satisfies never` exhaustiveness check; its sibling
+`routeTddFailure` (`execution-helpers.ts:102-105`) does not, and its fall-through silently returns
+`{ action: "pause" }`. A future `FailureCategory` added to the union compiles clean and silently routes
+to human-pause on this terminal path while the other path is compiler-checked. Asymmetric safety.
+
+**Fix:** add a `satisfies never` default branch to `routeTddFailure` mirroring `resolveMaxAttemptsOutcome`.
+
+> ✅ **Resolved** (`fix/story-orchestrator-should-fix`). `routeTddFailure` was restructured into an
+> exhaustive `switch` over `FailureCategory` with a `satisfies never` default, mirroring
+> `resolveMaxAttemptsOutcome`. **Behavior is identical**: `undefined` and `dependency-prep` both still
+> resolve to `pause` (now handled explicitly), every escalate-category is unchanged, and a runtime
+> `"unknown"` string still falls through to `pause`. A new `FailureCategory` member now fails
+> compilation until routed. Regression test added: `execution-stage.test.ts` — "pauses on
+> dependency-prep…".
+
+### 6. `sourceDiffCap` counts only added lines — Design gap
+
+`createMeasureSourceDiff` (`non-blocking-fix.ts:120-125`) sums **added** lines and discards deletions.
+A best-effort fix that *deletes* 500 unreviewed source lines and adds 3 passes the `maxLines` cap
+trivially. The un-reviewed-edit safety rail is add-biased.
+
+**Fix:** count `added + deleted` (or `max(added, deleted)`) against `maxLines`.
+
+### 7. verifier-passed + red-gate + reviews-ran → `undefined` category — Re-examined, no change
+
+In `deriveTddFailureCategory`, `verifierPassed` short-circuits the gate-derived branches
+(`full-suite-gate-exhausted`, `tests-failing`). The original concern was that a verifier-passed story
+which still failed would fall through to `undefined` (`tdd-failure-category.ts:101`) and route through
+a degraded disposition.
+
+> ⏸️ **Re-examined during the fix pass — no code change.** Tracing the reachable states shows the
+> `undefined` fallback is **correct**, not a defect:
+>
+> - When the verifier passed (`verifierPassed = verifier.success && !gateRegressedDuringRect`), the
+>   full-suite-gate is **exempted** from success aggregation (`execution-plan.ts:320`). So a red gate
+>   *alone* yields `success = true` — no category is needed.
+> - Therefore reaching `deriveTddFailureCategory` with `verifierPassed === true` requires `success` to
+>   be false for a **non-gate** reason: an unfixed `lint`/`typecheck` finding, or a failing
+>   semantic/adversarial review. Suppressing the *gate* categories in that case is correct — the gate
+>   is not the cause and was deliberately exempted.
+> - There is **no TDD category** that fits "a quality check / review couldn't be greened." `undefined`
+>   then routes via `routeTddFailure(undefined)` → `pause` (human review), which is a defensible
+>   terminal disposition for an uncategorizable quality failure. (Note the earlier audit's
+>   "escalate-then-fail" description was imprecise: the per-attempt path pauses.)
+>
+> Assigning a *richer* category here would mean inventing a new `FailureCategory` (e.g.
+> `quality-gate-exhausted`) and deciding its pause/escalate semantics across `routeTddFailure` and
+> `resolveMaxAttemptsOutcome` — a **design change**, not a robustness fix, and out of scope for this
+> pass. Downgraded **MEDIUM → LOW** and left as documented behavior. If the asymmetry with #9 is
+> later deemed undesirable, the right move is a dedicated quality-failure category, decided jointly
+> with #9.
+
+### 8. `isolation-violation` handling appears dead for the verifier path — Design gap
+
+`categorizeVerdict` only ever emits `verifier-rejected` / `tests-failing`, never `isolation-violation`,
+yet `decideStageAction` (`post-run.ts:71`, `shouldRollbackTddFailure`) and `routeTddFailure` both
+special-case `isolation-violation`. If no producer stamps it on the verifier path, a verifier-detected
+isolation breach is miscategorized as `verifier-rejected` (which still pauses on exhaustion, limiting
+blast radius).
+
+**Fix:** confirm the producer. If isolation violations are only stamped by the test-writer/implementer
+isolation gates (not the verifier), document that; otherwise wire `categorizeVerdict` to emit it.
+
+### 9. TDD vs non-TDD review-incomplete disposition asymmetry — Intentional, documented
+
+`applyPostRunInspection` only derives a `failureCategory` (and thus the `review-incomplete` → `pause`)
+when `isTdd`. A non-TDD story whose configured review never ran hard-**fails** instead of pausing
+(`post-run.ts:240-253`). Same root cause ("review skipped"), different terminal disposition. Documented
+and intentional, but a real semantic asymmetry.
+
+**Fix (optional):** route non-TDD `missingRequiredReviewPhases` through the same `review-incomplete`
+disposition so the pause/fail decision doesn't depend on strategy.
+
+---
+
+## Verified sound (no action)
+
+- Short-circuit RED→GREEN contract — reviews never judge a broken gate inside a rectification sweep.
+- All three resume loops are bounded: `resumeRectifyUsed` is one-shot per story; `runFixCycle` is
+  bounded by `maxAttemptsTotal` + per-strategy `maxAttempts`. No unbounded loop.
+- No cost double-counting on legitimate re-runs (each `runPhase` opens a fresh cost scope).
+- Escalation mechanics: `story.routing` is **not** mutated in place — the PRD is rebuilt immutably via
+  `userStories.map(...)`; `calculateMaxIterations` is a correct total-budget ceiling; `escalateTier`
+  returns `null` at the last rung (no infinite escalation).
+- `unresolvedDetail` / `priorFailures` threading: carried into the next tier intact, capped at 3, no drop.
+- Carve-out vs `missingRequiredReviewPhases` precedence: the `&&` correctly forbids laundering a story
+  that skipped configured reviews.
+
+---
+
+## Recommended fix plan
+
+**Must-fix (correctness, concrete, high confidence) — still OPEN:**
+
+1. **#1 — nbf snapshot throw.** Move `captureSnapshotRef` inside the try/catch; fail closed to
+   `{ran:false}`. Smallest diff, reproduced bug, violates a stated contract.
+2. **#2 — adversarial-review staleness.** Add `"adversarial-review"` to the `full-suite-rectify`
+   revalidation set. One-line change; add a regression test (tests edited → adversarial re-runs).
+3. **#3 — staleness guard status comparison.** Harden `gateRegressedDuringRect` to compare gate
+   pass/fail *status*, not just keys, so keyless (timeout/exec-fail) regressions can't be exempted.
+   Highest design value; pair with unit tests for the timeout and execution-failure representations.
+
+**Should-fix (robustness / disposition):**
+
+4. ✅ **#5 — `routeTddFailure` exhaustiveness guard** — **DONE** (`fix/story-orchestrator-should-fix`).
+   Behavior-preserving refactor to an exhaustive `switch` + `satisfies never`.
+5. ⏸️ **#7 — gate category under verifier-passed** — **re-examined, no change.** The `undefined → pause`
+   fallback is correct; a richer category is a design change (new `FailureCategory`), out of scope. See §7.
+6. ✅ **#4 — restore `phaseCosts` on nbf rollback** — **DONE** (`fix/story-orchestrator-should-fix`).
+   Snapshot at entry + in-place restore on rollback; cost SSOT (`CostAggregator`) unaffected.
+
+**Nice-to-have — still OPEN:**
+
+7. **#6 — count deletions in `sourceDiffCap`.**
+8. **#8 — confirm/wire `isolation-violation` producer.**
+9. **#9 — unify non-TDD review-incomplete disposition** (if the asymmetry is undesired; decide jointly with #7).
+
+**Remaining sequencing:** land #1, #2 as small independent commits (each with a focused regression
+test), then #3 (the staleness-guard status comparison) with unit tests for the timeout and
+execution-failure representations. #6 / #8 are low-priority follow-ups.
+
+> All findings are in **production** code and pre-date the e2e coverage PR (#1266); that PR's tests are
+> correct and independent of these fixes.

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -79,6 +79,14 @@ export interface NonBlockingFixArgs {
   advisoryFindings: readonly Finding[];
   cfg: NonBlockingFixConfig;
   phaseOutputs: Record<string, unknown>;
+  /**
+   * Per-phase cost accumulator. The best-effort rectify pass mutates this in place
+   * (same object the cycle accumulates into). Snapshotted at entry and restored on
+   * rollback so a discarded pass leaves no trace in the result's cost breakdown —
+   * symmetric with `phaseOutputs`. (True total spend still lives in the cost
+   * middleware / CostAggregator, the SSOT; this is the diagnostic per-phase split.)
+   */
+  phaseCosts: Record<string, number>;
   /** Runs the harness; returns true when it exhausted without resolving. */
   runRectify: (maxAttempts: number) => Promise<{ rectificationExhausted?: boolean }>;
 }
@@ -143,8 +151,10 @@ export async function runNonBlockingFix(
     return { ran: false, kept: false, restored: false };
   }
   // Shallow copy is sufficient: phase outputs are replaced wholesale by each stage,
-  // never mutated in place.
+  // never mutated in place. phaseCosts is a flat number map — a shallow copy is a full
+  // snapshot. Both are restored together on rollback so a discarded pass leaves no trace.
   const phaseOutputsSnapshot = { ...args.phaseOutputs };
+  const phaseCostsSnapshot = { ...args.phaseCosts };
   const restoreRef = await _deps.captureSnapshotRef(args.workdir, args.storyId);
   const maxAttempts = 1 + args.cfg.regressionAttempts;
 
@@ -173,7 +183,7 @@ export async function runNonBlockingFix(
           storyId: args.storyId,
           error: err instanceof Error ? err.message : String(err),
         });
-        return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, logger);
+        return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
       }
       if (metrics.fileCount > cap.maxFiles || metrics.sourceLineCount > cap.maxLines) {
         logger?.info("non-blocking-fix", "source diff exceeded cap — restoring", {
@@ -182,14 +192,14 @@ export async function runNonBlockingFix(
           sourceLineCount: metrics.sourceLineCount,
           cap,
         });
-        return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, logger);
+        return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
       }
     }
     logger?.info("non-blocking-fix", "best-effort fix kept", { storyId: args.storyId });
     return { ran: true, kept: true, restored: false };
   }
 
-  return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, logger);
+  return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
 }
 
 async function restoreToSnapshot(
@@ -197,14 +207,19 @@ async function restoreToSnapshot(
   _deps: NonBlockingFixDeps,
   restoreRef: string,
   phaseOutputsSnapshot: Record<string, unknown>,
+  phaseCostsSnapshot: Record<string, number>,
   logger: ReturnType<typeof getSafeLogger>,
 ): Promise<NonBlockingFixResult> {
   await _deps.rollbackToRef(args.workdir, restoreRef);
-  // In-place restore required: ExecutionPlan.run holds a direct reference to phaseOutputs;
-  // returning a new object would leave the caller with stale gate/verifier results from
-  // the failed best-effort pass. Intentional exception to the immutability rule.
+  // In-place restore required: ExecutionPlan.run holds a direct reference to phaseOutputs
+  // and phaseCosts; returning new objects would leave the caller with stale gate/verifier
+  // results and inflated costs from the failed best-effort pass. Intentional exception to
+  // the immutability rule. Cost is restored alongside outputs so the result's per-phase
+  // breakdown stays symmetric with its outputs after a discarded pass.
   for (const key of Object.keys(args.phaseOutputs)) delete args.phaseOutputs[key];
   Object.assign(args.phaseOutputs, phaseOutputsSnapshot);
+  for (const key of Object.keys(args.phaseCosts)) delete args.phaseCosts[key];
+  Object.assign(args.phaseCosts, phaseCostsSnapshot);
   logger?.info("non-blocking-fix", "best-effort fix exhausted — restored to adversarial-passed", {
     storyId: args.storyId,
   });

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -230,6 +230,7 @@ export class ExecutionPlan {
           advisoryFindings,
           cfg: advCfg,
           phaseOutputs,
+          phaseCosts,
           runRectify: (maxAttempts) =>
             runRectification(this.ctx, this.state, phaseCosts, phaseOutputs, {
               initialFindings: advisoryFindings,

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -76,31 +76,43 @@ export function routeTddFailure(
     return trimmedDetail ? `TDD ${category}: ${trimmedDetail}` : `TDD ${category}`;
   };
 
-  if (failureCategory === "isolation-violation") {
-    if (!isLiteMode) {
-      ctx.retryAsLite = true;
-    }
-    return { action: "escalate", reason: buildReason("isolation-violation") };
-  }
-
-  if (
-    failureCategory === "session-failure" ||
-    failureCategory === "tests-failing" ||
-    failureCategory === "full-suite-gate-exhausted" ||
-    failureCategory === "verifier-rejected" ||
-    failureCategory === "runtime-crash" ||
-    failureCategory === "review-incomplete"
-  ) {
-    return { action: "escalate", reason: buildReason(failureCategory) };
-  }
-
-  // S5: greenfield-no-tests → escalate so tier-escalation can switch to test-after
-  if (failureCategory === "greenfield-no-tests") {
-    return { action: "escalate", reason: buildReason("greenfield-no-tests") };
-  }
-
-  return {
+  // No specific category (e.g. a non-TDD-categorizable quality/review failure, or a
+  // non-three-session review verdict) → fall back to the human-review pause.
+  const pauseFallback: StageResult = {
     action: "pause",
     reason: reviewReason || "Three-session TDD requires review",
   };
+  if (failureCategory === undefined) {
+    return pauseFallback;
+  }
+
+  // Exhaustive over FailureCategory: a new member added to the union must be routed
+  // here explicitly, or the `satisfies never` default below fails compilation. Mirrors
+  // the guard in `resolveMaxAttemptsOutcome` so both terminal paths stay in lockstep.
+  switch (failureCategory) {
+    case "isolation-violation":
+      if (!isLiteMode) {
+        ctx.retryAsLite = true;
+      }
+      return { action: "escalate", reason: buildReason("isolation-violation") };
+    case "session-failure":
+    case "tests-failing":
+    case "full-suite-gate-exhausted":
+    case "verifier-rejected":
+    case "runtime-crash":
+    case "review-incomplete":
+    // S5: greenfield-no-tests → escalate so tier-escalation can switch to test-after
+    case "greenfield-no-tests":
+      return { action: "escalate", reason: buildReason(failureCategory) };
+    case "dependency-prep":
+      // Worktree dependency prep hard-fails in the iteration runner before the
+      // pipeline routes here, so this arm is unreachable in practice — handled
+      // explicitly to keep the exhaustiveness check honest. An infra prep failure
+      // is not auto-recoverable by a stronger tier, so pause for human review.
+      return pauseFallback;
+    default:
+      // Exhaustive check: if a new FailureCategory is added, this errors at compile time.
+      failureCategory satisfies never;
+      return pauseFallback;
+  }
 }

--- a/test/unit/execution/execution-stage.test.ts
+++ b/test/unit/execution/execution-stage.test.ts
@@ -124,6 +124,15 @@ describe("routeTddFailure", () => {
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
+  it("pauses on dependency-prep (infra prep failure, not tier-recoverable)", () => {
+    const ctx: MockContext = {};
+    const result = routeTddFailure("dependency-prep", false, ctx);
+
+    expect(result.action).toBe("pause");
+    if (result.action === "pause") expect(result.reason).toBe("Three-session TDD requires review");
+    expect(ctx.retryAsLite).toBeUndefined();
+  });
+
   it("uses custom reviewReason when pausing", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure(undefined, false, ctx, "Custom reason for pause");

--- a/test/unit/execution/non-blocking-fix.test.ts
+++ b/test/unit/execution/non-blocking-fix.test.ts
@@ -44,6 +44,7 @@ describe("runNonBlockingFix keep vs restore", () => {
     storyId: "us-001",
     advisoryFindings: [{ source: "adversarial-review", severity: "warning", category: "input", message: "m" }] as never,
     cfg: { enabled: true, scope: "both", regressionAttempts: 1, verifierGuard: true } as const,
+    phaseCosts: {} as Record<string, number>,
   };
   const fakeDeps = {
     captureSnapshotRef: async () => "snap-sha",
@@ -87,6 +88,50 @@ describe("runNonBlockingFix keep vs restore", () => {
     expect(rolled).toBe("snap-sha");
     expect(phaseOutputs["full-suite-gate"]).toEqual({ success: true }); // restored
   });
+
+  test("restored → phaseCosts rolled back to entry snapshot (no inflation from discarded pass)", async () => {
+    // The best-effort rectify pass accrues cost into the shared phaseCosts map. On
+    // rollback that cost must be reverted alongside phaseOutputs, so a discarded pass
+    // leaves the result's per-phase cost breakdown symmetric with its outputs.
+    const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
+    const phaseCosts: Record<string, number> = { implementer: 0.10 };
+    const res = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        phaseOutputs,
+        phaseCosts,
+        runRectify: async () => {
+          phaseCosts.implementer = 0.35; // pass spent more
+          phaseCosts["adversarial-review"] = 0.20; // and added a new phase
+          return { rectificationExhausted: true };
+        },
+      },
+      fakeDeps,
+    );
+    expect(res).toEqual({ ran: true, kept: false, restored: true });
+    // Reverted to the entry snapshot — the discarded pass's cost is gone, the new key removed.
+    expect(phaseCosts).toEqual({ implementer: 0.10 });
+  });
+
+  test("kept → phaseCosts retains the best-effort pass cost", async () => {
+    // When the pass is kept (resolved, within cap), its cost is real work and stays.
+    const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
+    const phaseCosts: Record<string, number> = { implementer: 0.10 };
+    const res = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        phaseOutputs,
+        phaseCosts,
+        runRectify: async () => {
+          phaseCosts.implementer = 0.35;
+          return { rectificationExhausted: false };
+        },
+      },
+      fakeDeps,
+    );
+    expect(res).toEqual({ ran: true, kept: true, restored: false });
+    expect(phaseCosts).toEqual({ implementer: 0.35 });
+  });
 });
 
 describe("nonBlockingExtraPhases with triage scope", () => {
@@ -129,6 +174,7 @@ describe("runNonBlockingFix sourceDiffCap", () => {
           sourceDiffCap: { maxFiles: 10, maxLines: 50 },
         },
         phaseOutputs: {},
+        phaseCosts: {},
         runRectify: async () => ({ rectificationExhausted: false }),
       },
       {
@@ -158,6 +204,7 @@ describe("runNonBlockingFix sourceDiffCap", () => {
           sourceDiffCap: { maxFiles: 5, maxLines: 500 },
         },
         phaseOutputs: {},
+        phaseCosts: {},
         runRectify: async () => ({ rectificationExhausted: false }),
       },
       {
@@ -187,6 +234,7 @@ describe("runNonBlockingFix sourceDiffCap", () => {
           sourceDiffCap: { maxFiles: 10, maxLines: 200 },
         },
         phaseOutputs: {},
+        phaseCosts: {},
         runRectify: async () => ({ rectificationExhausted: false }),
       },
       {
@@ -216,6 +264,7 @@ describe("runNonBlockingFix sourceDiffCap", () => {
           sourceDiffCap: { maxFiles: 10, maxLines: 200 },
         },
         phaseOutputs: {},
+        phaseCosts: {},
         runRectify: async () => ({ rectificationExhausted: false }),
       },
       {
@@ -247,6 +296,7 @@ describe("runNonBlockingFix sourceDiffCap", () => {
           sourceDiffCap: { maxFiles: 10, maxLines: 200 },
         },
         phaseOutputs: {},
+        phaseCosts: {},
         runRectify: async () => ({ rectificationExhausted: false }),
       },
       {


### PR DESCRIPTION
## Summary

Resolves the two **safe "should-fix"** robustness items from the StoryOrchestrator correctness audit, and lands the audit report itself. Production code + tests; all quality gates green.

Source: `docs/reports/20260620-story-orchestrator-correctness-audit.md` (added here).

## Fixes

### #5 — `routeTddFailure` exhaustiveness guard (`pipeline/stages/execution-helpers.ts`)
`routeTddFailure` had no `satisfies never` guard (unlike its sibling `resolveMaxAttemptsOutcome`), so a future `FailureCategory` member would silently fall through to `pause` on one terminal path while being compiler-checked on the other.

Restructured into an exhaustive `switch` with a `satisfies never` default. **Behavior-preserving** — verified against the existing tests:
- `undefined` → `pause` (now explicit), `dependency-prep` → `pause` (now explicit), runtime `"unknown"` → `pause` (default arm).
- All escalate-categories unchanged.
- A new `FailureCategory` member now **fails compilation** until routed.

Added a `dependency-prep` regression test.

### #4 — restore `phaseCosts` on nbf rollback (`execution/non-blocking-fix.ts`)
On an ADR-024 best-effort rollback, `restoreToSnapshot` reverted the git tree and `phaseOutputs` but **not** `phaseCosts` — so a *discarded* pass's token cost stayed in the result's per-phase breakdown, asymmetric with the restored outputs.

`NonBlockingFixArgs` now carries `phaseCosts`; `runNonBlockingFix` snapshots it at entry and `restoreToSnapshot` reverts it in place alongside `phaseOutputs`. **True total spend is unaffected** — it lives in the cost middleware / `CostAggregator` (the SSOT); this only corrects the diagnostic per-phase split. Added kept/restored cost regression tests.

### #7 — re-examined, intentionally NOT changed
The audit flagged `verifier-passed + red-gate → undefined category` as a gap. On implementation-level tracing, the `undefined → pause` fallback is **correct**: a verifier-passed story that still fails does so for a non-gate reason (unfixed lint/typecheck or a failing review), for which no TDD category fits; pausing for human review is a defensible disposition. A richer category would be a design change (new `FailureCategory`), out of scope for a robustness pass. Documented in the report; downgraded MEDIUM→LOW.

## Still open (tracked in the report)
Must-fix items **#1** (nbf snapshot throws into the verdict path), **#2** (`full-suite-rectify` excludes `adversarial-review` → stale verdict), **#3** (staleness guard blind to keyless gate failures) remain open — they warrant their own focused PR with regression tests.

## Test plan
- [x] `bun run test` — full suite green (unit + integration + ui)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] New regression tests: `execution-stage.test.ts` (dependency-prep route), `non-blocking-fix.test.ts` (phaseCosts kept/restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
