### PR TITLE
fix(execution): restore nbf pass that regressed the full-suite gate (ADR-024 §3, #1293)

### DIFF
--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -89,6 +89,22 @@ export interface NonBlockingFixArgs {
   phaseCosts: Record<string, number>;
   /** Runs the harness; returns true when it exhausted without resolving. */
   runRectify: (maxAttempts: number) => Promise<{ rectificationExhausted?: boolean }>;
+  /**
+   * Reports whether the KEPT working tree regressed the deterministic full-suite
+   * gate relative to the adversarial-passed baseline. ADR-024 §3: a deterministic
+   * red must revert, never ship.
+   *
+   * `rectificationExhausted` alone is insufficient: the inner rectify cycle can
+   * return not-exhausted via the verifier-SSOT exemption (verifier passed ⇒ gate
+   * red treated as pre-existing) even while its own revalidation left the full-suite
+   * gate red. Keeping that fix then trips the downstream staleness guard in
+   * `ExecutionPlan.run`, which fails the story — breaking the §1/§5 "can never fail
+   * the story" floor. The caller wires this to the SAME staleness predicate the final
+   * verdict uses, so the keep-decision and the verdict can never disagree.
+   *
+   * Absent ⇒ no gate check (backward-compatible).
+   */
+  keptTreeRegressed?: () => boolean;
 }
 
 export interface NonBlockingFixResult {
@@ -187,6 +203,17 @@ export async function runNonBlockingFix(
   }
 
   if (!exhausted) {
+    // ADR-024 §3: a deterministic red in the pass's own revalidation must revert,
+    // not ship. `rectificationExhausted` is insufficient — the inner cycle can report
+    // resolved via the verifier-SSOT exemption while leaving the full-suite gate red.
+    // Reuse the caller's staleness predicate (identical to the final verdict's) so a
+    // "kept then failed by the downstream guard" contradiction is impossible.
+    if (args.keptTreeRegressed?.()) {
+      logger?.info("non-blocking-fix", "kept tree regressed the full-suite gate — restoring (ADR-024 §3)", {
+        storyId: args.storyId,
+      });
+      return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
+    }
     // Enforce sourceDiffCap over the post-pass snapshot. A pass whose source
     // edits exceed the cap is treated as exhausted → restored (fail-safe).
     const cap = args.cfg.sourceDiffCap;

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -254,6 +254,14 @@ export class ExecutionPlan {
               maxAttempts,
               postValidate: this.state.nonBlockingFixPostValidate,
             }),
+          // ADR-024 §3 — restore any kept pass that regressed the full-suite gate.
+          // Same predicate + baseline the final verdict's staleness guard uses below
+          // (`gateRegressedDuringRect`), so nbf's keep-decision can never disagree with
+          // the verdict: a fix the guard would fail on is restored to adversarial-passed
+          // here instead, leaving the story green with zero net change.
+          keptTreeRegressed: () =>
+            gateName !== undefined &&
+            gateRegressedAfterRectification(phaseOutputs[gateName], preRectGateFailureKeys, gateName, this.ctx.storyId),
         },
         {
           measureSourceDiff: createMeasureSourceDiff({

--- a/test/e2e/non-blocking-fix.e2e.test.ts
+++ b/test/e2e/non-blocking-fix.e2e.test.ts
@@ -28,6 +28,19 @@ const ADVISORY_ADVERSARIAL = () => ({
 
 const impl = () => ({ output: JSON.stringify({ filesChanged: ["src/a.ts"] }) });
 
+// Three-session verifier verdict — approves, all tests passing. Drives the
+// verifier-SSOT exemption in the nbf revalidation (scope "both").
+const PASSING_VERDICT = JSON.stringify({
+  version: 1,
+  approved: true,
+  tests: { allPassing: true, passCount: 3, failCount: 0 },
+  testModifications: { detected: false, files: [], legitimate: true, reasoning: "no modifications" },
+  acceptanceCriteria: { allMet: true, criteria: [] },
+  quality: { rating: "good", issues: [] },
+  fixes: [],
+  reasoning: "All tests pass",
+});
+
 // Enable nbf in "source" scope (autofix-implementer only — no test edits, no verifier needed).
 // Every field is set explicitly: makeNaxConfig deep-merges raw objects against DEFAULT_CONFIG,
 // and nonBlockingFix is schema-`.optional()` (undefined by default), so zod defaults are NOT
@@ -39,6 +52,23 @@ const NBF_CONFIG = {
       nonBlockingFix: {
         enabled: true,
         scope: "source",
+        regressionAttempts: 1,
+        verifierGuard: true,
+        sourceDiffCap: { maxFiles: 10, maxLines: 500 },
+      },
+    },
+  },
+} as unknown as Partial<NaxConfig>;
+
+// Scope "both" — nbf runs autofix-implementer + autofix-test-writer, and verifierGuard
+// adds the verifier to the deterministic revalidation. This is the config under which the
+// verifier-SSOT exemption can mask a red full-suite gate (the rs-stock US-001 shape).
+const NBF_BOTH_CONFIG = {
+  review: {
+    adversarial: {
+      nonBlockingFix: {
+        enabled: true,
+        scope: "both",
         regressionAttempts: 1,
         verifierGuard: true,
         sourceDiffCap: { maxFiles: 10, maxLines: 500 },
@@ -92,5 +122,50 @@ describe("E2E: non-blocking fix (ADR-024)", () => {
     expect(nonBlockingFix?.ran).toBe(true);
     expect(nonBlockingFix?.restored).toBe(true);
     expect(nonBlockingFix?.kept).toBe(false);
+  });
+
+  test("best-effort fix regresses the full-suite gate -> restored, story stays green (issue #1293)", async () => {
+    // The rs-stock/tool-enabled-llmnode US-001 shape, end-to-end. Scope "both" puts the
+    // verifier in the nbf revalidation. The story is green through the main pipeline
+    // (full-suite gate passes at attempt 0), adversarial passes with an advisory finding,
+    // nbf runs — and its best-effort fix REGRESSES the full-suite gate (attempt >= 1).
+    // The verifier still passes, so the inner rectify cycle exempts the red gate and
+    // reports not-exhausted. Without the fix, nbf would KEEP that fix and the downstream
+    // verifier-SSOT staleness guard would fail the story (kept:true, success:false).
+    // With the fix, `keptTreeRegressed` catches the deterministic red (ADR-024 §3) and
+    // restores to the adversarial-passed snapshot — the story stays green, zero net change.
+    const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+    const verifier = () => ({ output: PASSING_VERDICT });
+    const { result, nonBlockingFix } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      config: NBF_BOTH_CONFIG,
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_SEMANTIC,
+        "reviewer-adversarial": ADVISORY_ADVERSARIAL,
+      },
+      gates: {
+        // attempt 0 (main pipeline): green. attempt >= 1 (nbf revalidation): the fix
+        // broke a test — structured failure so gateFailureKeys yields a NEW key absent
+        // from the (empty) verifier-time baseline → gateRegressedAfterRectification true.
+        fullSuite: (attempt) =>
+          attempt === 0
+            ? { passed: true, failed: 0 }
+            : {
+                passed: false,
+                failed: 1,
+                failures: [{ testName: "regressed by nbf best-effort fix", file: "test/a.test.ts", error: "AssertionError" }],
+              },
+      },
+    });
+
+    expect(nonBlockingFix).toBeDefined();
+    expect(nonBlockingFix?.ran).toBe(true);
+    expect(nonBlockingFix?.restored).toBe(true); // regression → revert (ADR-024 §3)
+    expect(nonBlockingFix?.kept).toBe(false); // NOT kept — this is the bug the fix closes
+    expect(result.success).toBe(true); // story stays green; the guard never trips
+    expect(result.gateRegressedDuringRect ?? false).toBe(false); // restored ⇒ final gate green
   });
 });

--- a/test/unit/execution/non-blocking-fix.test.ts
+++ b/test/unit/execution/non-blocking-fix.test.ts
@@ -65,6 +65,60 @@ describe("runNonBlockingFix keep vs restore", () => {
     expect(phaseOutputs["full-suite-gate"]).toEqual({ success: true });
   });
 
+  test("restored when kept tree regressed the full-suite gate (ADR-024 §3 deterministic red → revert)", async () => {
+    // The inner rectify cycle can return not-exhausted via the verifier-SSOT exemption
+    // even though its revalidation left the full-suite-gate RED. Keeping such a fix
+    // violates ADR-024 §3 (deterministic red → revert) and the downstream staleness
+    // guard (ExecutionPlan.run) would then fail the story — breaking the §1/§5
+    // "can never fail the story" floor. `keptTreeRegressed` reuses the exact staleness
+    // predicate the final verdict applies, so keep and verdict cannot disagree.
+    const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
+    let rolled = "";
+    const res = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        phaseOutputs,
+        runRectify: async () => {
+          phaseOutputs["full-suite-gate"] = { success: false }; // fix broke a test
+          return { rectificationExhausted: false }; // but cycle exempted the gate (verifier passed)
+        },
+        keptTreeRegressed: () => (phaseOutputs["full-suite-gate"] as { success?: boolean }).success === false,
+      },
+      {
+        captureSnapshotRef: async () => "snap-sha",
+        rollbackToRef: async (_w: string, ref: string) => {
+          rolled = ref;
+        },
+      },
+    );
+    expect(res).toEqual({ ran: true, kept: false, restored: true });
+    expect(rolled).toBe("snap-sha");
+    expect(phaseOutputs["full-suite-gate"]).toEqual({ success: true }); // restored to adversarial-passed
+  });
+
+  test("kept when keptTreeRegressed predicate reports no regression", async () => {
+    // Guard the non-restorative branch: a supplied predicate that returns false must
+    // not force a restore — the resolved, gate-green fix is kept.
+    const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
+    let rolled = "";
+    const res = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        phaseOutputs,
+        runRectify: async () => ({ rectificationExhausted: false }),
+        keptTreeRegressed: () => false,
+      },
+      {
+        captureSnapshotRef: async () => "snap-sha",
+        rollbackToRef: async (_w: string, ref: string) => {
+          rolled = ref;
+        },
+      },
+    );
+    expect(res).toEqual({ ran: true, kept: true, restored: false });
+    expect(rolled).toBe("");
+  });
+
   test("restored when harness exhausts — phaseOutputs rolled back", async () => {
     const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
     let rolled = "";


### PR DESCRIPTION
Closes #1293.

## Problem

The ADR-024 non-blocking best-effort fix (`nonBlockingFix`) could **keep** a fix that left the full-suite gate **red**, after which the downstream verifier-SSOT staleness guard in `ExecutionPlan.run` **failed the story** on that same regression — violating ADR-024 §1/§5 ("can never fail the story"; floor = adversarial-passed).

Two subsystems made contradictory decisions about the same gate failure:

| Subsystem | Rule applied to the red gate | Decision |
|:--|:--|:--|
| nbf keep/restore (`non-blocking-fix.ts`) | trusts `rectificationExhausted`, which the inner cycle computed via the verifier-SSOT **exemption** (verifier passed ⇒ red gate treated as pre-existing) | **KEEP** |
| final staleness guard (`execution-plan.ts`) | gate regressed vs verifier-time baseline → verdict stale | **FAIL story** |

## Observed run

`rs-stock` / `tool-enabled-llmnode` / US-001 (`run-2026-07-03T08-46-17-241Z`):

```
08:58:17  adversarial review PASSED (2 advisory warnings)
09:03:55  nbf validate scope: [full-suite-gate, lint-check, typecheck-check, verifier]
09:04:00  full-suite-gate FAILED (1 finding)   ← best-effort fix broke a test
09:08:06  verifier passed
09:08:06  non-blocking-fix :: best-effort fix KEPT
09:08:06  Gate regressed during rectification ... failing story
```

Net: US-001 failed and US-003/US-004 never ran — yet the deferred regression gate later fixed the same test and the suite ended **green**. A green suite with a failed feature is the tell-tale.

## Fix

Add `keptTreeRegressed?: () => boolean` to `NonBlockingFixArgs` and wire it at the call site to the **same** `gateRegressedAfterRectification(phaseOutputs[gateName], preRectGateFailureKeys, …)` predicate the final verdict uses. Per ADR-024 §3 a deterministic red must revert — so a kept pass that regressed the gate is now restored to the adversarial-passed snapshot instead. The story stays green with zero net change, and the keep-decision can never disagree with the verdict.

## Tests

- **Unit** (`test/unit/execution/non-blocking-fix.test.ts`): restore-on-gate-regression; keep-when-predicate-false. TDD red→green.
- **E2E** (`test/e2e/non-blocking-fix.e2e.test.ts`): drives the real Story Orchestrator in the rs-stock/US-001 shape (three-session-tdd + nbf scope "both", gate green in main pipeline / red in nbf revalidation, verifier passing). Asserts `restored:true`, `kept:false`, `success:true`. **Verified to fail when the predicate is disabled**, so it locks the fix in.

## Verification

- `bun run typecheck` — 0 errors
- `bun run test:e2e` — 24/24 pass
- `bun test test/unit/execution/` — 1081 pass
- `bun run lint` — clean

Distinct from #1282 (plain green→red semantic flip) — this is specifically the nbf-keep vs staleness-guard conflict.