### PR TITLE
feat(cli): resolve acceptance test targets in nax features resolve

### DIFF
--- a/src/cli/features-acceptance.ts
+++ b/src/cli/features-acceptance.ts
@@ -1,0 +1,115 @@
+import { existsSync } from "node:fs";
+import { join, relative } from "node:path";
+import { groupStoriesByPackage } from "../acceptance";
+import { findProjectDir, loadConfig, loadPackageOverride } from "../config";
+import { getSafeLogger } from "../logger";
+import { loadPRD } from "../prd";
+import { errorMessage } from "../utils/errors";
+
+/** One resolved acceptance test target — a single package the feature touches. */
+export interface AcceptanceGroupResult {
+  /** Package directory relative to repo root; "" for the root package. */
+  packageDir: string;
+  /** Canonical acceptance test path, relative to repo root (portable). */
+  testPath: string;
+  /** Whether the test file currently exists on disk. */
+  exists: boolean;
+  /** Resolved acceptance command (per-package override else root); may contain a {{FILE}} placeholder. */
+  command?: string;
+  /** Per-package detected language (drives the test-file extension). */
+  language?: string;
+}
+
+export type AcceptanceResolutionStatus = "ok" | "disabled" | "no-prd";
+
+/** Result of resolving a feature's acceptance test targets. */
+export interface AcceptanceResolution {
+  status: AcceptanceResolutionStatus;
+  /** Effective acceptance.enabled for the repo. */
+  enabled: boolean;
+  groups: AcceptanceGroupResult[];
+}
+
+/**
+ * Resolve the acceptance test target(s) for a feature, reusing the same SSOT
+ * (`groupStoriesByPackage`) that the runtime uses to place and run acceptance
+ * tests. Never throws — a missing/malformed PRD or non-nax repo resolves to
+ * `no-prd` so callers can branch deterministically.
+ *
+ * @param featureName - The .nax/features/<name> feature whose acceptance tests to resolve.
+ * @param workdir - Absolute path to the project directory (never process.cwd()).
+ */
+export async function resolveFeatureAcceptance(featureName: string, workdir: string): Promise<AcceptanceResolution> {
+  // The whole body is wrapped so this resolver NEVER throws — it is awaited
+  // inline inside resolveFeatureSpec, so a throw here would break the entire
+  // `nax features resolve` command (including spec resolution). Any failure
+  // (invalid/legacy config, malformed PRD, grouping error) degrades to no-prd.
+  // `enabled` is hoisted so the catch reports the last-known value.
+  let enabled = true;
+  try {
+    const naxDir = findProjectDir(workdir);
+    if (!naxDir) {
+      return { status: "no-prd", enabled, groups: [] };
+    }
+    const repoRoot = join(naxDir, "..");
+
+    const config = await loadConfig(workdir);
+    enabled = config.acceptance?.enabled ?? true;
+    if (!enabled) {
+      return { status: "disabled", enabled: false, groups: [] };
+    }
+
+    const prdPath = join(naxDir, "features", featureName, "prd.json");
+    if (!existsSync(prdPath)) {
+      return { status: "no-prd", enabled, groups: [] };
+    }
+
+    const prd = await loadPRD(prdPath);
+    const testGroups = await groupStoriesByPackage(
+      prd,
+      repoRoot,
+      featureName,
+      config.acceptance?.testPath,
+      config.project?.language,
+    );
+
+    const groups = await Promise.all(
+      testGroups.map(async (g): Promise<AcceptanceGroupResult> => {
+        // relative() yields "" for the root package — resolveGroupCommand treats "" as root.
+        const packageDir = relative(repoRoot, g.packageDir);
+        const command = await resolveGroupCommand(repoRoot, packageDir, config.acceptance?.command);
+        return {
+          packageDir,
+          testPath: relative(repoRoot, g.testPath),
+          exists: await Bun.file(g.testPath).exists(),
+          command,
+          language: g.language,
+        };
+      }),
+    );
+
+    return { status: "ok", enabled, groups };
+  } catch (err) {
+    // Invalid/legacy config, malformed PRD, or grouping failure. Log so a corrupt
+    // config/PRD is distinguishable from a feature that genuinely has no PRD.
+    getSafeLogger()?.warn("acceptance", "Failed to resolve feature acceptance targets", {
+      featureName,
+      cause: errorMessage(err),
+    });
+    return { status: "no-prd", enabled, groups: [] };
+  }
+}
+
+/**
+ * Resolve the acceptance command for a single package: a per-package override
+ * (.nax/mono/<packageDir>/config.json) wins over the root command.
+ */
+async function resolveGroupCommand(
+  repoRoot: string,
+  packageDir: string,
+  rootCommand: string | undefined,
+): Promise<string | undefined> {
+  if (packageDir === "") return rootCommand;
+  const override = await loadPackageOverride(repoRoot, packageDir);
+  return override?.acceptance?.command ?? rootCommand;
+}

--- a/src/cli/features-resolve.ts
+++ b/src/cli/features-resolve.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
 import { findProjectDir } from "../config";
 import { validateFeatureName } from "../utils/feature-name";
+import { type AcceptanceResolution, resolveFeatureAcceptance } from "./features-acceptance";
 
 export type ResolveStatus = "ok" | "ambiguous" | "missing" | "feature-not-found" | "not-a-nax-repo";
 
@@ -16,6 +17,8 @@ export interface ResolveResult {
   status: ResolveStatus;
   featureName?: string | null;
   specSource?: SpecSource | null;
+  /** Acceptance test target(s) for the feature. Present only on an `ok` result with a known featureName. */
+  acceptance?: AcceptanceResolution;
   candidates?: string[];
   checked?: string[];
   message: string;
@@ -162,6 +165,7 @@ export async function resolveFeatureSpec(name: string | undefined, workdir: stri
         status: "ok",
         featureName: name,
         specSource: source,
+        acceptance: await resolveFeatureAcceptance(name, workdir),
         message: `resolved spec: ${source.path}`,
       };
     }
@@ -215,6 +219,7 @@ export async function resolveFeatureSpec(name: string | undefined, workdir: stri
       status: "ok",
       featureName: onlyName,
       specSource: source,
+      acceptance: await resolveFeatureAcceptance(onlyName, workdir),
       message: `resolved spec: ${source.path}`,
     };
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -57,3 +57,9 @@ export {
 export { resolveRunProfileOverride } from "./resolve-run-profile";
 export { resolveFeatureSpec } from "./features-resolve";
 export type { ResolveResult, ResolveStatus, SpecSource, SpecSourceKind } from "./features-resolve";
+export { resolveFeatureAcceptance } from "./features-acceptance";
+export type {
+  AcceptanceGroupResult,
+  AcceptanceResolution,
+  AcceptanceResolutionStatus,
+} from "./features-acceptance";

--- a/test/unit/cli/features-acceptance.test.ts
+++ b/test/unit/cli/features-acceptance.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { resolveFeatureAcceptance } from "@/cli";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = makeTempDir("nax-accept-");
+});
+
+afterEach(() => {
+  cleanupTempDir(tempDir);
+});
+
+/** Creates .nax/config.json (partial config is layered over defaults by loadConfig). */
+function initRepo(config: Record<string, unknown> = {}): string {
+  const naxDir = join(tempDir, ".nax");
+  mkdirSync(join(naxDir, "features"), { recursive: true });
+  writeFileSync(join(naxDir, "config.json"), JSON.stringify({ name: "test-project", ...config }));
+  return naxDir;
+}
+
+/** Writes .nax/features/<name>/prd.json with the given stories. */
+function writePRD(
+  naxDir: string,
+  name: string,
+  stories: Array<{ id: string; workdir?: string; acceptanceCriteria?: string[]; status?: string }>,
+): void {
+  const dir = join(naxDir, "features", name);
+  mkdirSync(dir, { recursive: true });
+  const userStories = stories.map((s) => ({
+    id: s.id,
+    title: s.id,
+    description: "",
+    acceptanceCriteria: s.acceptanceCriteria ?? ["AC1"],
+    tags: [],
+    dependencies: [],
+    status: s.status ?? "passed",
+    passes: true,
+    escalations: [],
+    attempts: 0,
+    ...(s.workdir ? { workdir: s.workdir } : {}),
+  }));
+  writeFileSync(
+    join(dir, "prd.json"),
+    JSON.stringify({
+      project: "p",
+      feature: name,
+      branchName: "main",
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+      userStories,
+    }),
+  );
+}
+
+/** Writes a per-package override config under .nax/mono/<packageDir>/config.json. */
+function writePackageOverride(naxDir: string, packageDir: string, config: Record<string, unknown>): void {
+  const dir = join(naxDir, "mono", packageDir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify(config));
+}
+
+// ---------------------------------------------------------------------------
+// disabled
+// ---------------------------------------------------------------------------
+
+describe("acceptance disabled", () => {
+  test("returns status=disabled when acceptance.enabled is false", async () => {
+    const naxDir = initRepo({ acceptance: { enabled: false } });
+    writePRD(naxDir, "feat", [{ id: "US-001" }]);
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.status).toBe("disabled");
+    expect(result.enabled).toBe(false);
+    expect(result.groups).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// no-prd
+// ---------------------------------------------------------------------------
+
+describe("no prd.json", () => {
+  test("returns status=no-prd when the feature has no prd.json", async () => {
+    initRepo();
+    // No PRD written for "feat".
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.status).toBe("no-prd");
+    expect(result.enabled).toBe(true);
+    expect(result.groups).toEqual([]);
+  });
+
+  test("returns status=no-prd when prd.json is malformed (never throws)", async () => {
+    const naxDir = initRepo();
+    const dir = join(naxDir, "features", "feat");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "prd.json"), "{ not valid json");
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.status).toBe("no-prd");
+    expect(result.groups).toEqual([]);
+  });
+
+  test("degrades to no-prd (never throws) when the config is invalid/legacy", async () => {
+    // A legacy autoMode.defaultAgent key makes loadConfig throw — the resolver
+    // must catch it rather than break the whole `features resolve` command.
+    const naxDir = initRepo({ autoMode: { defaultAgent: "claude" } });
+    writePRD(naxDir, "feat", [{ id: "US-001" }]);
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.status).toBe("no-prd");
+    expect(result.groups).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// single-package
+// ---------------------------------------------------------------------------
+
+describe("single-package", () => {
+  test("resolves one root group with canonical testPath and exists=false when no file", async () => {
+    const naxDir = initRepo();
+    writePRD(naxDir, "feat", [{ id: "US-001" }]);
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.status).toBe("ok");
+    expect(result.enabled).toBe(true);
+    expect(result.groups).toHaveLength(1);
+    const [group] = result.groups;
+    expect(group.packageDir).toBe("");
+    expect(group.testPath).toBe(".nax/features/feat/.nax-acceptance.test.ts");
+    expect(group.exists).toBe(false);
+    expect(group.command).toBeUndefined();
+  });
+
+  test("exists=true when the acceptance test file is present on disk", async () => {
+    const naxDir = initRepo();
+    writePRD(naxDir, "feat", [{ id: "US-001" }]);
+    writeFileSync(join(naxDir, "features", "feat", ".nax-acceptance.test.ts"), "// test");
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.groups[0].exists).toBe(true);
+  });
+
+  test("surfaces the root acceptance.command", async () => {
+    const naxDir = initRepo({ acceptance: { command: "bun test {{FILE}}" } });
+    writePRD(naxDir, "feat", [{ id: "US-001" }]);
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.groups[0].command).toBe("bun test {{FILE}}");
+  });
+
+  test("honours a custom acceptance.testPath in the filename", async () => {
+    const naxDir = initRepo({ acceptance: { testPath: "acceptance.spec.ts" } });
+    writePRD(naxDir, "feat", [{ id: "US-001" }]);
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.groups[0].testPath).toBe(".nax/features/feat/acceptance.spec.ts");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// monorepo
+// ---------------------------------------------------------------------------
+
+describe("monorepo", () => {
+  test("resolves one group per package the feature touches", async () => {
+    const naxDir = initRepo();
+    writePRD(naxDir, "feat", [
+      { id: "US-001", workdir: "packages/core" },
+      { id: "US-002", workdir: "packages/api" },
+    ]);
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    expect(result.status).toBe("ok");
+    const byPkg = Object.fromEntries(result.groups.map((g) => [g.packageDir, g]));
+    expect(Object.keys(byPkg).sort()).toEqual(["packages/api", "packages/core"]);
+    expect(byPkg["packages/core"].testPath).toBe("packages/core/.nax/features/feat/.nax-acceptance.test.ts");
+    expect(byPkg["packages/api"].testPath).toBe("packages/api/.nax/features/feat/.nax-acceptance.test.ts");
+  });
+
+  test("per-package acceptance.command override beats the root command", async () => {
+    const naxDir = initRepo({ acceptance: { command: "bun test {{FILE}}" } });
+    writePRD(naxDir, "feat", [
+      { id: "US-001", workdir: "packages/core" },
+      { id: "US-002", workdir: "packages/api" },
+    ]);
+    writePackageOverride(naxDir, "packages/core", { acceptance: { command: "vitest run {{FILE}}" } });
+
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+
+    const byPkg = Object.fromEntries(result.groups.map((g) => [g.packageDir, g]));
+    expect(byPkg["packages/core"].command).toBe("vitest run {{FILE}}");
+    expect(byPkg["packages/api"].command).toBe("bun test {{FILE}}");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// not a nax repo
+// ---------------------------------------------------------------------------
+
+describe("not a nax repo", () => {
+  test("returns status=no-prd with enabled=true when there is no .nax dir", async () => {
+    // tempDir has no .nax — resolveFeatureAcceptance must not throw.
+    const result = await resolveFeatureAcceptance("feat", tempDir);
+    expect(result.status).toBe("no-prd");
+    expect(result.groups).toEqual([]);
+  });
+});

--- a/test/unit/cli/features-resolve.test.ts
+++ b/test/unit/cli/features-resolve.test.ts
@@ -68,6 +68,31 @@ describe("not-a-nax-repo", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Acceptance block attachment
+// ---------------------------------------------------------------------------
+
+describe("acceptance block", () => {
+  test("ok result with a named feature attaches the acceptance block", async () => {
+    const naxDir = initNaxRepo();
+    createFeature(naxDir, "auth", { prdJson: true });
+    const result = await resolveFeatureSpec("auth", tempDir);
+    expect(result.status).toBe("ok");
+    expect(result.featureName).toBe("auth");
+    expect(result.acceptance?.status).toBe("ok");
+    expect(result.acceptance?.groups[0].testPath).toBe(".nax/features/auth/.nax-acceptance.test.ts");
+  });
+
+  test("path-only ok result (featureName null) has no acceptance block", async () => {
+    initNaxRepo();
+    writeFileSync(join(tempDir, "my-spec.md"), "# content");
+    const result = await resolveFeatureSpec("./my-spec.md", tempDir);
+    expect(result.status).toBe("ok");
+    expect(result.featureName).toBeNull();
+    expect(result.acceptance).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Explicit path
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds an `acceptance` block to `nax features resolve --json`, so the command resolves a feature's acceptance-test targets in addition to its spec source.

## Why

The `nax-finish` skill (and any consumer) previously hand-rolled acceptance-test discovery in bash — a recursive `find` plus manual per-package `.nax/mono/<pkg>/config.json` reads. That is a heuristic mirror of nax's own placement logic and drifts the moment the runtime changes where acceptance tests live (the "one source of truth per concept" rule in `monorepo-awareness.md`). This makes `nax features resolve` the single source of truth for both spec and acceptance resolution.

## How

- New `src/cli/features-acceptance.ts` — `resolveFeatureAcceptance(featureName, workdir)` reuses the SSOT `groupStoriesByPackage` to return **one group per package the feature touches**: canonical repo-root-relative `testPath`, on-disk `exists` flag, resolved `command` (per-package override else root), and detected `language`.
- The resolver **never throws** — invalid/legacy config, missing or malformed PRD all degrade to `status: "no-prd"` (logged via `logger.warn` with the cause), so a bad config can never break the spec-resolution result it is attached to.
- `ResolveResult` gains the optional `acceptance` block, attached only to `ok` results carrying a `featureName` (path-only resolutions are unaffected). `bin/nax.ts` already serializes the whole result, so `--json` carries it with no CLI change.
- Exported from the `src/cli` barrel.

Verified live against a real monorepo: `graphify-kb` resolves both `apps/api` and `apps/cli` groups, each with its own command/language/exists.

A companion PR in `nax-toolkit-skills` updates `nax-finish` Step 3 to consume this block (with the old `find` retained as an older-nax fallback).

## Testing

- [x] Tests added/updated (`test/unit/cli/features-acceptance.test.ts` — 12 cases incl. disabled / no-prd / malformed-prd / invalid-legacy-config / single-package / monorepo / per-package command override; plus attachment tests in `features-resolve.test.ts`)
- [x] `bun test` passes (full suite: 1057 + integration + ui, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

No breaking changes — the field is purely additive. Resolving now loads config + the feature PRD on each `ok` resolution; it's cheap and degrades safely, but if a leaner spec-only resolve is ever wanted it could be gated behind a flag.
