### PR TITLE
feat: queue RETRY/PRIORITY commands, surface review warnings, fix config doc

### DIFF
--- a/docs/IMPROVEMENT-REPORT.md
+++ b/docs/IMPROVEMENT-REPORT.md
@@ -30,7 +30,8 @@ The open-issue backlog is small and well-groomed (6 open issues), so most items 
 - **Where:** `src/queue/types.ts`, `src/queue/manager.ts`.
 - **Gap:** Queue file accepts only `PAUSE` / `ABORT` / `SKIP <storyId>`. Yet `QueueManager` already has `resetToPending` (retry) and priority-sorted `enqueue` (reprioritize / inject) internally — none exposed as commands.
 - **Suggestion:** Add `RETRY <storyId>`, `PRIORITY <storyId> <n>`, `INJECT <story-json-or-path>` queue commands; low effort, primitives exist.
-- **Tracked:** No.
+- **Status:** ✅ `RETRY`/`PRIORITY` shipped in [PR #1290](https://github.com/nathapp-io/nax/pull/1290) — turned out the primitives weren't actually wired into the live execution path (`queue-check.ts` operates on `ctx.prd`/`ctx.stories` directly, bypassing `QueueManager`), so this was more than "just expose them": added `UserStory.priority`, `resetStoryToPending()`/`setStoryPriority()` PRD helpers, and priority-aware `getNextStory()` ordering. `INJECT` was scoped out as materially riskier (no schema to validate an ad hoc new story) — tracked in [#1288](https://github.com/nathapp-io/nax/issues/1288).
+- **Tracked:** Yes — #1288 (INJECT).
 
 ### 1.4 No dashboard or metrics export
 - **Where:** `src/metrics/` (rich `StoryMetrics` / `RunMetrics` / `AggregateMetrics`), output = JSONL under `~/.nax/<project>/…/runs/` + `nax status --cost`.
@@ -48,7 +49,8 @@ The open-issue backlog is small and well-groomed (6 open issues), so most items 
 - **Where:** ADR-025 §7 "Part A — run-time routing (DEFERRED)".
 - **Gap:** v1 ships a single global capability ladder; per-domain ladders and `routing.agents.strategy: "llm"` feeding `classifyRouteOp` are deferred with **no tracking issue** — risk of getting lost.
 - **Suggestion:** File a backlog issue referencing ADR-025 §7.
-- **Tracked:** No.
+- **Status:** ✅ Filed as [#1289](https://github.com/nathapp-io/nax/issues/1289).
+- **Tracked:** Yes — #1289.
 
 ---
 
@@ -58,13 +60,15 @@ The open-issue backlog is small and well-groomed (6 open issues), so most items 
 - **Where:** review severity handling (adversarial review → fix cycle).
 - **Gap:** Off-AC bugs found by adversarial review get downgraded to warning/info; with `review.blockingThreshold: "error"` they are never surfaced to the user at all. Real findings evaporate.
 - **Suggestion:** Aggregate non-blocking findings and report them at run end (severity-graded summary) — aggregation + surfacing, not a new review pass. Related open issue #1157 (whack-a-mole within a file) touches the same subsystem.
-- **Tracked:** Not directly (adjacent: #1157).
+- **Status:** ✅ Fixed in [PR #1290](https://github.com/nathapp-io/nax/pull/1290) — `ReviewAuditor.getAdvisoryFindings()` aggregates sub-threshold findings across the run; surfaced at run end via a severity-graded headless console summary (`formatAdvisorySummary`) plus a structured `logger.warn`. Aggregation only, no new review pass, per the suggestion.
+- **Tracked:** Yes — closed by #1290 (adjacent: #1157, still open).
 
 ### 2.2 `tdd.sessionTiers.implementer` is dead config
 - **Where:** `src/config/schemas-execution.ts:271-274` (intentionally not consumed — implementer follows `story.routing.modelTier` + escalation), but `src/cli/config-descriptions.ts:126` still documents it as "Model tier for implementer session".
 - **Gap:** Schema-present, CLI-documented, silently inert — actively misleading. (`testWriter` and `verifier` sub-fields ARE consumed: `src/operations/write-test.ts:63`, `src/operations/verify.ts:156`.)
 - **Suggestion:** Either warn at config load when set, or fix the CLI description to say it is ignored by design.
-- **Tracked:** No.
+- **Status:** ✅ Fixed in [PR #1290](https://github.com/nathapp-io/nax/pull/1290) — CLI description now states it's ignored by design (chose the doc-fix option, not a config-load warning).
+- **Tracked:** Yes — closed by #1290.
 
 ---
 
@@ -88,7 +92,14 @@ The open-issue backlog is small and well-groomed (6 open issues), so most items 
 
 ## 4. Suggested shortlist (value ÷ effort)
 
-1. **Cost budget cap** (§1.1) — safety feature, infrastructure (cost middleware) already in place.
-2. **Queue RETRY / PRIORITY / INJECT** (§1.3) — primitives exist, just expose them.
-3. **Surface dropped adversarial-review warnings** (§2.1) — known correctness hole; aggregation + reporting only.
-4. File tracking issues for §1.6 (ADR-025 Part A) and §2.2 (dead config) so they don't get lost.
+1. **Cost budget cap** (§1.1) — safety feature, infrastructure (cost middleware) already in place. **Not yet started.**
+2. **Queue RETRY / PRIORITY / INJECT** (§1.3) — primitives exist, just expose them. **✅ RETRY/PRIORITY done (#1290); INJECT tracked (#1288).**
+3. **Surface dropped adversarial-review warnings** (§2.1) — known correctness hole; aggregation + reporting only. **✅ Done (#1290).**
+4. File tracking issues for §1.6 (ADR-025 Part A) and §2.2 (dead config) so they don't get lost. **✅ Done — #1289 filed for §1.6; §2.2 fixed directly rather than just tracked (#1290).**
+
+### Remaining open items from this shortlist
+- §1.1 Cost budget cap — not started.
+- §1.2 Mid-session resume — not started.
+- §1.4 Dashboard / metrics export — not started.
+- §1.5 Plugin ecosystem — not started.
+- #1288 (INJECT queue command) and #1289 (ADR-025 §7 run-time routing) — tracked, not implemented.

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -122,7 +122,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "tdd.autoApproveVerifier": "Auto-approve legitimate fixes in verifier session",
   "tdd.sessionTiers": "Per-session model tier overrides",
   "tdd.sessionTiers.testWriter": "Model tier for test-writer session",
-  "tdd.sessionTiers.implementer": "Model tier for implementer session",
+  "tdd.sessionTiers.implementer":
+    "Ignored by design — implementer follows story.routing.modelTier + escalation, not this field. Kept optional so legacy configs still parse.",
   "tdd.sessionTiers.verifier": "Model tier for verifier session",
   "tdd.testWriterAllowedPaths": "Glob patterns for files test-writer can modify",
   "tdd.rollbackOnFailure": "Rollback git changes when TDD fails",

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -33,6 +33,7 @@ export {
   _regressionDeps,
   handleRunCompletion,
   _runCompletionDeps,
+  outputAdvisoryFindingsSummary,
   type DeferredRegressionOptions,
   type DeferredRegressionResult,
   type StorySnapshot,

--- a/src/execution/lifecycle/headless-formatter.ts
+++ b/src/execution/lifecycle/headless-formatter.ts
@@ -7,7 +7,8 @@
 
 import chalk from "chalk";
 import type { RunSummary } from "../../log-format";
-import { formatRunSummary } from "../../log-format";
+import { formatAdvisorySummary, formatRunSummary } from "../../log-format";
+import type { AdvisoryFindingSummaryEntry } from "../../runtime";
 import { NAX_VERSION } from "../../version";
 
 export interface RunHeaderOptions {
@@ -80,4 +81,24 @@ export function outputRunFooter(options: RunFooterOptions): void {
   });
 
   console.log(summaryOutput);
+}
+
+/**
+ * Output the non-blocking (advisory) review findings summary in headless mode.
+ * §2.1 — surfaces sub-threshold review findings that would otherwise only exist
+ * in the on-disk review-audit trail. No-op when there are none, or in json mode
+ * (findings are available via the review-audit JSONL trail instead).
+ */
+export function outputAdvisoryFindingsSummary(
+  findings: readonly AdvisoryFindingSummaryEntry[],
+  formatterMode: "quiet" | "normal" | "verbose" | "json",
+): void {
+  if (findings.length === 0 || formatterMode === "json") {
+    return;
+  }
+
+  const output = formatAdvisorySummary(findings, { mode: formatterMode, useColor: true });
+  if (output) {
+    console.log(output);
+  }
 }

--- a/src/execution/lifecycle/index.ts
+++ b/src/execution/lifecycle/index.ts
@@ -3,7 +3,13 @@
  */
 
 export { runAcceptanceLoop, type AcceptanceLoopContext, type AcceptanceLoopResult } from "./acceptance-loop";
-export { outputRunHeader, outputRunFooter, type RunHeaderOptions, type RunFooterOptions } from "./headless-formatter";
+export {
+  outputRunHeader,
+  outputRunFooter,
+  outputAdvisoryFindingsSummary,
+  type RunHeaderOptions,
+  type RunFooterOptions,
+} from "./headless-formatter";
 export {
   handleRunCompletion,
   _runCompletionDeps,

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -267,9 +267,22 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
     await options.statusWriter.writeFeatureStatus(options.featureDir, reportedTotal, options.iterations);
   }
 
+  // §2.1 — surface non-blocking (sub-threshold) review findings accumulated this run.
+  // Without this, real findings below `blockingThreshold` are only visible in a
+  // per-story debug log line and the on-disk `.nax/review-audit/` trail.
+  const advisoryFindings = options.runtime?.reviewAuditor?.getAdvisoryFindings() ?? [];
+  if (advisoryFindings.length > 0) {
+    logger?.warn("review", `${advisoryFindings.length} non-blocking review finding(s) surfaced at run end`, {
+      storyId: "_run",
+      count: advisoryFindings.length,
+      findings: advisoryFindings,
+    });
+  }
+
   // Output run footer in headless mode
   if (options.headless && options.formatterMode !== "json") {
-    const { outputRunFooter } = await import("./lifecycle/headless-formatter");
+    const { outputAdvisoryFindingsSummary, outputRunFooter } = await import("./lifecycle/headless-formatter");
+    outputAdvisoryFindingsSummary(advisoryFindings, options.formatterMode);
     outputRunFooter({
       finalCounts: {
         total: finalCounts.total,

--- a/src/log-format/formatter.ts
+++ b/src/log-format/formatter.ts
@@ -7,6 +7,8 @@
 
 import chalk from "chalk";
 import type { LogEntry } from "../logger/types.js";
+import { SEVERITY_RANK } from "../review/index.js";
+import type { AdvisoryFindingSummaryEntry } from "../review/review-audit.js";
 import { EMOJI, type FormatterOptions, type RunSummary } from "./types.js";
 
 /**
@@ -412,6 +414,50 @@ export function formatRunSummary(summary: RunSummary, options: FormatterOptions)
   lines.push(`  ${EMOJI.duration} Duration: ${c.bold(formatDuration(summary.durationMs))}`);
   lines.push(`  ${EMOJI.cost} Cost:     ${c.bold(formatCost(summary.totalCost))}`);
   lines.push(c.blue("═".repeat(60)));
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Format the run-end advisory (sub-threshold review) findings summary.
+ *
+ * §2.1 — adversarial/semantic review findings below `blockingThreshold` never
+ * block a story and, absent this call, only ever surface in a per-story debug
+ * log line and the on-disk `.nax/review-audit/` trail. This renders them as a
+ * severity-graded block so real findings are never silently dropped.
+ */
+export function formatAdvisorySummary(
+  findings: readonly AdvisoryFindingSummaryEntry[],
+  options: FormatterOptions,
+): string {
+  if (findings.length === 0) return "";
+
+  const { mode, useColor = true } = options;
+
+  if (mode === "json") {
+    return JSON.stringify(findings);
+  }
+
+  const c = useColor ? chalk : createNoopChalk();
+  const sorted = [...findings].sort((a, b) => (SEVERITY_RANK[b.severity] ?? 0) - (SEVERITY_RANK[a.severity] ?? 0));
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(c.yellow("─".repeat(60)));
+  lines.push(c.bold(c.yellow(`  ${EMOJI.warning} NON-BLOCKING REVIEW FINDINGS (${findings.length})`)));
+  lines.push(c.yellow("─".repeat(60)));
+
+  for (const f of sorted) {
+    const location = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : undefined;
+    const parts = [`[${f.severity}]`, f.storyId ?? "unknown", location, f.category].filter(
+      (v): v is string => typeof v === "string" && v.length > 0,
+    );
+    lines.push(`  ${c.gray(parts.join(" · "))}`);
+    lines.push(`    ${f.issue}`);
+  }
+
+  lines.push(c.yellow("─".repeat(60)));
   lines.push("");
 
   return lines.join("\n");

--- a/src/log-format/index.ts
+++ b/src/log-format/index.ts
@@ -10,6 +10,7 @@
 export {
   formatLogEntry,
   formatRunSummary,
+  formatAdvisorySummary,
   formatTimestamp,
   formatDuration,
   formatCost,

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -18,6 +18,7 @@ export type { PipelineRunResult } from "./runner";
 export { PipelineEventEmitter } from "./events";
 export type { PipelineEvents, RunSummary } from "./events";
 export { executionStage, _executionDeps } from "./stages";
+export { queueCheckStage } from "./stages/queue-check";
 export { resolveExecutionAgent } from "./stages/execution-helpers";
 export type { ResolvedExecutionAgent } from "./stages/execution-helpers";
 

--- a/src/pipeline/stages/queue-check.ts
+++ b/src/pipeline/stages/queue-check.ts
@@ -7,7 +7,7 @@
 
 import { clearQueueFile, readQueueFile } from "../../execution/queue-handler";
 import { getLogger } from "../../logger";
-import { markStorySkipped, savePRD } from "../../prd";
+import { markStorySkipped, resetStoryToPending, savePRD, setStoryPriority } from "../../prd";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 /**
@@ -63,6 +63,27 @@ export const queueCheckStage: PipelineStage = {
         await clearQueueFile(ctx.workdir);
 
         return { action: "pause", reason: "User requested abort" };
+      }
+
+      if (cmd.type === "RETRY") {
+        logger.warn("queue", "Retrying story by user request", { storyId: cmd.storyId });
+        resetStoryToPending(ctx.prd, cmd.storyId);
+
+        const prdPath = ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/nax/features/unknown/prd.json`;
+        await savePRD(ctx.prd, prdPath);
+        continue;
+      }
+
+      if (cmd.type === "PRIORITY") {
+        logger.warn("queue", "Setting story priority by user request", {
+          storyId: cmd.storyId,
+          priority: cmd.value,
+        });
+        setStoryPriority(ctx.prd, cmd.storyId, cmd.value);
+
+        const prdPath = ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/nax/features/unknown/prd.json`;
+        await savePRD(ctx.prd, prdPath);
+        continue;
       }
 
       if (cmd.type === "SKIP") {

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -121,19 +121,23 @@ export function getNextStory(prd: PRD, currentStoryId?: string | null, maxRetrie
     }
   }
 
-  return (
-    prd.userStories.find(
-      (s) =>
-        !s.passes &&
-        s.status !== "passed" &&
-        s.status !== "skipped" &&
-        s.status !== "blocked" &&
-        s.status !== "failed" &&
-        s.status !== "paused" &&
-        s.status !== "decomposed" &&
-        hasSatisfiedDependencies(s, storyIds, completedIds),
-    ) ?? null
+  const eligible = prd.userStories.filter(
+    (s) =>
+      !s.passes &&
+      s.status !== "passed" &&
+      s.status !== "skipped" &&
+      s.status !== "blocked" &&
+      s.status !== "failed" &&
+      s.status !== "paused" &&
+      s.status !== "decomposed" &&
+      hasSatisfiedDependencies(s, storyIds, completedIds),
   );
+
+  if (eligible.length === 0) return null;
+
+  // Priority 2: highest `priority` wins; ties keep array order (stable FIFO —
+  // `reduce` only replaces on strictly-greater priority).
+  return eligible.reduce((best, s) => ((s.priority ?? 0) > (best.priority ?? 0) ? s : best));
 }
 
 /**
@@ -301,6 +305,40 @@ export function markStorySkipped(prd: PRD, storyId: string): void {
   const story = prd.userStories.find((s) => s.id === storyId);
   if (story) {
     story.status = "skipped";
+  }
+}
+
+/**
+ * Reset a single story back to pending (RETRY queue command).
+ * Mirrors {@link resetFailedStoriesToPending}'s per-story behavior but targets
+ * one story by ID regardless of its current status (failed, skipped, blocked, ...).
+ */
+export function resetStoryToPending(prd: PRD, storyId: string): void {
+  const story = prd.userStories.find((s) => s.id === storyId);
+  if (!story) return;
+
+  story.status = "pending";
+  story.attempts = 0;
+  story.failureCategory = undefined;
+  story.failureStage = undefined;
+
+  if (story.routing) {
+    story.routing = {
+      ...story.routing,
+      ...(story.routing.initialModelTier !== undefined && {
+        modelTier: story.routing.initialModelTier,
+      }),
+      agent: story.routing.initialAgent,
+    };
+  }
+  story.escalations = [];
+}
+
+/** Set a story's scheduling priority (PRIORITY queue command). Higher = more urgent. */
+export function setStoryPriority(prd: PRD, storyId: string, priority: number): void {
+  const story = prd.userStories.find((s) => s.id === storyId);
+  if (story) {
+    story.priority = priority;
   }
 }
 

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -97,7 +97,9 @@ function isResumableCurrentStory(story: UserStory, maxRetries: number): boolean 
  * `status === "failed"` with `attempts <= maxRetries`, return it immediately
  * so the executor retries the same story before moving on.
  *
- * Priority 2 (normal): First pending story whose dependencies are satisfied.
+ * Priority 2 (normal): Among pending stories whose dependencies are satisfied,
+ * the highest `story.priority` wins (set via the PRIORITY queue command);
+ * ties keep array order (stable FIFO — the default when priority is unset).
  *
  * @param prd - PRD containing all stories
  * @param currentStoryId - ID of the story just executed (optional)

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -141,6 +141,8 @@ export interface UserStory {
   attempts: number;
   /** Story points estimate (optional, defaults to 1) */
   storyPoints?: number;
+  /** Scheduling priority (higher = more urgent). Defaults to 0 when unset. Set via the PRIORITY queue command. */
+  priority?: number;
   /** @deprecated Use contextFiles instead. Relevant source files for context injection */
   relevantFiles?: string[];
   /** Files loaded into agent prompt before execution. Entries may be plain path strings or

--- a/src/queue/manager.ts
+++ b/src/queue/manager.ts
@@ -204,6 +204,8 @@ export class QueueManager {
  * - PAUSE: Pause execution after current story
  * - ABORT: Mark all remaining stories as skipped and stop
  * - SKIP US-XXX: Skip a specific story
+ * - RETRY US-XXX: Reset a failed/skipped story back to pending
+ * - PRIORITY US-XXX <n>: Set a story's scheduling priority
  *
  * Everything else after "--- PENDING ---" is treated as guidance text.
  */
@@ -246,6 +248,30 @@ export function parseQueueFile(content: string): QueueFileResult {
       }
     } else if (upper === "SKIP") {
       // SKIP with no story ID, treat as guidance
+      guidance.push(trimmed);
+    } else if (upper.startsWith("RETRY ")) {
+      const storyId = trimmed.substring(6).trim();
+      if (storyId) {
+        commands.push({ type: "RETRY", storyId });
+      } else {
+        guidance.push(trimmed);
+      }
+    } else if (upper === "RETRY") {
+      // RETRY with no story ID, treat as guidance
+      guidance.push(trimmed);
+    } else if (upper.startsWith("PRIORITY ")) {
+      const rest = trimmed.substring(9).trim();
+      const parts = rest.split(/\s+/);
+      const storyId = parts[0];
+      const value = parts[1] !== undefined ? Number(parts[1]) : Number.NaN;
+      if (storyId && parts.length === 2 && Number.isFinite(value)) {
+        commands.push({ type: "PRIORITY", storyId, value });
+      } else {
+        // Missing/malformed storyId or value, treat as guidance
+        guidance.push(trimmed);
+      }
+    } else if (upper === "PRIORITY") {
+      // PRIORITY with no arguments, treat as guidance
       guidance.push(trimmed);
     } else {
       // Not a command, treat as guidance if in pending section

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -43,7 +43,12 @@ export interface QueueStats {
 }
 
 /** Queue command for mid-run control */
-export type QueueCommand = { type: "PAUSE" } | { type: "ABORT" } | { type: "SKIP"; storyId: string };
+export type QueueCommand =
+  | { type: "PAUSE" }
+  | { type: "ABORT" }
+  | { type: "SKIP"; storyId: string }
+  | { type: "RETRY"; storyId: string }
+  | { type: "PRIORITY"; storyId: string; value: number };
 
 /** Result of parsing a queue file */
 export interface QueueFileResult {

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -86,10 +86,29 @@ export type ReviewAuditDecision = Omit<ReviewAuditEntry, "sessionName" | "workdi
   workdir?: string;
 };
 
+/**
+ * A single sub-threshold review finding, flattened for run-end aggregation.
+ * §2.1 — these findings are real (found by the reviewer) but never blocked the
+ * story, so without this aggregation they are only visible in the per-story
+ * debug log / the on-disk audit trail.
+ */
+export interface AdvisoryFindingSummaryEntry {
+  storyId?: string;
+  featureName?: string;
+  reviewer: "semantic" | "adversarial";
+  severity: string;
+  category?: string;
+  file?: string;
+  line?: number;
+  issue: string;
+}
+
 export interface IReviewAuditor {
   recordDispatch(entry: ReviewAuditDispatch): void;
   recordDecision(entry: ReviewAuditDecision): void;
   flush(): Promise<void>;
+  /** Advisory (sub-threshold) findings accumulated across every `recordDecision` call this run. */
+  getAdvisoryFindings(): readonly AdvisoryFindingSummaryEntry[];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -167,12 +186,34 @@ export function createNoOpReviewAuditor(): IReviewAuditor {
     recordDispatch() {},
     recordDecision() {},
     async flush() {},
+    getAdvisoryFindings() {
+      return [];
+    },
   };
+}
+
+/** Flatten a decision's `advisoryFindings` (unknown[] from the reviewer's own shape) into summary entries. */
+function toAdvisorySummaryEntries(entry: ReviewAuditDecision): AdvisoryFindingSummaryEntry[] {
+  if (!entry.advisoryFindings || entry.advisoryFindings.length === 0) return [];
+  return entry.advisoryFindings.map((raw) => {
+    const f = raw as { severity?: string; category?: string; file?: string; line?: number; issue?: string };
+    return {
+      storyId: entry.storyId,
+      featureName: entry.featureName,
+      reviewer: entry.reviewer,
+      severity: f.severity ?? "info",
+      category: f.category,
+      file: f.file,
+      line: f.line,
+      issue: f.issue ?? "(no description)",
+    };
+  });
 }
 
 export class ReviewAuditor implements IReviewAuditor {
   private _queue: Promise<void> = Promise.resolve();
   private readonly _dispatches = new Map<string, ReviewAuditDispatch>();
+  private readonly _advisoryFindings: AdvisoryFindingSummaryEntry[] = [];
 
   constructor(
     private readonly _runId: string,
@@ -184,6 +225,8 @@ export class ReviewAuditor implements IReviewAuditor {
   }
 
   recordDecision(entry: ReviewAuditDecision): void {
+    this._advisoryFindings.push(...toAdvisorySummaryEntries(entry));
+
     const key = auditKey(entry.reviewer, entry.storyId);
     const dispatch = this._dispatches.get(key);
     this._dispatches.delete(key);
@@ -215,6 +258,10 @@ export class ReviewAuditor implements IReviewAuditor {
 
   async flush(): Promise<void> {
     await this._queue;
+  }
+
+  getAdvisoryFindings(): readonly AdvisoryFindingSummaryEntry[] {
+    return [...this._advisoryFindings];
   }
 }
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -14,6 +14,7 @@ export type {
 } from "./prompt-auditor";
 export { createNoOpReviewAuditor, ReviewAuditor, _reviewAuditDeps } from "../review/review-audit";
 export type {
+  AdvisoryFindingSummaryEntry,
   IReviewAuditor,
   ReviewAuditDecision,
   ReviewAuditDispatch,

--- a/src/utils/queue-writer.ts
+++ b/src/utils/queue-writer.ts
@@ -1,7 +1,7 @@
 /**
  * Queue Writer Utility
  *
- * Writes queue commands (PAUSE/ABORT/SKIP) to the queue file.
+ * Writes queue commands (PAUSE/ABORT/SKIP/RETRY/PRIORITY) to the queue file.
  * Used by the TUI to translate keyboard shortcuts into queue commands.
  */
 
@@ -41,6 +41,12 @@ export async function writeQueueCommand(queueFilePath: string, command: QueueCom
       break;
     case "SKIP":
       commandLine = `SKIP ${command.storyId}`;
+      break;
+    case "RETRY":
+      commandLine = `RETRY ${command.storyId}`;
+      break;
+    case "PRIORITY":
+      commandLine = `PRIORITY ${command.storyId} ${command.value}`;
       break;
     default: {
       const _exhaustive: never = command;

--- a/test/helpers/review-audit.ts
+++ b/test/helpers/review-audit.ts
@@ -19,6 +19,7 @@ export function captureAuditDecisions(): { auditor: IReviewAuditor; decisions: R
       decisions.push(entry);
     },
     flush: async () => {},
+    getAdvisoryFindings: () => [],
   };
   return { auditor, decisions };
 }

--- a/test/unit/execution/lifecycle/headless-formatter.test.ts
+++ b/test/unit/execution/lifecycle/headless-formatter.test.ts
@@ -1,0 +1,50 @@
+/**
+ * outputAdvisoryFindingsSummary() — §2.1 headless console surfacing of
+ * sub-threshold review findings.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { outputAdvisoryFindingsSummary } from "@/execution";
+import type { AdvisoryFindingSummaryEntry } from "@/runtime";
+
+function makeFinding(overrides: Partial<AdvisoryFindingSummaryEntry> = {}): AdvisoryFindingSummaryEntry {
+  return {
+    storyId: "US-001",
+    reviewer: "adversarial",
+    severity: "warning",
+    issue: "off-AC edge case not handled",
+    ...overrides,
+  };
+}
+
+describe("outputAdvisoryFindingsSummary", () => {
+  let logSpy: ReturnType<typeof mock>;
+  let origLog: typeof console.log;
+
+  beforeEach(() => {
+    origLog = console.log;
+    logSpy = mock(() => {});
+    console.log = logSpy as unknown as typeof console.log;
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+  });
+
+  test("does nothing when there are no findings", () => {
+    outputAdvisoryFindingsSummary([], "normal");
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test("does nothing in json mode (findings live in the review-audit trail instead)", () => {
+    outputAdvisoryFindingsSummary([makeFinding()], "json");
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test("prints the formatted summary in normal mode", () => {
+    outputAdvisoryFindingsSummary([makeFinding()], "normal");
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain("US-001");
+  });
+});

--- a/test/unit/execution/queue.test.ts
+++ b/test/unit/execution/queue.test.ts
@@ -234,4 +234,68 @@ ABORT
     expect(result.commands).toHaveLength(1);
     expect(result.commands[0]).toEqual({ type: "SKIP", storyId: "US-042" });
   });
+
+  test("parses RETRY command with story ID", () => {
+    const content = "RETRY US-042\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0]).toEqual({ type: "RETRY", storyId: "US-042" });
+  });
+
+  test("parses RETRY command case-insensitive and trims story ID", () => {
+    const content = "retry   US-001   \n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0]).toEqual({ type: "RETRY", storyId: "US-001" });
+  });
+
+  test("handles RETRY without story ID gracefully", () => {
+    const content = "RETRY\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(0);
+    expect(result.guidance).toHaveLength(1);
+  });
+
+  test("parses PRIORITY command with story ID and value", () => {
+    const content = "PRIORITY US-042 10\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0]).toEqual({ type: "PRIORITY", storyId: "US-042", value: 10 });
+  });
+
+  test("parses PRIORITY command case-insensitive with negative value", () => {
+    const content = "priority US-001 -5\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0]).toEqual({ type: "PRIORITY", storyId: "US-001", value: -5 });
+  });
+
+  test("handles PRIORITY with missing value gracefully", () => {
+    const content = "PRIORITY US-001\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(0);
+    expect(result.guidance).toHaveLength(1);
+  });
+
+  test("handles PRIORITY with non-numeric value gracefully", () => {
+    const content = "PRIORITY US-001 high\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(0);
+    expect(result.guidance).toHaveLength(1);
+  });
+
+  test("handles PRIORITY with no arguments gracefully", () => {
+    const content = "PRIORITY\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(0);
+    expect(result.guidance).toHaveLength(1);
+  });
 });

--- a/test/unit/log-format/formatter.test.ts
+++ b/test/unit/log-format/formatter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { formatLogEntry } from "../../../src/log-format";
+import { formatAdvisorySummary, formatLogEntry } from "../../../src/log-format";
 import type { LogEntry } from "../../../src/logger/types";
+import type { AdvisoryFindingSummaryEntry } from "../../../src/runtime";
 
 const TS = "2026-05-29T11:35:59.000Z";
 
@@ -172,5 +173,63 @@ describe("formatLogEntry — verbose mode does not double-print enriched fields"
     const jsonPart = jsonStart >= 0 ? text.slice(jsonStart) : "";
     expect(jsonPart).not.toContain("agentName");
     expect(jsonPart).not.toContain("messageUpdates");
+  });
+});
+
+// ── formatAdvisorySummary() — §2.1 surface sub-threshold review findings ───────
+
+function advisoryFinding(overrides: Partial<AdvisoryFindingSummaryEntry> = {}): AdvisoryFindingSummaryEntry {
+  return {
+    storyId: "US-001",
+    reviewer: "adversarial",
+    severity: "warning",
+    category: "correctness",
+    file: "src/foo.ts",
+    line: 12,
+    issue: "off-AC edge case not handled",
+    ...overrides,
+  };
+}
+
+describe("formatAdvisorySummary", () => {
+  test("returns empty string when there are no findings", () => {
+    expect(formatAdvisorySummary([], { mode: "normal", useColor: false })).toBe("");
+  });
+
+  test("json mode returns a JSON array of the findings", () => {
+    const findings = [advisoryFinding()];
+    const output = formatAdvisorySummary(findings, { mode: "json", useColor: false });
+    expect(JSON.parse(output)).toEqual(findings);
+  });
+
+  test("includes every finding's story ID, severity, and issue text", () => {
+    const findings = [
+      advisoryFinding({ storyId: "US-001", severity: "warning", issue: "issue A" }),
+      advisoryFinding({ storyId: "US-002", severity: "info", issue: "issue B" }),
+    ];
+    const output = plain(formatAdvisorySummary(findings, { mode: "normal", useColor: false }));
+
+    expect(output).toContain("US-001");
+    expect(output).toContain("warning");
+    expect(output).toContain("issue A");
+    expect(output).toContain("US-002");
+    expect(output).toContain("info");
+    expect(output).toContain("issue B");
+  });
+
+  test("groups findings by severity, higher severity first", () => {
+    const findings = [
+      advisoryFinding({ storyId: "US-001", severity: "info", issue: "low" }),
+      advisoryFinding({ storyId: "US-002", severity: "warning", issue: "mid" }),
+    ];
+    const output = plain(formatAdvisorySummary(findings, { mode: "normal", useColor: false }));
+
+    expect(output.indexOf("mid")).toBeLessThan(output.indexOf("low"));
+  });
+
+  test("quiet mode still returns a non-empty summary (never silently dropped)", () => {
+    const output = plain(formatAdvisorySummary([advisoryFinding()], { mode: "quiet", useColor: false }));
+    expect(output.length).toBeGreaterThan(0);
+    expect(output).toContain("US-001");
   });
 });

--- a/test/unit/pipeline/stages/queue-check.test.ts
+++ b/test/unit/pipeline/stages/queue-check.test.ts
@@ -1,0 +1,107 @@
+/**
+ * queue-check pipeline stage — RETRY / PRIORITY queue commands
+ *
+ * Locks in existing PAUSE/ABORT/SKIP behavior and adds coverage for the two
+ * new mid-run queue commands: RETRY (reset a story to pending) and PRIORITY
+ * (set a story's scheduling priority).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { initLogger, resetLogger } from "@/logger";
+import { queueCheckStage } from "@/pipeline";
+import type { PipelineContext } from "@/pipeline";
+import { makePRD, makeStory, makeTempDir } from "@test/helpers";
+
+function makeCtx(workdir: string, overrides: Partial<PipelineContext> = {}): PipelineContext {
+  const story = makeStory({ id: "US-001", status: "pending" });
+  const prd = makePRD({ userStories: [story] });
+  return {
+    workdir,
+    featureDir: workdir,
+    prd,
+    stories: [story],
+    story,
+    ...overrides,
+  } as unknown as PipelineContext;
+}
+
+describe("queueCheckStage — RETRY / PRIORITY", () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    initLogger({ level: "silent" });
+    workdir = makeTempDir("nax-queue-check-");
+  });
+
+  afterEach(() => {
+    resetLogger();
+  });
+
+  test("RETRY resets a failed story to pending and continues", async () => {
+    const failedStory = makeStory({ id: "US-001", status: "failed", attempts: 2 });
+    const prd = makePRD({ userStories: [failedStory] });
+    const ctx = makeCtx(workdir, { prd, stories: [failedStory], story: failedStory });
+
+    await Bun.write(join(workdir, ".queue.txt"), "RETRY US-001\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories[0].status).toBe("pending");
+    expect(ctx.prd.userStories[0].attempts).toBe(0);
+  });
+
+  test("RETRY for an unknown story ID is a no-op and continues", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, ".queue.txt"), "RETRY US-999\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories[0].status).toBe("pending");
+  });
+
+  test("PRIORITY sets a story's priority and continues", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, ".queue.txt"), "PRIORITY US-001 7\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories[0].priority).toBe(7);
+  });
+
+  test("RETRY and PRIORITY compose with existing SKIP handling", async () => {
+    const s1 = makeStory({ id: "US-001", status: "failed" });
+    const s2 = makeStory({ id: "US-002", status: "pending" });
+    const prd = makePRD({ userStories: [s1, s2] });
+    const ctx = makeCtx(workdir, { prd, stories: [s1, s2], story: s1 });
+
+    await Bun.write(join(workdir, ".queue.txt"), "RETRY US-001\nPRIORITY US-002 3\nSKIP US-002\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(ctx.prd.userStories[0].status).toBe("pending");
+    expect(ctx.prd.userStories[1].priority).toBe(3);
+    expect(ctx.prd.userStories[1].status).toBe("skipped");
+    // SKIP removed US-002 from the batch, leaving only US-001 — continue, not skip.
+    expect(result.action).toBe("continue");
+    expect(ctx.stories.map((s) => s.id)).toEqual(["US-001"]);
+  });
+
+  test("PAUSE still stops execution (existing behavior)", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, ".queue.txt"), "PAUSE\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("pause");
+  });
+
+  test("no queue file continues without side effects", async () => {
+    const ctx = makeCtx(workdir);
+    const result = await queueCheckStage.execute(ctx);
+    expect(result.action).toBe("continue");
+  });
+});

--- a/test/unit/pipeline/stages/queue-check.test.ts
+++ b/test/unit/pipeline/stages/queue-check.test.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { initLogger, resetLogger } from "@/logger";
 import { queueCheckStage } from "@/pipeline";
 import type { PipelineContext } from "@/pipeline";
-import { makePRD, makeStory, makeTempDir } from "@test/helpers";
+import { cleanupTempDir, makePRD, makeStory, makeTempDir } from "@test/helpers";
 
 function makeCtx(workdir: string, overrides: Partial<PipelineContext> = {}): PipelineContext {
   const story = makeStory({ id: "US-001", status: "pending" });
@@ -36,6 +36,7 @@ describe("queueCheckStage — RETRY / PRIORITY", () => {
 
   afterEach(() => {
     resetLogger();
+    cleanupTempDir(workdir);
   });
 
   test("RETRY resets a failed story to pending and continues", async () => {

--- a/test/unit/prd/prd-queue-actions.test.ts
+++ b/test/unit/prd/prd-queue-actions.test.ts
@@ -1,0 +1,139 @@
+/**
+ * resetStoryToPending() / setStoryPriority() Unit Tests
+ *
+ * Backs the RETRY and PRIORITY queue commands (queue-check pipeline stage).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { getNextStory, resetStoryToPending, setStoryPriority } from "@/prd";
+import type { PRD, UserStory } from "@/prd/types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeStory(id: string, overrides: Partial<UserStory> = {}): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "Test story",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+function makePrd(stories: UserStory[]): PRD {
+  return {
+    project: "test",
+    feature: "test-feature",
+    branchName: "feature/test",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: stories,
+  };
+}
+
+// ── resetStoryToPending() ───────────────────────────────────────────────────────
+
+describe("resetStoryToPending()", () => {
+  test("resets a failed story to pending and clears error state", () => {
+    const prd = makePrd([
+      makeStory("US-001", { status: "failed", attempts: 3, failureStage: "verify" }),
+    ]);
+    resetStoryToPending(prd, "US-001");
+
+    const story = prd.userStories[0];
+    expect(story.status).toBe("pending");
+    expect(story.attempts).toBe(0);
+  });
+
+  test("resets a skipped story to pending", () => {
+    const prd = makePrd([makeStory("US-001", { status: "skipped" })]);
+    resetStoryToPending(prd, "US-001");
+    expect(prd.userStories[0].status).toBe("pending");
+  });
+
+  test("restores initial routing rung and clears escalations", () => {
+    const prd = makePrd([
+      makeStory("US-001", {
+        status: "failed",
+        routing: { modelTier: "powerful", agent: "codex", initialModelTier: "fast", initialAgent: "claude" },
+        escalations: [{ fromTier: "fast", toTier: "powerful", reason: "retry", timestamp: "now" }],
+      }),
+    ]);
+    resetStoryToPending(prd, "US-001");
+
+    const story = prd.userStories[0];
+    expect(story.routing?.modelTier).toBe("fast");
+    expect(story.routing?.agent).toBe("claude");
+    expect(story.escalations).toEqual([]);
+  });
+
+  test("does nothing when story ID is not found", () => {
+    const prd = makePrd([makeStory("US-001", { status: "failed" })]);
+    resetStoryToPending(prd, "US-999");
+    expect(prd.userStories[0].status).toBe("failed");
+  });
+
+  test("is a no-op for a story that is already pending", () => {
+    const prd = makePrd([makeStory("US-001", { status: "pending" })]);
+    resetStoryToPending(prd, "US-001");
+    expect(prd.userStories[0].status).toBe("pending");
+  });
+});
+
+// ── setStoryPriority() ──────────────────────────────────────────────────────────
+
+describe("setStoryPriority()", () => {
+  test("sets the priority field on the matching story", () => {
+    const prd = makePrd([makeStory("US-001"), makeStory("US-002")]);
+    setStoryPriority(prd, "US-002", 10);
+
+    expect(prd.userStories[0].priority).toBeUndefined();
+    expect(prd.userStories[1].priority).toBe(10);
+  });
+
+  test("does nothing when story ID is not found", () => {
+    const prd = makePrd([makeStory("US-001")]);
+    setStoryPriority(prd, "US-999", 10);
+    expect(prd.userStories[0].priority).toBeUndefined();
+  });
+
+  test("overwrites an existing priority value", () => {
+    const prd = makePrd([makeStory("US-001", { priority: 3 })]);
+    setStoryPriority(prd, "US-001", -1);
+    expect(prd.userStories[0].priority).toBe(-1);
+  });
+});
+
+// ── getNextStory() priority ordering ────────────────────────────────────────────
+
+describe("getNextStory() priority ordering", () => {
+  test("picks the highest-priority eligible story over array order", () => {
+    const prd = makePrd([makeStory("US-001", { priority: 1 }), makeStory("US-002", { priority: 5 })]);
+    expect(getNextStory(prd)?.id).toBe("US-002");
+  });
+
+  test("falls back to array order (FIFO) when priorities are equal or unset", () => {
+    const prd = makePrd([makeStory("US-001"), makeStory("US-002")]);
+    expect(getNextStory(prd)?.id).toBe("US-001");
+  });
+
+  test("treats unset priority as 0 — a prioritized story wins over an unset one", () => {
+    const prd = makePrd([makeStory("US-001"), makeStory("US-002", { priority: 1 })]);
+    expect(getNextStory(prd)?.id).toBe("US-002");
+  });
+
+  test("still respects dependency/status eligibility before priority", () => {
+    const prd = makePrd([
+      makeStory("US-001", { priority: 10, dependencies: ["US-002"] }),
+      makeStory("US-002", { priority: 1 }),
+    ]);
+    // US-001 has higher priority but is blocked on US-002, which hasn't passed yet.
+    expect(getNextStory(prd)?.id).toBe("US-002");
+  });
+});

--- a/test/unit/prd/prd-queue-actions.test.ts
+++ b/test/unit/prd/prd-queue-actions.test.ts
@@ -6,44 +6,15 @@
 
 import { describe, expect, test } from "bun:test";
 import { getNextStory, resetStoryToPending, setStoryPriority } from "@/prd";
-import type { PRD, UserStory } from "@/prd/types";
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function makeStory(id: string, overrides: Partial<UserStory> = {}): UserStory {
-  return {
-    id,
-    title: `Story ${id}`,
-    description: "Test story",
-    acceptanceCriteria: [],
-    tags: [],
-    dependencies: [],
-    status: "pending",
-    passes: false,
-    escalations: [],
-    attempts: 0,
-    ...overrides,
-  };
-}
-
-function makePrd(stories: UserStory[]): PRD {
-  return {
-    project: "test",
-    feature: "test-feature",
-    branchName: "feature/test",
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    userStories: stories,
-  };
-}
+import { makePRD, makeStory } from "@test/helpers";
 
 // ── resetStoryToPending() ───────────────────────────────────────────────────────
 
 describe("resetStoryToPending()", () => {
   test("resets a failed story to pending and clears error state", () => {
-    const prd = makePrd([
-      makeStory("US-001", { status: "failed", attempts: 3, failureStage: "verify" }),
-    ]);
+    const prd = makePRD({
+      userStories: [makeStory({ id: "US-001", status: "failed", attempts: 3, failureStage: "verify" })],
+    });
     resetStoryToPending(prd, "US-001");
 
     const story = prd.userStories[0];
@@ -52,19 +23,22 @@ describe("resetStoryToPending()", () => {
   });
 
   test("resets a skipped story to pending", () => {
-    const prd = makePrd([makeStory("US-001", { status: "skipped" })]);
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", status: "skipped" })] });
     resetStoryToPending(prd, "US-001");
     expect(prd.userStories[0].status).toBe("pending");
   });
 
   test("restores initial routing rung and clears escalations", () => {
-    const prd = makePrd([
-      makeStory("US-001", {
-        status: "failed",
-        routing: { modelTier: "powerful", agent: "codex", initialModelTier: "fast", initialAgent: "claude" },
-        escalations: [{ fromTier: "fast", toTier: "powerful", reason: "retry", timestamp: "now" }],
-      }),
-    ]);
+    const prd = makePRD({
+      userStories: [
+        makeStory({
+          id: "US-001",
+          status: "failed",
+          routing: { modelTier: "powerful", agent: "codex", initialModelTier: "fast", initialAgent: "claude" },
+          escalations: [{ fromTier: "fast", toTier: "powerful", reason: "retry", timestamp: "now" }],
+        }),
+      ],
+    });
     resetStoryToPending(prd, "US-001");
 
     const story = prd.userStories[0];
@@ -74,13 +48,13 @@ describe("resetStoryToPending()", () => {
   });
 
   test("does nothing when story ID is not found", () => {
-    const prd = makePrd([makeStory("US-001", { status: "failed" })]);
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", status: "failed" })] });
     resetStoryToPending(prd, "US-999");
     expect(prd.userStories[0].status).toBe("failed");
   });
 
   test("is a no-op for a story that is already pending", () => {
-    const prd = makePrd([makeStory("US-001", { status: "pending" })]);
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", status: "pending" })] });
     resetStoryToPending(prd, "US-001");
     expect(prd.userStories[0].status).toBe("pending");
   });
@@ -90,7 +64,7 @@ describe("resetStoryToPending()", () => {
 
 describe("setStoryPriority()", () => {
   test("sets the priority field on the matching story", () => {
-    const prd = makePrd([makeStory("US-001"), makeStory("US-002")]);
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001" }), makeStory({ id: "US-002" })] });
     setStoryPriority(prd, "US-002", 10);
 
     expect(prd.userStories[0].priority).toBeUndefined();
@@ -98,13 +72,13 @@ describe("setStoryPriority()", () => {
   });
 
   test("does nothing when story ID is not found", () => {
-    const prd = makePrd([makeStory("US-001")]);
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001" })] });
     setStoryPriority(prd, "US-999", 10);
     expect(prd.userStories[0].priority).toBeUndefined();
   });
 
   test("overwrites an existing priority value", () => {
-    const prd = makePrd([makeStory("US-001", { priority: 3 })]);
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", priority: 3 })] });
     setStoryPriority(prd, "US-001", -1);
     expect(prd.userStories[0].priority).toBe(-1);
   });
@@ -114,25 +88,31 @@ describe("setStoryPriority()", () => {
 
 describe("getNextStory() priority ordering", () => {
   test("picks the highest-priority eligible story over array order", () => {
-    const prd = makePrd([makeStory("US-001", { priority: 1 }), makeStory("US-002", { priority: 5 })]);
+    const prd = makePRD({
+      userStories: [makeStory({ id: "US-001", priority: 1 }), makeStory({ id: "US-002", priority: 5 })],
+    });
     expect(getNextStory(prd)?.id).toBe("US-002");
   });
 
   test("falls back to array order (FIFO) when priorities are equal or unset", () => {
-    const prd = makePrd([makeStory("US-001"), makeStory("US-002")]);
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001" }), makeStory({ id: "US-002" })] });
     expect(getNextStory(prd)?.id).toBe("US-001");
   });
 
   test("treats unset priority as 0 — a prioritized story wins over an unset one", () => {
-    const prd = makePrd([makeStory("US-001"), makeStory("US-002", { priority: 1 })]);
+    const prd = makePRD({
+      userStories: [makeStory({ id: "US-001" }), makeStory({ id: "US-002", priority: 1 })],
+    });
     expect(getNextStory(prd)?.id).toBe("US-002");
   });
 
   test("still respects dependency/status eligibility before priority", () => {
-    const prd = makePrd([
-      makeStory("US-001", { priority: 10, dependencies: ["US-002"] }),
-      makeStory("US-002", { priority: 1 }),
-    ]);
+    const prd = makePRD({
+      userStories: [
+        makeStory({ id: "US-001", priority: 10, dependencies: ["US-002"] }),
+        makeStory({ id: "US-002", priority: 1 }),
+      ],
+    });
     // US-001 has higher priority but is blocked on US-002, which hasn't passed yet.
     expect(getNextStory(prd)?.id).toBe("US-002");
   });

--- a/test/unit/review/review-audit.test.ts
+++ b/test/unit/review/review-audit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { ReviewAuditor, writeReviewAudit, _reviewAuditDeps } from "../../../src/review/review-audit";
+import { ReviewAuditor, createNoOpReviewAuditor, writeReviewAudit, _reviewAuditDeps } from "../../../src/review/review-audit";
 import type { ReviewAuditEntry } from "../../../src/review/review-audit";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -279,5 +279,95 @@ describe("ReviewAuditor", () => {
     expect(second.sessionName).toBe("review-semantic-US-001");
     expect(second.sessionId).toBeNull();
     expect(second.recordId).toBeNull();
+  });
+});
+
+describe("ReviewAuditor.getAdvisoryFindings", () => {
+  let saved: typeof _reviewAuditDeps;
+
+  beforeEach(() => {
+    saved = { ..._reviewAuditDeps };
+  });
+
+  test("aggregates advisory findings from recorded decisions", async () => {
+    const { deps } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-1", "/tmp/workdir");
+
+    auditor.recordDecision({
+      reviewer: "adversarial",
+      storyId: "US-001",
+      featureName: "my-feature",
+      parsed: true,
+      passed: true,
+      blockingThreshold: "error",
+      result: { passed: true, findings: [] },
+      advisoryFindings: [{ severity: "warning", category: "correctness", file: "src/foo.ts", issue: "off-AC bug" }],
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    const summary = auditor.getAdvisoryFindings();
+    expect(summary).toHaveLength(1);
+    expect(summary[0]).toMatchObject({
+      storyId: "US-001",
+      reviewer: "adversarial",
+      severity: "warning",
+      category: "correctness",
+      file: "src/foo.ts",
+      issue: "off-AC bug",
+    });
+  });
+
+  test("decisions with no advisory findings contribute nothing", async () => {
+    const { deps } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-1", "/tmp/workdir");
+
+    auditor.recordDecision({
+      reviewer: "semantic",
+      storyId: "US-002",
+      parsed: true,
+      passed: true,
+      result: { passed: true, findings: [] },
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    expect(auditor.getAdvisoryFindings()).toHaveLength(0);
+  });
+
+  test("accumulates advisory findings across multiple stories", async () => {
+    const { deps } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-1", "/tmp/workdir");
+
+    auditor.recordDecision({
+      reviewer: "adversarial",
+      storyId: "US-001",
+      parsed: true,
+      passed: true,
+      result: { passed: true, findings: [] },
+      advisoryFindings: [{ severity: "info", issue: "a" }],
+    });
+    auditor.recordDecision({
+      reviewer: "semantic",
+      storyId: "US-002",
+      parsed: true,
+      passed: true,
+      result: { passed: true, findings: [] },
+      advisoryFindings: [{ severity: "warning", issue: "b" }, { severity: "warning", issue: "c" }],
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    const summary = auditor.getAdvisoryFindings();
+    expect(summary).toHaveLength(3);
+    expect(summary.map((f) => f.storyId)).toEqual(["US-001", "US-002", "US-002"]);
+  });
+
+  test("no-op auditor returns an empty advisory findings list", () => {
+    const auditor = createNoOpReviewAuditor();
+    expect(auditor.getAdvisoryFindings()).toEqual([]);
   });
 });

--- a/test/unit/utils/queue-writer.test.ts
+++ b/test/unit/utils/queue-writer.test.ts
@@ -26,6 +26,17 @@ describe("writeQueueCommand", () => {
     expect(commands).toEqual([{ type: "PAUSE" }, { type: "SKIP", storyId: "US-001" }, { type: "ABORT" }]);
   });
 
+  test("writes RETRY and PRIORITY commands", async () => {
+    await writeQueueCommand(queueFile, { type: "RETRY", storyId: "US-002" });
+    await writeQueueCommand(queueFile, { type: "PRIORITY", storyId: "US-003", value: 5 });
+
+    const { commands } = parseQueueFile(await Bun.file(queueFile).text());
+    expect(commands).toEqual([
+      { type: "RETRY", storyId: "US-002" },
+      { type: "PRIORITY", storyId: "US-003", value: 5 },
+    ]);
+  });
+
   test("serializes concurrent writes without clobbering (no read-modify-write race)", async () => {
     // Fire many writes concurrently — the per-path chain must serialize them so
     // every command lands instead of overwriting each other's read-modify-write.


### PR DESCRIPTION
## Summary

Implements the top of the value/effort shortlist from `docs/IMPROVEMENT-REPORT.md` (§1.3, §2.1, §2.2):

- **Queue commands** — adds `RETRY <storyId>` (resets a failed/skipped story to pending, restoring its initial routing rung) and `PRIORITY <storyId> <n>` (sets `UserStory.priority`, used as a tiebreaker in `getNextStory`) to the mid-run `.queue.txt` control file, alongside existing `PAUSE`/`ABORT`/`SKIP`. `INJECT` was scoped out as materially riskier (no schema to validate an ad hoc new story) — tracked in #1288.
- **Non-blocking review findings surfaced** — sub-threshold adversarial/semantic review findings (real findings that don't block a story) previously only reached a per-story debug log line and the on-disk `.nax/review-audit/` trail. `ReviewAuditor` now aggregates them across the run and `runner-completion.ts` surfaces a severity-graded summary at run end (headless console + structured `logger.warn`).
- **Config doc fix** — `tdd.sessionTiers.implementer`'s CLI description falsely claimed it sets the implementer's model tier; it's intentionally unconsumed (implementer follows `story.routing.modelTier` + escalation). Description now says so.

Tracking issues filed for deferred scope: #1288 (INJECT queue command), #1289 (ADR-025 §7 run-time routing).

## Test plan

- [x] `bun run test:bail` — full suite green (10,249+ tests, 0 failures)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (Biome + all custom checks: alias-internals, deep-relatives, nax-error, logger-storyid, file-sizes)
- [x] New unit tests added for: `parseQueueFile` RETRY/PRIORITY parsing, `writeQueueCommand`, `resetStoryToPending`/`setStoryPriority`/priority-aware `getNextStory`, `queueCheckStage` RETRY/PRIORITY handling, `ReviewAuditor.getAdvisoryFindings`, `formatAdvisorySummary`, `outputAdvisoryFindingsSummary`