### PR TITLE
fix(execution): staleness guard treats keyless gate failures as regressions (#3)

### DIFF
--- a/docs/reports/20260620-story-orchestrator-correctness-audit.md
+++ b/docs/reports/20260620-story-orchestrator-correctness-audit.md
@@ -4,9 +4,14 @@
 > - **#5** (`routeTddFailure` exhaustiveness guard) + **#4** (`phaseCosts` restored on nbf rollback):
 >   landed on `fix/story-orchestrator-should-fix` (merged, #1267).
 > - **#1** (nbf snapshot throws into the verdict path) + **#2** (`full-suite-rectify` re-runs
->   `adversarial-review`): landed on `fix/story-orchestrator-nbf-snapshot-adversarial-staleness`.
+>   `adversarial-review`): landed on `fix/story-orchestrator-nbf-snapshot-adversarial-staleness` (merged, #1268).
+> - **#3** (staleness guard blind to keyless gate failures): landed on
+>   `fix/staleness-guard-keyless-gate-failures` — keyless (timeout / execution-failure) gate failures
+>   are now treated as regressions, closing the carve-out laundering path.
 > - **#7** re-examined and intentionally left unchanged (the `undefined → pause` fallback is correct; see §7).
-> - **#3** (staleness guard blind to keyless gate failures) remains the one open must-fix item.
+>
+> **All must-fix items (#1, #2, #3) are now resolved.** Remaining open items are LOW nice-to-haves
+> (#6, #8) and the documented-by-design #9.
 
 > Scope: behavioral correctness of the per-story execution flow (`src/execution/story-orchestrator/`)
 > and its collaborators — rectification, resume loops, the verifier-SSOT carve-out + staleness guard,
@@ -29,7 +34,7 @@ guard's representational assumptions**. The highest-value fixes are #1, #2, and 
 |---|----------|------|----------|--------|
 | 1 | MEDIUM–HIGH | Confirmed bug | `non-blocking-fix.ts:158` | ✅ **Fixed** (`fix/story-orchestrator-nbf-snapshot-adversarial-staleness`) — snapshot capture wrapped; failure degrades to `ran:false`, never throws |
 | 2 | MEDIUM | Confirmed bug | `story-orchestrator/types.ts:174-182` | ✅ **Fixed** (`fix/story-orchestrator-nbf-snapshot-adversarial-staleness`) — `adversarial-review` added to `full-suite-rectify` revalidation set |
-| 3 | HIGH impact / conditional reach | Design weakness | `phase-eval.ts:110`, `full-suite-gate.ts` (timeout/exec-fail) | **Open** — staleness guard blind to keyless gate failures → a red suite *can* be exempted |
+| 3 | HIGH impact / conditional reach | Design weakness | `phase-eval.ts` (`gateRegressedAfterRectification`) | ✅ **Fixed** (`fix/staleness-guard-keyless-gate-failures`) — keyless (timeout/exec-fail) gate failures now treated as regressions |
 | 4 | LOW–MEDIUM | Confirmed bug (metrics) | `non-blocking-fix.ts:195-217` | ✅ **Fixed** (`fix/story-orchestrator-should-fix`) — `phaseCosts` snapshotted at entry, restored on rollback |
 | 5 | MEDIUM | Design gap | `pipeline/stages/execution-helpers.ts:64` | ✅ **Fixed** (`fix/story-orchestrator-should-fix`) — `routeTddFailure` now exhaustive (`satisfies never`) |
 | 6 | LOW–MEDIUM | Design gap | `non-blocking-fix.ts:120-125` | **Open** — `sourceDiffCap` counts only *added* lines; a large *deleting* edit bypasses the cap |
@@ -137,6 +142,22 @@ spot itself is verified.
 green/passing and the final gate is failing in *any* representation, treat the verdict as stale
 (revoke the exemption). Fold timeout / execution-failure / `failed>0-but-empty-findings` into the
 regression signal explicitly rather than relying on extractable keys.
+
+> ✅ **Resolved** (`fix/staleness-guard-keyless-gate-failures`). Extracted a pure
+> `gateRegressedAfterRectification(finalGateOutput, baselineKeys, gateName, storyId?)` in
+> `phase-eval.ts` and routed the carve-out's `gateRegressedDuringRect` through it. It returns false
+> when the final gate is green; when failing, it flags a regression if EITHER a structured failure key
+> is absent from the baseline (the original precise diff) **OR** the failure is keyless — a timeout
+> (`findings: []` → empty key set) or an execution-failure (synth key `"::"`). A keyless failure yields
+> no identity to prove it is the pre-existing failure the verifier blessed, so it conservatively counts
+> as a regression rather than being laundered into a pass. The structured-subset carve-out (legit
+> pre-existing failures) is preserved unchanged. Tests: five pure-function cases (green, subset, new
+> key, timeout, execution-failure) plus an end-to-end `ExecutionPlan.run` case proving a timeout
+> regression now fails the story instead of passing via the carve-out.
+>
+> **Scope note:** this closes the keyless-key blind spot. The deeper Finding 3 concern (baseline is
+> captured at main-loop end, not at verifier-pass time) is unchanged and remains a latent design point;
+> the conservative keyless handling de-risks it, but a full fix would re-anchor the baseline.
 
 ### 4. phaseCosts not restored on nbf rollback — Confirmed bug (metrics only)
 
@@ -258,9 +279,9 @@ disposition so the pause/fail decision doesn't depend on strategy.
    `captureSnapshotRef` wrapped; failure degrades to `ran:false`, never throws.
 2. ✅ **#2 — adversarial-review staleness** — **DONE** (same branch). `adversarial-review` added to the
    `full-suite-rectify` revalidation set; three dependent tests updated.
-3. **#3 — staleness guard status comparison** — **OPEN.** Harden `gateRegressedDuringRect` to compare
-   gate pass/fail *status*, not just keys, so keyless (timeout/exec-fail) regressions can't be exempted.
-   Highest design value; pair with unit tests for the timeout and execution-failure representations.
+3. ✅ **#3 — staleness guard status comparison** — **DONE** (`fix/staleness-guard-keyless-gate-failures`).
+   `gateRegressedAfterRectification` now treats keyless (timeout/exec-fail) gate failures as regressions;
+   pure-function + end-to-end tests added.
 
 **Should-fix (robustness / disposition):**
 
@@ -277,9 +298,9 @@ disposition so the pause/fail decision doesn't depend on strategy.
 8. **#8 — confirm/wire `isolation-violation` producer.**
 9. **#9 — unify non-TDD review-incomplete disposition** (if the asymmetry is undesired; decide jointly with #7).
 
-**Remaining work:** **#3** (the staleness-guard status comparison) is the last open must-fix — it
-changes the carve-out/staleness logic, so it warrants its own focused PR with unit tests for the
-timeout and execution-failure representations. #6 / #8 are low-priority follow-ups.
+**Remaining work:** all must-fix items are resolved. Open items are LOW nice-to-haves — **#6** (count
+deletions in `sourceDiffCap`), **#8** (confirm/wire the `isolation-violation` producer) — plus the
+documented-by-design **#9**. None are blocking.
 
 > All findings are in **production** code and pre-date the e2e coverage PR (#1266); that PR's tests are
 > correct and independent of these fixes.

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -45,6 +45,7 @@ export {
   phasesToRevalidate,
   orderGateLast,
   gateFailureKeys,
+  gateRegressedAfterRectification,
   refreshReviewInputForDispatch,
   withIncreasingFailuresBail,
   type OrchestratorSlot,

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -8,7 +8,7 @@ import {
   nonBlockingExtraPhases,
   shouldRunNonBlockingFix,
 } from "../non-blocking-fix";
-import { gateFailureKeys, phaseExplicitlyPassed, phasePassed } from "./phase-eval";
+import { gateFailureKeys, gateRegressedAfterRectification, phaseExplicitlyPassed, phasePassed } from "./phase-eval";
 import { collectOrderedPhases } from "./phase-state";
 import { runRectification } from "./rectification";
 import { _storyOrchestratorDeps, runPhase } from "./run-phase";
@@ -271,9 +271,11 @@ export class ExecutionPlan {
     // SSOT requires an explicit pass — see `phaseExplicitlyPassed` for why we
     // don't use the defensive `phasePassed` here.
     const verifierExplicitlyPassed = verifierName !== undefined && phaseExplicitlyPassed(phaseOutputs[verifierName]);
+    // Compares the FINAL gate against the verifier-time baseline, including keyless
+    // (timeout / execution-failure) regressions the raw key-diff is blind to (audit #3).
     const gateRegressedDuringRect =
       gateName !== undefined &&
-      [...gateFailureKeys(phaseOutputs[gateName])].some((k) => !preRectGateFailureKeys.has(k));
+      gateRegressedAfterRectification(phaseOutputs[gateName], preRectGateFailureKeys, gateName, this.ctx.storyId);
     const verifierPassedSsot = verifierExplicitlyPassed && !gateRegressedDuringRect;
     if (verifierExplicitlyPassed && gateRegressedDuringRect) {
       logger?.warn(

--- a/src/execution/story-orchestrator/index.ts
+++ b/src/execution/story-orchestrator/index.ts
@@ -3,7 +3,13 @@
 
 export { StoryOrchestratorBuilder } from "./builder";
 export { ExecutionPlan } from "./execution-plan";
-export { extractPhaseFindings, gateFailureKeys, orderGateLast, phasesToRevalidate } from "./phase-eval";
+export {
+  extractPhaseFindings,
+  gateFailureKeys,
+  gateRegressedAfterRectification,
+  orderGateLast,
+  phasesToRevalidate,
+} from "./phase-eval";
 export { runRectification } from "./rectification";
 export { _storyOrchestratorDeps, refreshReviewInputForDispatch, withIncreasingFailuresBail } from "./run-phase";
 export {

--- a/src/execution/story-orchestrator/phase-eval.ts
+++ b/src/execution/story-orchestrator/phase-eval.ts
@@ -113,6 +113,49 @@ export function gateFailureKeys(gateOutput: unknown): Set<string> {
 }
 
 /**
+ * The key `gateFailureKeys` emits for a gate failure with no identity — both `file`
+ * and `rule` empty. Produced by execution-failure synth findings (non-zero exit, no
+ * structured failures). Such a key cannot be diffed against a baseline, so the
+ * staleness guard must treat it as a regression rather than a comparable identity.
+ */
+const KEYLESS_GATE_FAILURE_KEY = "::";
+
+/**
+ * Did the full-suite gate REGRESS during rectification relative to the verifier-time
+ * baseline? Drives the verifier-SSOT carve-out: a verifier that passed exempts a red
+ * gate as a "pre-existing/unrelated regression" ONLY while the gate did not get worse
+ * after the verifier blessed it.
+ *
+ * Returns false when the final gate is passing (green ⇒ nothing to be stale about).
+ *
+ * When the final gate is failing, it regressed if EITHER:
+ *  - it carries a structured failure key absent from `baselineKeys` (a new, identifiable
+ *    failing test), OR
+ *  - it failed in a KEYLESS form — a timeout (`findings: []` ⇒ empty key set) or an
+ *    execution-failure (synth finding ⇒ `"::"`). These yield no identity to compare, so
+ *    the structured key-diff alone is blind to them (audit #3). We cannot prove a keyless
+ *    failure is the same one the verifier blessed, and silently exempting an unidentifiable
+ *    red suite is exactly the laundering this guards against — so treat it as a regression.
+ *
+ * Pure over (output, baseline, gateName) — exported for unit testing.
+ */
+export function gateRegressedAfterRectification(
+  finalGateOutput: unknown,
+  baselineKeys: ReadonlySet<string>,
+  gateName: string,
+  storyId?: string,
+): boolean {
+  // Green gate ⇒ not regressed. Also guards the keyless check below: a passing gate
+  // has an empty key set too, but must never be read as a keyless failure.
+  if (phasePassed(gateName, finalGateOutput, storyId)) return false;
+
+  const finalKeys = gateFailureKeys(finalGateOutput);
+  const hasNewStructuredKey = [...finalKeys].some((k) => !baselineKeys.has(k));
+  const isKeylessFailure = finalKeys.size === 0 || finalKeys.has(KEYLESS_GATE_FAILURE_KEY);
+  return hasNewStructuredKey || isKeylessFailure;
+}
+
+/**
  * Determine which phases to re-run after a fix iteration.
  *
  * The verifier IS eligible for revalidation when a strategy mapped to include

--- a/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
+++ b/test/unit/execution/story-orchestrator-carveout-staleness.test.ts
@@ -16,7 +16,12 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { type DEFAULT_CONFIG, pickSelector } from "@/config";
-import { StoryOrchestratorBuilder, _storyOrchestratorDeps, gateFailureKeys } from "@/execution";
+import {
+  StoryOrchestratorBuilder,
+  _storyOrchestratorDeps,
+  gateFailureKeys,
+  gateRegressedAfterRectification,
+} from "@/execution";
 import { deriveTddFailureCategory } from "@/execution";
 import type { CallContext, DeterministicOperation, RunOperation } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
@@ -92,6 +97,50 @@ describe("gateFailureKeys", () => {
   test("returns empty set for undefined / non-object output", () => {
     expect(gateFailureKeys(undefined).size).toBe(0);
     expect(gateFailureKeys("nope").size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// gateRegressedAfterRectification — pure (audit #3: keyless-failure blind spot)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("gateRegressedAfterRectification", () => {
+  const GATE = "full-suite-gate";
+  // An execution-failure synth finding: source test-runner, no file/rule → key "::".
+  const execFailFinding = { source: "test-runner", category: "execution-failed", severity: "error", message: "boom" };
+
+  test("green final gate → not regressed", () => {
+    const out = { success: true, passed: true, findings: [] };
+    expect(gateRegressedAfterRectification(out, new Set(), GATE)).toBe(false);
+    // Even with a non-empty baseline (pre-existing failures the verifier blessed).
+    expect(gateRegressedAfterRectification(out, new Set(["foo.test.ts::t-a"]), GATE)).toBe(false);
+  });
+
+  test("structured failure that is a SUBSET of baseline → not regressed (carve-out preserved)", () => {
+    const out = { success: false, passed: false, findings: [testFinding("foo.test.ts", "t-a")] };
+    const baseline = new Set(["foo.test.ts::t-a", "bar.test.ts::t-b"]);
+    expect(gateRegressedAfterRectification(out, baseline, GATE)).toBe(false);
+  });
+
+  test("NEW structured failure key absent from baseline → regressed", () => {
+    const out = { success: false, passed: false, findings: [testFinding("new.test.ts", "t-new")] };
+    const baseline = new Set(["foo.test.ts::t-a"]);
+    expect(gateRegressedAfterRectification(out, baseline, GATE)).toBe(true);
+  });
+
+  test("TIMEOUT (failing, findings: []) → regressed even though there is no key to diff (#3)", () => {
+    // Before #3 this returned false: empty key set ⇒ [].some(...) ⇒ false ⇒ laundered.
+    const timeoutOut = { success: false, passed: false, status: "timeout", findings: [] };
+    expect(gateRegressedAfterRectification(timeoutOut, new Set(["foo.test.ts::t-a"]), GATE)).toBe(true);
+    // Even when the baseline was already failing with structured keys.
+    expect(gateRegressedAfterRectification(timeoutOut, new Set(), GATE)).toBe(true);
+  });
+
+  test("EXECUTION-FAILURE (failing, synth key '::') → regressed even if baseline also had '::' (#3)", () => {
+    // Before #3: '::' ∈ baseline ⇒ not "new" ⇒ false ⇒ a story-caused suite crash laundered.
+    const out = { success: false, passed: false, status: "execution-failed", findings: [execFailFinding] };
+    expect(gateRegressedAfterRectification(out, new Set(["::"]), GATE)).toBe(true);
+    expect(gateRegressedAfterRectification(out, new Set(["foo.test.ts::t-a"]), GATE)).toBe(true);
   });
 });
 
@@ -219,6 +268,83 @@ describe("ExecutionPlan.run — carve-out staleness", () => {
       // Without the fix the carve-out would exempt the gate → success=true.
       expect(result.success).toBe(false);
       expect(result.gateRegressedDuringRect).toBe(true);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+
+  test("verifier passed but the gate regressed into a KEYLESS failure (timeout) → story fails (audit #3)", async () => {
+    // Same shape as the structured-regression test above, but rectification drives the gate
+    // green → FAILING-WITH-NO-FINDINGS (a timeout: success:false, findings:[]). The pre-#3
+    // key-diff was blind to this — an empty key set never produces a "new" key — so the
+    // verifier-SSOT carve-out laundered a genuinely red suite into a pass. With #3 the
+    // keyless failure is treated as a regression and the story fails.
+    const config = makeNaxConfig({
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2, abortOnIncreasingFailures: false } },
+    });
+    rt = makeTestRuntime({ config });
+
+    let gateCalls = 0;
+    const gateOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "full-suite-gate",
+      stage: "verify",
+      config: testSel,
+      execute: async () => {
+        gateCalls++;
+        const ok = gateCalls === 1;
+        // Re-runs report a timeout: failing, but with NO structured findings → no keys.
+        return { success: ok, passed: ok, estimatedCostUsd: 0, status: ok ? "passed" : "timeout", findings: [] };
+      },
+    };
+    let reviewCalls = 0;
+    const reviewOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "semantic-review",
+      stage: "verify",
+      config: testSel,
+      execute: async () => {
+        reviewCalls++;
+        const ok = reviewCalls > 1;
+        return {
+          success: ok,
+          passed: ok,
+          estimatedCostUsd: 0,
+          findings: ok
+            ? []
+            : [{ source: "semantic", category: "x", severity: "error", message: "r", rule: "r", file: "a.ts" }],
+        };
+      },
+    };
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = (async (
+      _ctx: unknown,
+      op: { kind?: string; execute?: (i: unknown, c: unknown) => unknown },
+      input: unknown,
+    ) => {
+      if (op.kind === "deterministic" && op.execute) return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    }) as typeof _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.runFixCycle = (async (cycle: { validate: (c: unknown, o: unknown) => Promise<unknown> }) => {
+      await cycle.validate({}, { mode: "full", strategiesRun: ["autofix-implementer"] });
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    try {
+      const ctx = {
+        runtime: rt,
+        packageView: rt.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-keyless",
+      } as unknown as CallContext;
+      const result = await buildPlan(ctx, gateOp, reviewOp).run();
+      // The keyless gate failure is now recognised as a regression — no silent pass.
+      expect(result.gateRegressedDuringRect).toBe(true);
+      expect(result.success).toBe(false);
     } finally {
       _storyOrchestratorDeps.callOp = origCallOp;
       _storyOrchestratorDeps.runFixCycle = origRunFixCycle;


### PR DESCRIPTION
## Summary

Resolves the final **must-fix** item (#3) from the StoryOrchestrator correctness audit (`docs/reports/20260620-story-orchestrator-correctness-audit.md`). With this, **all three must-fix items (#1, #2, #3) are resolved.**

## The bug

The verifier-SSOT carve-out exempts a red full-suite-gate when the verifier passed — *unless* rectification introduced a **new** gate failure (which makes the verdict stale). "New" was decided purely by diffing `file::testName` identity keys (`gateFailureKeys`).

But gate failures change representation:
- a **timeout** yields `findings: []` → empty key set → `[].some(newKey)` is always `false`;
- an **execution-failure** yields a synth finding with no `file`/`rule` → key `"::"`.

Neither produces a comparable key, so the key-diff was **blind** to them: a gate that regressed into a keyless failure was laundered into a **pass** via the carve-out, leaking a genuinely red suite to the deferred regression sweep.

## The fix

A pure `gateRegressedAfterRectification(finalGateOutput, baselineKeys, gateName, storyId?)` in `phase-eval.ts`, called from the carve-out in `execution-plan.ts`:

- **green final gate → not regressed** (this guard is essential: a passing gate also has an empty key set, and must never be read as a keyless failure);
- **failing final gate → regressed** if EITHER a structured key is absent from baseline (the original precise diff, **preserved**) OR the failure is **keyless** (empty key set, or `"::"`).

A keyless failure carries no identity to prove it's the same failure the verifier blessed, so it conservatively counts as a regression rather than being silently exempted. Worst case for a genuinely-flaky unrelated timeout: the story routes to escalation (`tests-failing`) instead of being laundered — a strictly safer failure mode. The structured-subset carve-out (legitimate pre-existing failures) is unchanged.

## Tests
- 5 pure-function cases: green, structured-subset (carve-out preserved), new-key, **timeout**, **execution-failure**.
- 1 end-to-end `ExecutionPlan.run` case: a verifier-passed story whose gate regresses into a timeout now **fails** (`gateRegressedDuringRect=true`, `success=false`) instead of passing via the carve-out.

## Code review
Reviewed (code-reviewer agent): **Approve**, no CRITICAL/HIGH. The reviewer traced the key producers to confirm `"::"`, verified the green-gate guard is necessary, confirmed the legitimate carve-out is preserved, and simulated the pre-fix predicate to prove the new tests fail on old code. (Two LOW notes are pre-existing/out-of-scope.)

## Scope note
This closes the keyless-key blind spot. The deeper Finding 3 (the baseline is captured at main-loop end, not at verifier-pass time) is unchanged — the conservative keyless handling de-risks it; a full fix would re-anchor the baseline. Tracked in the report.

## Test plan
- [x] `bun run test` — full suite green (0 fail)
- [x] `bun run test:e2e` — 23 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
