### PR TITLE
fix(acceptance): parse vitest default-reporter FAIL headers for AC ids

### DIFF
--- a/src/test-runners/ac-parser.ts
+++ b/src/test-runners/ac-parser.ts
@@ -13,13 +13,23 @@
 import { detectFramework } from "./detector";
 
 /**
+ * Strips ANSI SGR color codes so failure markers and AC tokens match on plain text.
+ * Built via RegExp() so the ESC byte (0x1b) is not a control character in the source
+ * regex literal (which Biome's noControlCharactersInRegex rightly forbids).
+ */
+const ANSI_SGR_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+/**
  * Parse test runner output to extract failed AC IDs.
  *
  * Supported frameworks and their failure markers:
  * - Bun:        "(fail) AC-N: description [duration]"
  * - Go:         "--- FAIL: TestAC-N_desc (0.00s)"
  * - pytest:     "FAILED tests/...::test_AC_N_desc"
- * - Jest/Vitest: "  ● AC-N: description" or "× AC-N: description"
+ * - Jest/Vitest: "  ● AC-N: description", "× AC-N: description", or vitest's
+ *   default-reporter block header " FAIL  <file> > <suite> > AC-N: description"
+ *
+ * ANSI color codes are stripped before matching (vitest/jest colorize the marker).
  *
  * Special sentinels:
  * - AC-HOOK: bun lifecycle hook timeout (beforeAll/afterAll timed out, no AC label)
@@ -29,9 +39,12 @@ import { detectFramework } from "./detector";
  * @returns Deduplicated array of AC IDs, e.g. ["AC-1", "AC-3", "AC-HOOK"]
  */
 export function parseTestFailures(output: string): string[] {
-  const framework = detectFramework(output);
+  // Strip ANSI color codes first: vitest/jest colorize the "FAIL" marker and test
+  // titles, which would otherwise sit between "AC" and the number and break matching.
+  const clean = output.replace(ANSI_SGR_PATTERN, "");
+  const framework = detectFramework(clean);
   const failedACs: string[] = [];
-  const lines = output.split("\n");
+  const lines = clean.split("\n");
 
   for (const line of lines) {
     // Bun: "(fail) AC-N: description [duration]"
@@ -67,9 +80,14 @@ export function parseTestFailures(output: string): string[] {
       }
     }
 
-    // Jest / Vitest: "  ● AC-N: description" or "× AC-N: description"
+    // Jest / Vitest. Two output shapes carry the failing test name (and AC label):
+    //  - bullet markers: "  ● AC-N: description" (jest summary) / "× AC-N: ..." (vitest verbose)
+    //  - vitest default-reporter block headers: " FAIL  <file> > <suite> > AC-N: ..."
+    // The default reporter never uses bullet glyphs, so the FAIL header is the only
+    // place the AC id appears — without it these failures fell through to AC-ERROR.
+    // `(?:^|\s)FAIL\s` matches the header but not pytest's "FAILED" (no whitespace after FAIL).
     if (framework === "jest" || framework === "vitest" || framework === "unknown") {
-      if (/[●×✕]/.test(line)) {
+      if (/[●×✕]/.test(line) || /(?:^|\s)FAIL\s/.test(line)) {
         const acMatch = line.match(/AC[-_]?(\d+)/i);
         if (acMatch) {
           const acId = `AC-${acMatch[1]}`;

--- a/src/test-runners/ac-parser.ts
+++ b/src/test-runners/ac-parser.ts
@@ -13,11 +13,13 @@
 import { detectFramework } from "./detector";
 
 /**
- * Strips ANSI SGR color codes so failure markers and AC tokens match on plain text.
+ * Strips ANSI escape sequences (CSI: SGR color codes plus cursor/erase codes such
+ * as the `\x1b[2K` vitest's live reporter prefixes lines with) so failure markers
+ * and AC tokens match on plain text — including the line-leading FAIL badge.
  * Built via RegExp() so the ESC byte (0x1b) is not a control character in the source
  * regex literal (which Biome's noControlCharactersInRegex rightly forbids).
  */
-const ANSI_SGR_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[A-Za-z]`, "g");
 
 /**
  * Parse test runner output to extract failed AC IDs.
@@ -39,9 +41,10 @@ const ANSI_SGR_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"
  * @returns Deduplicated array of AC IDs, e.g. ["AC-1", "AC-3", "AC-HOOK"]
  */
 export function parseTestFailures(output: string): string[] {
-  // Strip ANSI color codes first: vitest/jest colorize the "FAIL" marker and test
-  // titles, which would otherwise sit between "AC" and the number and break matching.
-  const clean = output.replace(ANSI_SGR_PATTERN, "");
+  // Strip ANSI escapes first: vitest/jest colorize the "FAIL" marker and test titles,
+  // and the live reporter prefixes lines with cursor/erase codes — both would otherwise
+  // sit between tokens and break matching (and defeat the line-start FAIL anchor below).
+  const clean = output.replace(ANSI_ESCAPE_PATTERN, "");
   const framework = detectFramework(clean);
   const failedACs: string[] = [];
   const lines = clean.split("\n");
@@ -85,9 +88,11 @@ export function parseTestFailures(output: string): string[] {
     //  - vitest default-reporter block headers: " FAIL  <file> > <suite> > AC-N: ..."
     // The default reporter never uses bullet glyphs, so the FAIL header is the only
     // place the AC id appears — without it these failures fell through to AC-ERROR.
-    // `(?:^|\s)FAIL\s` matches the header but not pytest's "FAILED" (no whitespace after FAIL).
+    // The FAIL badge is anchored to the (ANSI-stripped) line start, so a passing line
+    // whose title merely contains the word "FAIL" is not matched; `\s` after FAIL also
+    // excludes pytest's "FAILED" (handled by its own branch above).
     if (framework === "jest" || framework === "vitest" || framework === "unknown") {
-      if (/[●×✕]/.test(line) || /(?:^|\s)FAIL\s/.test(line)) {
+      if (/[●×✕]/.test(line) || /^\s*FAIL\s/.test(line)) {
         const acMatch = line.match(/AC[-_]?(\d+)/i);
         if (acMatch) {
           const acId = `AC-${acMatch[1]}`;

--- a/test/unit/pipeline/stages/acceptance.test.ts
+++ b/test/unit/pipeline/stages/acceptance.test.ts
@@ -363,6 +363,36 @@ describe("parseTestFailures()", () => {
 
     expect(parseTestFailures(output)).toEqual([]);
   });
+
+  test("vitest default reporter: extracts AC IDs from FAIL block headers", () => {
+    const output = [
+      " ❯ .nax/features/x/.nax-acceptance.test.tsx (5 tests | 2 failed) 120ms",
+      "",
+      "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯",
+      "",
+      " FAIL  .nax/features/x/.nax-acceptance.test.tsx > Watchlist > AC-9: updates the watchlist",
+      'AssertionError: expected undefined to be "w1"',
+      " ❯ .nax/features/x/.nax-acceptance.test.tsx:649:26",
+      "",
+      " FAIL  .nax/features/x/.nax-acceptance.test.tsx > AC-12: removes a ticker",
+      "AssertionError: expected 2 to be 1",
+      "",
+      " Test Files  1 failed (1)",
+      "      Tests  2 failed | 3 passed (5)",
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual(["AC-9", "AC-12"]);
+  });
+
+  test("vitest: extracts AC IDs from ANSI-colored FAIL headers", () => {
+    const esc = String.fromCharCode(27); // ANSI escape (vitest colorizes the FAIL marker)
+    const output = [
+      " Test Files  1 failed (1)",
+      `${esc}[31m${esc}[7m FAIL ${esc}[27m${esc}[39m .nax/x.test.tsx > ${esc}[1mAC-3: does the thing${esc}[22m`,
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual(["AC-3"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/pipeline/stages/acceptance.test.ts
+++ b/test/unit/pipeline/stages/acceptance.test.ts
@@ -393,6 +393,32 @@ describe("parseTestFailures()", () => {
 
     expect(parseTestFailures(output)).toEqual(["AC-3"]);
   });
+
+  test("vitest: does NOT match a passing test whose title contains the word FAIL", () => {
+    const output = [
+      " Test Files  1 passed (1)",
+      "   ✓ AC-7: handles FAIL responses gracefully 5ms",
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual([]);
+  });
+
+  test("vitest: strips leading erase-line codes before the FAIL anchor", () => {
+    const esc = String.fromCharCode(27);
+    const output = [
+      " Test Files  1 failed (1)",
+      `${esc}[2K${esc}[1G FAIL  .nax/x.test.tsx > AC-4: still detected`,
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual(["AC-4"]);
+  });
+
+  test("pytest FAILED lines are not double-handled by the vitest FAIL branch (unknown framework)", () => {
+    // No framework summary line → detector returns "unknown" → all branches run.
+    const output = "FAILED tests/test_feature.py::test_AC_2_empty_input - AssertionError";
+
+    expect(parseTestFailures(output)).toEqual(["AC-2"]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When acceptance tests run under **vitest's default reporter**, real per-AC failures were silently reclassified as a crash (`AC-ERROR` — *"Tests errored with no AC failures parsed"*), so diagnosis could not attribute or fix them.

Root cause: `parseTestFailures()` (`src/test-runners/ac-parser.ts`) only matched vitest failures on lines containing the bullet glyphs `●`/`×`/`✕` — which appear in **jest** summaries and vitest's **verbose** reporter. The default reporter emits failing tests as block headers:

```
 FAIL  <file> > <suite> > AC-N: description
```

with **no glyph**, so the AC label (the only copy of it) was never read. Combined with a non-zero exit, this fell through to the `AC-ERROR` branch in `src/pipeline/stages/acceptance.ts:211`.

Observed in a real run (`logs/2026-06-22T03-28-57.jsonl`), where an `apps/web` vitest failure (`callArg.id === undefined`) logged `AC-ERROR` instead of its actual AC id.

## Fix

In `src/test-runners/ac-parser.ts`:

1. **Match vitest default-reporter `FAIL` headers** — the jest/vitest/unknown branch now also matches `/^\s*FAIL\s/`. Anchored to the (ANSI-stripped) line start so a *passing* test whose title merely contains the word "FAIL" is not falsely matched, and the trailing `\s` excludes pytest's `FAILED` (handled by its own branch).
2. **Strip ANSI escapes before matching** — both runners colorize the marker/title, and the live reporter prefixes lines with cursor/erase CSI codes. Stripping all CSI sequences (not just SGR) keeps the line-start anchor reliable. Built via `new RegExp(String.fromCharCode(27) + ...)` to avoid a control char in a regex literal (Biome `noControlCharactersInRegex`).

## Tests

Added to `test/unit/pipeline/stages/acceptance.test.ts` (`parseTestFailures()` block):

- ✅ vitest default-reporter multi-failure block → extracts `["AC-9", "AC-12"]`
- ✅ ANSI-colored `FAIL` header → `["AC-3"]`
- ✅ erase-line code prefix stripped before anchor → `["AC-4"]`
- ✅ **negative:** passing line `✓ AC-7: handles FAIL gracefully` → `[]`
- ✅ **negative:** pytest `FAILED ... AC-2` under the unknown-framework path → `["AC-2"]` (not double-handled)

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean (all ratchets at baseline)
- `bun run test` — all phases pass (unit / integration / ui)

A code review (code-reviewer agent) flagged the passing-title false positive (HIGH); it is fixed in the second commit with the line-start anchor + negative regression tests.

## Scope

Fixes **parsing/attribution** only. The underlying `apps/web` product bug and the `apps/api` missing-`MagicMock`-import test bug from that run are separate and not addressed here.
