### PR TITLE
fix(execution): route single-session non-blocking fix to implementer

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -243,7 +243,24 @@ export async function buildPlanForStrategy(
     // findings list (then stalls asking the human for them). Pin the floor to
     // "info" so all advisory findings render. Blocking-cycle strategies above
     // are unaffected — they don't pass this option.
-    if (nbf.scope === "source") {
+    if (!isThreeSession) {
+      // Single-session strategies (tdd-simple / test-after / no-test) have no
+      // separate test-writer session — the one warm implementer session authored
+      // both source and tests. Route ALL advisory adversarial findings to that
+      // implementer regardless of nbf.scope, instead of resuming a cold,
+      // context-less test-writer session (which the three-session "both"/"triage"
+      // scopes below do). Mirrors the main rectification's single-session carve-out
+      // (`includeAdversarialReview: !isThreeSession`, test-writer gated on
+      // isThreeSession). Without this, a single-session story's non-blocking fix
+      // dispatched an `autofix-test-writer` strategy that woke a stale test-writer
+      // session (#1276 follow-up: US-003 in the 2026-06-23 run log).
+      nbStrategies.push(
+        makeAutofixImplementerStrategy(story, config, nbSink, {
+          includeAdversarialReview: true,
+          promptSeverityFloor: "info",
+        }) as FixStrategy<Finding, unknown, unknown, unknown>,
+      );
+    } else if (nbf.scope === "source") {
       // implementer claims adversarial findings in SOURCE scope (both session modes)
       nbStrategies.push(
         makeAutofixImplementerStrategy(story, config, nbSink, {

--- a/test/unit/execution/build-plan-for-strategy-triage-assembly.test.ts
+++ b/test/unit/execution/build-plan-for-strategy-triage-assembly.test.ts
@@ -32,7 +32,9 @@ describe("buildPlanForStrategy — AC1: triage scope NBF strategy assembly (US-0
   let capturedStrategyNamesByCall: string[][] = [];
   // Full strategy objects from each fix-cycle call, so tests can invoke
   // buildInput and assert the prompt severity floor was wired (not just names).
-  let capturedStrategiesByCall: Array<Array<{ name: string; buildInput: (...args: never[]) => unknown }>> = [];
+  let capturedStrategiesByCall: Array<
+    Array<{ name: string; buildInput: (...args: never[]) => unknown; appliesTo: (f: never) => boolean }>
+  > = [];
   let origRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
   let origCallOp: typeof _storyOrchestratorDeps.callOp;
   let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
@@ -81,7 +83,9 @@ describe("buildPlanForStrategy — AC1: triage scope NBF strategy assembly (US-0
       return { success: true };
     }) as typeof _storyOrchestratorDeps.callOp;
     _storyOrchestratorDeps.runFixCycle = mock(
-      async (cycle: { strategies: Array<{ name: string; buildInput: (...args: never[]) => unknown }> }) => {
+      async (cycle: {
+        strategies: Array<{ name: string; buildInput: (...args: never[]) => unknown; appliesTo: (f: never) => boolean }>;
+      }) => {
         capturedStrategyNamesByCall.push(cycle.strategies.map((s) => s.name));
         capturedStrategiesByCall.push(cycle.strategies);
         return { iterations: [], finalFindings: [], exitReason: "no-strategy" as const, costUsd: 0 };
@@ -284,4 +288,69 @@ describe("buildPlanForStrategy — AC1: triage scope NBF strategy assembly (US-0
     expect(nbfNames).toContain("full-suite-rectify");
     expect(nbfNames).not.toContain("autofix-test-writer");
   });
+
+  // Single-session strategies (tdd-simple / test-after / no-test) have no
+  // separate test-writer session. The non-blocking fix must route advisory
+  // adversarial findings to the warm implementer instead of waking a cold
+  // test-writer session — regardless of nbf.scope. (US-003 in 2026-06-23 run log.)
+  function makeSingleSessionInputs(story: UserStory, config: ReturnType<typeof makeNaxConfig>): PlanInputs {
+    return makeMockPlanInputs({
+      story,
+      implementer: makeImplementerInput(story),
+      verifyScoped: { workdir: "/tmp/test", storyId: story.id },
+      adversarialReview: {
+        story,
+        adversarialConfig: config.review.adversarial!,
+        mode: config.review.adversarial!.diffMode,
+      },
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+  }
+
+  const advisoryAdversarial = {
+    source: "adversarial-review",
+    severity: "info",
+    category: "test-gap",
+    message: "advisory gap",
+    fixTarget: "test",
+  } as never;
+
+  for (const scope of ["both", "triage", "source"] as const) {
+    test(`single-session (tdd-simple) NBF scope=${scope} routes adversarial to implementer, never test-writer`, async () => {
+      // Green story (every op except adversarial-review succeeds) so the
+      // non-blocking fix cycle runs and is the captured strategy set.
+      _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+        if (op.name === "adversarial-review") {
+          return { success: true, passed: true, advisoryFindings: [advisoryAdversarial] };
+        }
+        return { success: true };
+      }) as typeof _storyOrchestratorDeps.callOp;
+
+      const story = makeStory({ attempts: 1 });
+      const config = withNbfScope(scope);
+      const ctx = makeCtxWithRuntime(config);
+      const inputs = makeSingleSessionInputs(story, config);
+      const plan = await buildPlanForStrategy(ctx, story, config, "tdd-simple", inputs);
+      await plan.run();
+
+      const nbfSet = capturedStrategiesByCall[0] ?? [];
+      const nbfNames = nbfSet.map((s) => s.name);
+      // No cold test-writer session for a single-session story.
+      expect(nbfNames).not.toContain("autofix-test-writer");
+      expect(nbfNames).toContain("autofix-implementer");
+      expect(nbfNames).toContain("full-suite-rectify");
+      // The implementer must claim the advisory adversarial finding — otherwise it
+      // has no owner and the cycle exits "no-strategy" without a single fix attempt.
+      const implementer = nbfSet.find((s) => s.name === "autofix-implementer");
+      expect(implementer?.appliesTo(advisoryAdversarial)).toBe(true);
+      // The "info" floor must reach the op input — advisory findings sit below the
+      // run's blocking threshold, so a dropped floor renders an empty prompt.
+      const floor = (
+        implementer?.buildInput([advisoryAdversarial] as never, [] as never, {} as never) as {
+          blockingThreshold?: string;
+        }
+      )?.blockingThreshold;
+      expect(floor).toBe("info");
+    });
+  }
 });


### PR DESCRIPTION
## Problem

In the run log `logs/2026-06-23T07-29-54.jsonl`, **US-003** is a single-session story (`Agent did not commit after single-session session`), yet its ADR-024 **non-blocking best-effort fix** ran the `autofix-test-writer` strategy and resumed a cold `nax-…-us-003-test-writer` session that the single-session path never warms.

The **main rectification** in `src/execution/build-plan-for-strategy.ts` already handles this correctly — it routes adversarial findings to the implementer (`includeAdversarialReview: !isThreeSession`) and only adds `makeAutofixTestWriterStrategy` `if (isThreeSession)`. But the **non-blocking-fix strategy block** (added later) never inherited that session-awareness: its default `both` scope (and `triage`) unconditionally pushed a test-writer strategy. Since `scope` defaults to `"both"`, every single-session story hit this path.

## Fix

Added a `!isThreeSession` short-circuit ahead of the nbf scope branching so single-session strategies (`tdd-simple` / `test-after` / `no-test`) route **all** advisory adversarial findings to the warm implementer (`includeAdversarialReview: true`) and never add a test-writer strategy, regardless of `nbf.scope`. Three-session behavior (`source` / `triage` / `both`) is unchanged. The unconditional `full-suite-rectify` strategy still composes correctly (its `appliesTo` is disjoint from the implementer's adversarial claims).

## Tests

`test/unit/execution/build-plan-for-strategy-triage-assembly.test.ts` — added a parameterized test across all three scopes for the `tdd-simple` (single-session) strategy asserting the nbf set:
- contains `autofix-implementer` + `full-suite-rectify`,
- **never** contains `autofix-test-writer`,
- the implementer actually claims the advisory adversarial finding (`appliesTo` → true), so the cycle doesn't exit `no-strategy`,
- the implementer's `promptSeverityFloor` is wired to `"info"` (advisory findings sit below the blocking threshold — a dropped floor renders an empty prompt).

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- Target unit tests 7/7 ✅ (30 expect calls)
- nbf integration + fix-assembly tests 12/12 ✅

## Review

Reviewed via the code-reviewer agent — **APPROVE**, no CRITICAL/HIGH issues. Confirmed the fix mirrors the main rectification's single-session semantics, composes correctly with `full-suite-rectify`, and handles all single-session edge cases. The one actionable LOW finding (assert the `"info"` floor) was incorporated.