### PR TITLE
docs(execution): isolation-violation is advisory-by-design, not a missing producer (#8)

### DIFF
--- a/docs/reports/20260620-story-orchestrator-correctness-audit.md
+++ b/docs/reports/20260620-story-orchestrator-correctness-audit.md
@@ -10,8 +10,9 @@
 >   are now treated as regressions, closing the carve-out laundering path.
 > - **#7** re-examined and intentionally left unchanged (the `undefined → pause` fallback is correct; see §7).
 >
-> **All must-fix items (#1, #2, #3) are now resolved.** Remaining open items are LOW nice-to-haves
-> (#6, #8) and the documented-by-design #9.
+> **All must-fix items (#1, #2, #3) are now resolved.** **#8** resolved as documented (mechanical
+> isolation check is advisory by design; verifier owns legitimacy — `fix/isolation-violation-producer`).
+> Remaining open: only the LOW **#6** (sourceDiffCap added-only) and the documented-by-design **#9**.
 
 > Scope: behavioral correctness of the per-story execution flow (`src/execution/story-orchestrator/`)
 > and its collaborators — rectification, resume loops, the verifier-SSOT carve-out + staleness guard,
@@ -39,7 +40,7 @@ guard's representational assumptions**. The highest-value fixes are #1, #2, and 
 | 5 | MEDIUM | Design gap | `pipeline/stages/execution-helpers.ts:64` | ✅ **Fixed** (`fix/story-orchestrator-should-fix`) — `routeTddFailure` now exhaustive (`satisfies never`) |
 | 6 | LOW–MEDIUM | Design gap | `non-blocking-fix.ts:120-125` | **Open** — `sourceDiffCap` counts only *added* lines; a large *deleting* edit bypasses the cap |
 | 7 | MEDIUM → LOW | Re-examined | `tdd-failure-category.ts:101` | ⏸️ **No change** — on inspection the `undefined → pause` fallback is correct; a richer category needs a design change (see below) |
-| 8 | LOW | Design gap | `tdd-failure-category.ts:32` | **Open** — `isolation-violation` handling appears dead for the verifier path |
+| 8 | LOW | Design gap | `tdd-failure-category.ts:32` | ✅ **Resolved as documented** (`fix/isolation-violation-producer`) — mechanical isolation check is advisory by design; verifier owns legitimacy. Not a missing producer |
 | 9 | LOW | Intentional asymmetry | `post-run.ts:245` | **Open** (by design) — TDD pauses vs non-TDD hard-fails for the same "review never ran" root cause |
 
 Gating note: #1, #4, #6 only bite when the **non-blocking fix is enabled** (`review.adversarial.nonBlockingFix.enabled`, default `false`).
@@ -243,6 +244,22 @@ blast radius).
 
 **Fix:** confirm the producer. If isolation violations are only stamped by the test-writer/implementer
 isolation gates (not the verifier), document that; otherwise wire `categorizeVerdict` to emit it.
+
+> ✅ **Resolved as documented** (`fix/isolation-violation-producer`). Investigation confirmed
+> `"isolation-violation"` has **no producer** anywhere in `src/` — but this is **by design, not a bug
+> to wire**. The *mechanical* isolation check (`verifyTestWriterIsolation` /
+> `verifyImplementerIsolation`) detects which files changed but **cannot judge legitimacy** (a stub in
+> `src/` may be required); only the verifier can. So `run-phase.ts` logs a mechanical violation as
+> **advisory** — it never flips phase success or stamps the category. Legitimacy is owned by the
+> verifier, which emits `verifier-rejected` for illegitimate test edits (`tdd/verdict.ts`). Wiring the
+> mechanical check to fail runs would punish violations the verifier might deem legitimate (and would
+> add escalation churn after long dormancy), so we deliberately do **not**. The consumer machinery
+> (`deriveTddFailureCategory` passthrough, `routeTddFailure` → escalate + `retryAsLite`, tier → pause,
+> `shouldRollbackTddFailure`) is **not dead** — it stays wired for a verifier- or plugin-driven producer
+> that *can* assess legitimacy; `deriveTddFailureCategory` already passes through
+> `verifierOutput.failureCategory`. Documented at the two key sites (`run-phase.ts` advisory log,
+> `types.ts` `FailureCategory` definition) so it is not re-flagged as a missing producer. No runtime
+> behavior change.
 
 ### 9. TDD vs non-TDD review-incomplete disposition asymmetry — Intentional, documented
 

--- a/docs/reports/20260620-story-orchestrator-correctness-audit.md
+++ b/docs/reports/20260620-story-orchestrator-correctness-audit.md
@@ -260,6 +260,17 @@ isolation gates (not the verifier), document that; otherwise wire `categorizeVer
 > `verifierOutput.failureCategory`. Documented at the two key sites (`run-phase.ts` advisory log,
 > `types.ts` `FailureCategory` definition) so it is not re-flagged as a missing producer. No runtime
 > behavior change.
+>
+> **Follow-up — can the verifier produce it?** Investigated whether `categorizeVerdict` could emit
+> `isolation-violation` instead of folding cases into `verifier-rejected`. It **structurally cannot**:
+> the `VerifierVerdict` (`tdd/verdict.ts`) reviews the *implementer*, not the test-writer, and has no
+> field describing test-writer-wrote-source. Its only isolation-adjacent signal, `testModifications`
+> (the implementer editing tests), correctly maps to `verifier-rejected` — routing it to
+> `isolation-violation` would be wrong, because that category escalates with `retryAsLite=true`, which
+> *relaxes* isolation on retry (the opposite of enforcing "don't edit tests"). A genuine producer would
+> require **new verifier scope** — a verdict field where the verifier judges the test-writer's isolation
+> legitimacy — which is a feature well beyond this LOW item. Conclusion: the category is producer-less by
+> design *and structural necessity*, not oversight. Left as documented.
 
 ### 9. TDD vs non-TDD review-incomplete disposition asymmetry — Intentional, documented
 

--- a/src/execution/story-orchestrator/run-phase.ts
+++ b/src/execution/story-orchestrator/run-phase.ts
@@ -177,12 +177,22 @@ export async function runPhase(
         });
       }
 
+      // Isolation is ADVISORY here, by design. The mechanical check
+      // (verifyTestWriterIsolation / verifyImplementerIsolation) detects which files
+      // changed but cannot judge whether a change is LEGITIMATE — only the verifier can
+      // (e.g. a stub in src/ may be required). So a mechanical violation is logged, not
+      // enforced: it never flips phase success and never produces the `isolation-violation`
+      // FailureCategory. Legitimacy is owned by the verifier, which emits `verifier-rejected`
+      // for illegitimate test modifications (see tdd/verdict.ts). The `isolation-violation`
+      // category's consumer machinery (escalate→retryAsLite, pause, rollback) stays wired for
+      // a verifier- or plugin-driven producer; do not wire this mechanical check to it.
+      // (Audit #8 — resolved as documented, not a missing producer.)
       const isolation = (output as { isolation?: { passed: boolean; violations: string[] } })?.isolation;
       if (isolation) {
         if (isolation.passed) {
           logger?.info("tdd", "Isolation maintained", { storyId: ctx.storyId, role: opName });
         } else {
-          logger?.error("tdd", "Isolation violated", {
+          logger?.error("tdd", "Isolation violated (advisory — verifier judges legitimacy)", {
             storyId: ctx.storyId,
             role: opName,
             violations: isolation.violations,

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -18,10 +18,24 @@ export type FailureCategory =
   /**
    * Test-writer violated file isolation or created no test files. Routed (escalate →
    * retryAsLite → pause) by `routeTddFailure` / `resolveMaxAttemptsOutcome` and rolled back
-   * by `shouldRollbackTddFailure`. NOTE: no producer currently emits this — the *mechanical*
-   * isolation check is advisory only (it cannot judge legitimacy; see run-phase.ts), and the
-   * verifier emits `verifier-rejected` for illegitimate test edits. This category is reserved
-   * for a verifier- or plugin-driven producer that can assess legitimacy. Audit #8.
+   * by `shouldRollbackTddFailure`.
+   *
+   * NO producer currently emits this, by design — and the verifier *structurally cannot*
+   * (Audit #8):
+   *   - The *mechanical* isolation checks (`verifyTestWriterIsolation` /
+   *     `verifyImplementerIsolation`) detect which files changed but cannot judge whether a
+   *     change is legitimate (a stub in src/ may be required), so they stay advisory — see
+   *     run-phase.ts.
+   *   - The verifier reviews the *implementer*, not the test-writer. Its `VerifierVerdict`
+   *     (tdd/verdict.ts) has no field describing test-writer-wrote-source; `testModifications`
+   *     describes the *implementer editing tests*, which correctly maps to `verifier-rejected`.
+   *     Routing that to `isolation-violation` would be wrong — `retryAsLite` *relaxes* isolation
+   *     on retry, the opposite of enforcing "don't edit tests."
+   *
+   * So a real producer would need NEW verifier scope (a verdict field where the verifier judges
+   * the test-writer's isolation legitimacy) or a plugin. The routing/rollback machinery stays
+   * wired for such a producer via `deriveTddFailureCategory`'s `verifierOutput.failureCategory`
+   * passthrough; until then it is dormant, not dead.
    */
   | "isolation-violation"
   /** A session crashed, timed out, or the agent failed to produce usable output */

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -15,7 +15,14 @@ export type TddSessionRole = "test-writer" | "implementer" | "verifier";
 
 /** Failure categories for story-run results. */
 export type FailureCategory =
-  /** Test-writer violated file isolation or created no test files */
+  /**
+   * Test-writer violated file isolation or created no test files. Routed (escalate →
+   * retryAsLite → pause) by `routeTddFailure` / `resolveMaxAttemptsOutcome` and rolled back
+   * by `shouldRollbackTddFailure`. NOTE: no producer currently emits this — the *mechanical*
+   * isolation check is advisory only (it cannot judge legitimacy; see run-phase.ts), and the
+   * verifier emits `verifier-rejected` for illegitimate test edits. This category is reserved
+   * for a verifier- or plugin-driven producer that can assess legitimacy. Audit #8.
+   */
   | "isolation-violation"
   /** A session crashed, timed out, or the agent failed to produce usable output */
   | "session-failure"


### PR DESCRIPTION
## Summary

Resolves audit item **#8** (`docs/reports/20260620-story-orchestrator-correctness-audit.md`). **Documentation only — no runtime behavior change.**

## Investigation outcome

`"isolation-violation"` has **no producer** anywhere in `src/` — confirmed by grep and by tracing the detection → enforcement path. But this is **by design, not a wiring bug**:

- The **mechanical** isolation check (`verifyTestWriterIsolation` / `verifyImplementerIsolation`) detects *which files changed* but **cannot judge whether a change is legitimate** — e.g. a stub in `src/` may be required. Only the verifier can make that call.
- So `run-phase.ts` logs a mechanical violation as **advisory**: it never flips phase success and never stamps the `isolation-violation` category.
- **Legitimacy is owned by the verifier**, which emits `verifier-rejected` for illegitimate test modifications (`tdd/verdict.ts`). Wiring the mechanical check to fail runs would punish violations the verifier might deem legitimate (and add escalation churn after long dormancy).

The consumer machinery (`deriveTddFailureCategory` passthrough, `routeTddFailure` → escalate + `retryAsLite`, tier → pause, `shouldRollbackTddFailure`) is **not dead** — it stays wired for a verifier- or plugin-driven producer that *can* assess legitimacy; `deriveTddFailureCategory` already passes through `verifierOutput.failureCategory`.

## Changes
- `run-phase.ts` — comment explaining the advisory-by-design rationale; the violation log line now reads "advisory — verifier judges legitimacy".
- `types.ts` — `FailureCategory` doc-comment notes `isolation-violation` is currently producer-less by design and reserved for a legitimacy-aware (verifier/plugin) producer.
- Report — #8 marked resolved-as-documented.

## Audit status
All must-fix (#1–#3) resolved; should-fix (#4, #5) resolved; #7 and #8 resolved-as-documented. Remaining open: only LOW **#6** (sourceDiffCap added-only) and by-design **#9**.

## Test plan
- [x] `bun run test` — full suite green (0 fail)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
