### PR TITLE
fix(execution): bootstrap, set up, and verify brand-new package stories

### DIFF
--- a/src/agents/acp/adapter-lifecycle.ts
+++ b/src/agents/acp/adapter-lifecycle.ts
@@ -5,6 +5,7 @@
 
 import { createHash } from "node:crypto";
 import type { ModelDef } from "../../config/schema";
+import { NaxError } from "../../errors";
 import { getSafeLogger } from "../../logger";
 import type { ProtocolIds } from "../../runtime/protocol-types";
 import { sleep, which } from "../../utils/bun-deps";
@@ -21,6 +22,20 @@ export const _acpAdapterDeps = {
   which,
 
   sleep,
+
+  /**
+   * Check that a session's cwd exists and is a directory. Injectable so tests
+   * don't touch real disk. Uses stat().isDirectory() because Bun.file(dir)
+   * .exists() returns false for directories.
+   */
+  async cwdExists(dir: string): Promise<boolean> {
+    const { stat } = await import("node:fs/promises");
+    try {
+      return (await stat(dir)).isDirectory();
+    } catch {
+      return false;
+    }
+  },
 
   /**
    * Create an ACP client for the given command string.
@@ -153,6 +168,20 @@ export async function ensureAcpSession(
 ): Promise<{ session: AcpSession; resumed: boolean }> {
   if (!agentName) {
     throw new Error("[acp-adapter] agentName is required for ensureAcpSession");
+  }
+
+  // Fail fast with an actionable error if the session cwd is missing. acpx would
+  // otherwise spawn the agent subprocess in a nonexistent directory and die with
+  // a cryptic "Failed to spawn agent command". The common trigger is a new
+  // feature on a brand-new package (story.workdir pointing at a not-yet-created
+  // dir); ensureStoryPackageDirs bootstraps these up front, so reaching this
+  // guard signals a path that bypassed that step.
+  if (client.cwd && !(await _acpAdapterDeps.cwdExists(client.cwd))) {
+    throw new NaxError(
+      `[acp-adapter] Session cwd does not exist: ${client.cwd} — cannot start agent "${agentName}". If this is a new package for the feature, ensure its directory is created before the run.`,
+      "SESSION_CWD_MISSING",
+      { stage: "open-session", agentName, cwd: client.cwd, sessionName },
+    );
   }
 
   if (client.loadSession) {

--- a/src/agents/acp/adapter-session-types.ts
+++ b/src/agents/acp/adapter-session-types.ts
@@ -57,6 +57,8 @@ export interface AcpClientOptions {
 }
 
 export interface AcpClient {
+  /** Working directory the client spawns agent subprocesses in (when known). */
+  readonly cwd?: string;
   start(): Promise<void>;
   createSession(opts: { agentName: string; permissionMode: string; sessionName?: string }): Promise<AcpSession>;
   /** Resume an existing named session. Returns null if the session is not found. */

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -542,7 +542,7 @@ function parseSessionIds(stdout: string): { sessionId: string | undefined; recor
  */
 export class SpawnAcpClient implements AcpClient {
   private readonly model: string;
-  private readonly cwd: string;
+  readonly cwd: string;
   private readonly timeoutSeconds: number;
   private readonly promptRetries: number;
   private readonly env: Record<string, string | undefined>;

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -202,10 +202,10 @@ export interface QualityConfig {
     lintFixScoped?: string;
     /** Auto-fix formatting (e.g., "biome format --write") */
     formatFix?: string;
-    /** Scoped auto-format command template with {{files}} placeholder */
     formatFixScoped?: string;
-    /** Build command (e.g., "bun run build") */
     build?: string;
+    /** One-time package init (e.g. "uv sync"/"bun install"); see schema for full docs. */
+    setup?: string;
   };
   /** Lint output parsing preferences for scope-aware rectification splitting. */
   lintOutput?: {

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -159,6 +159,14 @@ export const QualityConfigSchema = z.object({
       formatFix: z.string().optional(),
       formatFixScoped: z.string().optional(),
       build: z.string().optional(),
+      /**
+       * One-time package initialization (e.g. `uv sync`, `bun install`,
+       * `go mod download`). Runs once per newly-created package directory
+       * (story.workdir that did not exist at run start), after the implementer
+       * scaffolds the manifest and before the first verify/test gate. Layerable
+       * per-package via `.nax/mono/<pkg>/config.json`.
+       */
+      setup: z.string().optional(),
     })
     .default({}),
   lintOutput: z

--- a/src/execution/ensure-package-dirs.ts
+++ b/src/execution/ensure-package-dirs.ts
@@ -1,0 +1,99 @@
+/**
+ * Ensure Story Package Directories
+ *
+ * When a PRD story targets a package that does not exist yet (a new feature on
+ * a brand-new package — e.g. `story.workdir = "packages/portfolio"`), nax
+ * resolves the agent session's cwd to `join(repoRoot, story.workdir)` and hands
+ * that path to acpx. `posix_spawn` cannot start a subprocess in a nonexistent
+ * cwd, so every session dies on launch: the implementer hard-fails
+ * ("Failed to spawn agent command"), and the acceptance generator degrades
+ * silently to a skeleton test. No run could ever bootstrap a new package.
+ *
+ * This module creates any missing story package directories once, up front,
+ * before either the pre-run acceptance pipeline or the execution loop opens a
+ * session — fixing both symptoms at a single chokepoint.
+ */
+
+import path from "node:path";
+import { getSafeLogger } from "../logger";
+import type { PRD } from "../prd";
+
+/**
+ * Injectable filesystem dependencies. Tests override these to avoid touching
+ * real disk; production uses Bun.file().exists() + node:fs/promises mkdir
+ * (no Bun-native mkdir equivalent — same pattern as semantic-verdict.ts).
+ */
+export const _ensurePackageDirsDeps = {
+  // Bun.file(dir).exists() returns false for directories — use stat().isDirectory().
+  exists: async (p: string): Promise<boolean> => {
+    const { stat } = await import("node:fs/promises");
+    try {
+      return (await stat(p)).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  mkdirp: async (p: string): Promise<void> => {
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(p, { recursive: true });
+  },
+};
+
+/**
+ * Create package directories for any story whose `workdir` points to a path
+ * that does not yet exist under the repo root. Idempotent: existing dirs are
+ * left untouched. Stories without a workdir (root-scoped) are ignored.
+ *
+ * Directory existence (not file existence) is what matters because acpx needs a
+ * real directory as cwd. Note `Bun.file(dir).exists()` returns false for
+ * directories, so the default dep uses stat().isDirectory().
+ *
+ * @param prd - The PRD whose stories may target new packages.
+ * @param workdir - Absolute repo root.
+ * @param deps - Injectable FS deps (test seam).
+ * @returns Absolute paths of the directories that were created.
+ */
+export async function ensureStoryPackageDirs(
+  prd: PRD,
+  workdir: string,
+  deps: typeof _ensurePackageDirsDeps = _ensurePackageDirsDeps,
+): Promise<string[]> {
+  const logger = getSafeLogger();
+
+  // Map unique relative workdir -> a representative storyId for log correlation.
+  const relToStoryId = new Map<string, string>();
+  for (const story of prd.userStories) {
+    const rel = story.workdir?.trim();
+    if (!rel) continue;
+    if (!relToStoryId.has(rel)) relToStoryId.set(rel, story.id);
+  }
+
+  const created: string[] = [];
+  for (const [rel, storyId] of relToStoryId) {
+    const abs = path.resolve(workdir, rel);
+
+    // Safety: never create directories outside the repo root (defends against
+    // a malformed PRD with `../` traversal in workdir).
+    const rootWithSep = workdir.endsWith(path.sep) ? workdir : workdir + path.sep;
+    if (abs !== workdir && !abs.startsWith(rootWithSep)) {
+      logger?.warn("execution", "Skipping story workdir outside repo root", {
+        storyId,
+        packageDir: rel,
+        resolved: abs,
+      });
+      continue;
+    }
+
+    if (await deps.exists(abs)) continue;
+
+    await deps.mkdirp(abs);
+    created.push(abs);
+    logger?.info("execution", "Created missing package directory for story", {
+      storyId,
+      packageDir: rel,
+      resolved: abs,
+    });
+  }
+
+  return created;
+}

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -6,6 +6,7 @@ export { groupStoriesIntoBatches, type StoryBatch } from "./batching";
 export { escalateTier, getTierConfig, calculateMaxIterations, resolveMaxAttemptsOutcome } from "./escalation";
 export { readQueueFile, clearQueueFile } from "./queue-handler";
 export { ensureStoryPackageDirs } from "./ensure-package-dirs";
+export { _newPackageSetupDeps, markNewPackageDirs, maybeRunNewPackageSetup } from "./new-package-setup";
 export {
   hookCtx,
   maybeGetContext,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -5,6 +5,7 @@ export { appendProgress } from "./progress";
 export { groupStoriesIntoBatches, type StoryBatch } from "./batching";
 export { escalateTier, getTierConfig, calculateMaxIterations, resolveMaxAttemptsOutcome } from "./escalation";
 export { readQueueFile, clearQueueFile } from "./queue-handler";
+export { ensureStoryPackageDirs } from "./ensure-package-dirs";
 export {
   hookCtx,
   maybeGetContext,

--- a/src/execution/new-package-setup.ts
+++ b/src/execution/new-package-setup.ts
@@ -1,0 +1,114 @@
+/**
+ * New-Package Setup
+ *
+ * When a story targets a package that did not exist at run start (new feature on
+ * a new package), ensureStoryPackageDirs creates the directory but it is empty —
+ * no manifest, no installed dependencies. The implementer scaffolds the manifest
+ * (pyproject.toml / package.json / go.mod / Cargo.toml) during its phase, after
+ * which the package may need a one-time init step (`uv sync`, `bun install`,
+ * `go mod download`) before its tests can run.
+ *
+ * This module runs `quality.commands.setup` (per-package layerable) exactly once
+ * per newly-created package per run, lazily, right before that package's first
+ * verify/test gate — which is after the implementer has produced the manifest.
+ * Existing packages are never touched: only directories registered via
+ * markNewPackageDirs (i.e. created this run) are eligible.
+ *
+ * The runtime instance is the per-run key for the idempotency registry, so the
+ * setup command fires once even though a package may pass through multiple gates
+ * (full-suite-gate and verify-scoped) across iterations.
+ */
+
+import path from "node:path";
+import { getSafeLogger } from "../logger";
+import { spawn } from "../utils/bun-deps";
+import { parseCommandToArgv } from "../utils/command-argv";
+
+/** Per-run registry: which package dirs are newly created, and which have had setup run. */
+const registry = new WeakMap<object, { pending: Set<string>; done: Set<string> }>();
+
+const MAX_SETUP_OUTPUT_CHARS = 2000;
+
+function normalize(dir: string): string {
+  return path.resolve(dir);
+}
+
+/**
+ * Record package directories created this run as eligible for one-time setup.
+ * Keyed by the run's runtime instance.
+ */
+export function markNewPackageDirs(runtime: object | undefined, absDirs: readonly string[]): void {
+  if (!runtime || absDirs.length === 0) return;
+  let slot = registry.get(runtime);
+  if (!slot) {
+    slot = { pending: new Set<string>(), done: new Set<string>() };
+    registry.set(runtime, slot);
+  }
+  for (const dir of absDirs) slot.pending.add(normalize(dir));
+}
+
+/**
+ * Claim the one-time setup for a package. Returns true exactly once for a
+ * pending (newly-created), not-yet-setup package; false otherwise. Marks the
+ * package done on claim so concurrent/repeat gate calls do not re-run setup.
+ */
+function claimSetup(runtime: object, absPackageDir: string): boolean {
+  const slot = registry.get(runtime);
+  if (!slot) return false;
+  const key = normalize(absPackageDir);
+  if (!slot.pending.has(key) || slot.done.has(key)) return false;
+  slot.done.add(key);
+  return true;
+}
+
+/** Injectable process spawn for testability. */
+export const _newPackageSetupDeps = { spawn };
+
+/**
+ * Run `quality.commands.setup` for a newly-created package, once. No-op when the
+ * package was not created this run, setup is already done, or no command is
+ * configured. Failures are logged (warn) and swallowed — the subsequent verify
+ * gate surfaces the real impact rather than this helper changing gate control flow.
+ */
+export async function maybeRunNewPackageSetup(opts: {
+  runtime: object | undefined;
+  storyId: string;
+  packageDir: string;
+  setupCommand: string | undefined;
+}): Promise<void> {
+  const { runtime, storyId, packageDir, setupCommand } = opts;
+  if (!runtime || !setupCommand) return;
+  if (!claimSetup(runtime, packageDir)) return;
+
+  const argv = parseCommandToArgv(setupCommand);
+  if (argv.length === 0) return;
+
+  const logger = getSafeLogger();
+  logger?.info("setup", "Running setup for newly-created package", { storyId, packageDir, command: setupCommand });
+
+  try {
+    const proc = _newPackageSetupDeps.spawn(argv, { cwd: packageDir, stdout: "pipe", stderr: "pipe" });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    if (exitCode !== 0) {
+      const output = [stdout, stderr].filter(Boolean).join("\n").slice(-MAX_SETUP_OUTPUT_CHARS);
+      logger?.warn("setup", "Package setup command failed — continuing; verification will surface the impact", {
+        storyId,
+        packageDir,
+        exitCode,
+        output,
+      });
+      return;
+    }
+    logger?.debug("setup", "Package setup complete", { storyId, packageDir });
+  } catch (err) {
+    logger?.warn("setup", "Package setup command threw — continuing", {
+      storyId,
+      packageDir,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -20,6 +20,7 @@ import type { DispatchContext } from "../runtime/dispatch-context";
 import { SessionManager } from "../session";
 import { precomputeBatchPlan } from "./batching";
 import type { DeferredReviewResult } from "./deferred-review";
+import { ensureStoryPackageDirs } from "./ensure-package-dirs";
 import { getAllReadyStories } from "./helpers";
 
 /**
@@ -118,6 +119,27 @@ export async function runExecutionPhase(
 
   // Clear LLM routing cache at start of new run
   clearLlmCache();
+
+  // Create package directories for stories targeting not-yet-existing packages
+  // (new feature on a new package). Must run before any session opens — both the
+  // pre-run acceptance pipeline (inside executeUnified) and the execution loop
+  // resolve the agent cwd to join(repoRoot, story.workdir); acpx cannot spawn in
+  // a nonexistent cwd. Skipped under dryRun so planning never mutates the tree.
+  if (!options.dryRun) {
+    try {
+      const createdDirs = await ensureStoryPackageDirs(prd, options.workdir);
+      if (createdDirs.length > 0) {
+        logger?.info("execution", "Bootstrapped new package directories", {
+          count: createdDirs.length,
+          dirs: createdDirs,
+        });
+      }
+    } catch (err) {
+      logger?.warn("execution", "Failed to ensure story package directories — continuing", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
 
   // PERF-1: Precompute batch plan once from ready stories
   const readyStories = getAllReadyStories(prd);

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -22,6 +22,7 @@ import { precomputeBatchPlan } from "./batching";
 import type { DeferredReviewResult } from "./deferred-review";
 import { ensureStoryPackageDirs } from "./ensure-package-dirs";
 import { getAllReadyStories } from "./helpers";
+import { markNewPackageDirs } from "./new-package-setup";
 
 /**
  * Options for the execution phase.
@@ -129,6 +130,10 @@ export async function runExecutionPhase(
     try {
       const createdDirs = await ensureStoryPackageDirs(prd, options.workdir);
       if (createdDirs.length > 0) {
+        // Register the new dirs so quality.commands.setup runs once per package,
+        // lazily, before that package's first verify gate (after the implementer
+        // scaffolds its manifest).
+        markNewPackageDirs(options.runtime, createdDirs);
         logger?.info("execution", "Bootstrapped new package directories", {
           count: createdDirs.length,
           dirs: createdDirs,

--- a/src/operations/full-suite-gate.ts
+++ b/src/operations/full-suite-gate.ts
@@ -19,6 +19,9 @@
 import type { NaxConfig } from "../config";
 import { rectificationGateConfigSelector } from "../config/selectors";
 import { NaxError } from "../errors";
+// Leaf import (not the execution barrel) to avoid the execution→operations cycle;
+// same file resolves to one module, so the setup registry stays a singleton.
+import { maybeRunNewPackageSetup } from "../execution/new-package-setup";
 import { executionFailureToFinding, testSummaryToFindings } from "../findings";
 import type { Finding } from "../findings/types";
 import { getLogger } from "../logger";
@@ -218,6 +221,14 @@ export const fullSuiteGateOp: DeterministicOperation<
     }
 
     const gateCtx = await deps.resolveGateContext(input, ctx);
+    // One-time init for a newly-created package (e.g. `uv sync` / `bun install`),
+    // now that the implementer has scaffolded the manifest. No-op for existing packages.
+    await maybeRunNewPackageSetup({
+      runtime: ctx.runtime,
+      storyId: input.story.id,
+      packageDir: ctx.packageView.packageDir,
+      setupCommand: gateCtx.config.quality?.commands?.setup,
+    });
     logger.info("verify[regression]", "Running full-suite gate", {
       storyId: input.story.id,
       packageDir: input.story.workdir,

--- a/src/operations/full-suite-gate.ts
+++ b/src/operations/full-suite-gate.ts
@@ -126,10 +126,18 @@ export const _fullSuiteGateDeps: FullSuiteGateDeps = {
       input.workdir,
       input.story.workdir,
     );
+    // Detection fallback: no command configured (root or per-package) — derive one
+    // from the package's manifest. Runs from the package dir, since the default was
+    // detected there (e.g. a new package's freshly-scaffolded pyproject.toml).
     if (!resolvedTestCmd) {
+      const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
+      const detected = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).test;
+      if (detected) {
+        return { config, testCmd: detected, fullSuiteTimeout, cmdWorkdir: ctx.packageView.packageDir };
+      }
       const pkg = input.story.workdir ?? input.workdir;
       throw new NaxError(
-        `No test command configured for package "${pkg}". Set quality.commands.test in .nax/config.json or .nax/mono/<pkg>/config.json.`,
+        `No test command configured or detected for package "${pkg}". Set quality.commands.test in .nax/config.json or .nax/mono/<pkg>/config.json.`,
         "TEST_COMMAND_MISSING",
         {
           stage: "full-suite-gate",

--- a/src/operations/full-suite-gate.ts
+++ b/src/operations/full-suite-gate.ts
@@ -131,9 +131,11 @@ export const _fullSuiteGateDeps: FullSuiteGateDeps = {
     // detected there (e.g. a new package's freshly-scaffolded pyproject.toml).
     if (!resolvedTestCmd) {
       const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
-      const detected = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).test;
+      // input.workdir is the resolved ABSOLUTE package dir (CallContext.packageDir = ctx.workdir).
+      // ctx.packageView.packageDir is the RELATIVE key — never probe/spawn against it.
+      const detected = (await resolveDefaultQualityCommands(input.workdir)).test;
       if (detected) {
-        return { config, testCmd: detected, fullSuiteTimeout, cmdWorkdir: ctx.packageView.packageDir };
+        return { config, testCmd: detected, fullSuiteTimeout, cmdWorkdir: input.workdir };
       }
       const pkg = input.story.workdir ?? input.workdir;
       throw new NaxError(
@@ -234,7 +236,8 @@ export const fullSuiteGateOp: DeterministicOperation<
     await maybeRunNewPackageSetup({
       runtime: ctx.runtime,
       storyId: input.story.id,
-      packageDir: ctx.packageView.packageDir,
+      // Absolute package dir — must match the abs dirs registered via markNewPackageDirs.
+      packageDir: input.workdir,
       setupCommand: gateCtx.config.quality?.commands?.setup,
     });
     logger.info("verify[regression]", "Running full-suite gate", {

--- a/src/operations/lint-check.ts
+++ b/src/operations/lint-check.ts
@@ -41,9 +41,19 @@ export const lintCheckOp: DeterministicOperation<LintCheckInput, LintCheckOutput
     deps: LintCheckDeps = _lintCheckDeps,
   ): Promise<LintCheckOutput> {
     const quality = ctx.packageView.select(qualityConfigSelector).quality;
-    const command = quality?.commands?.lint;
+    let command = quality?.commands?.lint;
 
-    // No command configured → skip (success, non-blocking) with a warning.
+    // Detection fallback: derive a default from the package's manifest when no
+    // command is configured (only emitted when the tool/config is present). Runs
+    // from the package dir, since that is where it was detected.
+    let detectedFromPackage = false;
+    if (!command) {
+      const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
+      command = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).lint;
+      detectedFromPackage = Boolean(command);
+    }
+
+    // No command configured or detected → skip (success, non-blocking) with a warning.
     // Never spawn an empty command (that would exit 0 and read as a false pass).
     if (!command) {
       getSafeLogger()?.warn("quality", "No lint command configured — skipping lint gate", {
@@ -53,8 +63,12 @@ export const lintCheckOp: DeterministicOperation<LintCheckInput, LintCheckOutput
       return { success: true, status: "skipped", findings: [], durationMs: 0 };
     }
 
-    // Root-config fallback: command was not defined per-package, so run from repo root.
-    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
+    // Detected default → run from the package dir; configured-but-no-override → repo root.
+    const cmdWorkdir = detectedFromPackage
+      ? ctx.packageView.packageDir
+      : ctx.packageView.hasOverride
+        ? input.workdir
+        : ctx.packageView.repoRoot;
     const start = Date.now();
     const result = await deps.runQualityCommand({
       commandName: "lint",

--- a/src/operations/lint-check.ts
+++ b/src/operations/lint-check.ts
@@ -49,7 +49,9 @@ export const lintCheckOp: DeterministicOperation<LintCheckInput, LintCheckOutput
     let detectedFromPackage = false;
     if (!command) {
       const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
-      command = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).lint;
+      // input.workdir is the resolved ABSOLUTE package dir; ctx.packageView.packageDir
+      // is the RELATIVE key — never probe the filesystem against it.
+      command = (await resolveDefaultQualityCommands(input.workdir)).lint;
       detectedFromPackage = Boolean(command);
     }
 
@@ -63,9 +65,10 @@ export const lintCheckOp: DeterministicOperation<LintCheckInput, LintCheckOutput
       return { success: true, status: "skipped", findings: [], durationMs: 0 };
     }
 
-    // Detected default → run from the package dir; configured-but-no-override → repo root.
+    // Detected default → run from the package dir (absolute input.workdir, not the
+    // relative packageView key); configured-but-no-override → repo root.
     const cmdWorkdir = detectedFromPackage
-      ? ctx.packageView.packageDir
+      ? input.workdir
       : ctx.packageView.hasOverride
         ? input.workdir
         : ctx.packageView.repoRoot;

--- a/src/operations/typecheck-check.ts
+++ b/src/operations/typecheck-check.ts
@@ -45,7 +45,17 @@ export const typecheckCheckOp: DeterministicOperation<TypecheckCheckInput, Typec
     deps: TypecheckCheckDeps = _typecheckCheckDeps,
   ): Promise<TypecheckCheckOutput> {
     const quality = ctx.packageView.select(qualityConfigSelector).quality;
-    const command = quality?.commands?.typecheck;
+    let command = quality?.commands?.typecheck;
+
+    // Detection fallback: derive a default from the package's manifest when no
+    // command is configured (only safe built-ins / present-config). Runs from the
+    // package dir, since that is where it was detected.
+    let detectedFromPackage = false;
+    if (!command) {
+      const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
+      command = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).typecheck;
+      detectedFromPackage = Boolean(command);
+    }
 
     if (!command) {
       getSafeLogger()?.warn("quality", "No typecheck command configured — skipping typecheck gate", {
@@ -55,8 +65,12 @@ export const typecheckCheckOp: DeterministicOperation<TypecheckCheckInput, Typec
       return { success: true, status: "skipped", findings: [], durationMs: 0 };
     }
 
-    // Root-config fallback: command was not defined per-package, so run from repo root.
-    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
+    // Detected default → run from the package dir; configured-but-no-override → repo root.
+    const cmdWorkdir = detectedFromPackage
+      ? ctx.packageView.packageDir
+      : ctx.packageView.hasOverride
+        ? input.workdir
+        : ctx.packageView.repoRoot;
     const start = Date.now();
     const result = await deps.runQualityCommand({
       commandName: "typecheck",

--- a/src/operations/typecheck-check.ts
+++ b/src/operations/typecheck-check.ts
@@ -53,7 +53,9 @@ export const typecheckCheckOp: DeterministicOperation<TypecheckCheckInput, Typec
     let detectedFromPackage = false;
     if (!command) {
       const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
-      command = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).typecheck;
+      // input.workdir is the resolved ABSOLUTE package dir; ctx.packageView.packageDir
+      // is the RELATIVE key — never probe the filesystem against it.
+      command = (await resolveDefaultQualityCommands(input.workdir)).typecheck;
       detectedFromPackage = Boolean(command);
     }
 
@@ -65,9 +67,10 @@ export const typecheckCheckOp: DeterministicOperation<TypecheckCheckInput, Typec
       return { success: true, status: "skipped", findings: [], durationMs: 0 };
     }
 
-    // Detected default → run from the package dir; configured-but-no-override → repo root.
+    // Detected default → run from the package dir (absolute input.workdir, not the
+    // relative packageView key); configured-but-no-override → repo root.
     const cmdWorkdir = detectedFromPackage
-      ? ctx.packageView.packageDir
+      ? input.workdir
       : ctx.packageView.hasOverride
         ? input.workdir
         : ctx.packageView.repoRoot;

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -76,7 +76,9 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     let detectedFromPackage = false;
     if (!baseCommand) {
       const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
-      baseCommand = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).test;
+      // input.workdir is the resolved ABSOLUTE package dir; ctx.packageView.packageDir
+      // is the RELATIVE key — never probe the filesystem against it.
+      baseCommand = (await resolveDefaultQualityCommands(input.workdir)).test;
       detectedFromPackage = Boolean(baseCommand);
     }
 
@@ -101,7 +103,8 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     await maybeRunNewPackageSetup({
       runtime: ctx.runtime,
       storyId: input.storyId,
-      packageDir: ctx.packageView.packageDir,
+      // Absolute package dir — must match the abs dirs registered via markNewPackageDirs.
+      packageDir: input.workdir,
       setupCommand: quality.quality?.commands?.setup,
     });
 
@@ -161,9 +164,10 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     // for agent-cleanup. The legacy ScopedStrategy also used regression(), so this preserves parity
     // — it is NOT a new perf regression introduced by this port.
     const scopedTimeout = quality.execution?.regressionGate?.timeoutSeconds ?? 600;
-    // Detected default → run from the package dir; configured-but-no-override → repo root.
+    // Detected default → run from the package dir (absolute input.workdir, not the
+    // relative packageView key); configured-but-no-override → repo root.
     const cmdWorkdir = detectedFromPackage
-      ? ctx.packageView.packageDir
+      ? input.workdir
       : ctx.packageView.hasOverride
         ? input.workdir
         : ctx.packageView.repoRoot;

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -1,5 +1,7 @@
 import { qualityConfigSelector } from "../config";
 import type { QualityConfig } from "../config/selectors";
+// Leaf import (not the execution barrel) to avoid the execution→operations cycle.
+import { maybeRunNewPackageSetup } from "../execution/new-package-setup";
 import { executionFailureToFinding, testSummaryToFindings } from "../findings";
 import type { Finding } from "../findings/types";
 import { getLogger } from "../logger";
@@ -83,6 +85,15 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
         isFullSuite: true,
       };
     }
+
+    // One-time init for a newly-created package (e.g. `uv sync` / `bun install`),
+    // now that the implementer has scaffolded the manifest. No-op for existing packages.
+    await maybeRunNewPackageSetup({
+      runtime: ctx.runtime,
+      storyId: input.storyId,
+      packageDir: ctx.packageView.packageDir,
+      setupCommand: quality.quality?.commands?.setup,
+    });
 
     const regressionMode = input.regressionMode ?? "deferred";
     // Note: smart-runner config lives at execution.smartTestRunner (not quality.smartRunner).

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -68,9 +68,19 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
   ): Promise<VerifyScopedOutput> {
     const logger = getLogger();
     const quality = ctx.packageView.select(qualityConfigSelector);
-    const baseCommand = quality.quality?.commands?.test;
+    let baseCommand = quality.quality?.commands?.test;
 
-    // No test command configured → skip (deferred run-end gate still covers regressions).
+    // Detection fallback: no command configured (root or per-package) — derive one
+    // from the package's manifest (e.g. a new package's scaffolded pyproject.toml).
+    // When used, tests run from the package dir since that is where it was detected.
+    let detectedFromPackage = false;
+    if (!baseCommand) {
+      const { resolveDefaultQualityCommands } = await import("../quality/command-defaults");
+      baseCommand = (await resolveDefaultQualityCommands(ctx.packageView.packageDir)).test;
+      detectedFromPackage = Boolean(baseCommand);
+    }
+
+    // No test command configured or detected → skip (deferred run-end gate still covers regressions).
     if (!baseCommand) {
       logger.warn("quality", "No test command configured — skipping scoped verify", {
         storyId: input.storyId,
@@ -108,7 +118,7 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       // via qualityConfigSelector = pickSelector("quality", "quality", "execution").
       smartRunnerConfig: quality.execution?.smartTestRunner,
       scopeTestThreshold: quality.quality?.scopeTestThreshold,
-      fallbackFullSuiteCommand: quality.quality?.commands?.test,
+      fallbackFullSuiteCommand: baseCommand,
       naxIgnoreIndex: input.naxIgnoreIndex,
       repoRoot: input.repoRoot,
       packagePrefix: input.packagePrefix,
@@ -151,8 +161,12 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     // for agent-cleanup. The legacy ScopedStrategy also used regression(), so this preserves parity
     // — it is NOT a new perf regression introduced by this port.
     const scopedTimeout = quality.execution?.regressionGate?.timeoutSeconds ?? 600;
-    // Root-config fallback: command was not defined per-package, so run from repo root.
-    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
+    // Detected default → run from the package dir; configured-but-no-override → repo root.
+    const cmdWorkdir = detectedFromPackage
+      ? ctx.packageView.packageDir
+      : ctx.packageView.hasOverride
+        ? input.workdir
+        : ctx.packageView.repoRoot;
     logger.info("verify[scoped]", "Running scoped tests", {
       storyId: input.storyId,
       packageDir: input.packageDir,

--- a/src/quality/command-defaults.ts
+++ b/src/quality/command-defaults.ts
@@ -58,7 +58,12 @@ export async function resolveDefaultQualityCommands(packageDir: string): Promise
   const cached = memo.get(packageDir);
   if (cached) return cached;
   const result = await compute(packageDir);
-  memo.set(packageDir, result);
+  // Only memoize non-empty results. An empty {} means no manifest was detected
+  // yet — a new package's manifest may be scaffolded by the implementer later in
+  // the same long-lived process, so caching {} would permanently mask it.
+  if (result.test || result.typecheck || result.lint) {
+    memo.set(packageDir, result);
+  }
   return result;
 }
 

--- a/src/quality/command-defaults.ts
+++ b/src/quality/command-defaults.ts
@@ -1,0 +1,154 @@
+/**
+ * Detection-Based Default Quality Commands
+ *
+ * Fallback test/lint/typecheck commands derived from a package's manifest, used
+ * ONLY when no command is configured (explicit config — root or per-package —
+ * always wins). The primary driver is a brand-new package created mid-run: by
+ * the time a verify gate runs, the implementer has scaffolded the manifest, so
+ * detection here yields a runnable command where config alone resolved nothing.
+ *
+ * Conservatism rule: only emit a command that is a toolchain built-in (e.g.
+ * `go vet`, `cargo check`) or whose tool/config marker is present (tsconfig,
+ * biome.json, [tool.ruff]). This avoids turning today's graceful "no command —
+ * skip" into a false failure from an uninstalled tool. When unsure, omit.
+ */
+
+import { join } from "node:path";
+import { detectLanguage } from "../project/detector";
+
+export interface DefaultQualityCommands {
+  test?: string;
+  lint?: string;
+  typecheck?: string;
+}
+
+/** Injectable deps for testability — avoids touching real disk / mock.module(). */
+export const _commandDefaultsDeps = {
+  fileExists: (p: string): Promise<boolean> => Bun.file(p).exists(),
+  readText: async (p: string): Promise<string> => {
+    try {
+      return await Bun.file(p).text();
+    } catch {
+      return "";
+    }
+  },
+  readJson: async (p: string): Promise<Record<string, unknown> | null> => {
+    try {
+      return (await Bun.file(p).json()) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  },
+  detectLanguage,
+};
+
+const memo = new Map<string, DefaultQualityCommands>();
+
+/** Reset the per-process memo. For tests only. */
+export function clearCommandDefaultsCache(): void {
+  memo.clear();
+}
+
+/**
+ * Resolve conservative default quality commands for a package by detecting its
+ * manifest. Memoized per packageDir. Returns {} when the language is unknown or
+ * no safe defaults apply.
+ */
+export async function resolveDefaultQualityCommands(packageDir: string): Promise<DefaultQualityCommands> {
+  const cached = memo.get(packageDir);
+  if (cached) return cached;
+  const result = await compute(packageDir);
+  memo.set(packageDir, result);
+  return result;
+}
+
+async function compute(packageDir: string): Promise<DefaultQualityCommands> {
+  const language = await _commandDefaultsDeps.detectLanguage(packageDir);
+  switch (language) {
+    case "go":
+      // All Go built-ins — safe to default unconditionally.
+      return { test: "go test ./...", typecheck: "go build ./...", lint: "go vet ./..." };
+    case "rust":
+      // cargo check/clippy/test ship with a standard rustup toolchain.
+      return { test: "cargo test", typecheck: "cargo check", lint: "cargo clippy" };
+    case "python":
+      return pythonDefaults(packageDir);
+    case "typescript":
+    case "javascript":
+      return jsDefaults(packageDir);
+    default:
+      return {};
+  }
+}
+
+/** Python: pytest under the detected runner; lint/typecheck only when configured. */
+async function pythonDefaults(packageDir: string): Promise<DefaultQualityCommands> {
+  const deps = _commandDefaultsDeps;
+  const pyproject = await deps.readText(join(packageDir, "pyproject.toml"));
+
+  let prefix = "";
+  if ((await deps.fileExists(join(packageDir, "uv.lock"))) || pyproject.includes("[tool.uv]")) {
+    prefix = "uv run ";
+  } else if ((await deps.fileExists(join(packageDir, "poetry.lock"))) || pyproject.includes("[tool.poetry]")) {
+    prefix = "poetry run ";
+  }
+
+  const result: DefaultQualityCommands = { test: `${prefix}pytest` };
+  // mypy/ruff are optional — only default when their config is present.
+  if (pyproject.includes("[tool.mypy]") || (await deps.fileExists(join(packageDir, "mypy.ini")))) {
+    result.typecheck = `${prefix}mypy .`;
+  }
+  if (
+    pyproject.includes("[tool.ruff]") ||
+    (await deps.fileExists(join(packageDir, "ruff.toml"))) ||
+    (await deps.fileExists(join(packageDir, ".ruff.toml")))
+  ) {
+    result.lint = `${prefix}ruff check .`;
+  }
+  return result;
+}
+
+/** JS/TS: package-manager-aware test; typecheck/lint only when their config is present. */
+async function jsDefaults(packageDir: string): Promise<DefaultQualityCommands> {
+  const deps = _commandDefaultsDeps;
+  const pm = await detectJsPackageManager(packageDir);
+  const pkg = await deps.readJson(join(packageDir, "package.json"));
+  const scripts = (pkg?.scripts as Record<string, unknown> | undefined) ?? {};
+
+  const result: DefaultQualityCommands = {};
+
+  if (typeof scripts.test === "string" && scripts.test.trim().length > 0) {
+    result.test = `${pm} run test`;
+  } else if (pm === "bun") {
+    result.test = "bun test";
+  }
+
+  if (typeof scripts.typecheck === "string") {
+    result.typecheck = `${pm} run typecheck`;
+  } else if (await deps.fileExists(join(packageDir, "tsconfig.json"))) {
+    result.typecheck = `${pm === "bun" ? "bunx" : `${pm} exec`} tsc --noEmit`;
+  }
+
+  if (await deps.fileExists(join(packageDir, "biome.json"))) {
+    result.lint = `${pm === "bun" ? "bunx" : `${pm} exec`} biome check .`;
+  } else if (
+    (await deps.fileExists(join(packageDir, ".eslintrc"))) ||
+    (await deps.fileExists(join(packageDir, ".eslintrc.json"))) ||
+    (await deps.fileExists(join(packageDir, ".eslintrc.js"))) ||
+    (await deps.fileExists(join(packageDir, "eslint.config.js")))
+  ) {
+    result.lint = `${pm === "bun" ? "bunx" : `${pm} exec`} eslint .`;
+  }
+
+  return result;
+}
+
+async function detectJsPackageManager(packageDir: string): Promise<"bun" | "pnpm" | "yarn" | "npm"> {
+  const deps = _commandDefaultsDeps;
+  if ((await deps.fileExists(join(packageDir, "bun.lock"))) || (await deps.fileExists(join(packageDir, "bun.lockb")))) {
+    return "bun";
+  }
+  if (await deps.fileExists(join(packageDir, "pnpm-lock.yaml"))) return "pnpm";
+  if (await deps.fileExists(join(packageDir, "yarn.lock"))) return "yarn";
+  return "npm";
+}

--- a/src/quality/index.ts
+++ b/src/quality/index.ts
@@ -9,6 +9,12 @@ export type { QualityCommandOptions, QualityCommandResult } from "./runner";
 export { resolveQualityTestCommands, _commandResolverDeps } from "./command-resolver";
 export type { ResolvedTestCommands } from "./command-resolver";
 export {
+  resolveDefaultQualityCommands,
+  clearCommandDefaultsCache,
+  _commandDefaultsDeps,
+} from "./command-defaults";
+export type { DefaultQualityCommands } from "./command-defaults";
+export {
   parseSelfVerificationMarker,
   resolveSelfVerificationPromptInput,
 } from "./self-verification";

--- a/test/unit/agents/acp/adapter-lifecycle.test.ts
+++ b/test/unit/agents/acp/adapter-lifecycle.test.ts
@@ -13,9 +13,69 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  _acpAdapterDeps,
+  ensureAcpSession,
   runSessionPrompt,
 } from "../../../../src/agents/acp/adapter";
-import type { AcpSession, AcpSessionResponse } from "../../../../src/agents/acp/adapter";
+import type { AcpClient, AcpSession, AcpSessionResponse } from "../../../../src/agents/acp/adapter";
+import { withDepsRestore } from "../../../helpers/deps";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ensureAcpSession — cwd existence guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ensureAcpSession — cwd guard", () => {
+  withDepsRestore(_acpAdapterDeps, ["cwdExists"]);
+
+  function makeClient(cwd: string | undefined, opts?: { onCreate?: () => void }): AcpClient {
+    const session: AcpSession = {
+      prompt: async () => ({ stopReason: "end_turn", messages: [] }),
+      cancelActivePrompt: async () => {},
+      close: async () => {},
+    };
+    return {
+      cwd,
+      start: async () => {},
+      createSession: async () => {
+        opts?.onCreate?.();
+        return session;
+      },
+      close: async () => {},
+    } as AcpClient;
+  }
+
+  test("throws an actionable error when the session cwd does not exist", async () => {
+    _acpAdapterDeps.cwdExists = () => Promise.resolve(false);
+    let created = false;
+    const client = makeClient("/repo/packages/portfolio", { onCreate: () => (created = true) });
+
+    await expect(ensureAcpSession(client, "sess-1", "claude", "approve-reads")).rejects.toThrow(
+      /Session cwd does not exist: \/repo\/packages\/portfolio/,
+    );
+    expect(created).toBe(false);
+  });
+
+  test("creates the session when the cwd exists", async () => {
+    _acpAdapterDeps.cwdExists = () => Promise.resolve(true);
+    const client = makeClient("/repo/packages/core");
+
+    const { session, resumed } = await ensureAcpSession(client, "sess-1", "claude", "approve-reads");
+    expect(session).toBeDefined();
+    expect(resumed).toBe(false);
+  });
+
+  test("skips the guard when the client does not expose a cwd", async () => {
+    let checked = false;
+    _acpAdapterDeps.cwdExists = () => {
+      checked = true;
+      return Promise.resolve(false);
+    };
+    const client = makeClient(undefined);
+
+    await expect(ensureAcpSession(client, "sess-1", "claude", "approve-reads")).resolves.toBeDefined();
+    expect(checked).toBe(false);
+  });
+});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // runSessionPrompt — timer cleanup

--- a/test/unit/execution/ensure-package-dirs.test.ts
+++ b/test/unit/execution/ensure-package-dirs.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for ensureStoryPackageDirs — creates package directories for stories
+ * whose workdir points to a not-yet-existing package (new feature on a new
+ * package). Without this, agent sessions spawn with a nonexistent cwd and die
+ * on launch (implementer hard-fails, acceptance-gen degrades silently).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ensureStoryPackageDirs } from "@/execution";
+import type { _ensurePackageDirsDeps } from "@/execution/ensure-package-dirs";
+import type { PRD, UserStory } from "@/prd";
+
+const ROOT = "/repo";
+
+function makeStory(id: string, workdir?: string): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "",
+    acceptanceCriteria: [],
+    dependencies: [],
+    status: "pending",
+    ...(workdir !== undefined ? { workdir } : {}),
+  } as UserStory;
+}
+
+function makePrd(stories: UserStory[]): PRD {
+  return { feature: "feat", userStories: stories } as PRD;
+}
+
+function makeDeps(existing: Set<string>) {
+  const created: string[] = [];
+  return {
+    deps: {
+      exists: async (p: string) => existing.has(p),
+      mkdirp: async (p: string) => {
+        created.push(p);
+        existing.add(p);
+      },
+    } satisfies typeof _ensurePackageDirsDeps,
+    created,
+  };
+}
+
+describe("ensureStoryPackageDirs", () => {
+  test("creates the package dir when story.workdir does not exist", async () => {
+    const { deps, created } = makeDeps(new Set([ROOT]));
+    const prd = makePrd([makeStory("US-001", "packages/portfolio")]);
+
+    const result = await ensureStoryPackageDirs(prd, ROOT, deps);
+
+    expect(created).toEqual(["/repo/packages/portfolio"]);
+    expect(result).toEqual(["/repo/packages/portfolio"]);
+  });
+
+  test("does not recreate an existing package dir", async () => {
+    const { deps, created } = makeDeps(new Set([ROOT, "/repo/packages/core"]));
+    const prd = makePrd([makeStory("US-001", "packages/core")]);
+
+    const result = await ensureStoryPackageDirs(prd, ROOT, deps);
+
+    expect(created).toEqual([]);
+    expect(result).toEqual([]);
+  });
+
+  test("deduplicates stories sharing the same workdir", async () => {
+    const { deps, created } = makeDeps(new Set([ROOT]));
+    const prd = makePrd([
+      makeStory("US-001", "packages/portfolio"),
+      makeStory("US-002", "packages/portfolio"),
+    ]);
+
+    await ensureStoryPackageDirs(prd, ROOT, deps);
+
+    expect(created).toEqual(["/repo/packages/portfolio"]);
+  });
+
+  test("ignores stories without a workdir (root-scoped)", async () => {
+    const { deps, created } = makeDeps(new Set([ROOT]));
+    const prd = makePrd([makeStory("US-001"), makeStory("US-002", "")]);
+
+    await ensureStoryPackageDirs(prd, ROOT, deps);
+
+    expect(created).toEqual([]);
+  });
+
+  test("creates dirs for multiple distinct new packages", async () => {
+    const { deps, created } = makeDeps(new Set([ROOT, "/repo/packages/core"]));
+    const prd = makePrd([
+      makeStory("US-001", "packages/portfolio"),
+      makeStory("US-002", "packages/core"),
+      makeStory("US-003", "apps/web"),
+    ]);
+
+    const result = await ensureStoryPackageDirs(prd, ROOT, deps);
+
+    expect(new Set(created)).toEqual(new Set(["/repo/packages/portfolio", "/repo/apps/web"]));
+    expect(new Set(result)).toEqual(new Set(["/repo/packages/portfolio", "/repo/apps/web"]));
+  });
+
+  test("never escapes the repo root via traversal in workdir", async () => {
+    const { deps, created } = makeDeps(new Set([ROOT]));
+    const prd = makePrd([makeStory("US-001", "../evil")]);
+
+    await ensureStoryPackageDirs(prd, ROOT, deps);
+
+    expect(created).toEqual([]);
+  });
+});

--- a/test/unit/execution/ensure-package-dirs.test.ts
+++ b/test/unit/execution/ensure-package-dirs.test.ts
@@ -6,26 +6,19 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { makePRD, makeStory } from "@test/helpers";
 import { ensureStoryPackageDirs } from "@/execution";
 import type { _ensurePackageDirsDeps } from "@/execution/ensure-package-dirs";
-import type { PRD, UserStory } from "@/prd";
+import type { UserStory } from "@/prd";
 
 const ROOT = "/repo";
 
-function makeStory(id: string, workdir?: string): UserStory {
-  return {
-    id,
-    title: `Story ${id}`,
-    description: "",
-    acceptanceCriteria: [],
-    dependencies: [],
-    status: "pending",
-    ...(workdir !== undefined ? { workdir } : {}),
-  } as UserStory;
+function story(id: string, workdir?: string): UserStory {
+  return makeStory(workdir !== undefined ? { id, workdir } : { id });
 }
 
-function makePrd(stories: UserStory[]): PRD {
-  return { feature: "feat", userStories: stories } as PRD;
+function makePrd(stories: UserStory[]): ReturnType<typeof makePRD> {
+  return makePRD({ userStories: stories });
 }
 
 function makeDeps(existing: Set<string>) {
@@ -45,7 +38,7 @@ function makeDeps(existing: Set<string>) {
 describe("ensureStoryPackageDirs", () => {
   test("creates the package dir when story.workdir does not exist", async () => {
     const { deps, created } = makeDeps(new Set([ROOT]));
-    const prd = makePrd([makeStory("US-001", "packages/portfolio")]);
+    const prd = makePrd([story("US-001", "packages/portfolio")]);
 
     const result = await ensureStoryPackageDirs(prd, ROOT, deps);
 
@@ -55,7 +48,7 @@ describe("ensureStoryPackageDirs", () => {
 
   test("does not recreate an existing package dir", async () => {
     const { deps, created } = makeDeps(new Set([ROOT, "/repo/packages/core"]));
-    const prd = makePrd([makeStory("US-001", "packages/core")]);
+    const prd = makePrd([story("US-001", "packages/core")]);
 
     const result = await ensureStoryPackageDirs(prd, ROOT, deps);
 
@@ -66,8 +59,8 @@ describe("ensureStoryPackageDirs", () => {
   test("deduplicates stories sharing the same workdir", async () => {
     const { deps, created } = makeDeps(new Set([ROOT]));
     const prd = makePrd([
-      makeStory("US-001", "packages/portfolio"),
-      makeStory("US-002", "packages/portfolio"),
+      story("US-001", "packages/portfolio"),
+      story("US-002", "packages/portfolio"),
     ]);
 
     await ensureStoryPackageDirs(prd, ROOT, deps);
@@ -77,7 +70,7 @@ describe("ensureStoryPackageDirs", () => {
 
   test("ignores stories without a workdir (root-scoped)", async () => {
     const { deps, created } = makeDeps(new Set([ROOT]));
-    const prd = makePrd([makeStory("US-001"), makeStory("US-002", "")]);
+    const prd = makePrd([story("US-001"), story("US-002", "")]);
 
     await ensureStoryPackageDirs(prd, ROOT, deps);
 
@@ -87,9 +80,9 @@ describe("ensureStoryPackageDirs", () => {
   test("creates dirs for multiple distinct new packages", async () => {
     const { deps, created } = makeDeps(new Set([ROOT, "/repo/packages/core"]));
     const prd = makePrd([
-      makeStory("US-001", "packages/portfolio"),
-      makeStory("US-002", "packages/core"),
-      makeStory("US-003", "apps/web"),
+      story("US-001", "packages/portfolio"),
+      story("US-002", "packages/core"),
+      story("US-003", "apps/web"),
     ]);
 
     const result = await ensureStoryPackageDirs(prd, ROOT, deps);
@@ -100,7 +93,7 @@ describe("ensureStoryPackageDirs", () => {
 
   test("never escapes the repo root via traversal in workdir", async () => {
     const { deps, created } = makeDeps(new Set([ROOT]));
-    const prd = makePrd([makeStory("US-001", "../evil")]);
+    const prd = makePrd([story("US-001", "../evil")]);
 
     await ensureStoryPackageDirs(prd, ROOT, deps);
 

--- a/test/unit/execution/new-package-setup.test.ts
+++ b/test/unit/execution/new-package-setup.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for new-package setup — runs quality.commands.setup once per
+ * newly-created package, before its first verify gate. Existing packages and
+ * un-marked dirs are never set up.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { _newPackageSetupDeps, markNewPackageDirs, maybeRunNewPackageSetup } from "@/execution";
+
+function textStream(text = ""): ReadableStream<Uint8Array> {
+  return new Response(text).body as ReadableStream<Uint8Array>;
+}
+
+function spawnOk(exitCode = 0, capture?: { argv?: string[]; cwd?: string }) {
+  return mock((argv: string[], opts: { cwd: string }) => {
+    if (capture) {
+      capture.argv = argv;
+      capture.cwd = opts.cwd;
+    }
+    return {
+      exited: Promise.resolve(exitCode),
+      stdout: textStream(),
+      stderr: textStream(exitCode === 0 ? "" : "boom"),
+      pid: 1,
+      kill: () => {},
+    };
+  });
+}
+
+const originalSpawn = _newPackageSetupDeps.spawn;
+
+describe("maybeRunNewPackageSetup", () => {
+  afterEach(() => {
+    _newPackageSetupDeps.spawn = originalSpawn;
+  });
+
+  test("runs the setup command in the package dir for a newly-created package", async () => {
+    const capture: { argv?: string[]; cwd?: string } = {};
+    _newPackageSetupDeps.spawn = spawnOk(0, capture) as typeof _newPackageSetupDeps.spawn;
+    const runtime = {};
+    markNewPackageDirs(runtime, ["/repo/packages/portfolio"]);
+
+    await maybeRunNewPackageSetup({
+      runtime,
+      storyId: "US-001",
+      packageDir: "/repo/packages/portfolio",
+      setupCommand: "uv sync",
+    });
+
+    expect(capture.argv).toEqual(["uv", "sync"]);
+    expect(capture.cwd).toBe("/repo/packages/portfolio");
+  });
+
+  test("runs at most once per package even across multiple gates", async () => {
+    const spawnMock = spawnOk(0);
+    _newPackageSetupDeps.spawn = spawnMock as typeof _newPackageSetupDeps.spawn;
+    const runtime = {};
+    markNewPackageDirs(runtime, ["/repo/packages/portfolio"]);
+
+    const opts = {
+      runtime,
+      storyId: "US-001",
+      packageDir: "/repo/packages/portfolio",
+      setupCommand: "uv sync",
+    };
+    await maybeRunNewPackageSetup(opts);
+    await maybeRunNewPackageSetup(opts);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does nothing for a package that was not created this run", async () => {
+    const spawnMock = spawnOk(0);
+    _newPackageSetupDeps.spawn = spawnMock as typeof _newPackageSetupDeps.spawn;
+    const runtime = {};
+    // No markNewPackageDirs for this package.
+
+    await maybeRunNewPackageSetup({
+      runtime,
+      storyId: "US-001",
+      packageDir: "/repo/packages/core",
+      setupCommand: "uv sync",
+    });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when no setup command is configured", async () => {
+    const spawnMock = spawnOk(0);
+    _newPackageSetupDeps.spawn = spawnMock as typeof _newPackageSetupDeps.spawn;
+    const runtime = {};
+    markNewPackageDirs(runtime, ["/repo/packages/portfolio"]);
+
+    await maybeRunNewPackageSetup({
+      runtime,
+      storyId: "US-001",
+      packageDir: "/repo/packages/portfolio",
+      setupCommand: undefined,
+    });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("normalizes paths so trailing-slash variants match the registry", async () => {
+    const spawnMock = spawnOk(0);
+    _newPackageSetupDeps.spawn = spawnMock as typeof _newPackageSetupDeps.spawn;
+    const runtime = {};
+    markNewPackageDirs(runtime, ["/repo/packages/portfolio/"]);
+
+    await maybeRunNewPackageSetup({
+      runtime,
+      storyId: "US-001",
+      packageDir: "/repo/packages/portfolio",
+      setupCommand: "uv sync",
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("swallows a failing setup command (verify gate surfaces the impact)", async () => {
+    _newPackageSetupDeps.spawn = spawnOk(1) as typeof _newPackageSetupDeps.spawn;
+    const runtime = {};
+    markNewPackageDirs(runtime, ["/repo/packages/portfolio"]);
+
+    await expect(
+      maybeRunNewPackageSetup({
+        runtime,
+        storyId: "US-001",
+        packageDir: "/repo/packages/portfolio",
+        setupCommand: "uv sync",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("no-op when runtime is undefined", async () => {
+    const spawnMock = spawnOk(0);
+    _newPackageSetupDeps.spawn = spawnMock as typeof _newPackageSetupDeps.spawn;
+
+    await maybeRunNewPackageSetup({
+      runtime: undefined,
+      storyId: "US-001",
+      packageDir: "/repo/packages/portfolio",
+      setupCommand: "uv sync",
+    });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/operations/full-suite-gate.test.ts
+++ b/test/unit/operations/full-suite-gate.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { fullSuiteGateOp, _fullSuiteGateDeps } from "@/operations";
+import { _commandDefaultsDeps, clearCommandDefaultsCache } from "@/quality";
 
 function ctxWithConfig(config: any = {}, opts: { hasOverride?: boolean; repoRoot?: string } = {}) {
   return {
@@ -280,5 +281,42 @@ describe("fullSuiteGateOp — ported RegressionStrategy behavior (issue #1116)",
       deps,
     );
     expect(seenWorkdir).toBe("/repo");
+  });
+});
+
+describe("fullSuiteGateOp — resolveGateContext detection fallback", () => {
+  const originalDefaults = { ..._commandDefaultsDeps };
+  afterEach(() => {
+    Object.assign(_commandDefaultsDeps, originalDefaults);
+    clearCommandDefaultsCache();
+  });
+
+  test("derives a test command from the manifest and runs it from the package dir", async () => {
+    clearCommandDefaultsCache();
+    _commandDefaultsDeps.detectLanguage = async () => "go";
+    const ctx = ctxWithConfig({ quality: { commands: {} } });
+    ctx.packageView.packageDir = "/repo/packages/new";
+
+    const gateCtx = await _fullSuiteGateDeps.resolveGateContext(
+      { story: { id: "US-001", workdir: "packages/new" } as any, workdir: "/repo" },
+      ctx,
+    );
+
+    expect(gateCtx.testCmd).toBe("go test ./...");
+    expect(gateCtx.cmdWorkdir).toBe("/repo/packages/new");
+  });
+
+  test("throws TEST_COMMAND_MISSING when neither config nor detection yields a command", async () => {
+    clearCommandDefaultsCache();
+    _commandDefaultsDeps.detectLanguage = async () => undefined;
+    const ctx = ctxWithConfig({ quality: { commands: {} } });
+    ctx.packageView.packageDir = "/repo/packages/empty";
+
+    await expect(
+      _fullSuiteGateDeps.resolveGateContext(
+        { story: { id: "US-001", workdir: "packages/empty" } as any, workdir: "/repo" },
+        ctx,
+      ),
+    ).rejects.toThrow(/No test command configured or detected/);
   });
 });

--- a/test/unit/operations/full-suite-gate.test.ts
+++ b/test/unit/operations/full-suite-gate.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { _newPackageSetupDeps, markNewPackageDirs } from "@/execution";
 import { fullSuiteGateOp, _fullSuiteGateDeps } from "@/operations";
 import { _commandDefaultsDeps, clearCommandDefaultsCache } from "@/quality";
 
@@ -293,15 +294,23 @@ describe("fullSuiteGateOp — resolveGateContext detection fallback", () => {
 
   test("derives a test command from the manifest and runs it from the package dir", async () => {
     clearCommandDefaultsCache();
-    _commandDefaultsDeps.detectLanguage = async () => "go";
+    // Regression (C1): detection MUST probe the absolute input.workdir, never the
+    // relative packageView.packageDir key — otherwise a run launched from a cwd !=
+    // repoRoot probes the wrong directory and silently detects nothing.
+    let probedDir = "";
+    _commandDefaultsDeps.detectLanguage = async (dir: string) => {
+      probedDir = dir;
+      return "go";
+    };
     const ctx = ctxWithConfig({ quality: { commands: {} } });
-    ctx.packageView.packageDir = "/repo/packages/new";
+    ctx.packageView.packageDir = "packages/new"; // relative key, as in production
 
     const gateCtx = await _fullSuiteGateDeps.resolveGateContext(
-      { story: { id: "US-001", workdir: "packages/new" } as any, workdir: "/repo" },
+      { story: { id: "US-001", workdir: "packages/new" } as any, workdir: "/repo/packages/new" },
       ctx,
     );
 
+    expect(probedDir).toBe("/repo/packages/new"); // absolute, not "packages/new"
     expect(gateCtx.testCmd).toBe("go test ./...");
     expect(gateCtx.cmdWorkdir).toBe("/repo/packages/new");
   });
@@ -310,13 +319,65 @@ describe("fullSuiteGateOp — resolveGateContext detection fallback", () => {
     clearCommandDefaultsCache();
     _commandDefaultsDeps.detectLanguage = async () => undefined;
     const ctx = ctxWithConfig({ quality: { commands: {} } });
-    ctx.packageView.packageDir = "/repo/packages/empty";
+    ctx.packageView.packageDir = "packages/empty"; // relative key, as in production
 
     await expect(
       _fullSuiteGateDeps.resolveGateContext(
-        { story: { id: "US-001", workdir: "packages/empty" } as any, workdir: "/repo" },
+        { story: { id: "US-001", workdir: "packages/empty" } as any, workdir: "/repo/packages/empty" },
         ctx,
       ),
     ).rejects.toThrow(/No test command configured or detected/);
+  });
+});
+
+describe("fullSuiteGateOp — new-package setup wiring (C1 regression)", () => {
+  const originalSpawn = _newPackageSetupDeps.spawn;
+  afterEach(() => {
+    _newPackageSetupDeps.spawn = originalSpawn;
+  });
+
+  function spawnCapture(capture: { cwd?: string; count: number }) {
+    return mock((_argv: string[], opts: { cwd: string }) => {
+      capture.cwd = opts.cwd;
+      capture.count += 1;
+      return {
+        exited: Promise.resolve(0),
+        stdout: new Response("").body,
+        stderr: new Response("").body,
+        pid: 1,
+        kill: () => {},
+      };
+    });
+  }
+
+  test("setup fires when dirs are registered as ABSOLUTE but packageView.packageDir is RELATIVE", async () => {
+    // This is the exact production wiring the original code got wrong:
+    // markNewPackageDirs receives absolute dirs (resolved against options.workdir),
+    // while ctx.packageView.packageDir is the relative key. The gate must pass
+    // input.workdir (absolute) so the registry match succeeds and setup runs once.
+    const capture = { cwd: undefined as string | undefined, count: 0 };
+    _newPackageSetupDeps.spawn = spawnCapture(capture) as typeof _newPackageSetupDeps.spawn;
+
+    const ctx = ctxWithConfig({ quality: { commands: { setup: "uv sync" } } });
+    ctx.packageView.packageDir = "packages/portfolio"; // RELATIVE key (production shape)
+    markNewPackageDirs(ctx.runtime, ["/repo/packages/portfolio"]); // ABSOLUTE registration
+
+    const deps = makeDeps({
+      resolveGateContext: async () => ({
+        config: { quality: { commands: { setup: "uv sync" } } } as any,
+        testCmd: "bun test",
+        fullSuiteTimeout: 60,
+        cmdWorkdir: "/repo/packages/portfolio",
+      }),
+    });
+
+    await fullSuiteGateOp.execute(
+      { story: { id: "US-001", workdir: "packages/portfolio" } as any, workdir: "/repo/packages/portfolio" },
+      ctx,
+      deps,
+    );
+
+    expect(capture.count).toBe(1);
+    expect(capture.cwd).toBe("/repo/packages/portfolio");
   });
 });

--- a/test/unit/quality/command-defaults.test.ts
+++ b/test/unit/quality/command-defaults.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for detection-based default quality commands — the fallback used when no
+ * test/lint/typecheck command is configured. Conservative: only emits commands
+ * that are toolchain built-ins or whose tool/config marker is present.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  _commandDefaultsDeps,
+  clearCommandDefaultsCache,
+  resolveDefaultQualityCommands,
+} from "@/quality";
+
+type Lang = "go" | "rust" | "python" | "typescript" | "javascript" | undefined;
+
+const original = { ..._commandDefaultsDeps };
+
+/** Configure deps: a set of existing files, pyproject text, package.json, and detected language. */
+function setup(opts: {
+  language: Lang;
+  files?: string[];
+  pyproject?: string;
+  pkgJson?: Record<string, unknown> | null;
+}) {
+  const files = new Set((opts.files ?? []).map((f) => `/pkg/${f}`));
+  _commandDefaultsDeps.detectLanguage = async () => opts.language;
+  _commandDefaultsDeps.fileExists = async (p: string) => files.has(p);
+  _commandDefaultsDeps.readText = async (p: string) => (p.endsWith("pyproject.toml") ? (opts.pyproject ?? "") : "");
+  _commandDefaultsDeps.readJson = async () => opts.pkgJson ?? null;
+}
+
+describe("resolveDefaultQualityCommands", () => {
+  beforeEach(() => clearCommandDefaultsCache());
+  afterEach(() => {
+    Object.assign(_commandDefaultsDeps, original);
+    clearCommandDefaultsCache();
+  });
+
+  test("go uses built-in commands for all three", async () => {
+    setup({ language: "go" });
+    expect(await resolveDefaultQualityCommands("/pkg")).toEqual({
+      test: "go test ./...",
+      typecheck: "go build ./...",
+      lint: "go vet ./...",
+    });
+  });
+
+  test("rust uses cargo commands", async () => {
+    setup({ language: "rust" });
+    expect(await resolveDefaultQualityCommands("/pkg")).toEqual({
+      test: "cargo test",
+      typecheck: "cargo check",
+      lint: "cargo clippy",
+    });
+  });
+
+  test("python with uv.lock prefixes uv run; mypy/ruff only when configured", async () => {
+    setup({ language: "python", files: ["uv.lock"], pyproject: "[tool.uv]\n[tool.mypy]\n[tool.ruff]" });
+    expect(await resolveDefaultQualityCommands("/pkg")).toEqual({
+      test: "uv run pytest",
+      typecheck: "uv run mypy .",
+      lint: "uv run ruff check .",
+    });
+  });
+
+  test("plain python defaults to bare pytest and omits lint/typecheck", async () => {
+    setup({ language: "python", pyproject: "[project]\nname='x'" });
+    expect(await resolveDefaultQualityCommands("/pkg")).toEqual({ test: "pytest" });
+  });
+
+  test("poetry python prefixes poetry run", async () => {
+    setup({ language: "python", files: ["poetry.lock"], pyproject: "[tool.poetry]" });
+    expect((await resolveDefaultQualityCommands("/pkg")).test).toBe("poetry run pytest");
+  });
+
+  test("typescript with bun + scripts.test + tsconfig + biome", async () => {
+    setup({
+      language: "typescript",
+      files: ["bun.lock", "tsconfig.json", "biome.json"],
+      pkgJson: { scripts: { test: "bun test" } },
+    });
+    expect(await resolveDefaultQualityCommands("/pkg")).toEqual({
+      test: "bun run test",
+      typecheck: "bunx tsc --noEmit",
+      lint: "bunx biome check .",
+    });
+  });
+
+  test("typescript with pnpm and no test script omits test; tsconfig drives typecheck", async () => {
+    setup({ language: "typescript", files: ["pnpm-lock.yaml", "tsconfig.json"], pkgJson: { scripts: {} } });
+    expect(await resolveDefaultQualityCommands("/pkg")).toEqual({ typecheck: "pnpm exec tsc --noEmit" });
+  });
+
+  test("unknown language yields no defaults", async () => {
+    setup({ language: undefined });
+    expect(await resolveDefaultQualityCommands("/pkg")).toEqual({});
+  });
+
+  test("memoizes per packageDir", async () => {
+    let calls = 0;
+    setup({ language: "go" });
+    _commandDefaultsDeps.detectLanguage = async () => {
+      calls++;
+      return "go";
+    };
+    await resolveDefaultQualityCommands("/pkg-memo");
+    await resolveDefaultQualityCommands("/pkg-memo");
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

In monorepo runs (reproduced in `logs/2026-06-20T21-12-10.jsonl`), a `prd.json` story whose `workdir` points to a **brand-new package that doesn't exist on disk yet** (a new feature on a new package) broke the orchestrator:

- The agent session cwd resolves to `join(repoRoot, story.workdir)`. `acpx`/`posix_spawn` cannot start a subprocess in a nonexistent cwd, so **the implementer hard-failed** ("Failed to spawn agent command").
- **The acceptance generator failed silently**, degrading to a skeleton test.

Even once the directory exists, an empty package with no per-package config, no test command, and uninstalled dependencies could not be implemented or verified.

## Fix — three layers

1. **Bootstrap missing package dirs** (`src/execution/ensure-package-dirs.ts`) — before any session opens, `mkdir -p` any story `workdir` that doesn't exist (dryRun-guarded, `../` traversal-guarded, idempotent). Plus a loud safety net: `adapter-lifecycle.ts` now throws a clear `SESSION_CWD_MISSING` `NaxError` instead of a cryptic spawn failure if a session cwd is ever missing.
2. **One-time new-package setup** (`src/execution/new-package-setup.ts`) — runs `quality.commands.setup` (new optional config key, e.g. `uv sync` / `bun install`) **once per newly-created package**, lazily, before that package's first verify gate (after the implementer has scaffolded the manifest). Idempotency via a runtime-instance-keyed `WeakMap`.
3. **Detection-based default commands** (`src/quality/command-defaults.ts`) — for config-less new packages, derive conservative default test/lint/typecheck commands per language (Go/Rust/Python/JS-TS), emitting only toolchain built-ins or commands whose tool config is actually present. Wired into the gate ops as a fallback when no command is configured. Greenfield detection already handles the no-test-files case by switching to test-after.

## Code review

A code-reviewer pass found a **Critical path-mismatch (C1)**: the gate ops used `ctx.packageView.packageDir`, which is the **relative** key — not absolute. In any run launched from a cwd ≠ repo root, new-package setup never fired and detection probed the wrong directory, silently no-opping layers 2 and 3. Fixed by using `input.workdir` (the resolved absolute package dir) for the detection probe, the detected-default `cmdWorkdir`, and the setup `packageDir` across all four gate ops. Also stopped memoizing empty detection results (I1). Added regression tests asserting the absolute/relative wiring.

## Known limitation

Parallel **worktree** mode + a brand-new package: the bootstrap creates the dir in the main repo, which a fresh worktree checkout won't contain. This combination now fails **loudly** via `SESSION_CWD_MISSING` (a strict improvement over the prior cryptic failure) rather than being fully handled — tracked as follow-up.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — all ratchets pass (file-sizes, nax-error, logger-storyid, alias-internals, deep-relatives)
- [x] `bun run test:bail` — full suite green (unit + integration + ui)
- [x] New/expanded tests: `ensure-package-dirs` (6), `new-package-setup` (7), `command-defaults` (9), `adapter-lifecycle` cwd-guard (+3), `full-suite-gate` detection + C1 regression (+3)
