### PR TITLE
fix(execution): nbf snapshot fail-safe + full-suite-rectify re-runs adversarial-review (#1, #2)

### DIFF
--- a/docs/reports/20260620-story-orchestrator-correctness-audit.md
+++ b/docs/reports/20260620-story-orchestrator-correctness-audit.md
@@ -1,10 +1,12 @@
 # StoryOrchestrator Correctness Audit — 2026-06-20
 
-> **Update (2026-06-20):** the two safe "should-fix" robustness items have landed on
-> `fix/story-orchestrator-should-fix` — **#5** (`routeTddFailure` exhaustiveness guard) and **#4**
-> (`phaseCosts` restored on nbf rollback), each with regression tests. **#7** was re-examined during
-> implementation and intentionally left unchanged (the `undefined → pause` fallback is correct; see §7).
-> The must-fix items **#1, #2, #3** remain open.
+> **Update (2026-06-20):** resolution progress —
+> - **#5** (`routeTddFailure` exhaustiveness guard) + **#4** (`phaseCosts` restored on nbf rollback):
+>   landed on `fix/story-orchestrator-should-fix` (merged, #1267).
+> - **#1** (nbf snapshot throws into the verdict path) + **#2** (`full-suite-rectify` re-runs
+>   `adversarial-review`): landed on `fix/story-orchestrator-nbf-snapshot-adversarial-staleness`.
+> - **#7** re-examined and intentionally left unchanged (the `undefined → pause` fallback is correct; see §7).
+> - **#3** (staleness guard blind to keyless gate failures) remains the one open must-fix item.
 
 > Scope: behavioral correctness of the per-story execution flow (`src/execution/story-orchestrator/`)
 > and its collaborators — rectification, resume loops, the verifier-SSOT carve-out + staleness guard,
@@ -25,8 +27,8 @@ guard's representational assumptions**. The highest-value fixes are #1, #2, and 
 
 | # | Severity | Type | Location | Status |
 |---|----------|------|----------|--------|
-| 1 | MEDIUM–HIGH | Confirmed bug | `non-blocking-fix.ts:148` | **Open** — nbf snapshot capture throws into the verdict path (violates documented contract); reproduced empirically |
-| 2 | MEDIUM | Confirmed bug | `story-orchestrator/types.ts:174-181` | **Open** — `full-suite-rectify` edits tests but never re-runs `adversarial-review` → stale verdict |
+| 1 | MEDIUM–HIGH | Confirmed bug | `non-blocking-fix.ts:158` | ✅ **Fixed** (`fix/story-orchestrator-nbf-snapshot-adversarial-staleness`) — snapshot capture wrapped; failure degrades to `ran:false`, never throws |
+| 2 | MEDIUM | Confirmed bug | `story-orchestrator/types.ts:174-182` | ✅ **Fixed** (`fix/story-orchestrator-nbf-snapshot-adversarial-staleness`) — `adversarial-review` added to `full-suite-rectify` revalidation set |
 | 3 | HIGH impact / conditional reach | Design weakness | `phase-eval.ts:110`, `full-suite-gate.ts` (timeout/exec-fail) | **Open** — staleness guard blind to keyless gate failures → a red suite *can* be exempted |
 | 4 | LOW–MEDIUM | Confirmed bug (metrics) | `non-blocking-fix.ts:195-217` | ✅ **Fixed** (`fix/story-orchestrator-should-fix`) — `phaseCosts` snapshotted at entry, restored on rollback |
 | 5 | MEDIUM | Design gap | `pipeline/stages/execution-helpers.ts:64` | ✅ **Fixed** (`fix/story-orchestrator-should-fix`) — `routeTddFailure` now exhaustive (`satisfies never`) |
@@ -68,6 +70,13 @@ non-git temp workdir (the e2e PR works around it by stubbing the git deps).
 `{ ran: false, kept: false, restored: false }` (treat an unsnapshottable tree as "cannot run nbf",
 never as a story failure).
 
+> ✅ **Resolved** (`fix/story-orchestrator-nbf-snapshot-adversarial-staleness`). `captureSnapshotRef`
+> is now wrapped in its own try/catch: a failure logs a warning and returns
+> `{ ran: false, kept: false, restored: false }` — `runRectify` is never invoked (no rollback point),
+> so the tree and `phaseOutputs`/`phaseCosts` are untouched. The "never throws into the caller's
+> verdict path" contract now holds for non-git / git-flaky workdirs. Regression test:
+> `non-blocking-fix.test.ts` — "snapshot capture fails → returns ran:false and does NOT throw".
+
 ### 2. `full-suite-rectify` edits tests but never re-runs adversarial-review — Confirmed bug
 
 ```ts
@@ -83,6 +92,16 @@ the pre-rectification adversarial verdict is read as current against rewritten t
 
 **Fix:** add `"adversarial-review"` to the `full-suite-rectify` revalidation set. (Alternative:
 force-rerun reviews in the resume whenever rectification edited tests, instead of trusting a prior pass.)
+
+> ✅ **Resolved** (`fix/story-orchestrator-nbf-snapshot-adversarial-staleness`). `adversarial-review`
+> added to `STRATEGY_TO_REVALIDATION_PHASES["full-suite-rectify"]`, so editing tests now re-runs the
+> review that judges them. **Ripple (intended):** three tests that encoded the old exclusion were
+> updated — `story-orchestrator-revalidation.test.ts` (AC3.4 now asserts adversarial *included*),
+> `story-orchestrator-carveout-staleness.test.ts` (the completeness-guard repro now uses
+> `mechanical-lintfix`, the realistic strategy that still excludes a review), and the
+> `resume.e2e.test.ts` scenario (a persistent-red-gate story under full-suite-rectify is now *fully*
+> review-judged → the verifier-SSOT carve-out PASS path, repurposed as the #2 regression). This
+> closes the US-002 "silent pass without adversarial judgment" gap at the source for full-suite-rectify.
 
 ### 3. Staleness guard is blind to keyless gate failures — Design weakness (high impact)
 
@@ -233,14 +252,14 @@ disposition so the pause/fail decision doesn't depend on strategy.
 
 ## Recommended fix plan
 
-**Must-fix (correctness, concrete, high confidence) — still OPEN:**
+**Must-fix (correctness, concrete, high confidence):**
 
-1. **#1 — nbf snapshot throw.** Move `captureSnapshotRef` inside the try/catch; fail closed to
-   `{ran:false}`. Smallest diff, reproduced bug, violates a stated contract.
-2. **#2 — adversarial-review staleness.** Add `"adversarial-review"` to the `full-suite-rectify`
-   revalidation set. One-line change; add a regression test (tests edited → adversarial re-runs).
-3. **#3 — staleness guard status comparison.** Harden `gateRegressedDuringRect` to compare gate
-   pass/fail *status*, not just keys, so keyless (timeout/exec-fail) regressions can't be exempted.
+1. ✅ **#1 — nbf snapshot throw** — **DONE** (`fix/story-orchestrator-nbf-snapshot-adversarial-staleness`).
+   `captureSnapshotRef` wrapped; failure degrades to `ran:false`, never throws.
+2. ✅ **#2 — adversarial-review staleness** — **DONE** (same branch). `adversarial-review` added to the
+   `full-suite-rectify` revalidation set; three dependent tests updated.
+3. **#3 — staleness guard status comparison** — **OPEN.** Harden `gateRegressedDuringRect` to compare
+   gate pass/fail *status*, not just keys, so keyless (timeout/exec-fail) regressions can't be exempted.
    Highest design value; pair with unit tests for the timeout and execution-failure representations.
 
 **Should-fix (robustness / disposition):**
@@ -258,9 +277,9 @@ disposition so the pause/fail decision doesn't depend on strategy.
 8. **#8 — confirm/wire `isolation-violation` producer.**
 9. **#9 — unify non-TDD review-incomplete disposition** (if the asymmetry is undesired; decide jointly with #7).
 
-**Remaining sequencing:** land #1, #2 as small independent commits (each with a focused regression
-test), then #3 (the staleness-guard status comparison) with unit tests for the timeout and
-execution-failure representations. #6 / #8 are low-priority follow-ups.
+**Remaining work:** **#3** (the staleness-guard status comparison) is the last open must-fix — it
+changes the carve-out/staleness logic, so it warrants its own focused PR with unit tests for the
+timeout and execution-failure representations. #6 / #8 are low-priority follow-ups.
 
 > All findings are in **production** code and pre-date the e2e coverage PR (#1266); that PR's tests are
 > correct and independent of these fixes.

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -155,7 +155,23 @@ export async function runNonBlockingFix(
   // snapshot. Both are restored together on rollback so a discarded pass leaves no trace.
   const phaseOutputsSnapshot = { ...args.phaseOutputs };
   const phaseCostsSnapshot = { ...args.phaseCosts };
-  const restoreRef = await _deps.captureSnapshotRef(args.workdir, args.storyId);
+
+  // The snapshot ref is the rollback point. If it cannot be captured (non-git workdir,
+  // detached/transient git failure), the best-effort pass has no safe undo, so skip it
+  // entirely rather than throw. This honours the module contract — "never throws into the
+  // caller's verdict path": a snapshot failure must degrade to "nbf did not run", never to
+  // a hard story failure. The capture sits OUTSIDE the rectify try/catch below, so without
+  // this guard its throw would propagate straight through ExecutionPlan.run(). (Audit #1.)
+  let restoreRef: string;
+  try {
+    restoreRef = await _deps.captureSnapshotRef(args.workdir, args.storyId);
+  } catch (err) {
+    logger?.warn("non-blocking-fix", "snapshot capture failed — skipping best-effort pass (no rollback point)", {
+      storyId: args.storyId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { ran: false, kept: false, restored: false };
+  }
   const maxAttempts = 1 + args.cfg.regressionAttempts;
 
   let exhausted = false;

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -170,7 +170,10 @@ export const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[
   // excluded. Same once-per-story semantics as above.
   "autofix-test-writer": ["lint-check", "typecheck-check", "full-suite-gate", "adversarial-review"],
   // full-suite-rectify edits TEST code to fix failing tests — this legitimately
-  // changes the verifier's verdict, so verifier IS re-judged.
+  // changes the verifier's verdict, so verifier IS re-judged. adversarial-review is
+  // included because it specifically judges test quality/coverage: rewriting tests is
+  // exactly when its prior verdict goes stale, so it must re-run rather than be read as
+  // a pre-rectification pass by the post-rectification resume. (Audit #2.)
   "full-suite-rectify": [
     "lint-check",
     "typecheck-check",
@@ -178,6 +181,7 @@ export const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[
     "verifier",
     "verify-scoped",
     "semantic-review",
+    "adversarial-review",
   ],
 };
 

--- a/test/e2e/resume.e2e.test.ts
+++ b/test/e2e/resume.e2e.test.ts
@@ -23,14 +23,16 @@ const FAIL_LINT: QualityCommandResult = {
 };
 
 describe("E2E: post-rectification resume", () => {
-  test("review-incomplete: carve-out cannot launder a story whose adversarial-review never ran (US-002)", async () => {
-    // The full-suite-gate (canonical pos 4) fails persistently. full-suite-rectify
-    // re-judges the verifier, which PASSES — so the verifier-SSOT carve-out exempts the
-    // (still-red) gate from success aggregation. The resume then walks the canonical order
-    // and reaches semantic-review (pos 9), but breaks again at the still-red gate before
-    // adversarial-review (pos 10) can run. The completeness guard (US-002) refuses to let
-    // the carve-out pass a story that was never adversarially reviewed: it forces
-    // success=false and surfaces the never-run review for escalation routing.
+  test("carve-out PASS path: full-suite-rectify re-runs BOTH reviews, so an exempted red gate is fully judged (audit #2)", async () => {
+    // The full-suite-gate (canonical pos 4) fails persistently with the SAME finding.
+    // full-suite-rectify re-judges the verifier, which PASSES — so the verifier-SSOT
+    // carve-out treats the still-red gate as a pre-existing/unrelated regression and
+    // exempts it from success aggregation. Crucially, since audit #2, full-suite-rectify's
+    // revalidation set includes BOTH semantic- AND adversarial-review, so the code is fully
+    // review-judged before the carve-out lets it pass. The completeness guard
+    // (missingRequiredReviewPhases) therefore stays empty and the story passes legitimately
+    // — no longer the "silent pass without adversarial judgment" US-002 gap, which #2 closes
+    // at the source. This also exercises the verifier-SSOT carve-out PASS path end-to-end.
     const verifier = () => ({ output: PASSING_VERDICT });
     const { result, phaseLog } = await runOrchestratorE2E({
       strategy: "three-session-tdd",
@@ -51,14 +53,16 @@ describe("E2E: post-rectification resume", () => {
       },
     });
 
-    // Despite the verifier-SSOT carve-out exempting the red gate, the story cannot pass.
-    expect(result.success).toBe(false);
-    expect(result.missingRequiredReviewPhases).toBeDefined();
-    expect(result.missingRequiredReviewPhases).toContain("adversarial-review");
-    // The resume reached semantic-review (it ran) but never adversarial-review — that gap
-    // is precisely what the US-002 guard catches.
+    // The gate is genuinely red, but the verifier-SSOT carve-out exempts it.
+    const gateOut = result.phaseOutputs["full-suite-gate"] as { success?: boolean } | undefined;
+    expect(gateOut?.success).toBe(false);
+    // Story passes: gate exempted AND every configured review ran and passed.
+    expect(result.success).toBe(true);
+    expect(result.missingRequiredReviewPhases).toBeUndefined();
+    // audit #2: full-suite-rectify edits tests, so adversarial-review re-runs (its prior
+    // verdict would be stale). Both reviews appear in the log.
     expect(phaseLog).toContain("semantic-review");
-    expect(phaseLog).not.toContain("adversarial-review");
+    expect(phaseLog).toContain("adversarial-review");
   });
 
   test("mechanical-only resume: exhausted lint-only findings still run the reviews", async () => {

--- a/test/unit/execution/non-blocking-fix.test.ts
+++ b/test/unit/execution/non-blocking-fix.test.ts
@@ -89,6 +89,41 @@ describe("runNonBlockingFix keep vs restore", () => {
     expect(phaseOutputs["full-suite-gate"]).toEqual({ success: true }); // restored
   });
 
+  test("snapshot capture fails → returns ran:false and does NOT throw (audit #1)", async () => {
+    // A non-git workdir or transient git failure makes captureSnapshotRef throw. The pass
+    // must degrade to "did not run" — never propagate the throw into the caller's verdict
+    // path (the module contract). runRectify must not even be invoked (no rollback point).
+    const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
+    const phaseCosts: Record<string, number> = { implementer: 0.1 };
+    let rectifyCalled = false;
+    let rolled = false;
+    const res = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        phaseOutputs,
+        phaseCosts,
+        runRectify: async () => {
+          rectifyCalled = true;
+          return { rectificationExhausted: false };
+        },
+      },
+      {
+        captureSnapshotRef: async () => {
+          throw new Error("git rev-parse HEAD failed in non-blocking-fix snapshot");
+        },
+        rollbackToRef: async () => {
+          rolled = true;
+        },
+      },
+    );
+    expect(res).toEqual({ ran: false, kept: false, restored: false });
+    expect(rectifyCalled).toBe(false); // never started — no safe undo point
+    expect(rolled).toBe(false);
+    // Tree state untouched: no rectify ran, so phaseOutputs/phaseCosts are unchanged.
+    expect(phaseOutputs["full-suite-gate"]).toEqual({ success: true });
+    expect(phaseCosts).toEqual({ implementer: 0.1 });
+  });
+
   test("restored → phaseCosts rolled back to entry snapshot (no inflation from discarded pass)", async () => {
     // The best-effort rectify pass accrues cost into the shared phaseCosts map. On
     // rollback that cost must be reverted alongside phaseOutputs, so a discarded pass

--- a/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
+++ b/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
@@ -291,11 +291,13 @@ describe("ExecutionPlan.run — carve-out staleness", () => {
 //
 // Repro: full-suite-gate stays red with the SAME finding through rectification
 // (subset of baseline → NOT regressed → carve-out would normally exempt it).
-// verifier + semantic-review pass during the lite revalidation (full-suite-rectify
-// scope excludes adversarial-review). The post-rectification resume loop breaks at
-// the still-red gate (canonical pos 4) before reaching adversarial-review (pos 10),
-// so adversarial-review never runs — yet the verifier-SSOT carve-out exempts the
-// gate and the story passes WITHOUT adversarial judgment.
+// verifier + semantic-review pass during the lite revalidation under a strategy whose
+// scope excludes adversarial-review (mechanical-lintfix — since audit #2, full-suite-rectify
+// DOES re-run adversarial, so a mechanical strategy is now the realistic way a review is
+// skipped). The post-rectification resume loop breaks at the still-red gate (canonical
+// pos 4) before reaching adversarial-review (pos 10), so adversarial-review never runs —
+// yet the verifier-SSOT carve-out exempts the gate. The completeness guard must still fail
+// the story rather than pass it WITHOUT adversarial judgment.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("ExecutionPlan.run — completeness guard (configured review must run)", () => {
@@ -348,12 +350,13 @@ describe("ExecutionPlan.run — completeness guard (configured review must run)"
       if (op.kind === "deterministic" && op.execute) return op.execute(input, _ctx);
       return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
     }) as typeof _storyOrchestratorDeps.callOp;
-    // Lite revalidation in full-suite-rectify scope: gate-last (carve-out discards
-    // it after verifier passes), excludes adversarial-review. Exit "resolved".
+    // Lite revalidation under mechanical-lintfix scope: revalidates lint-check only, so
+    // adversarial-review is excluded (full-suite-rectify now includes it — audit #2 — so a
+    // mechanical strategy is the realistic way a configured review is skipped). Exit "resolved".
     _storyOrchestratorDeps.runFixCycle = (async (cycle: {
       validate: (c: unknown, o: unknown) => Promise<unknown>;
     }) => {
-      await cycle.validate({}, { mode: "lite", strategiesRun: ["full-suite-rectify"] });
+      await cycle.validate({}, { mode: "lite", strategiesRun: ["mechanical-lintfix"] });
       return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
     }) as typeof _storyOrchestratorDeps.runFixCycle;
 

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -344,11 +344,12 @@ describe("phasesToRevalidate — AC3.3: mechanical-lintfix → only lint-check",
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC3.4: strategiesRun=["full-suite-rectify"] → lint, typecheck, gate, scoped, semantic; NO adversarial
+// AC3.4: strategiesRun=["full-suite-rectify"] → lint, typecheck, gate, verifier, scoped,
+// semantic AND adversarial (it edits tests → both reviews re-judge). (Audit #2.)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("phasesToRevalidate — AC3.4: full-suite-rectify → verifier included, adversarial excluded", () => {
-  test("AC3.4: strategiesRun=['full-suite-rectify'] → lint, typecheck, gate, verifier, scoped, semantic called; adversarial excluded", async () => {
+describe("phasesToRevalidate — AC3.4: full-suite-rectify → verifier + both reviews included", () => {
+  test("AC3.4: strategiesRun=['full-suite-rectify'] → lint, typecheck, gate, verifier, scoped, semantic, adversarial all called", async () => {
     const ctx = makeCtx();
     const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
 
@@ -369,8 +370,10 @@ describe("phasesToRevalidate — AC3.4: full-suite-rectify → verifier included
     // full-suite-rectify is a code-editing strategy — verifier re-judges the TDD verdict
     expect(called.has("verifier")).toBe(true);
 
-    // adversarial-review is NOT in full-suite-rectify's revalidation set
-    expect(called.has("adversarial-review")).toBe(false);
+    // adversarial-review IS now in full-suite-rectify's revalidation set: this strategy
+    // edits TEST code, which is exactly what adversarial-review judges, so its prior
+    // verdict is stale and must re-run rather than be read as a pre-rectification pass.
+    expect(called.has("adversarial-review")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Resolves the two highest-priority **must-fix** correctness items from the StoryOrchestrator audit (`docs/reports/20260620-story-orchestrator-correctness-audit.md`). Production code + tests; all gates green.

## #1 — nbf `captureSnapshotRef` must not throw into the verdict path

`runNonBlockingFix` captured its rollback snapshot **outside** its try/catch, so a non-git workdir or a transient `git rev-parse` failure propagated `SNAPSHOT_REF_FAILED` straight through `ExecutionPlan.run()` — turning an *advisory* best-effort pass into a **hard story crash**, violating the module's documented *"never throws into the caller's verdict path"* contract. (Reproduced empirically during the e2e work.)

**Fix:** wrap the capture. On failure, log and return `{ ran:false, kept:false, restored:false }` without invoking `runRectify` (no rollback point) — the tree and `phaseOutputs`/`phaseCosts` are left untouched. Regression test: `non-blocking-fix.test.ts` — "snapshot capture fails → returns ran:false and does NOT throw".

## #2 — `full-suite-rectify` edits tests but never re-judged `adversarial-review`

`STRATEGY_TO_REVALIDATION_PHASES["full-suite-rectify"]` excluded `adversarial-review`. That strategy **rewrites test code**, and `adversarial-review` is the phase that judges test quality — so after a rewrite, the post-rectification resume read the review's **pre-rectification pass as current** (a stale verdict).

**Fix:** add `adversarial-review` to the set. This closes the US-002 "silent pass without adversarial judgment" gap *at the source* for `full-suite-rectify`.

### Intended ripple — three tests encoded the old exclusion and were updated
- `story-orchestrator-revalidation.test.ts` (AC3.4) → now asserts adversarial **included**.
- `story-orchestrator-carveout-staleness.test.ts` → the completeness-guard repro now uses `mechanical-lintfix` (the realistic strategy that still excludes a review), keeping the guard meaningful.
- `resume.e2e.test.ts` → the persistent-red-gate scenario is now **fully review-judged**; repurposed as the #2 regression **and** the first end-to-end coverage of the verifier-SSOT carve-out **PASS** path (which the audit had noted was hard to construct).

## Still open
**#3** (staleness guard blind to keyless gate failures — timeout → `[]`, exec-fail → `"::"`) remains the last must-fix. It changes the carve-out/staleness logic and warrants its own focused PR.

## Test plan
- [x] `bun run test` — full suite green (unit + integration + ui)
- [x] `bun run test:e2e` — 23 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
