### PR TITLE
fix(execution): skip non-blocking fix when story is not green (ADR-024 §5)

### DIFF
--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -214,11 +214,25 @@ export class ExecutionPlan {
 
     // ADR-024 — non-blocking best-effort fix over advisory adversarial findings.
     // Only when the story is currently green (adversarial passed, nothing pending).
+    //
+    // This green precondition is load-bearing, not cosmetic: nbf's floor guarantee
+    // (§5, restore-to-adversarial-passed) only holds when the entry state IS the
+    // adversarial-passed tree. Without the guard, a story whose outer rectification
+    // exhausted with unfixed review findings (e.g. semantic-review short-circuit)
+    // still entered nbf, kept cosmetic edits on the red tree, and then escalated on
+    // the real failures it never touched — polluting the next tier's working tree
+    // for no benefit (log 2026-06-24, US-001). Skip nbf entirely when the story is
+    // red: there is no passed state to improve upon, and the blocking failures must
+    // flow to escalation untouched.
+    const storyCurrentlyGreen =
+      !rectResult.rectificationExhausted &&
+      Object.entries(phaseOutputs).every(([name, output]) => phasePassed(name, output, this.ctx.storyId));
     const advCfg = this.state.adversarialReview ? this.state.nonBlockingFix : undefined;
     const advisoryOut = phaseOutputs["adversarial-review"] as { advisoryFindings?: Finding[] } | undefined;
     const advisoryFindings = advisoryOut?.advisoryFindings ?? [];
     if (
       advCfg &&
+      storyCurrentlyGreen &&
       this.state.rectification &&
       this.ctx.storyId &&
       shouldRunNonBlockingFix(advCfg, advisoryFindings.length)

--- a/test/unit/execution/non-blocking-fix-wiring.test.ts
+++ b/test/unit/execution/non-blocking-fix-wiring.test.ts
@@ -130,4 +130,80 @@ describe("non-blocking-fix runtime wiring", () => {
     const deps = runNonBlockingFix.mock.calls[0]?.[1] as { measureSourceDiff?: unknown } | undefined;
     expect(typeof deps?.measureSourceDiff).toBe("function");
   });
+
+  test("non-blocking fix is SKIPPED when the story is not green (rectification exhausted with unfixed findings)", async () => {
+    // Regression: log 2026-06-24 US-001. Adversarial review FAILED (blocking findings)
+    // yet its output still carried advisoryFindings. The outer rectification fixed the
+    // blocking findings but its revalidation flipped semantic-review red and exhausted
+    // (validate-short-circuit, 6 unfixed findings). nbf then read those advisory findings
+    // off the still-failing adversarial output, ran on the red tree, kept cosmetic edits,
+    // and the story escalated on the real failures. ADR-024 §5: nbf only acts on an
+    // already-green (adversarial-passed) story; its restore-to-adversarial-passed floor is
+    // meaningless when the entry state is red.
+    const runNonBlockingFix = mock(async () => ({ ran: true, kept: true, restored: false }));
+    (_storyOrchestratorDeps as { runNonBlockingFix?: typeof runNonBlockingFix }).runNonBlockingFix = runNonBlockingFix;
+
+    // Adversarial review FAILS (blocking findings) but still surfaces advisory findings —
+    // so the main loop short-circuits here and the story is red, yet advisoryFindings > 0.
+    _storyOrchestratorDeps.callOp = mock(async (_ctx, op) => {
+      if (op.name === "adversarial-review") {
+        return {
+          success: false,
+          passed: false,
+          normalizedFindings: [
+            { source: "adversarial-review", severity: "error", category: "logic", message: "blocking finding" },
+          ],
+          advisoryFindings: [
+            { source: "adversarial-review", severity: "warning", category: "input", message: "advisory finding" },
+          ],
+        };
+      }
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    // Outer rectification exhausts with a non-mechanical unfixed finding → story is red.
+    _storyOrchestratorDeps.runFixCycle = mock(async () => ({
+      iterations: [{}],
+      finalFindings: [{ source: "semantic-review", severity: "error", category: "logic", message: "unfixable" }],
+      exitReason: "max-attempts-total" as const,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const config = makeNaxConfig({
+      quality: { autofix: { enabled: true } },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+      review: {
+        adversarial: {
+          model: "balanced",
+          diffMode: "ref",
+          rules: [],
+          timeoutMs: 600_000,
+          parallel: false,
+          maxConcurrentSessions: 2,
+          nonBlockingFix: { enabled: true, scope: "triage", regressionAttempts: 1, verifierGuard: true },
+        },
+      },
+    });
+    const story = makeStory({ attempts: 1 });
+    runtime = makeTestRuntime({ config });
+    const ctx = makeMockCallContext({ runtime });
+    const inputs = makeMockPlanInputs({
+      story,
+      implementer: { story },
+      fullSuiteGate: { story, workdir: "/tmp/test" },
+      verifier: { story },
+      adversarialReview: {
+        story,
+        workdir: "/tmp/test",
+        adversarialConfig: config.review.adversarial!,
+        mode: config.review.adversarial!.diffMode,
+      },
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    await plan.run();
+
+    expect(runNonBlockingFix).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem

The ADR-024 non-blocking best-effort fix (nbf) is meant to run **only when the story is already green** (adversarial passed, nothing pending) — its restore-to-adversarial-passed floor (§5) is meaningless when the entry state is red. The code comment at `execution-plan.ts` said exactly this, but the guard only checked `advisoryFindings.length > 0`, never the green precondition.

### Observed failure (`logs/2026-06-24T14-49-54.jsonl`, US-001)

| Step | What ran | Result |
|---|---|---|
| 1 | semantic-review (main loop) | passed |
| 2 | adversarial-review (main loop) | **failed — 10 blocking findings** + carries `advisoryFindings` |
| 3 | rectification fixes adversarial via `autofix-implementer` | source edited |
| 4 | rectification revalidation re-runs semantic-review | **flips red — 7→5→6 findings** (reviewer nondeterminism) |
| 5 | rectification exhausts → `validate-short-circuit` | `rectificationExhausted: true` → **story RED** |
| 6 | **nbf runs (the bug)** — reads advisory findings off the still-failing adversarial output | `"best-effort fix kept"` on a red tree |
| 7 | success=false (semantic red) → escalate | tier → balanced |

By step 5 the story was terminally red, yet nbf still fired, did a useless adversarial best-effort pass, "kept" it (nbf's own revalidation deliberately skips reviews, so it can't see the red semantic), and left those edits in the tree handed to the balanced-tier retry.

The escalation itself is **correct** (6 genuinely-unfixable semantic findings). The defect is purely that nbf engaged on a red story.

## Fix

Add a `storyCurrentlyGreen` precondition to the nbf execution condition in `ExecutionPlan.run`:

```ts
const storyCurrentlyGreen =
  !rectResult.rectificationExhausted &&
  Object.entries(phaseOutputs).every(([name, output]) => phasePassed(name, output, this.ctx.storyId));
```

A red story now flows straight to escalation untouched. Normal green stories are unaffected (all phases pass → `storyCurrentlyGreen` true → nbf runs as before).

## Test

`non-blocking-fix-wiring.test.ts` — new regression test reproducing the exact log shape: adversarial-review fails with both blocking + advisory findings, outer rectification exhausts → asserts `runNonBlockingFix` is **not** called.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun test test/unit/execution/` — 1061 pass, 0 fail

## Follow-up

#1282 tracks the separate, deeper question this surfaced: should the **blocking** rectification cycle re-run **already-green** LLM reviews at all? That's the root of the phantom green→red flip (step 4) — an optimization with its own complexity/soundness tradeoffs, deliberately scoped out of this PR.