### PR TITLE
fix(regression): count pytest errors as failures and stop blind rectification

### DIFF
--- a/src/execution/lifecycle/run-regression.ts
+++ b/src/execution/lifecycle/run-regression.ts
@@ -18,8 +18,40 @@ import type { PRD, UserStory } from "@/prd";
 import { countStories } from "@/prd";
 import type { NaxRuntime } from "@/runtime";
 import { parseTestOutput } from "@/test-runners";
+import type { TestSummary } from "@/test-runners";
 import { hasCommitsForStory } from "@/utils/git";
 import { fullSuite } from "@/verification";
+
+/** Max chars of raw test output embedded in a synthetic regression finding. */
+const SYNTHETIC_FINDING_OUTPUT_LIMIT = 2000;
+
+/**
+ * Build the findings that drive a story's rectification cycle.
+ *
+ * When the parser yields structured failures, map them directly. When it does
+ * NOT — count-only output, or a runner format we can't fully parse, while the
+ * suite is still failing — fall back to a single synthetic finding carrying the
+ * raw output. Without this fallback the fix cycle receives zero findings and
+ * `runFixCycle` short-circuits to exitReason "resolved" *without ever invoking
+ * the agent*, falsely reporting a fix that never ran (the blind-rectifier bug:
+ * empty findings are indistinguishable from an all-green suite).
+ *
+ * Callers MUST only invoke this when the suite is known to be failing.
+ */
+function buildRegressionFindings(summary: TestSummary, rawOutput: string): Finding[] {
+  const structured = testSummaryToFindings(summary);
+  if (structured.length > 0) return structured;
+  return [
+    {
+      source: "test-runner",
+      severity: "error",
+      category: "failed-test",
+      rule: "regression-suite",
+      message: `Full test suite is failing but no individual test failures could be parsed from the output. Diagnose and fix the underlying failure. Raw test output:\n\n${rawOutput.slice(0, SYNTHETIC_FINDING_OUTPUT_LIMIT)}`,
+      fixTarget: "source",
+    },
+  ];
+}
 
 /**
  * Injectable dependencies for testing (avoids mock.module() which leaks in Bun 1.x).
@@ -405,7 +437,10 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
     });
 
     const storyStartMs = Date.now();
-    const initialFindings = testSummaryToFindings(_regressionDeps.parseTestOutput(currentTestOutput));
+    const initialFindings = buildRegressionFindings(
+      _regressionDeps.parseTestOutput(currentTestOutput),
+      currentTestOutput,
+    );
     const packageView = runtime.packages.repo();
     const cycleCtx: FixCycleContext = {
       runtime,
@@ -424,7 +459,10 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       validate: async (_cycleCtx, _opts) => {
         const verification = await _regressionDeps.runVerification(verifyOpts);
         if (verification.success) return [];
-        if (verification.output) return testSummaryToFindings(_regressionDeps.parseTestOutput(verification.output));
+        // Suite still failing — never return an empty finding set here, or the
+        // cycle would falsely conclude "resolved" (see buildRegressionFindings).
+        if (verification.output)
+          return buildRegressionFindings(_regressionDeps.parseTestOutput(verification.output), verification.output);
         return initialFindings;
       },
     };

--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -273,10 +273,12 @@ function parseJestOutput(output: string): TestSummary {
 function parsePytestOutput(output: string): TestSummary {
   const common = parseCommonOutput(output);
 
-  // Structured failure names from "FAILED path::test_name - reason" lines
+  // Structured failure names from "FAILED path::test_name - reason" lines.
+  // Allow a leading turbo-style task prefix ("pkg:test: FAILED ...") so the
+  // anchor survives monorepo aggregate output.
   const failures: TestFailure[] = [];
   for (const line of output.split("\n")) {
-    const m = line.match(/^FAILED\s+(\S+)(?:\s+-\s+(.*))?$/);
+    const m = line.match(/^(?:\S+:\s+)?FAILED\s+(\S+)(?:\s+-\s+(.*))?$/);
     if (m) {
       const [, location, reason] = m;
       const parts = location.split("::");
@@ -288,6 +290,26 @@ function parsePytestOutput(output: string): TestSummary {
       });
     }
   }
+
+  // Collection/import errors: "ERROR collecting <path>" (ERRORS block header) or
+  // "ERROR <path> - <reason>" (short summary). Both forms refer to the same file,
+  // so dedupe by path and prefer the entry carrying a reason.
+  const errorByFile = new Map<string, TestFailure>();
+  for (const line of output.split("\n")) {
+    const em = line.match(/\bERROR\s+(?:collecting\s+)?(\S+\.\w+)(?:\s+-\s+(.*))?/);
+    if (!em) continue;
+    const [, location, reason] = em;
+    const file = location.split("::")[0] ?? location;
+    const existing = errorByFile.get(file);
+    if (existing && existing.error !== "Collection/import error") continue;
+    errorByFile.set(file, {
+      file,
+      testName: `collection error: ${file}`,
+      error: reason?.trim() || "Collection/import error",
+      stackTrace: [],
+    });
+  }
+  failures.push(...errorByFile.values());
 
   // Merge file:line stackTrace entries from the verbose FAILURES block
   const verboseStacks = parsePytestVerboseStacks(output);
@@ -449,6 +471,21 @@ function parseCommonOutput(output: string): TestSummary {
       failed = Number.parseInt(failMatches[failMatches.length - 1][1], 10);
     }
   }
+
+  // pytest categorises collection/import/fixture problems as "errors" — a bucket
+  // distinct from "failed" but equally fatal to the suite (e.g.
+  // "230 passed, 10 errors in 5.29s"). Fold the error count into `failed` so the
+  // suite is not reported as all-green. Scope the match to summary-style lines
+  // (those carrying "passed"/"failed" or an "in <n>s" duration) so stray
+  // "N errors" noise from other runners' stack traces is ignored. Last summary
+  // line wins, mirroring the pass/fail "last occurrence" rule above.
+  let errorCount = 0;
+  for (const line of output.split("\n")) {
+    if (!/\b(?:passed|failed)\b/i.test(line) && !/\bin\s+[\d.]+s\b/i.test(line)) continue;
+    const errMatch = line.match(/(\d+)\s+errors?\b/i);
+    if (errMatch) errorCount = Number.parseInt(errMatch[1], 10);
+  }
+  failed += errorCount;
 
   return { passed, failed, failures: [] };
 }

--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -291,21 +291,28 @@ function parsePytestOutput(output: string): TestSummary {
     }
   }
 
-  // Collection/import errors: "ERROR collecting <path>" (ERRORS block header) or
-  // "ERROR <path> - <reason>" (short summary). Both forms refer to the same file,
-  // so dedupe by path and prefer the entry carrying a reason.
+  // Collection/import errors come in two line-anchored forms (both tolerate a
+  // leading turbo task prefix like "pkg:test: "):
+  //   - ERRORS block header:  "____ ERROR collecting <path> ____"
+  //   - short summary:        "ERROR <path>[::test] - <reason>"
+  // Requiring either the "collecting" keyword or a " - <reason>" tail keeps
+  // captured app-log lines (e.g. "ERROR app.py:42 boom") from manufacturing
+  // phantom failures. Dedupe by file, preferring the entry carrying a reason.
+  const PLACEHOLDER_REASON = "Collection/import error";
   const errorByFile = new Map<string, TestFailure>();
   for (const line of output.split("\n")) {
-    const em = line.match(/\bERROR\s+(?:collecting\s+)?(\S+\.\w+)(?:\s+-\s+(.*))?/);
-    if (!em) continue;
-    const [, location, reason] = em;
+    const collecting = line.match(/^(?:\S+:\s+)?_*\s*ERROR\s+collecting\s+(\S+\.\w+)/);
+    const summary = line.match(/^(?:\S+:\s+)?ERROR\s+(\S+\.\w+(?:::\S+)?)\s+-\s+(.*)/);
+    const location = collecting?.[1] ?? summary?.[1];
+    if (!location) continue;
+    const reason = summary?.[2]?.trim();
     const file = location.split("::")[0] ?? location;
     const existing = errorByFile.get(file);
-    if (existing && existing.error !== "Collection/import error") continue;
+    if (existing && existing.error !== PLACEHOLDER_REASON) continue;
     errorByFile.set(file, {
       file,
       testName: `collection error: ${file}`,
-      error: reason?.trim() || "Collection/import error",
+      error: reason || PLACEHOLDER_REASON,
       stackTrace: [],
     });
   }
@@ -475,17 +482,16 @@ function parseCommonOutput(output: string): TestSummary {
   // pytest categorises collection/import/fixture problems as "errors" — a bucket
   // distinct from "failed" but equally fatal to the suite (e.g.
   // "230 passed, 10 errors in 5.29s"). Fold the error count into `failed` so the
-  // suite is not reported as all-green. Scope the match to summary-style lines
-  // (those carrying "passed"/"failed" or an "in <n>s" duration) so stray
-  // "N errors" noise from other runners' stack traces is ignored. Last summary
-  // line wins, mirroring the pass/fail "last occurrence" rule above.
-  let errorCount = 0;
-  for (const line of output.split("\n")) {
-    if (!/\b(?:passed|failed)\b/i.test(line) && !/\bin\s+[\d.]+s\b/i.test(line)) continue;
-    const errMatch = line.match(/(\d+)\s+errors?\b/i);
-    if (errMatch) errorCount = Number.parseInt(errMatch[1], 10);
+  // suite is not reported as all-green. This runs for ALL frameworks
+  // (analyzeTestExitCode calls parseCommonOutput directly), so the match is
+  // tightly scoped to the pytest summary tail via a lookahead: the count must be
+  // immediately followed by "... in <n>s" on the same line. That excludes
+  // incidental phrasing like "passed in 1.2s (4 errors suppressed)" and app-log
+  // noise. Last matching count wins, mirroring the pass/fail rule above.
+  const errorMatches = Array.from(output.matchAll(/(\d+)\s+errors?\b(?=[^\n]*\bin\s+[\d.]+\s*s\b)/gi));
+  if (errorMatches.length > 0) {
+    failed += Number.parseInt(errorMatches[errorMatches.length - 1][1], 10);
   }
-  failed += errorCount;
 
   return { passed, failed, failures: [] };
 }

--- a/test/unit/execution/lifecycle/run-regression.test.ts
+++ b/test/unit/execution/lifecycle/run-regression.test.ts
@@ -231,6 +231,48 @@ describe("runDeferredRegression — early exit after first story", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Blind-rectifier guard: empty structured failures must not no-op as "resolved"
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("runDeferredRegression — synthetic finding when no structured failures parsed", () => {
+  test("feeds the fix cycle a non-empty finding so it cannot short-circuit to resolved", async () => {
+    const verifyCalls: string[] = [];
+    _regressionDeps.runVerification = mock(async () => {
+      const call = verifyCalls.length;
+      verifyCalls.push(`call-${call}`);
+      // initial: suite fails (non-zero exit) but only a count is parseable, no
+      // structured failures — the rs-stock "230 passed, 10 errors" shape.
+      if (call === 0) {
+        return makeVerifyResult({
+          output: "======================== 230 passed, 10 errors in 5.29s ========================",
+          passCount: 230,
+          failCount: 0,
+        });
+      }
+      return makePassResult(230);
+    });
+
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 230, failed: 0, failures: [] }));
+
+    let capturedFindingCount = -1;
+    _regressionDeps.runFixCycle = mock(async (cycle, cycleCtx) => {
+      capturedFindingCount = cycle.findings.length;
+      // sanity: the synthetic finding must be one the rectify strategy applies to
+      expect(cycle.findings[0]?.source).toBe("test-runner");
+      void cycleCtx;
+      return makeFixCycleResult(true, 0.1);
+    });
+
+    const result = await runDeferredRegression(makeOptions(["US-001"]));
+
+    // Before the fix this was 0 → runFixCycle would short-circuit to "resolved"
+    // without ever invoking the agent, falsely reporting a successful fix.
+    expect(capturedFindingCount).toBeGreaterThan(0);
+    expect(result.rectificationAttempts).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Early exit: second story fixes the rest
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/test/unit/test-runners/parser.test.ts
+++ b/test/unit/test-runners/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseTestOutput } from "@/test-runners";
+import { analyzeTestExitCode, parseTestOutput } from "@/test-runners";
 
 describe("pytest output — structured error/stack extraction", () => {
   test("extracts stackTrace file:line reference from verbose FAILURES block", () => {
@@ -94,6 +94,85 @@ FAILED tests/test_foo.py::test_bar - AssertionError: assert 1 == 2
     expect(result.failures[0].file).toBe("tests/test_foo.py");
     expect(result.failures[0].testName).toBe("test_bar");
     expect(result.failures[0].error).toBe("AssertionError: assert 1 == 2");
+  });
+});
+
+describe("pytest output — collection/import errors count as failures", () => {
+  test("counts pytest 'errors' category in the summary line as failed", () => {
+    const output = `
+==================================== ERRORS ====================================
+______________ ERROR collecting tests/unit/test_alpaca_adapter.py ______________
+ImportError while importing test module 'tests/unit/test_alpaca_adapter.py'.
+E   ModuleNotFoundError: No module named 'respx'
+=========================== short test summary info ============================
+ERROR tests/unit/test_alpaca_adapter.py - ImportError while importing test mo...
+======================== 230 passed, 10 errors in 5.29s ========================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.passed).toBe(230);
+    expect(result.failed).toBe(10);
+  });
+
+  test("counts errors under a turbo line prefix (monorepo aggregate output)", () => {
+    const output = `
+stock-portfolio:test: ==================================== ERRORS ====================================
+stock-portfolio:test: ______________ ERROR collecting tests/unit/test_alpaca_adapter.py ______________
+stock-portfolio:test: E   ModuleNotFoundError: No module named 'respx'
+stock-portfolio:test: =========================== short test summary info ============================
+stock-portfolio:test: ERROR tests/unit/test_alpaca_adapter.py - ImportError while importing test mo...
+stock-portfolio:test: ======================== 230 passed, 10 errors in 5.29s ========================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.passed).toBe(230);
+    expect(result.failed).toBe(10);
+  });
+
+  test("combines failed + errors when both are present", () => {
+    const output = `
+FAILED tests/test_foo.py::test_bar - AssertionError: assert 1 == 2
+=================== 2 failed, 5 passed, 1 error in 0.42s ===================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.passed).toBe(5);
+    expect(result.failed).toBe(3);
+  });
+
+  test("extracts collection errors into structured failures with file paths", () => {
+    const output = `
+==================================== ERRORS ====================================
+______________ ERROR collecting tests/unit/test_alpaca_adapter.py ______________
+E   ModuleNotFoundError: No module named 'respx'
+=========================== short test summary info ============================
+ERROR tests/unit/test_alpaca_adapter.py - ImportError while importing test module
+ERROR tests/unit/test_broker_cancel.py - ImportError while importing test module
+======================== 230 passed, 2 errors in 5.29s ========================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    const files = result.failures.map((f) => f.file).sort();
+    expect(files).toEqual(["tests/unit/test_alpaca_adapter.py", "tests/unit/test_broker_cancel.py"]);
+    expect(result.failures.every((f) => f.error.length > 0)).toBe(true);
+  });
+
+  test("analyzeTestExitCode does NOT classify collection errors as environmental", () => {
+    const output = `
+=========================== short test summary info ============================
+ERROR tests/unit/test_alpaca_adapter.py - ImportError while importing test module
+======================== 230 passed, 10 errors in 5.29s ========================
+`.trim();
+
+    const analysis = analyzeTestExitCode(output, 1);
+
+    expect(analysis.failCount).toBe(10);
+    expect(analysis.allTestsPassed).toBe(false);
+    expect(analysis.isEnvironmentalFailure).toBe(false);
   });
 });
 

--- a/test/unit/test-runners/parser.test.ts
+++ b/test/unit/test-runners/parser.test.ts
@@ -161,6 +161,33 @@ ERROR tests/unit/test_broker_cancel.py - ImportError while importing test module
     expect(result.failures.every((f) => f.error.length > 0)).toBe(true);
   });
 
+  test("does NOT count incidental 'N errors' phrasing that is not a pytest summary tail", () => {
+    // "4 errors" trails the duration, so it is not a pytest count — must be ignored.
+    const output = `
+ok - all checks passed in 1.2s (4 errors suppressed)
+=========================== short test summary info ============================
+3 passed in 1.2s
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failed).toBe(0);
+  });
+
+  test("does NOT manufacture failures from captured app-log lines containing ERROR", () => {
+    const output = `
+tests/test_app.py::test_run
+ERROR app.py:42 something went wrong at runtime
+ERROR    root:client.py:13 connection reset
+=================================== 5 passed in 1.10s ===================================
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failures).toHaveLength(0);
+    expect(result.failed).toBe(0);
+  });
+
   test("analyzeTestExitCode does NOT classify collection errors as environmental", () => {
     const output = `
 =========================== short test summary info ============================


### PR DESCRIPTION
## Problem

A deferred regression run on a Python (pytest) monorepo logged the contradictory state:

```
Full suite still failing after story rectification — continuing  { failCount: 0, passCount: 230 }
```

…and looped 7 "rectifications" that each logged **"Story US-XXX rectified successfully"** while the suite stayed red. No agent turn ever ran.

Root cause is two compounding defects in nax (the orchestrated repo was fine — its actual issue was a missing test dep, `ModuleNotFoundError: No module named 'respx'`).

## Defect 1 — parser ignored pytest's `errors` category

pytest distinguishes **failures** (assertions) from **errors** (collection/import/fixture), e.g.:

```
======================== 230 passed, 10 errors in 5.29s ========================
```

`parseCommonOutput` only ever matched `fail`, so `failed = 0`. Worse, `analyzeTestExitCode` then saw `passCount>0 && failCount===0 && exit≠0` and **misclassified a real collection failure as `ENVIRONMENTAL_FAILURE`** ("Check linter/typecheck/missing files").

Fix (`src/test-runners/parser.ts`):
- Fold pytest `errors` into the `failed` count, scoped via lookahead to the pytest summary tail (`... in <n>s`) so it stays safe for bun/jest/go (which also flow through `parseCommonOutput` via `analyzeTestExitCode`).
- Extract `ERROR collecting <path>` / `ERROR <path> - <reason>` into structured `failures[]`, line-anchored and turbo-prefix tolerant, requiring `collecting` or a ` - reason` so captured app-log lines can't manufacture phantom failures.
- `FAILED` extraction also tolerates a turbo task-line prefix.

## Defect 2 — blind rectifier

`testSummaryToFindings` maps only structured `failures[]`. An empty list yielded **zero findings**, and `runFixCycle` short-circuits to `exitReason: "resolved"` on empty findings *without invoking the agent* — so a fix that never ran was reported as success.

Fix (`src/execution/lifecycle/run-regression.ts`):
- New `buildRegressionFindings()` synthesizes a fallback finding carrying the raw output whenever the suite is failing but no structured failures were parsed. Wired into both the initial findings and the `validate` re-check, so an unparsed failure can never resolve to green.

## Verification

- Reproduced against the real captured output: now parses `passed=230, failed=10`, 10 structured failures, `isEnvironmentalFailure=false`.
- New tests: pytest-errors parsing (incl. the turbo+pytest shape), two false-positive guards (incidental "N errors", captured `ERROR` app-log lines), and a regression-gate guard asserting the fix cycle receives a non-empty finding set.
- `bun run typecheck` ✅ · `bun run lint` ✅ (baseline unchanged) · full suite **1058 pass / 0 fail**.

## Review

Incorporates a code-review pass: tightened the error-count scan and the `ERROR`-line regex to eliminate cross-framework false-positive risk.