### PR TITLE
feat(schedule): add one-shot `nax run --schedule` with countdown gate

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -82,6 +82,7 @@ import { loadHooksConfig } from "../src/hooks";
 import { type LogLevel, initLogger, resetLogger } from "../src/logger";
 import { countStories, loadPRD } from "../src/prd";
 import { AgentStreamEventBus, projectOutputDir } from "../src/runtime";
+import { resolveScheduleGate, waitForSchedule } from "../src/schedule";
 import { PipelineEventEmitter, type StoryDisplayState, renderTui } from "../src/tui";
 import { NAX_BUILD_INFO, NAX_VERSION } from "../src/version";
 
@@ -388,6 +389,7 @@ program
     collectProfile,
     [],
   )
+  .option("--schedule <when>", "Defer run start until <when> (e.g. 30m, 1h30m, 17:00, 2026-07-02T02:00)")
   .action(async (options) => {
     // Validate directory path
     let workdir: string;
@@ -395,6 +397,13 @@ program
       workdir = validateDirectory(options.dir);
     } catch (err) {
       console.error(chalk.red(`Invalid directory: ${(err as Error).message}`));
+      process.exit(1);
+    }
+
+    // Parse --schedule early so a bad value errors before any setup.
+    const scheduleGate = resolveScheduleGate(options.schedule, new Date());
+    if (!scheduleGate.ok) {
+      console.error(chalk.red(`Invalid --schedule: ${scheduleGate.error}`));
       process.exit(1);
     }
 
@@ -635,6 +644,22 @@ program
       if (Number.isNaN(parallel) || parallel < 0) {
         console.error(chalk.red("--parallel must be a non-negative integer"));
         process.exit(1);
+      }
+    }
+
+    if (scheduleGate.target) {
+      const scheduleController = new AbortController();
+      const onSigint = () => scheduleController.abort();
+      process.once("SIGINT", onSigint);
+      const outcome = await waitForSchedule(scheduleGate.target, {
+        label: options.feature,
+        headless: useHeadless || formatterMode === "json",
+        signal: scheduleController.signal,
+      });
+      process.removeListener("SIGINT", onSigint);
+      if (outcome === "cancelled") {
+        console.log(chalk.dim("\nScheduled run cancelled."));
+        process.exit(0);
       }
     }
 

--- a/docs/superpowers/plans/2026-07-01-scheduled-run.md
+++ b/docs/superpowers/plans/2026-07-01-scheduled-run.md
@@ -1,0 +1,793 @@
+# Scheduled Run (`nax run --schedule`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a one-shot, foreground `--schedule <when>` flag to `nax run` that defers the run start until a wall-clock trigger, showing a live countdown, then hands off to the existing run path.
+
+**Architecture:** Two small dependency-injected modules under `src/schedule/` — a pure parser (`parseSchedule(input, now) → target|error`) and a countdown gate (`waitForSchedule(target, opts) → "fired"|"cancelled"`). The CLI parses `--schedule` early (fail fast), then calls the gate immediately before the existing `run({...})` invocation in `bin/nax.ts`. No daemon, no persistence, no reboot survival.
+
+**Tech Stack:** Bun 1.3.7+, TypeScript strict, `bun:test`, commander (CLI), chalk (output). Reuses `cancellableDelay` from `src/utils/bun-deps.ts` and `NaxError` from `src/errors.ts`.
+
+## Global Constraints
+
+- **Bun-native only** — no Node.js `fs`/`child_process`/`setTimeout`-for-delay. Delays use `cancellableDelay(ms, signal)` from `src/utils/bun-deps.ts`.
+- **TypeScript strict** — no `any` without justification.
+- **Barrel imports** — consumers import from `@/schedule`, never `@/schedule/parse`. Every dir with 2+ exports gets an `index.ts`.
+- **File size** — source ≤ 600 lines, test ≤ 800 lines. All files here are far smaller.
+- **Errors** — use `NaxError(message, code, context)`; expected bad input returns a structured result, not a throw.
+- **Logging** — project logger (`src/logger`), never `console.log` in `src/`. (CLI entry `bin/nax.ts` already uses `console` + chalk for user-facing output — match that locally.)
+- **Test commands** — never bare `bun test`. Use `timeout 15 bun test <path> --timeout=5000`.
+- **Tests use `_deps` injection** — never `mock.module()`; never `Bun.sleep()` in tests.
+- **Conventional commits**, one concern per commit, no attribution.
+
+---
+
+## File Structure
+
+- `src/schedule/types.ts` — `ScheduleParseResult` discriminated union.
+- `src/schedule/parse.ts` — pure `parseSchedule(input, now)`.
+- `src/schedule/wait.ts` — `waitForSchedule(target, opts)` countdown gate with `_deps`.
+- `src/schedule/index.ts` — barrel re-exporting the above.
+- `bin/nax.ts` — add `--schedule` option + gate wiring before `run({...})` (line ~641).
+- `test/unit/schedule/parse.test.ts` — parser table tests.
+- `test/unit/schedule/wait.test.ts` — countdown/cancel tests with fake clock.
+- `test/unit/schedule/format.test.ts` — remaining-time formatting (folded into wait.ts).
+
+---
+
+## Task 1: Schedule parser — types + relative durations
+
+**Files:**
+- Create: `src/schedule/types.ts`
+- Create: `src/schedule/parse.ts`
+- Create: `src/schedule/index.ts`
+- Test: `test/unit/schedule/parse.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type ScheduleParseResult = { ok: true; target: Date } | { ok: false; error: string }`
+  - `function parseSchedule(input: string, now: Date): ScheduleParseResult`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/unit/schedule/parse.test.ts
+import { describe, expect, test } from "bun:test";
+import { parseSchedule } from "@/schedule";
+
+const NOW = new Date("2026-07-01T12:00:00"); // local
+
+describe("parseSchedule — relative durations", () => {
+  test.each([
+    ["30m", 30 * 60_000],
+    ["2h", 2 * 3_600_000],
+    ["90s", 90_000],
+    ["1h30m", 90 * 60_000],
+    ["1d", 86_400_000],
+  ])("%s → now + %d ms", (input, deltaMs) => {
+    const r = parseSchedule(input as string, NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.target.getTime()).toBe(NOW.getTime() + (deltaMs as number));
+  });
+
+  test.each(["0s", "5x", "m30", "1h30", "-5m", ""])("rejects %p", (input) => {
+    const r = parseSchedule(input as string, NOW);
+    expect(r.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 15 bun test test/unit/schedule/parse.test.ts --timeout=5000`
+Expected: FAIL — cannot resolve `@/schedule`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/schedule/types.ts
+export type ScheduleParseResult =
+  | { ok: true; target: Date }
+  | { ok: false; error: string };
+```
+
+```typescript
+// src/schedule/parse.ts
+import type { ScheduleParseResult } from "./types";
+
+const ACCEPTED =
+  "Accepted: relative (30m, 2h, 90s, 1h30m, 1d), time-of-day (17:00), or ISO datetime (2026-07-02T02:00).";
+
+const UNIT_MS: Record<string, number> = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+const DURATION_RE = /^(\d+[smhd])+$/;
+const SEGMENT_RE = /(\d+)([smhd])/g;
+
+function parseRelative(input: string, now: Date): ScheduleParseResult | null {
+  if (!DURATION_RE.test(input)) return null;
+  let totalMs = 0;
+  for (const [, n, unit] of input.matchAll(SEGMENT_RE)) {
+    totalMs += Number(n) * UNIT_MS[unit];
+  }
+  if (totalMs <= 0) return { ok: false, error: `Duration must be positive. ${ACCEPTED}` };
+  return { ok: true, target: new Date(now.getTime() + totalMs) };
+}
+
+export function parseSchedule(input: string, now: Date): ScheduleParseResult {
+  const trimmed = input.trim();
+  if (trimmed === "") return { ok: false, error: `Empty schedule value. ${ACCEPTED}` };
+
+  const relative = parseRelative(trimmed, now);
+  if (relative) return relative;
+
+  return { ok: false, error: `Unrecognized schedule "${input}". ${ACCEPTED}` };
+}
+```
+
+```typescript
+// src/schedule/index.ts
+export { parseSchedule } from "./parse";
+export type { ScheduleParseResult } from "./types";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 15 bun test test/unit/schedule/parse.test.ts --timeout=5000`
+Expected: PASS (all relative + rejection cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schedule/ test/unit/schedule/parse.test.ts
+git commit -m "feat(schedule): add parseSchedule with relative-duration support"
+```
+
+---
+
+## Task 2: Schedule parser — time-of-day (`HH:MM`) with roll-to-tomorrow
+
+**Files:**
+- Modify: `src/schedule/parse.ts`
+- Test: `test/unit/schedule/parse.test.ts` (add describe block)
+
+**Interfaces:**
+- Consumes: `parseSchedule` from Task 1.
+- Produces: `HH:MM` handling — same `parseSchedule` signature.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// append to test/unit/schedule/parse.test.ts
+describe("parseSchedule — time of day", () => {
+  const noon = new Date("2026-07-01T12:00:00");
+
+  test("future time today stays today", () => {
+    const r = parseSchedule("17:00", noon);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.target.getFullYear()).toBe(2026);
+      expect(r.target.getMonth()).toBe(6); // July
+      expect(r.target.getDate()).toBe(1);
+      expect(r.target.getHours()).toBe(17);
+      expect(r.target.getMinutes()).toBe(0);
+      expect(r.target.getSeconds()).toBe(0);
+    }
+  });
+
+  test("past time today rolls to tomorrow", () => {
+    const r = parseSchedule("09:30", noon);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.target.getDate()).toBe(2); // rolled to July 2
+      expect(r.target.getHours()).toBe(9);
+      expect(r.target.getMinutes()).toBe(30);
+    }
+  });
+
+  test.each(["24:00", "12:60", "9:5", "17:0"])("rejects malformed %p", (input) => {
+    expect(parseSchedule(input as string, noon).ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 15 bun test test/unit/schedule/parse.test.ts --timeout=5000`
+Expected: FAIL — `17:00` currently hits the "Unrecognized" branch.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add above the final `return` in `parseSchedule`, and add the helper:
+
+```typescript
+// src/schedule/parse.ts — add helper
+const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+function parseTimeOfDay(input: string, now: Date): ScheduleParseResult | null {
+  const m = TIME_RE.exec(input);
+  if (!m) return null;
+  const hours = Number(m[1]);
+  const minutes = Number(m[2]);
+  const target = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    hours,
+    minutes,
+    0,
+    0,
+  );
+  if (target.getTime() <= now.getTime()) {
+    target.setDate(target.getDate() + 1); // roll to tomorrow
+  }
+  return { ok: true, target };
+}
+```
+
+```typescript
+// src/schedule/parse.ts — in parseSchedule, before the final return:
+  const timeOfDay = parseTimeOfDay(trimmed, now);
+  if (timeOfDay) return timeOfDay;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 15 bun test test/unit/schedule/parse.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schedule/parse.ts test/unit/schedule/parse.test.ts
+git commit -m "feat(schedule): add time-of-day parsing with roll-to-tomorrow"
+```
+
+---
+
+## Task 3: Schedule parser — ISO datetime, local tz, past-error, date-only reject
+
+**Files:**
+- Modify: `src/schedule/parse.ts`
+- Test: `test/unit/schedule/parse.test.ts` (add describe block)
+
+**Interfaces:**
+- Consumes: `parseSchedule` from Task 2.
+- Produces: ISO datetime handling — same signature. This is the terminal branch (replaces the "Unrecognized" fallthrough for ISO-shaped input).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// append to test/unit/schedule/parse.test.ts
+describe("parseSchedule — ISO datetime", () => {
+  const now = new Date("2026-07-01T12:00:00");
+
+  test("naive datetime is interpreted as local time", () => {
+    const r = parseSchedule("2026-07-02T02:00", now);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.target.getFullYear()).toBe(2026);
+      expect(r.target.getDate()).toBe(2);
+      expect(r.target.getHours()).toBe(2); // local, not UTC
+      expect(r.target.getMinutes()).toBe(0);
+    }
+  });
+
+  test("explicit Z offset is honored", () => {
+    const r = parseSchedule("2026-07-02T02:00:00Z", now);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.target.getTime()).toBe(Date.parse("2026-07-02T02:00:00Z"));
+  });
+
+  test("past datetime errors", () => {
+    const r = parseSchedule("2026-06-01T00:00", now);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("past");
+  });
+
+  test("bare date-only is rejected", () => {
+    const r = parseSchedule("2026-07-02", now);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("time");
+  });
+
+  test("garbage is rejected", () => {
+    expect(parseSchedule("not-a-date", now).ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 15 bun test test/unit/schedule/parse.test.ts --timeout=5000`
+Expected: FAIL — ISO inputs currently hit "Unrecognized".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add helpers and replace the final `return` in `parseSchedule`:
+
+```typescript
+// src/schedule/parse.ts — add helpers
+// Naive: YYYY-MM-DDTHH:MM(:SS)? with NO offset/Z. Construct explicitly as local.
+const NAIVE_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/;
+// Date-only: YYYY-MM-DD with no time component.
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+// Has an explicit offset or Z after a time component.
+const OFFSET_RE = /T\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(Z|[+-]\d{2}:?\d{2})$/;
+
+function parseIso(input: string, now: Date): ScheduleParseResult {
+  if (DATE_ONLY_RE.test(input)) {
+    return {
+      ok: false,
+      error: `Date-only value "${input}" has no time — specify a time, e.g. ${input}T02:00.`,
+    };
+  }
+
+  let target: Date | null = null;
+
+  const naive = NAIVE_RE.exec(input);
+  if (naive) {
+    const [, y, mo, d, h, mi, s] = naive;
+    // Explicit local-time construction — avoids new Date()'s date-only-UTC footgun.
+    target = new Date(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s ?? "0"), 0);
+  } else if (OFFSET_RE.test(input)) {
+    const parsed = new Date(input);
+    if (!Number.isNaN(parsed.getTime())) target = parsed;
+  }
+
+  if (!target || Number.isNaN(target.getTime())) {
+    return { ok: false, error: `Unrecognized schedule "${input}". ${ACCEPTED}` };
+  }
+  if (target.getTime() <= now.getTime()) {
+    return { ok: false, error: `Scheduled time ${input} is in the past.` };
+  }
+  return { ok: true, target };
+}
+```
+
+```typescript
+// src/schedule/parse.ts — replace the final `return { ok:false, error:"Unrecognized..." }`
+  return parseIso(trimmed, now);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 15 bun test test/unit/schedule/parse.test.ts --timeout=5000`
+Expected: PASS (all parse describe blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schedule/parse.ts test/unit/schedule/parse.test.ts
+git commit -m "feat(schedule): add ISO datetime parsing with local-tz + past guard"
+```
+
+---
+
+## Task 4: Countdown gate — `formatRemaining` helper
+
+**Files:**
+- Create: `src/schedule/wait.ts`
+- Modify: `src/schedule/index.ts`
+- Test: `test/unit/schedule/format.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `function formatRemaining(ms: number): string` — `HH:MM:SS`, clamps negatives to `00:00:00`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/unit/schedule/format.test.ts
+import { describe, expect, test } from "bun:test";
+import { formatRemaining } from "@/schedule";
+
+describe("formatRemaining", () => {
+  test.each([
+    [0, "00:00:00"],
+    [-5_000, "00:00:00"],
+    [1_000, "00:00:01"],
+    [61_000, "00:01:01"],
+    [3_661_000, "01:01:01"],
+    [90_061_000, "25:01:01"], // > 24h stays in hours
+  ])("%d ms → %s", (ms, expected) => {
+    expect(formatRemaining(ms as number)).toBe(expected);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 15 bun test test/unit/schedule/format.test.ts --timeout=5000`
+Expected: FAIL — `formatRemaining` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/schedule/wait.ts
+export function formatRemaining(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+```
+
+```typescript
+// src/schedule/index.ts — add
+export { formatRemaining, waitForSchedule } from "./wait";
+export type { WaitDeps, WaitOutcome } from "./wait";
+```
+
+> Note: `waitForSchedule`/`WaitDeps`/`WaitOutcome` are added in Task 5. Add the full export line now; Task 5 makes it resolve. If running tasks strictly independently, temporarily export only `formatRemaining` here and add the rest in Task 5.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 15 bun test test/unit/schedule/format.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schedule/wait.ts src/schedule/index.ts test/unit/schedule/format.test.ts
+git commit -m "feat(schedule): add formatRemaining countdown helper"
+```
+
+---
+
+## Task 5: Countdown gate — `waitForSchedule` with fake clock + cancellation
+
+**Files:**
+- Modify: `src/schedule/wait.ts`
+- Modify: `src/schedule/index.ts` (ensure full export line from Task 4)
+- Test: `test/unit/schedule/wait.test.ts`
+
+**Interfaces:**
+- Consumes: `formatRemaining`, `cancellableDelay` from `@/utils/bun-deps`.
+- Produces:
+  - `type WaitOutcome = "fired" | "cancelled"`
+  - `interface WaitDeps { now: () => number; delay: (ms: number, signal?: AbortSignal) => Promise<void>; render: (line: string) => void; }`
+  - `function waitForSchedule(target: Date, opts: { label: string; headless: boolean; signal: AbortSignal; _deps?: Partial<WaitDeps> }): Promise<WaitOutcome>`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/unit/schedule/wait.test.ts
+import { describe, expect, test } from "bun:test";
+import { waitForSchedule } from "@/schedule";
+
+function fakeDeps(startMs: number, stepMs: number) {
+  let current = startMs;
+  const lines: string[] = [];
+  return {
+    lines,
+    deps: {
+      now: () => current,
+      // Each "delay" advances the fake clock by stepMs instead of waiting.
+      delay: async (_ms: number, signal?: AbortSignal) => {
+        if (signal?.aborted) throw new Error("aborted");
+        current += stepMs;
+      },
+      render: (line: string) => lines.push(line),
+    },
+  };
+}
+
+describe("waitForSchedule", () => {
+  test("counts down and fires at target", async () => {
+    const start = 1_000_000;
+    const { lines, deps } = fakeDeps(start, 1_000);
+    const target = new Date(start + 3_000);
+    const outcome = await waitForSchedule(target, {
+      label: "feat-x",
+      headless: false,
+      signal: new AbortController().signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("fired");
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.some((l) => l.includes("feat-x"))).toBe(true);
+  });
+
+  test("returns cancelled when signal aborts", async () => {
+    const start = 1_000_000;
+    const controller = new AbortController();
+    const { deps } = fakeDeps(start, 1_000);
+    // Abort immediately; delay throws → treated as cancellation.
+    controller.abort();
+    const outcome = await waitForSchedule(new Date(start + 60_000), {
+      label: "feat-x",
+      headless: false,
+      signal: controller.signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("cancelled");
+  });
+
+  test("headless emits no render lines", async () => {
+    const start = 1_000_000;
+    const { lines, deps } = fakeDeps(start, 5_000);
+    const outcome = await waitForSchedule(new Date(start + 3_000), {
+      label: "feat-x",
+      headless: true,
+      signal: new AbortController().signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("fired");
+    expect(lines.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 15 bun test test/unit/schedule/wait.test.ts --timeout=5000`
+Expected: FAIL — `waitForSchedule` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/schedule/wait.ts — add below formatRemaining
+import { cancellableDelay } from "@/utils/bun-deps";
+
+export type WaitOutcome = "fired" | "cancelled";
+
+export interface WaitDeps {
+  now: () => number;
+  delay: (ms: number, signal?: AbortSignal) => Promise<void>;
+  render: (line: string) => void;
+}
+
+const TICK_MS = 1_000;
+
+const DEFAULT_DEPS: WaitDeps = {
+  now: () => Date.now(),
+  delay: (ms, signal) => cancellableDelay(ms, signal),
+  render: (line) => {
+    // Rewrite the current TTY line in place.
+    process.stdout.write(`\r${line}`);
+  },
+};
+
+export async function waitForSchedule(
+  target: Date,
+  opts: { label: string; headless: boolean; signal: AbortSignal; _deps?: Partial<WaitDeps> },
+): Promise<WaitOutcome> {
+  const deps: WaitDeps = { ...DEFAULT_DEPS, ...opts._deps };
+  const targetMs = target.getTime();
+
+  while (deps.now() < targetMs) {
+    if (opts.signal.aborted) return "cancelled";
+    const remaining = targetMs - deps.now();
+    if (!opts.headless) {
+      deps.render(
+        `⏳ Scheduled run of "${opts.label}" — starting in ${formatRemaining(remaining)}   (Ctrl-C to cancel)`,
+      );
+    }
+    const wait = Math.min(TICK_MS, remaining);
+    try {
+      await deps.delay(wait, opts.signal);
+    } catch {
+      return "cancelled"; // delay rejects on abort
+    }
+  }
+
+  if (!opts.headless) deps.render("\n"); // clear the countdown line before run output
+  return "fired";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 15 bun test test/unit/schedule/wait.test.ts --timeout=5000`
+Expected: PASS (fires, cancels, headless-silent).
+
+- [ ] **Step 5: Run the full schedule suite**
+
+Run: `timeout 20 bun test test/unit/schedule/ --timeout=5000`
+Expected: PASS — parse, format, wait all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/schedule/wait.ts src/schedule/index.ts test/unit/schedule/wait.test.ts
+git commit -m "feat(schedule): add waitForSchedule countdown gate with cancellation"
+```
+
+---
+
+## Task 6: CLI wiring — `--schedule` flag, fail-fast parse, gate before run
+
+**Files:**
+- Modify: `bin/nax.ts` (run command: option block ~365-390; gate before `run({...})` at ~641)
+- Test: `test/unit/cli/schedule-flag.test.ts`
+
+**Interfaces:**
+- Consumes: `parseSchedule`, `waitForSchedule` from `@/schedule`; `NaxError` from `@/errors` (or relative `../src/errors`).
+- Produces: user-facing CLI behavior. Extract the gate into a small exported helper so it is unit-testable without spawning nax.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/unit/cli/schedule-flag.test.ts
+import { describe, expect, test } from "bun:test";
+import { resolveScheduleGate } from "@/schedule";
+
+const NOW = new Date("2026-07-01T12:00:00");
+
+describe("resolveScheduleGate", () => {
+  test("undefined schedule → run immediately, no target", () => {
+    const r = resolveScheduleGate(undefined, NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.target).toBeNull();
+  });
+
+  test("valid relative schedule → target set", () => {
+    const r = resolveScheduleGate("30m", NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok && r.target) expect(r.target.getTime()).toBe(NOW.getTime() + 30 * 60_000);
+  });
+
+  test("invalid schedule → error", () => {
+    const r = resolveScheduleGate("nonsense", NOW);
+    expect(r.ok).toBe(false);
+  });
+
+  test("past absolute → error", () => {
+    const r = resolveScheduleGate("2026-06-01T00:00", NOW);
+    expect(r.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 15 bun test test/unit/cli/schedule-flag.test.ts --timeout=5000`
+Expected: FAIL — `resolveScheduleGate` not exported.
+
+- [ ] **Step 3: Write minimal implementation — helper**
+
+```typescript
+// src/schedule/parse.ts — add (keeps CLI thin, reuses parseSchedule)
+export type ScheduleGateResult =
+  | { ok: true; target: Date | null }
+  | { ok: false; error: string };
+
+export function resolveScheduleGate(input: string | undefined, now: Date): ScheduleGateResult {
+  if (input === undefined) return { ok: true, target: null };
+  const parsed = parseSchedule(input, now);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+  return { ok: true, target: parsed.target };
+}
+```
+
+```typescript
+// src/schedule/index.ts — add
+export { resolveScheduleGate } from "./parse";
+export type { ScheduleGateResult } from "./parse";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 15 bun test test/unit/cli/schedule-flag.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into `bin/nax.ts`**
+
+Add the option in the `run` command builder (after the `--profile` option, before `.action`):
+
+```typescript
+  .option(
+    "--schedule <when>",
+    "Defer run start until <when> (e.g. 30m, 1h30m, 17:00, 2026-07-02T02:00)",
+  )
+```
+
+Add imports near the other `../src/...` imports at the top of `bin/nax.ts`:
+
+```typescript
+import { resolveScheduleGate, waitForSchedule } from "../src/schedule";
+```
+
+Parse the flag early — inside the `run` action, right after the existing `validateDirectory` block (fail fast before any expensive work):
+
+```typescript
+    // Parse --schedule early so a bad value errors before any setup.
+    const scheduleGate = resolveScheduleGate(options.schedule, new Date());
+    if (!scheduleGate.ok) {
+      console.error(chalk.red(`Invalid --schedule: ${scheduleGate.error}`));
+      process.exit(1);
+    }
+```
+
+Perform the wait immediately before the `const result = await run({...})` call (~line 641):
+
+```typescript
+    if (scheduleGate.target) {
+      const scheduleController = new AbortController();
+      const onSigint = () => scheduleController.abort();
+      process.once("SIGINT", onSigint);
+      const outcome = await waitForSchedule(scheduleGate.target, {
+        label: options.feature,
+        headless: useHeadless || formatterMode === "json",
+        signal: scheduleController.signal,
+      });
+      process.removeListener("SIGINT", onSigint);
+      if (outcome === "cancelled") {
+        console.log(chalk.dim("\nScheduled run cancelled."));
+        process.exit(0);
+      }
+    }
+```
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run: `bun run typecheck && bun x biome check src/schedule bin/nax.ts`
+Expected: no errors.
+
+- [ ] **Step 7: Manual smoke test**
+
+Run: `bun run bin/nax.ts run -f nonexistent --schedule 3s --dir /tmp 2>&1 | head -5`
+Expected: either a fast countdown then the normal "nax not initialized"/PRD error, or the schedule error if the value were bad — confirming the gate fires and hands off. (Use a real initialized feature dir for a full end-to-end check.)
+
+Run: `bun run bin/nax.ts run -f whatever --schedule bogus 2>&1 | head -2`
+Expected: `Invalid --schedule: Unrecognized schedule "bogus". ...`, exit 1.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/schedule/parse.ts src/schedule/index.ts bin/nax.ts test/unit/cli/schedule-flag.test.ts
+git commit -m "feat(schedule): wire --schedule flag into nax run with countdown gate"
+```
+
+---
+
+## Task 7: Full-suite gate + docs note
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-01-scheduled-run-design.md` (mark Status: Implemented) — optional
+- No new code.
+
+- [ ] **Step 1: Run the schedule + CLI unit suites**
+
+Run: `timeout 30 bun test test/unit/schedule/ test/unit/cli/schedule-flag.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck + lint (file-size + alias checks included)**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors; `src/schedule/*` under size limits; barrel imports clean.
+
+- [ ] **Step 3: Run the full unit suite as a regression gate**
+
+Run: `bun run test:bail`
+Expected: PASS (no regressions from the `bin/nax.ts` edit).
+
+- [ ] **Step 4: Commit any doc status change**
+
+```bash
+git add docs/superpowers/specs/2026-07-01-scheduled-run-design.md
+git commit -m "docs(schedule): mark scheduled-run spec implemented"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Grammar (relative / time-of-day / ISO) → Tasks 1, 2, 3. ✓
+- Roll-to-tomorrow, past-error, date-only reject, local tz → Tasks 2, 3. ✓
+- Countdown display + `HH:MM:SS` → Tasks 4, 5. ✓
+- Cancellation (Ctrl-C) → Task 5 (signal) + Task 6 (SIGINT wiring). ✓
+- Headless/JSON suppression → Task 5 (`headless` flag) + Task 6 (`headless || json`). ✓
+- Fail-fast placement before `run()` → Task 6. ✓
+- DI/testability (`_deps`, fake clock, pure parser) → Tasks 1–5. ✓
+- Barrel `src/schedule/index.ts` → Tasks 1, 4, 5, 6. ✓
+- Reuse `cancellableDelay`, `NaxError` → Tasks 5, 6. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `ScheduleParseResult` (`{ok,target}|{ok,error}`) used consistently across Tasks 1–3; `WaitOutcome`/`WaitDeps` defined in Task 5 and consumed in Task 6; `resolveScheduleGate` returns `ScheduleGateResult` used identically in the CLI test and wiring. ✓
+
+**Note on Task 4/5 export coupling:** Task 4's barrel line references `waitForSchedule` (added in Task 5). If executing tasks in strict isolation, export only `formatRemaining` in Task 4 and add the rest in Task 5 (flagged inline). Sequential execution is unaffected.

--- a/docs/superpowers/specs/2026-07-01-scheduled-run-design.md
+++ b/docs/superpowers/specs/2026-07-01-scheduled-run-design.md
@@ -1,0 +1,205 @@
+# Scheduled Run (`nax run --schedule`) — Design
+
+**Date:** 2026-07-01
+**Status:** Draft — pending review
+**Scope:** Add a one-shot, foreground scheduled start to `nax run`.
+
+## 1. Summary
+
+Add a `--schedule <when>` flag to `nax run` that defers the start of an
+orchestration run until a wall-clock trigger fires. While waiting, the command
+holds the terminal and displays a live countdown; when the countdown reaches
+zero, it hands off to the **exact** run path that exists today (`run({...})` at
+`bin/nax.ts:641`). Ctrl-C during the wait cancels cleanly, before any run
+starts.
+
+This is deliberately the smallest thing that delivers "start my run later":
+foreground only, one-shot only, no reboot survival.
+
+## 2. Goals / Non-Goals
+
+### Goals
+- `nax run -f <feature> --schedule <when>` waits until `<when>`, shows a
+  countdown, then runs normally.
+- Support relative delays, time-of-day, and explicit ISO datetime.
+- Fail fast: cheap validation (bad flags, nax not initialized, missing PRD,
+  unparseable `--schedule`, past absolute time) surfaces **before** the wait —
+  never after a 30-minute countdown.
+- Deterministic, unit-testable time parsing decoupled from wall clock via `_deps`.
+
+### Non-Goals (explicit YAGNI)
+- **No recurring / cron.** One-shot only. (Deferred; the same flag can later
+  accept a cron expression without breaking this design.)
+- **No reboot survival.** No OS cron/launchd/systemd, no schedule store on disk.
+  If the process dies, the schedule is gone.
+- **No daemon.** No detached background process, no `nax schedule` subcommand,
+  no PID tracking beyond what a run already does.
+- **No queueing** of multiple features.
+
+## 3. User Experience
+
+```bash
+nax run -f my-feature --schedule 30m       # fire in 30 minutes
+nax run -f my-feature --schedule 1h30m     # fire in 90 minutes
+nax run -f my-feature --schedule 17:00      # fire at 5pm local today (or tomorrow if past)
+nax run -f my-feature --schedule 2026-07-02T02:00   # fire at that local instant
+```
+
+While waiting, a single self-updating line:
+
+```
+⏳ Scheduled run of "my-feature" — starting in 00:29:47   (Ctrl-C to cancel)
+```
+
+On zero, the line is cleared and the normal run output/TUI takes over. Ctrl-C
+during the wait prints `Scheduled run cancelled.` and exits 0 without starting
+a run.
+
+`--schedule` composes with existing flags (`--plan`, `--parallel`, `--headless`,
+`--profile`, …); it only gates *when* `run()` is called. In `--json` / headless
+mode the countdown is suppressed — instead a single structured line is logged at
+start (`scheduled`, target ISO) so machine consumers aren't fed a redraw loop.
+
+## 4. Schedule Grammar
+
+| Form | Example | Meaning |
+|:--|:--|:--|
+| Relative delay | `30m`, `2h`, `90s`, `1h30m` | now + duration |
+| Time of day | `17:00`, `09:30` | that time **today** in machine-local tz; if already past, **roll to tomorrow** |
+| ISO datetime | `2026-07-02T02:00` | that exact instant, **machine-local** unless an offset/`Z` is present |
+
+### Edge rules (confirmed with user)
+1. **Time-of-day already past today** → roll to tomorrow (do not error).
+2. **Absolute time / ISO in the past** → error immediately with a clear message
+   (never fire instantly — protects against typos).
+3. **Timezone:** naive datetime = machine-local tz. Explicit offset/`Z` is
+   honored. **Bare date-only (`2026-07-02`, no time) is rejected** with an
+   actionable error (`specify a time, e.g. 2026-07-02T02:00`) — this sidesteps
+   JavaScript's `new Date()` footgun where date-only strings parse as UTC but
+   date-time strings parse as local. We never feed the raw string to `new Date()`
+   for the naive case; we parse fields explicitly and construct local time.
+
+Relative-duration grammar: one or more `<int><unit>` segments, units `s`/`m`/`h`
+(optionally `d`), no whitespace, positive integers. Anything else → parse error
+listing the accepted forms.
+
+## 5. Architecture
+
+Two new, small, independently testable units plus a thin wiring change in the
+CLI. All prompt/LLM concerns are untouched.
+
+### 5.1 `src/schedule/parse.ts` — pure parser
+```
+parseSchedule(input: string, now: Date): { target: Date } | { error: string }
+```
+- Pure function of `(input, now)`. No `Date.now()` inside — `now` is injected,
+  making every case (relative, roll-to-tomorrow, past-error, tz) a deterministic
+  unit test with a fixed `now`.
+- Returns a discriminated union (parsed target vs. structured error string) —
+  matches the repo's "return validation results, don't throw for expected bad
+  input" convention. Truly exceptional states are not expected here.
+- Dispatches by shape: duration regex → relative; `HH:MM` → time-of-day;
+  otherwise → ISO path (with the date-only rejection and offset handling above).
+
+### 5.2 `src/schedule/wait.ts` — countdown gate
+```
+waitForSchedule(target: Date, opts: {
+  label: string;
+  headless: boolean;
+  render?: (line: string) => void;   // _deps: default writes/clears a TTY line
+  clock?: () => number;              // _deps: default Date.now
+  sleep?: (ms, signal) => Promise;   // _deps: default cancellable Bun.sleep
+  signal: AbortSignal;               // Ctrl-C
+}): Promise<"fired" | "cancelled">
+```
+- Loops on a tick (≈1s), recomputes `target − clock()`, renders `HH:MM:SS`
+  remaining. On `≤0` resolves `"fired"`. On abort resolves `"cancelled"`.
+- **No `setInterval`.** Uses cancellable `Bun.sleep(tickMs, { signal })` per the
+  Bun-native rule; the `setTimeout`+`clearTimeout` exception is unnecessary here.
+- Headless/JSON: skip the render loop, emit one structured `scheduled` log line
+  via the project logger, then a single cancellable sleep to target.
+- `render`/`clock`/`sleep` are injected (`_deps` pattern) so the tick loop is
+  unit-tested with a fake clock and a captured render buffer — no real waiting.
+
+### 5.3 CLI wiring — `bin/nax.ts` run action
+- New commander option:
+  `.option("--schedule <when>", "Defer run start until <when> (e.g. 30m, 17:00, ISO datetime)")`
+- Placement of the gate (critical for fail-fast): **after** the cheap
+  validations already in the action (directory validation, `--plan/--from`
+  checks, nax-init check, PRD-exists check, `--parallel` parse) and **before**
+  TUI construction and the `run({...})` call at line 641. Concretely: parse
+  `--schedule` up front (so a bad value errors instantly), but perform the
+  actual *wait* right before `run()`, once we already know the run is viable.
+- Wire an `AbortController` to `SIGINT` for the wait window only; after `run()`
+  begins, the existing run/TUI signal handling owns Ctrl-C as it does today.
+- If `waitForSchedule` returns `"cancelled"`, print the cancel notice and
+  `process.exit(0)` without calling `run()`.
+
+### 5.4 Barrel + module layout
+- New dir `src/schedule/` with `index.ts` (barrel), `parse.ts`, `wait.ts`,
+  `types.ts`. Consumers import from `@/schedule` (barrel rule). Files well under
+  the 600-line limit.
+
+## 6. Data Flow
+
+```
+nax run -f F --schedule 30m
+  → commander parses flags
+  → [cheap validation: dir, plan/from, nax-init, prd exists]           (fail fast)
+  → parseSchedule("30m", now)                                          (fail fast on bad value / past time)
+       → { target }  |  { error }→ print + exit 1
+  → [existing setup up to just before run(): config, hooks, statusFile]
+  → waitForSchedule(target, { label:F, headless, signal })            (countdown OR structured log)
+       → "cancelled" → print notice, exit 0
+       → "fired"     ↓
+  → run({ prdPath, workdir, config, … })                              (UNCHANGED existing path)
+```
+
+## 7. Error Handling
+
+- Parser errors → `NaxError` code `SCHEDULE_INVALID` at the CLI boundary, printed
+  in red with the accepted-forms hint, `exit 1`. (CLI surfaces the message; the
+  parser itself returns the structured error string — no throw for expected bad
+  input.)
+- Past absolute time → same path, message names the offending instant.
+- Ctrl-C during wait → clean `exit 0`, no run, no partial artifacts (nothing has
+  been created yet — the gate is before run setup that writes state).
+- Everything downstream of `run()` keeps its current error handling verbatim.
+
+## 8. Testing Plan
+
+Unit (`test/unit/schedule/`), following `_deps` mocking + `test.each`:
+- **parse.test.ts** — table-driven over `(input, now) → expected target|error`:
+  relative single/compound units; `HH:MM` future vs. past-today (roll); ISO
+  local; ISO with `Z`/offset; date-only rejection; past-instant error; garbage
+  input; boundary (`0s`, huge durations).
+- **wait.test.ts** — fake `clock` + captured `render`: countdown formats
+  `HH:MM:SS` correctly; resolves `"fired"` at zero; resolves `"cancelled"` on
+  abort mid-wait; headless path emits exactly one structured line and no render
+  loop.
+- **CLI integration** (light, mock the run path): `--schedule` with a near-future
+  value calls `run()` once after the gate; bad value exits 1 before `run()`;
+  cancel exits 0 without `run()`. Mock `run` — do not spawn a real nax process
+  (per forbidden-patterns).
+
+Coverage target: the two `src/schedule/` modules ≥ 80% (they're pure/DI, so
+100% is realistic).
+
+## 9. Alternatives Considered
+
+- **Detached daemon + `~/.nax/schedules/` store** — survives terminal close.
+  Rejected for v1: user explicitly does not need reboot survival, and the
+  foreground `--schedule` UX (with countdown) was the user's own proposal.
+  Several days of daemon lifecycle/PID work for little gain now.
+- **Recurring cron in foreground** — would keep the process alive re-running
+  forever. Rejected: awkward without reboot survival, and out of scope
+  (one-shot only). The `--schedule` flag is forward-compatible with adding a
+  cron form later.
+- **Separate `nax schedule` subcommand** — more surface, duplicates the whole
+  `run` flag set. Rejected in favor of a single flag on the existing command.
+
+## 10. Open Questions
+
+None blocking. Future extension seam noted: `parseSchedule` can grow a cron
+branch returning a recurrence rather than a single `target`, and
+`waitForSchedule` can loop, without changing the CLI contract.

--- a/docs/superpowers/specs/2026-07-01-scheduled-run-design.md
+++ b/docs/superpowers/specs/2026-07-01-scheduled-run-design.md
@@ -1,7 +1,7 @@
 # Scheduled Run (`nax run --schedule`) — Design
 
 **Date:** 2026-07-01
-**Status:** Draft — pending review
+**Status:** Implemented
 **Scope:** Add a one-shot, foreground scheduled start to `nax run`.
 
 ## 1. Summary

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -1,4 +1,5 @@
-export { parseSchedule } from "./parse";
+export { parseSchedule, resolveScheduleGate } from "./parse";
+export type { ScheduleGateResult } from "./parse";
 export type { ScheduleParseResult } from "./types";
 export { formatRemaining, waitForSchedule } from "./wait";
 export type { WaitDeps, WaitOutcome } from "./wait";

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -1,0 +1,2 @@
+export { parseSchedule } from "./parse";
+export type { ScheduleParseResult } from "./types";

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -1,3 +1,4 @@
 export { parseSchedule } from "./parse";
 export type { ScheduleParseResult } from "./types";
-export { formatRemaining } from "./wait";
+export { formatRemaining, waitForSchedule } from "./wait";
+export type { WaitDeps, WaitOutcome } from "./wait";

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -1,2 +1,3 @@
 export { parseSchedule } from "./parse";
 export type { ScheduleParseResult } from "./types";
+export { formatRemaining } from "./wait";

--- a/src/schedule/parse.ts
+++ b/src/schedule/parse.ts
@@ -67,6 +67,15 @@ function parseRelative(input: string, now: Date): ScheduleParseResult | null {
   return { ok: true, target: new Date(now.getTime() + totalMs) };
 }
 
+export type ScheduleGateResult = { ok: true; target: Date | null } | { ok: false; error: string };
+
+export function resolveScheduleGate(input: string | undefined, now: Date): ScheduleGateResult {
+  if (input === undefined) return { ok: true, target: null };
+  const parsed = parseSchedule(input, now);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+  return { ok: true, target: parsed.target };
+}
+
 export function parseSchedule(input: string, now: Date): ScheduleParseResult {
   const trimmed = input.trim();
   if (trimmed === "") return { ok: false, error: `Empty schedule value. ${ACCEPTED}` };

--- a/src/schedule/parse.ts
+++ b/src/schedule/parse.ts
@@ -7,6 +7,20 @@ const UNIT_MS: Record<string, number> = { s: 1_000, m: 60_000, h: 3_600_000, d: 
 const DURATION_RE = /^(\d+[smhd])+$/;
 const SEGMENT_RE = /(\d+)([smhd])/g;
 
+const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+function parseTimeOfDay(input: string, now: Date): ScheduleParseResult | null {
+  const m = TIME_RE.exec(input);
+  if (!m) return null;
+  const hours = Number(m[1]);
+  const minutes = Number(m[2]);
+  const target = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, 0, 0);
+  if (target.getTime() <= now.getTime()) {
+    target.setDate(target.getDate() + 1); // roll to tomorrow
+  }
+  return { ok: true, target };
+}
+
 function parseRelative(input: string, now: Date): ScheduleParseResult | null {
   if (!DURATION_RE.test(input)) return null;
   let totalMs = 0;
@@ -23,6 +37,9 @@ export function parseSchedule(input: string, now: Date): ScheduleParseResult {
 
   const relative = parseRelative(trimmed, now);
   if (relative) return relative;
+
+  const timeOfDay = parseTimeOfDay(trimmed, now);
+  if (timeOfDay) return timeOfDay;
 
   return { ok: false, error: `Unrecognized schedule "${input}". ${ACCEPTED}` };
 }

--- a/src/schedule/parse.ts
+++ b/src/schedule/parse.ts
@@ -9,6 +9,13 @@ const SEGMENT_RE = /(\d+)([smhd])/g;
 
 const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
 
+// Naive: YYYY-MM-DDTHH:MM(:SS)? with NO offset/Z. Construct explicitly as local.
+const NAIVE_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/;
+// Date-only: YYYY-MM-DD with no time component.
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+// Has an explicit offset or Z after a time component.
+const OFFSET_RE = /T\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(Z|[+-]\d{2}:?\d{2})$/;
+
 function parseTimeOfDay(input: string, now: Date): ScheduleParseResult | null {
   const m = TIME_RE.exec(input);
   if (!m) return null;
@@ -17,6 +24,35 @@ function parseTimeOfDay(input: string, now: Date): ScheduleParseResult | null {
   const target = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, 0, 0);
   if (target.getTime() <= now.getTime()) {
     target.setDate(target.getDate() + 1); // roll to tomorrow
+  }
+  return { ok: true, target };
+}
+
+function parseIso(input: string, now: Date): ScheduleParseResult {
+  if (DATE_ONLY_RE.test(input)) {
+    return {
+      ok: false,
+      error: `Date-only value "${input}" has no time — specify a time, e.g. ${input}T02:00.`,
+    };
+  }
+
+  let target: Date | null = null;
+
+  const naive = NAIVE_RE.exec(input);
+  if (naive) {
+    const [, y, mo, d, h, mi, s] = naive;
+    // Explicit local-time construction — avoids new Date()'s date-only-UTC footgun.
+    target = new Date(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s ?? "0"), 0);
+  } else if (OFFSET_RE.test(input)) {
+    const parsed = new Date(input);
+    if (!Number.isNaN(parsed.getTime())) target = parsed;
+  }
+
+  if (!target || Number.isNaN(target.getTime())) {
+    return { ok: false, error: `Unrecognized schedule "${input}". ${ACCEPTED}` };
+  }
+  if (target.getTime() <= now.getTime()) {
+    return { ok: false, error: `Scheduled time ${input} is in the past.` };
   }
   return { ok: true, target };
 }
@@ -41,5 +77,5 @@ export function parseSchedule(input: string, now: Date): ScheduleParseResult {
   const timeOfDay = parseTimeOfDay(trimmed, now);
   if (timeOfDay) return timeOfDay;
 
-  return { ok: false, error: `Unrecognized schedule "${input}". ${ACCEPTED}` };
+  return parseIso(trimmed, now);
 }

--- a/src/schedule/parse.ts
+++ b/src/schedule/parse.ts
@@ -1,0 +1,28 @@
+import type { ScheduleParseResult } from "./types";
+
+const ACCEPTED =
+  "Accepted: relative (30m, 2h, 90s, 1h30m, 1d), time-of-day (17:00), or ISO datetime (2026-07-02T02:00).";
+
+const UNIT_MS: Record<string, number> = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+const DURATION_RE = /^(\d+[smhd])+$/;
+const SEGMENT_RE = /(\d+)([smhd])/g;
+
+function parseRelative(input: string, now: Date): ScheduleParseResult | null {
+  if (!DURATION_RE.test(input)) return null;
+  let totalMs = 0;
+  for (const [, n, unit] of input.matchAll(SEGMENT_RE)) {
+    totalMs += Number(n) * UNIT_MS[unit];
+  }
+  if (totalMs <= 0) return { ok: false, error: `Duration must be positive. ${ACCEPTED}` };
+  return { ok: true, target: new Date(now.getTime() + totalMs) };
+}
+
+export function parseSchedule(input: string, now: Date): ScheduleParseResult {
+  const trimmed = input.trim();
+  if (trimmed === "") return { ok: false, error: `Empty schedule value. ${ACCEPTED}` };
+
+  const relative = parseRelative(trimmed, now);
+  if (relative) return relative;
+
+  return { ok: false, error: `Unrecognized schedule "${input}". ${ACCEPTED}` };
+}

--- a/src/schedule/types.ts
+++ b/src/schedule/types.ts
@@ -1,0 +1,1 @@
+export type ScheduleParseResult = { ok: true; target: Date } | { ok: false; error: string };

--- a/src/schedule/wait.ts
+++ b/src/schedule/wait.ts
@@ -1,3 +1,5 @@
+import { cancellableDelay } from "@/utils/bun-deps";
+
 export function formatRemaining(ms: number): string {
   const total = Math.max(0, Math.floor(ms / 1000));
   const h = Math.floor(total / 3600);
@@ -5,4 +7,50 @@ export function formatRemaining(ms: number): string {
   const s = total % 60;
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+
+export type WaitOutcome = "fired" | "cancelled";
+
+export interface WaitDeps {
+  now: () => number;
+  delay: (ms: number, signal?: AbortSignal) => Promise<void>;
+  render: (line: string) => void;
+}
+
+const TICK_MS = 1_000;
+
+const DEFAULT_DEPS: WaitDeps = {
+  now: () => Date.now(),
+  delay: (ms, signal) => cancellableDelay(ms, signal),
+  render: (line) => {
+    // Rewrite the current TTY line in place.
+    process.stdout.write(`\r${line}`);
+  },
+};
+
+export async function waitForSchedule(
+  target: Date,
+  opts: { label: string; headless: boolean; signal: AbortSignal; _deps?: Partial<WaitDeps> },
+): Promise<WaitOutcome> {
+  const deps: WaitDeps = { ...DEFAULT_DEPS, ...opts._deps };
+  const targetMs = target.getTime();
+
+  while (deps.now() < targetMs) {
+    if (opts.signal.aborted) return "cancelled";
+    const remaining = targetMs - deps.now();
+    if (!opts.headless) {
+      deps.render(
+        `[WAIT] Scheduled run of "${opts.label}" — starting in ${formatRemaining(remaining)}   (Ctrl-C to cancel)`,
+      );
+    }
+    const wait = Math.min(TICK_MS, remaining);
+    try {
+      await deps.delay(wait, opts.signal);
+    } catch {
+      return "cancelled"; // delay rejects on abort
+    }
+  }
+
+  if (!opts.headless) deps.render("\n"); // clear the countdown line before run output
+  return "fired";
 }

--- a/src/schedule/wait.ts
+++ b/src/schedule/wait.ts
@@ -1,0 +1,8 @@
+export function formatRemaining(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}

--- a/src/schedule/wait.ts
+++ b/src/schedule/wait.ts
@@ -1,3 +1,4 @@
+import { getSafeLogger } from "@/logger";
 import { cancellableDelay } from "@/utils/bun-deps";
 
 export function formatRemaining(ms: number): string {
@@ -15,6 +16,7 @@ export interface WaitDeps {
   now: () => number;
   delay: (ms: number, signal?: AbortSignal) => Promise<void>;
   render: (line: string) => void;
+  log: (message: string, data: Record<string, unknown>) => void;
 }
 
 const TICK_MS = 1_000;
@@ -26,6 +28,7 @@ const DEFAULT_DEPS: WaitDeps = {
     // Rewrite the current TTY line in place.
     process.stdout.write(`\r${line}`);
   },
+  log: (message, data) => getSafeLogger()?.info("schedule", message, data),
 };
 
 export async function waitForSchedule(
@@ -34,6 +37,10 @@ export async function waitForSchedule(
 ): Promise<WaitOutcome> {
   const deps: WaitDeps = { ...DEFAULT_DEPS, ...opts._deps };
   const targetMs = target.getTime();
+
+  if (opts.headless) {
+    deps.log("Scheduled run waiting", { label: opts.label, targetIso: target.toISOString() });
+  }
 
   while (deps.now() < targetMs) {
     if (opts.signal.aborted) return "cancelled";

--- a/test/unit/cli/schedule-flag.test.ts
+++ b/test/unit/cli/schedule-flag.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { resolveScheduleGate } from "@/schedule";
+
+const NOW = new Date("2026-07-01T12:00:00");
+
+describe("resolveScheduleGate", () => {
+  test("undefined schedule → run immediately, no target", () => {
+    const r = resolveScheduleGate(undefined, NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.target).toBeNull();
+  });
+
+  test("valid relative schedule → target set", () => {
+    const r = resolveScheduleGate("30m", NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok && r.target) expect(r.target.getTime()).toBe(NOW.getTime() + 30 * 60_000);
+  });
+
+  test("invalid schedule → error", () => {
+    const r = resolveScheduleGate("nonsense", NOW);
+    expect(r.ok).toBe(false);
+  });
+
+  test("past absolute → error", () => {
+    const r = resolveScheduleGate("2026-06-01T00:00", NOW);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/test/unit/schedule/format.test.ts
+++ b/test/unit/schedule/format.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { formatRemaining } from "@/schedule";
+
+describe("formatRemaining", () => {
+  test.each([
+    [0, "00:00:00"],
+    [-5_000, "00:00:00"],
+    [1_000, "00:00:01"],
+    [61_000, "00:01:01"],
+    [3_661_000, "01:01:01"],
+    [90_061_000, "25:01:01"], // > 24h stays in hours
+  ])("%d ms → %s", (ms, expected) => {
+    expect(formatRemaining(ms as number)).toBe(expected);
+  });
+});

--- a/test/unit/schedule/parse.test.ts
+++ b/test/unit/schedule/parse.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { parseSchedule } from "@/schedule";
+
+const NOW = new Date("2026-07-01T12:00:00"); // local
+
+describe("parseSchedule — relative durations", () => {
+  test.each([
+    ["30m", 30 * 60_000],
+    ["2h", 2 * 3_600_000],
+    ["90s", 90_000],
+    ["1h30m", 90 * 60_000],
+    ["1d", 86_400_000],
+  ])("%s → now + %d ms", (input, deltaMs) => {
+    const r = parseSchedule(input as string, NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.target.getTime()).toBe(NOW.getTime() + (deltaMs as number));
+  });
+
+  test.each(["0s", "5x", "m30", "1h30", "-5m", ""])("rejects %p", (input) => {
+    const r = parseSchedule(input as string, NOW);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/test/unit/schedule/parse.test.ts
+++ b/test/unit/schedule/parse.test.ts
@@ -52,3 +52,40 @@ describe("parseSchedule — time of day", () => {
     expect(parseSchedule(input as string, noon).ok).toBe(false);
   });
 });
+
+describe("parseSchedule — ISO datetime", () => {
+  const now = new Date("2026-07-01T12:00:00");
+
+  test("naive datetime is interpreted as local time", () => {
+    const r = parseSchedule("2026-07-02T02:00", now);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.target.getFullYear()).toBe(2026);
+      expect(r.target.getDate()).toBe(2);
+      expect(r.target.getHours()).toBe(2); // local, not UTC
+      expect(r.target.getMinutes()).toBe(0);
+    }
+  });
+
+  test("explicit Z offset is honored", () => {
+    const r = parseSchedule("2026-07-02T02:00:00Z", now);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.target.getTime()).toBe(Date.parse("2026-07-02T02:00:00Z"));
+  });
+
+  test("past datetime errors", () => {
+    const r = parseSchedule("2026-06-01T00:00", now);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("past");
+  });
+
+  test("bare date-only is rejected", () => {
+    const r = parseSchedule("2026-07-02", now);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("time");
+  });
+
+  test("garbage is rejected", () => {
+    expect(parseSchedule("not-a-date", now).ok).toBe(false);
+  });
+});

--- a/test/unit/schedule/parse.test.ts
+++ b/test/unit/schedule/parse.test.ts
@@ -21,3 +21,34 @@ describe("parseSchedule — relative durations", () => {
     expect(r.ok).toBe(false);
   });
 });
+
+describe("parseSchedule — time of day", () => {
+  const noon = new Date("2026-07-01T12:00:00");
+
+  test("future time today stays today", () => {
+    const r = parseSchedule("17:00", noon);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.target.getFullYear()).toBe(2026);
+      expect(r.target.getMonth()).toBe(6); // July
+      expect(r.target.getDate()).toBe(1);
+      expect(r.target.getHours()).toBe(17);
+      expect(r.target.getMinutes()).toBe(0);
+      expect(r.target.getSeconds()).toBe(0);
+    }
+  });
+
+  test("past time today rolls to tomorrow", () => {
+    const r = parseSchedule("09:30", noon);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.target.getDate()).toBe(2); // rolled to July 2
+      expect(r.target.getHours()).toBe(9);
+      expect(r.target.getMinutes()).toBe(30);
+    }
+  });
+
+  test.each(["24:00", "12:60", "9:5", "17:0"])("rejects malformed %p", (input) => {
+    expect(parseSchedule(input as string, noon).ok).toBe(false);
+  });
+});

--- a/test/unit/schedule/wait.test.ts
+++ b/test/unit/schedule/wait.test.ts
@@ -4,8 +4,10 @@ import { waitForSchedule } from "@/schedule";
 function fakeDeps(startMs: number, stepMs: number) {
   let current = startMs;
   const lines: string[] = [];
+  const logs: Array<{ message: string; data: Record<string, unknown> }> = [];
   return {
     lines,
+    logs,
     deps: {
       now: () => current,
       // Each "delay" advances the fake clock by stepMs instead of waiting.
@@ -14,6 +16,7 @@ function fakeDeps(startMs: number, stepMs: number) {
         current += stepMs;
       },
       render: (line: string) => lines.push(line),
+      log: (message: string, data: Record<string, unknown>) => logs.push({ message, data }),
     },
   };
 }
@@ -60,5 +63,22 @@ describe("waitForSchedule", () => {
     });
     expect(outcome).toBe("fired");
     expect(lines.length).toBe(0);
+  });
+
+  test("headless emits exactly one structured log line with target ISO", async () => {
+    const start = 1_000_000;
+    const { lines, logs, deps } = fakeDeps(start, 5_000);
+    const target = new Date(start + 3_000);
+    const outcome = await waitForSchedule(target, {
+      label: "feat-x",
+      headless: true,
+      signal: new AbortController().signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("fired");
+    expect(lines.length).toBe(0);              // still no render lines
+    expect(logs.length).toBe(1);               // exactly one structured line
+    expect(logs[0].data.targetIso).toBe(target.toISOString());
+    expect(logs[0].data.label).toBe("feat-x");
   });
 });

--- a/test/unit/schedule/wait.test.ts
+++ b/test/unit/schedule/wait.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { waitForSchedule } from "@/schedule";
+
+function fakeDeps(startMs: number, stepMs: number) {
+  let current = startMs;
+  const lines: string[] = [];
+  return {
+    lines,
+    deps: {
+      now: () => current,
+      // Each "delay" advances the fake clock by stepMs instead of waiting.
+      delay: async (_ms: number, signal?: AbortSignal) => {
+        if (signal?.aborted) throw new Error("aborted");
+        current += stepMs;
+      },
+      render: (line: string) => lines.push(line),
+    },
+  };
+}
+
+describe("waitForSchedule", () => {
+  test("counts down and fires at target", async () => {
+    const start = 1_000_000;
+    const { lines, deps } = fakeDeps(start, 1_000);
+    const target = new Date(start + 3_000);
+    const outcome = await waitForSchedule(target, {
+      label: "feat-x",
+      headless: false,
+      signal: new AbortController().signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("fired");
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.some((l) => l.includes("feat-x"))).toBe(true);
+  });
+
+  test("returns cancelled when signal aborts", async () => {
+    const start = 1_000_000;
+    const controller = new AbortController();
+    const { deps } = fakeDeps(start, 1_000);
+    // Abort immediately; delay throws → treated as cancellation.
+    controller.abort();
+    const outcome = await waitForSchedule(new Date(start + 60_000), {
+      label: "feat-x",
+      headless: false,
+      signal: controller.signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("cancelled");
+  });
+
+  test("headless emits no render lines", async () => {
+    const start = 1_000_000;
+    const { lines, deps } = fakeDeps(start, 5_000);
+    const outcome = await waitForSchedule(new Date(start + 3_000), {
+      label: "feat-x",
+      headless: true,
+      signal: new AbortController().signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("fired");
+    expect(lines.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a one-shot, foreground **`nax run --schedule <when>`** flag that defers the start of an orchestration run until a wall-clock trigger, shows a live countdown, then hands off to the existing `run(...)` path. No daemon, no persistence, no reboot survival — the smallest thing that delivers "start my run later".

```bash
nax run -f my-feature --schedule 30m                 # fire in 30 minutes
nax run -f my-feature --schedule 1h30m               # fire in 90 minutes
nax run -f my-feature --schedule 17:00               # 5pm local today (or tomorrow if past)
nax run -f my-feature --schedule 2026-07-02T02:00    # exact local instant
```

While waiting, a single self-updating line:

```
[WAIT] Scheduled run of "my-feature" — starting in 00:29:47   (Ctrl-C to cancel)
```

## Schedule grammar

| Form | Example | Meaning |
|:--|:--|:--|
| Relative delay | `30m`, `2h`, `90s`, `1h30m`, `1d` | now + duration |
| Time of day | `17:00` | that time today (machine-local); rolls to **tomorrow** if already past |
| ISO datetime | `2026-07-02T02:00` | that exact instant, **machine-local** unless an offset/`Z` is present |

Edge rules: absolute times in the past **error** (never fire instantly); bare date-only (`2026-07-02`) is **rejected** with an actionable message — this sidesteps JavaScript's `new Date()` footgun where date-only strings parse as UTC but date-time strings parse as local. Naive datetimes are constructed from explicit local fields rather than via `new Date(string)`.

## Architecture

Two small, dependency-injected modules plus thin CLI wiring:

- **`src/schedule/parse.ts`** — pure `parseSchedule(input, now)` returning a `{ ok, target } | { ok, error }` discriminated union. No `Date.now()` inside — fully deterministic, table-tested.
- **`src/schedule/wait.ts`** — `waitForSchedule(target, opts)` countdown gate with injectable `now`/`delay`/`render`/`log`. Reuses `cancellableDelay` from `@/utils/bun-deps` (no `setInterval`). Headless/JSON suppresses the redraw loop and emits **one structured log line** (`targetIso`) instead.
- **`bin/nax.ts`** — `--schedule` option; fail-fast parse right after directory validation (a bad value errors before any setup); the wait runs immediately before `run(...)` with a SIGINT handler scoped to the wait window only (removed before the run's own signal handling takes over). Cancelling during the countdown exits 0 without starting a run.

## Behavior notes

- **One-shot only** — no cron/recurring (the `--schedule` flag is forward-compatible with adding it later).
- **Fail-fast** — bad `--schedule` value, past absolute time, and cheap validations all surface before the countdown; you never wait 30 minutes to learn the run was misconfigured.
- **Headless/JSON** — no countdown redraw; a single `schedule` log line with the target ISO so machine consumers know it's waiting, not hung.

## Test plan

- `test/unit/schedule/parse.test.ts` — relative / time-of-day / ISO, roll-to-tomorrow, past-guard, date-only rejection, tz handling
- `test/unit/schedule/format.test.ts` — `HH:MM:SS` formatting incl. >24h
- `test/unit/schedule/wait.test.ts` — fake-clock countdown, fired vs cancelled, headless-silent + structured log line
- `test/unit/cli/schedule-flag.test.ts` — `resolveScheduleGate` gate resolution
- Gates: **typecheck clean**, **lint clean** (all custom checks at/under baseline), **full suite green** (unit + integration + ui, 0 fail)

## Process

Built via brainstorm → spec → plan → subagent-driven TDD (7 tasks, each independently spec+quality reviewed) → whole-branch review. The final review returned "merge-ready with fixes"; the one Important finding (missing headless structured log) was fixed and verified. Design spec and implementation plan are included under `docs/superpowers/`.
