### PR TITLE
feat(execution): cost budget cap — --max-cost CLI flag + distinguishable cost-limit run status

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -601,8 +601,8 @@ program
     }
     config.execution.maxIterations = Number.parseInt(options.maxIterations, 10);
     if (options.maxCost !== undefined) {
-      const maxCost = Number.parseFloat(options.maxCost);
-      if (Number.isNaN(maxCost) || maxCost <= 0) {
+      const maxCost = Number(options.maxCost);
+      if (!Number.isFinite(maxCost) || maxCost <= 0) {
         console.error(chalk.red("--max-cost must be a positive number"));
         process.exit(1);
       }

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -368,6 +368,7 @@ program
   .requiredOption("-f, --feature <name>", "Feature name")
   .option("-a, --agent <name>", "Force a specific agent")
   .option("-m, --max-iterations <n>", "Max iterations", "20")
+  .option("--max-cost <usd>", "Override cost limit (USD) for this run — aborts execution when exceeded")
   .option("--dry-run", "Show plan without executing", false)
   .option("--no-context", "Disable context builder (skip file context in prompts)")
   .option("--no-batch", "Disable story batching (execute all stories individually)")
@@ -599,6 +600,14 @@ program
       config.agent.default = options.agent;
     }
     config.execution.maxIterations = Number.parseInt(options.maxIterations, 10);
+    if (options.maxCost !== undefined) {
+      const maxCost = Number.parseFloat(options.maxCost);
+      if (Number.isNaN(maxCost) || maxCost <= 0) {
+        console.error(chalk.red("--max-cost must be a positive number"));
+        process.exit(1);
+      }
+      config.execution.costLimit = maxCost;
+    }
 
     const globalNaxDir = join(homedir(), ".nax");
     const hooks = await loadHooksConfig(naxDir, globalNaxDir);
@@ -1313,7 +1322,7 @@ const runs = program
   .description("Show all registered runs from the central registry (~/.nax/runs/)")
   .option("--project <name>", "Filter by project name")
   .option("--last <N>", "Limit to N most recent runs (default: 20)")
-  .option("--status <status>", "Filter by status (running|completed|failed|crashed)")
+  .option("--status <status>", "Filter by status (running|completed|failed|crashed|cost-limit)")
   .action(async (options) => {
     try {
       await runsCommand({

--- a/docs/IMPROVEMENT-REPORT.md
+++ b/docs/IMPROVEMENT-REPORT.md
@@ -78,13 +78,13 @@ The open-issue backlog is small and well-groomed (6 open issues), so most items 
 |---|---|---|
 | `runTddSession` takes 19 positional params; options-object refactor flagged P4 | `src/tdd/session-runner.ts`, `docs/follow-up-runTddSession-options-refactor.md` | Doc only, no issue |
 | `@deprecated` shims awaiting cleanup: `routeStory`/`routeTask`, `validateConfig`, `extractJsonFromMarkdown` wrapper, `decompose-prompt`, `RectifierPromptBuilder` class → static factories | `src/routing/router.ts:269-291`, `src/config/index.ts:53`, `src/routing/strategies/llm-parsing.ts:63`, `src/agents/shared/decompose-prompt.ts:2`, `src/prompts/builders/rectifier-builder.ts:10` | No |
-| `routing.llm.batchMode` / `retries` deprecation shims | `src/config/loader.ts:198,289-320` | #856 (intentional) |
+| `routing.llm.batchMode` / `retries` deprecation shims | `src/config/loader.ts:198,289-320` | ✅ #856 closed (retry policy unified via `RetryStrategy`) |
 | Rule-based prompt optimizer is real working code but off by default and undiscoverable; CLAUDE.md calls the optimizer "no-op" (only half true) | `src/optimizer/rule-based.optimizer.ts`, `src/optimizer/index.ts` | No |
 | `nax setup` is functional but absent from README quick start / CLI table | `src/cli/setup.ts` | No |
 | Stale docs: `docs/release-triage.md` generated 2026-04-21, well behind HEAD; `src/test-runners/resolver.ts:11` "[Phase 1: stub]" comment appears stale (replacement exported in `detect/index.ts:177`) | — | No |
-| `modelDef.env` overrides ignored in `complete()`/`decompose()`/`plan()` | referenced as #391 in release-triage | #391 (verify still open) |
+| `modelDef.env` overrides ignored in `complete()`/`decompose()`/`plan()` | referenced as #391 in release-triage | ✅ #391 closed — verified fixed (`spawn-client.ts` now threads `opts.env`) |
 | Worktree dependency `inherit` semantics / parallel routing / repo-root provisioning | — | **#574 (open)** |
-| Agent-swap metric propagation deferred | `src/agents/manager.ts:217` | #1131 (verify status) |
+| Agent-swap metric propagation deferred | `src/agents/manager.ts:217` | ✅ #1131 closed (post-refactor migration gaps resolved) |
 | `IReviewPlugin` retention decision deferred by ADR-023 §6 | — | No |
 | Reserved Phase-2 fields unused: debate citation/evidence-mode (`src/debate/types.ts:98`, `src/prd/schema.ts:335,355`), progressive context digest threading (`src/pipeline/stages/context.ts:86,177`), session retry-limit interface (`src/session/types.ts:153-155`) | — | No |
 
@@ -98,8 +98,10 @@ The open-issue backlog is small and well-groomed (6 open issues), so most items 
 4. File tracking issues for §1.6 (ADR-025 Part A) and §2.2 (dead config) so they don't get lost. **✅ Done — #1289 filed for §1.6; §2.2 fixed directly rather than just tracked (#1290).**
 
 ### Remaining open items from this shortlist
-- §1.1 Cost budget cap — not started.
-- §1.2 Mid-session resume — not started.
-- §1.4 Dashboard / metrics export — not started.
-- §1.5 Plugin ecosystem — not started.
+> Re-verified 2026-07-03 (post-#1290): `maxCostUsd` absent from `src/config`/`src/execution` (grep-confirmed); #391, #856, #1131 in §3 are closed and fixed in code, updated above.
+
+- **§1.1 Cost budget cap — not started. Recommended next pick** (highest value/effort ratio: `CostAggregator` middleware already exists, needs `execution.maxCostUsd` config field + abort-on-overspend check in the runner loop).
+- §1.2 Mid-session resume — not started (second priority; larger surface, touches crash-recovery + session checkpointing).
+- §1.4 Dashboard / metrics export — not started (cheapest slice is `nax status --cost --json` schema stabilization).
+- §1.5 Plugin ecosystem — not started (needs 2-3 reference plugins to substantiate the extensibility claim).
 - #1288 (INJECT queue command) and #1289 (ADR-025 §7 run-time routing) — tracked, not implemented.

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -62,7 +62,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   execution: "Execution limits and timeouts",
   "execution.maxIterations": "Max iterations per feature run (auto-calculated if not set)",
   "execution.iterationDelayMs": "Delay between iterations in milliseconds",
-  "execution.costLimit": "Max cost in USD before pausing execution",
+  "execution.costLimit": "Max cost in USD before pausing execution (override per run with `nax run --max-cost`)",
   "execution.sessionTimeoutSeconds": "Timeout per agent coding session in seconds",
   "execution.verificationTimeoutSeconds": "Verification subprocess timeout in seconds",
   "execution.maxStoriesPerFeature": "Max stories per feature (prevents memory exhaustion)",

--- a/src/cli/status-features.ts
+++ b/src/cli/status-features.ts
@@ -47,6 +47,8 @@ interface FeatureSummary {
     pid: number;
     crashedAt?: string;
   };
+  /** True when the most recent run stopped after hitting execution.costLimit. */
+  costLimitStopped?: boolean;
 }
 
 /** Check if a process is alive via POSIX signal 0 (portable, no subprocess) */
@@ -147,6 +149,8 @@ async function getFeatureSummary(featureName: string, featureDir: string): Promi
         pid: status.run.pid,
         crashedAt: status.run.crashedAt,
       };
+    } else if (status.run.status === "cost-limit") {
+      summary.costLimitStopped = true;
     }
   }
 
@@ -224,6 +228,13 @@ async function displayAllFeatures(projectDir: string): Promise<void> {
         console.log(chalk.dim(`   Signal:     ${projectStatus.run.crashSignal}`));
       }
       console.log();
+    } else if (projectStatus.run.status === "cost-limit") {
+      console.log(chalk.magenta("💰 Cost Limit Reached:\n"));
+      console.log(chalk.dim(`   Feature:    ${projectStatus.run.feature}`));
+      console.log(chalk.dim(`   Run ID:     ${projectStatus.run.id}`));
+      console.log(chalk.dim(`   Spent:      $${projectStatus.cost.spent.toFixed(4)}`));
+      console.log(chalk.dim(`   Limit:      $${(projectStatus.cost.limit ?? 0).toFixed(4)}`));
+      console.log();
     }
   }
 
@@ -252,6 +263,8 @@ async function displayAllFeatures(projectDir: string): Promise<void> {
       status = chalk.yellow("⚡ Running");
     } else if (summary.crashedRun) {
       status = chalk.red("💥 Crashed");
+    } else if (summary.costLimitStopped) {
+      status = chalk.magenta("💰 Cost limit");
     } else {
       status = chalk.dim("—");
     }

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -32,7 +32,7 @@ export interface RunsOptions {
   /** Limit number of runs displayed (default: 20) */
   last?: number;
   /** Filter by run status */
-  status?: "running" | "completed" | "failed" | "crashed";
+  status?: NaxStatusFile["run"]["status"];
 }
 
 interface RunRow {
@@ -80,6 +80,8 @@ function colorStatus(status: string): string {
       return chalk.red(status);
     case "running":
       return chalk.yellow(status);
+    case "cost-limit":
+      return chalk.magenta(status);
     case "[unavailable]":
       return chalk.dim(status);
     default:

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -50,13 +50,16 @@ export interface SequentialExecutionContext extends DispatchContext {
   naxIgnoreIndex?: NaxIgnoreIndex;
 }
 
+/** Reason the sequential/parallel execution loop stopped. */
+export type ExitReason = "completed" | "cost-limit" | "max-iterations" | "stalled" | "no-stories" | "pre-merge-aborted";
+
 export interface SequentialExecutionResult {
   prd: PRD;
   iterations: number;
   storiesCompleted: number;
   totalCost: number;
   allStoryMetrics: StoryMetrics[];
-  exitReason: "completed" | "cost-limit" | "max-iterations" | "stalled" | "no-stories" | "pre-merge-aborted";
+  exitReason: ExitReason;
   deferredReview?: DeferredReviewResult;
 }
 

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -26,6 +26,7 @@ import { purgeStaleScratch } from "../../session/scratch-purge";
 import { clearWorkspaceCache } from "../../test-runners/detect/workspace";
 import { clearGitRootCache } from "../../verification/smart-runner";
 import type { DeferredReviewResult } from "../deferred-review";
+import type { ExitReason } from "../executor-types";
 import { closeAllRunSessions } from "../session-manager-runtime";
 import type { StatusWriter } from "../status-writer";
 import { runDeferredRegression } from "./run-regression";
@@ -72,6 +73,8 @@ export interface RunCompletionOptions extends DispatchContext {
    * the run only when config.review.pluginMode === "gating".
    */
   deferredReview?: DeferredReviewResult;
+  /** Why the execution phase stopped — used to distinguish a cost-limit stop from a normal completion. */
+  exitReason?: ExitReason;
 }
 
 export interface RunCompletionResult {
@@ -112,6 +115,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     statusWriter,
     config,
     hooksConfig,
+    exitReason,
   } = options;
 
   // Run deferred regression gate before final metrics
@@ -450,7 +454,9 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   // Update final status
   statusWriter.setPrd(prd);
   statusWriter.setCurrentStory(null);
-  statusWriter.setRunStatus(isComplete(prd) ? "completed" : isStalled(prd) ? "stalled" : "running");
+  statusWriter.setRunStatus(
+    exitReason === "cost-limit" ? "cost-limit" : isComplete(prd) ? "completed" : isStalled(prd) ? "stalled" : "running",
+  );
   await statusWriter.update(reportedTotal, iterations);
 
   return {

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -119,6 +119,10 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   } = options;
 
   // Run deferred regression gate before final metrics
+  // Tracked separately from the setRunStatus("failed") call below (line ~188) so a
+  // cost-limit exit can never mask a genuine regression-gate failure — see the final
+  // classification at the end of this function.
+  let regressionGateFailed = false;
   const regressionMode = config.execution.regressionGate?.mode;
   if (options.skipRegression) {
     // Regression phase already passed on a prior run — skip
@@ -186,6 +190,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
       }
       // Reflect regression gate failure in run status (RL-004)
       statusWriter.setRunStatus("failed");
+      regressionGateFailed = true;
 
       if (hooksConfig) {
         await _runCompletionDeps.fireHook(
@@ -455,7 +460,15 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   statusWriter.setPrd(prd);
   statusWriter.setCurrentStory(null);
   statusWriter.setRunStatus(
-    exitReason === "cost-limit" ? "cost-limit" : isComplete(prd) ? "completed" : isStalled(prd) ? "stalled" : "running",
+    regressionGateFailed
+      ? "failed"
+      : exitReason === "cost-limit"
+        ? "cost-limit"
+        : isComplete(prd)
+          ? "completed"
+          : isStalled(prd)
+            ? "stalled"
+            : "running",
   );
   await statusWriter.update(reportedTotal, iterations);
 

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -266,10 +266,13 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
     // A gating-mode plugin reviewer failure fails the run even when all stories passed
     // (#1146 G2). Folded in here — not via setRunStatus inside handleRunCompletion, which
     // this line would otherwise clobber back to "completed".
-    const finalStatus =
-      options.exitReason === "cost-limit"
+    // pluginGateFailed is checked first so a genuine gate failure is never masked by a
+    // cost-limit stop — the budget being hit doesn't make a reviewer failure less real.
+    const finalStatus = pluginGateFailed
+      ? "failed"
+      : options.exitReason === "cost-limit"
         ? "cost-limit"
-        : isComplete(options.prd) && !pluginGateFailed
+        : isComplete(options.prd)
           ? "completed"
           : "failed";
     options.statusWriter.setRunStatus(finalStatus);

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -24,6 +24,7 @@ import { errorMessage } from "@/utils/errors";
 import { autoCommitIfDirty } from "@/utils/git";
 import { stopHeartbeat, writeExitSummary } from "./crash-recovery";
 import type { DeferredReviewResult } from "./deferred-review";
+import type { ExitReason } from "./executor-types";
 import type { AcceptanceLoopContext, AcceptanceLoopResult } from "./lifecycle/acceptance-loop";
 import type { RunCompletionOptions, RunCompletionResult } from "./lifecycle/run-completion";
 import { hookCtx } from "./story-context";
@@ -61,6 +62,8 @@ export interface RunnerCompletionOptions extends DispatchContext {
   pluginProviderCache?: import("../context/engine").PluginProviderCache;
   /** End-of-run deferred plugin review result (#1146 G2). Forwarded to handleRunCompletion. */
   deferredReview?: DeferredReviewResult;
+  /** Why the execution phase stopped — used to distinguish a cost-limit stop from a normal completion. */
+  exitReason?: ExitReason;
 }
 
 /**
@@ -248,6 +251,7 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
     sessionManager: options.sessionManager,
     pluginProviderCache: options.pluginProviderCache,
     deferredReview: options.deferredReview,
+    exitReason: options.exitReason,
     runtime: options.runtime,
     abortSignal: options.abortSignal,
   });
@@ -262,7 +266,12 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
     // A gating-mode plugin reviewer failure fails the run even when all stories passed
     // (#1146 G2). Folded in here — not via setRunStatus inside handleRunCompletion, which
     // this line would otherwise clobber back to "completed".
-    const finalStatus = isComplete(options.prd) && !pluginGateFailed ? "completed" : "failed";
+    const finalStatus =
+      options.exitReason === "cost-limit"
+        ? "cost-limit"
+        : isComplete(options.prd) && !pluginGateFailed
+          ? "completed"
+          : "failed";
     options.statusWriter.setRunStatus(finalStatus);
     await options.statusWriter.writeFeatureStatus(options.featureDir, reportedTotal, options.iterations);
   }

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -21,6 +21,7 @@ import { SessionManager } from "../session";
 import { precomputeBatchPlan } from "./batching";
 import type { DeferredReviewResult } from "./deferred-review";
 import { ensureStoryPackageDirs } from "./ensure-package-dirs";
+import type { ExitReason } from "./executor-types";
 import { getAllReadyStories } from "./helpers";
 import { markNewPackageDirs } from "./new-package-setup";
 
@@ -68,6 +69,8 @@ export interface RunnerExecutionResult {
   durationMs?: number;
   /** End-of-run deferred plugin review result (#1146 G2). Forwarded to the completion phase. */
   deferredReview?: DeferredReviewResult;
+  /** Why the unified executor's loop stopped — forwarded to the completion phase for status reporting. */
+  exitReason: ExitReason;
 }
 
 /**
@@ -222,5 +225,6 @@ export async function runExecutionPhase(
     totalCost,
     allStoryMetrics,
     deferredReview: unifiedResult.deferredReview,
+    exitReason: unifiedResult.exitReason,
   };
 }

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -243,6 +243,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
       agentManager,
       pluginProviderCache,
       deferredReview: executionResult.deferredReview,
+      exitReason: executionResult.exitReason,
       runtime,
       abortSignal: shutdownController.signal,
     });

--- a/src/execution/status-file.ts
+++ b/src/execution/status-file.ts
@@ -68,7 +68,7 @@ export interface NaxStatusFile {
     /** ISO 8601 start timestamp */
     startedAt: string;
     /** Current run status */
-    status: "running" | "completed" | "failed" | "stalled" | "crashed" | "precheck-failed";
+    status: "running" | "completed" | "failed" | "stalled" | "crashed" | "precheck-failed" | "cost-limit";
     /** Whether this is a dry run */
     dryRun: boolean;
     /** Process ID for crash detection */

--- a/test/integration/execution/status-file.test.ts
+++ b/test/integration/execution/status-file.test.ts
@@ -218,7 +218,7 @@ describe("buildStatusSnapshot", () => {
   });
 
   test("all run status values are accepted", () => {
-    const statuses: NaxStatusFile["run"]["status"][] = ["running", "completed", "failed", "stalled"];
+    const statuses: NaxStatusFile["run"]["status"][] = ["running", "completed", "failed", "stalled", "cost-limit"];
     for (const runStatus of statuses) {
       const snapshot = buildStatusSnapshot(makeRunState({ runStatus }));
       expect(snapshot.run.status).toBe(runStatus);

--- a/test/unit/cli/status-features.test.ts
+++ b/test/unit/cli/status-features.test.ts
@@ -351,4 +351,43 @@ describe("displayFeatureDetails - PostRun Status Display (US-004)", () => {
     const output = consoleOutput.join("\n");
     expect(output).toContain("Cost limit");
   });
+
+  test("displays 'Cost Limit Reached' project-level banner when project status is cost-limit", async () => {
+    const naxDir = join(testDir, ".nax");
+    const featuresDir = join(naxDir, "features");
+    const featureDir = join(featuresDir, "test-feature");
+    mkdirSync(featureDir, { recursive: true });
+    writeFileSync(join(naxDir, "config.json"), "{}");
+
+    const prd = createTestPRD("test-feature");
+    writeFileSync(join(featureDir, "prd.json"), JSON.stringify(prd, null, 2));
+    createStatusFile(featureDir);
+
+    // Project-level status.json (read from the output root, not the feature dir)
+    const projectStatus: NaxStatusFile = {
+      version: 1,
+      run: {
+        id: "run-2026-01-01T00-00-00-000Z",
+        feature: "test-feature",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        status: "cost-limit",
+        dryRun: false,
+        pid: 12345,
+      },
+      progress: { total: 1, passed: 0, failed: 0, paused: 0, blocked: 0, pending: 1 },
+      cost: { spent: 5.5, limit: 5.0 },
+      current: null,
+      iterations: 3,
+      updatedAt: "2026-01-01T01:00:00.000Z",
+      durationMs: 3600000,
+    };
+    writeFileSync(join(naxDir, "status.json"), JSON.stringify(projectStatus, null, 2));
+
+    // Act: no `feature` option → renders the all-features view, including the project banner
+    await displayFeatureStatus({ dir: testDir });
+
+    const output = consoleOutput.join("\n");
+    expect(output).toContain("Cost Limit Reached");
+    expect(output).toContain("$5.5000");
+  });
 });

--- a/test/unit/cli/status-features.test.ts
+++ b/test/unit/cli/status-features.test.ts
@@ -319,4 +319,36 @@ describe("displayFeatureDetails - PostRun Status Display (US-004)", () => {
     const output = consoleOutput.join("\n");
     expect(output).toContain("Acceptance: failed");
   });
+
+  // ============================================================================
+  // Cost-limit run status surfaces distinctly in the all-features table
+  // ============================================================================
+
+  test("all-features table shows 'Cost limit' status for a feature whose run stopped on cost-limit", async () => {
+    const naxDir = join(testDir, ".nax");
+    const featuresDir = join(naxDir, "features");
+    const featureDir = join(featuresDir, "test-feature");
+    mkdirSync(featureDir, { recursive: true });
+    writeFileSync(join(naxDir, "config.json"), "{}");
+
+    const prd = createTestPRD("test-feature");
+    writeFileSync(join(featureDir, "prd.json"), JSON.stringify(prd, null, 2));
+
+    createStatusFile(featureDir, {
+      run: {
+        id: "run-2026-01-01T00-00-00-000Z",
+        feature: "test-feature",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        status: "cost-limit",
+        dryRun: false,
+        pid: 12345,
+      },
+    });
+
+    // Act: no `feature` option → renders the all-features table
+    await displayFeatureStatus({ dir: testDir });
+
+    const output = consoleOutput.join("\n");
+    expect(output).toContain("Cost limit");
+  });
 });

--- a/test/unit/execution/lifecycle-completion.test.ts
+++ b/test/unit/execution/lifecycle-completion.test.ts
@@ -526,4 +526,21 @@ describe("handleRunCompletion - cost-limit exitReason surfaces distinctly", () =
 
     expect(statusWriter.setRunStatus).not.toHaveBeenCalledWith("cost-limit");
   });
+
+  test("a genuine regression-gate failure is not masked by a cost-limit exitReason", async () => {
+    const config = makeConfig("deferred", "bun test");
+    const statusWriter = makeStatusWriter();
+    const prd = makePRD([{ id: "US-001", status: "passed" }]);
+
+    _runCompletionDeps.runDeferredRegression = mock(
+      async (): Promise<DeferredRegressionResult> => MOCK_REGRESSION_FAILURE,
+    ) as typeof _runCompletionDeps.runDeferredRegression;
+
+    await handleRunCompletion({
+      ...makeOpts(config, prd, undefined, { exitReason: "cost-limit" }),
+      statusWriter: statusWriter as unknown as RunCompletionOptions["statusWriter"],
+    });
+
+    expect(statusWriter.setRunStatus).toHaveBeenLastCalledWith("failed");
+  });
 });

--- a/test/unit/execution/lifecycle-completion.test.ts
+++ b/test/unit/execution/lifecycle-completion.test.ts
@@ -499,3 +499,31 @@ describe("handleRunCompletion - run status on regression failure (RL-004)", () =
     expect(passWriter.setRunStatus).not.toHaveBeenCalledWith("failed");
   });
 });
+
+describe("handleRunCompletion - cost-limit exitReason surfaces distinctly", () => {
+  test("sets run status to 'cost-limit' when exitReason is 'cost-limit', regardless of PRD completeness", async () => {
+    const config = makeConfig("deferred", "bun test");
+    const statusWriter = makeStatusWriter();
+    const prd = makePRD([{ id: "US-001", status: "passed" }, { id: "US-002", status: "pending" }]);
+
+    await handleRunCompletion({
+      ...makeOpts(config, prd, undefined, { exitReason: "cost-limit" }),
+      statusWriter: statusWriter as unknown as RunCompletionOptions["statusWriter"],
+    });
+
+    expect(statusWriter.setRunStatus).toHaveBeenCalledWith("cost-limit");
+  });
+
+  test("does not set 'cost-limit' when exitReason is absent, even with an incomplete PRD", async () => {
+    const config = makeConfig("deferred", "bun test");
+    const statusWriter = makeStatusWriter();
+    const prd = makePRD([{ id: "US-001", status: "passed" }, { id: "US-002", status: "pending" }]);
+
+    await handleRunCompletion({
+      ...makeOpts(config, prd),
+      statusWriter: statusWriter as unknown as RunCompletionOptions["statusWriter"],
+    });
+
+    expect(statusWriter.setRunStatus).not.toHaveBeenCalledWith("cost-limit");
+  });
+});

--- a/test/unit/execution/runner-completion-skip.test.ts
+++ b/test/unit/execution/runner-completion-skip.test.ts
@@ -331,3 +331,40 @@ describe("runCompletionPhase - skip only applies when acceptance/regression conf
     expect(_runnerCompletionDeps.runAcceptanceLoop).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cost-limit exit reason surfaces as a distinct feature-level run status
+// ---------------------------------------------------------------------------
+
+describe("runCompletionPhase - cost-limit exitReason surfaces distinctly", () => {
+  test("sets feature-level run status to cost-limit when exitReason is cost-limit, even with incomplete stories", async () => {
+    const statusWriter = makeStatusWriter(makePostRunStatus("passed", "passed"));
+    const prd = makePRD([
+      { id: "US-001", status: "passed" },
+      { id: "US-002", status: "pending" },
+    ]);
+    const config = makeConfig(true);
+
+    await runCompletionPhase({
+      ...makeOpts(config, prd, statusWriter),
+      featureDir: `${WORKDIR}/features/test-feature`,
+      exitReason: "cost-limit",
+    });
+
+    expect(statusWriter.setRunStatus).toHaveBeenCalledWith("cost-limit");
+  });
+
+  test("falls back to completed/failed classification when exitReason is not cost-limit", async () => {
+    const statusWriter = makeStatusWriter(makePostRunStatus("passed", "passed"));
+    const prd = makePRD([{ id: "US-001", status: "passed" }]);
+    const config = makeConfig(true);
+
+    await runCompletionPhase({
+      ...makeOpts(config, prd, statusWriter),
+      featureDir: `${WORKDIR}/features/test-feature`,
+      exitReason: "completed",
+    });
+
+    expect(statusWriter.setRunStatus).toHaveBeenCalledWith("completed");
+  });
+});

--- a/test/unit/execution/runner-completion-skip.test.ts
+++ b/test/unit/execution/runner-completion-skip.test.ts
@@ -367,4 +367,33 @@ describe("runCompletionPhase - cost-limit exitReason surfaces distinctly", () =>
 
     expect(statusWriter.setRunStatus).toHaveBeenCalledWith("completed");
   });
+
+  test("a gating plugin-reviewer failure is not masked by a cost-limit exitReason", async () => {
+    const statusWriter = makeStatusWriter(makePostRunStatus("passed", "passed"));
+    const prd = makePRD([{ id: "US-001", status: "passed" }]);
+    const config = makeNaxConfig({
+      acceptance: { enabled: true, maxRetries: 3 },
+      execution: {
+        regressionGate: { enabled: true, mode: "deferred", timeoutSeconds: 30, acceptOnTimeout: true },
+      },
+      quality: { commands: { test: "bun test" } },
+      review: { pluginMode: "gating" },
+    });
+
+    await runCompletionPhase({
+      ...makeOpts(config, prd, statusWriter),
+      featureDir: `${WORKDIR}/features/test-feature`,
+      exitReason: "cost-limit",
+      deferredReview: {
+        runStartRef: "abc123",
+        changedFiles: [],
+        reviewerResults: [{ name: "my-reviewer", passed: false, output: "findings" }],
+        anyFailed: true,
+      },
+    });
+
+    // The feature-level status write (SFC-002) is the last call and is authoritative for
+    // `nax status` — it must reflect the gating failure, not the cost-limit exitReason.
+    expect(statusWriter.setRunStatus).toHaveBeenLastCalledWith("failed");
+  });
 });


### PR DESCRIPTION
## Summary

`execution.costLimit` already existed and was enforced end-to-end in the unified executor (abort-on-overspend with an interactive/warning trigger), but had two real gaps:

1. It could only be set via `.nax/config.json` — no way to override it for a single run.
2. A cost-limit-triggered stop was recorded identically to a normal `"completed"` run in `status.json`, so nothing downstream (`nax status`, `nax runs`, CI, scripts) could tell a budget abort apart from a normal finish.

This closes both gaps, narrowed down from `docs/IMPROVEMENT-REPORT.md` §1.1 after discovering the cost-cap mechanism already existed (the original "no cost cap at all" framing was stale).

- `nax run --max-cost <usd>` overrides `config.execution.costLimit` for a single run, with validation (`Number.isFinite` + positive, rejecting `"5abc"`/`Infinity`-style inputs)
- `exitReason: "cost-limit"` (already returned by the unified executor) now threads through `runner-execution.ts` → `runner.ts` → `runner-completion.ts` / `lifecycle/run-completion.ts`, setting the persisted run status to a new `"cost-limit"` value instead of `"completed"`/`"failed"`
- `nax status` (single-feature banner + all-features table) and `nax runs --status` now recognize and display `"cost-limit"` distinctly

### Review fixes (second commit)
An internal review caught two precedence issues before this went further, both fixed:
- A genuine gating plugin-review failure or regression-gate failure now always wins over a `cost-limit` classification — a hard failure shouldn't be silently hidden behind "we ran out of budget"
- `nax runs`'s `--status` type/`colorStatus()` were stale (missing `stalled`/`precheck-failed`/`cost-limit`), now aligned to the `NaxStatusFile` SSOT

## Test plan
- [x] `bun x tsc --noEmit` (+ contracts) — clean
- [x] `bun run lint` — clean (including file-size ratchet)
- [x] Full suite (`bun run test:bail`): unit 9196 pass, integration 1058 pass, UI 15 pass — 0 failures
- [x] New/updated tests: CLI `--max-cost` config override plumbing, both status-classification precedence fixes (plugin-gate and regression-gate vs. cost-limit), `nax status` project-level "Cost Limit Reached" banner and all-features table display