### PR TITLE
fix(metrics): record real metrics for failed-in-execution stories (#1296)

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -34,6 +34,8 @@ export {
   handleRunCompletion,
   _runCompletionDeps,
   outputAdvisoryFindingsSummary,
+  synthesizeBackfillMetric,
+  type BackfillMetricArgs,
   type DeferredRegressionOptions,
   type DeferredRegressionResult,
   type StorySnapshot,

--- a/src/execution/lifecycle/backfill-story-metrics.ts
+++ b/src/execution/lifecycle/backfill-story-metrics.ts
@@ -1,0 +1,102 @@
+/**
+ * Back-fill synthesis for stories that have aggregator cost but no execution-phase
+ * StoryMetrics entry.
+ *
+ * A story only gets a real metric from the completion pipeline stage
+ * (`collectStoryMetrics` / `collectBatchMetrics`), which runs on the SUCCESS path.
+ * A story that FAILS in the execution stage makes the pipeline stop at its
+ * `finalAction` (fail/escalate/pause) before the completion stage — so it has cost
+ * in the aggregator but no metric. Without distinguishing it, such a story fell into
+ * the "completion-phase-only spend" back-fill and was stamped `attempts: 0`,
+ * `modelUsed: <agentName>`, `durationMs: 0`, `source: "completion-phase"` — corrupt
+ * analytics for a story that genuinely ran (issue #1296).
+ *
+ * This module is the single source of truth for that synthesis. It emits:
+ *  - `execution-failed` — the story ran and failed in the execution stage; synthesize
+ *    from the story's own routing / attempts / escalations so the values are real.
+ *  - `completion-phase` — cost incurred only after execution (acceptance / hardening /
+ *    diagnosis); the placeholder shape, unchanged.
+ */
+import { resolveModelForAgent } from "@/config";
+import type { NaxConfig } from "@/config";
+import type { StoryMetrics } from "@/metrics";
+import type { UserStory } from "@/prd/types";
+
+export interface BackfillMetricArgs {
+  storyId: string;
+  /** The story from the PRD, if found. */
+  story: UserStory | undefined;
+  /** Aggregator cost for this story (already known to be > 0 by the caller). */
+  totalCostUsd: number;
+  config: NaxConfig;
+  /** Resolved default agent, used only for the completion-phase placeholder. */
+  defaultAgent: string;
+  /** Timestamp for startedAt/completedAt (execution timing is not persisted on the story). */
+  timestamp: string;
+}
+
+/** True when the story ran and terminated as a failure in the execution stage. */
+function isExecutionFailure(story: UserStory | undefined): boolean {
+  return (
+    story != null && (story.status === "failed" || story.status === "regression-failed") && (story.attempts ?? 0) > 0
+  );
+}
+
+/**
+ * Synthesize a StoryMetrics entry for a story with cost but no execution-phase metric.
+ * Pure over its inputs — exported for unit testing.
+ */
+export function synthesizeBackfillMetric(args: BackfillMetricArgs): StoryMetrics {
+  const { storyId, story, totalCostUsd, config, defaultAgent, timestamp } = args;
+
+  if (story != null && isExecutionFailure(story)) {
+    const tier = story.routing?.modelTier ?? "balanced";
+    const agent = story.routing?.agent ?? defaultAgent;
+    let modelUsed = agent;
+    try {
+      modelUsed = resolveModelForAgent(config.models, agent, tier, defaultAgent).model;
+    } catch {
+      /* tier not configured for this agent — fall back to the agent name */
+    }
+    const escalations = story.escalations ?? [];
+    const finalTier = escalations.length > 0 ? escalations[escalations.length - 1].toTier : tier;
+    // Mirror buildStoryMetrics: cross-tier failures live in priorFailures, current-tier in attempts.
+    const attempts = (story.priorFailures?.length ?? 0) + Math.max(1, story.attempts ?? 1);
+    return {
+      storyId,
+      complexity: story.routing?.complexity ?? "medium",
+      initialComplexity: story.routing?.initialComplexity ?? story.routing?.complexity,
+      modelTier: tier,
+      modelUsed,
+      agentUsed: agent,
+      attempts,
+      finalTier,
+      success: false,
+      cost: totalCostUsd,
+      durationMs: 0, // per-story execution duration is not persisted on the story
+      firstPassSuccess: false,
+      startedAt: timestamp,
+      completedAt: timestamp,
+      source: "execution-failed",
+      runtimeCrashes: 0,
+    };
+  }
+
+  // Completion-phase-only spend (acceptance refinement / hardening / diagnosis).
+  return {
+    storyId,
+    complexity: story?.routing?.complexity ?? "medium",
+    modelTier: "balanced",
+    modelUsed: defaultAgent,
+    attempts: 0,
+    finalTier: "balanced",
+    success: story?.passes ?? true,
+    cost: totalCostUsd,
+    durationMs: 0,
+    firstPassSuccess: story?.passes ?? true,
+    startedAt: timestamp,
+    completedAt: timestamp,
+    source: "completion-phase",
+    runtimeCrashes: 0,
+  };
+}

--- a/src/execution/lifecycle/index.ts
+++ b/src/execution/lifecycle/index.ts
@@ -16,6 +16,7 @@ export {
   type RunCompletionOptions,
   type RunCompletionResult,
 } from "./run-completion";
+export { synthesizeBackfillMetric, type BackfillMetricArgs } from "./backfill-story-metrics";
 export { cleanupRun, type RunCleanupOptions } from "./run-cleanup";
 export { setupRun, type RunSetupOptions, type RunSetupResult } from "./run-setup";
 export {

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -29,6 +29,7 @@ import type { DeferredReviewResult } from "../deferred-review";
 import type { ExitReason } from "../executor-types";
 import { closeAllRunSessions } from "../session-manager-runtime";
 import type { StatusWriter } from "../status-writer";
+import { synthesizeBackfillMetric } from "./backfill-story-metrics";
 import { runDeferredRegression } from "./run-regression";
 
 /**
@@ -307,22 +308,21 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
       const existingIdx = existingIndex.get(storyId);
       if (existingIdx === undefined) {
         const story = prd.userStories.find((s) => s.id === storyId);
-        allStoryMetrics.push({
-          storyId,
-          complexity: story?.routing?.complexity ?? "medium",
-          modelTier: "balanced",
-          modelUsed: defaultAgent,
-          attempts: 0,
-          finalTier: "balanced",
-          success: story?.passes ?? true,
-          cost: snap.totalCostUsd,
-          durationMs: 0,
-          firstPassSuccess: story?.passes ?? true,
-          startedAt: completionCompletedAt,
-          completedAt: completionCompletedAt,
-          source: "completion-phase" as const,
-          runtimeCrashes: 0,
-        });
+        // A story with cost but no execution-phase metric either failed in the
+        // execution stage (pipeline stopped before the completion stage) or spent
+        // only in completion phases. synthesizeBackfillMetric distinguishes the two so
+        // a failed story gets its real attempts/model/tier instead of the corrupt
+        // attempts:0 / modelUsed=<agentName> placeholder (issue #1296).
+        allStoryMetrics.push(
+          synthesizeBackfillMetric({
+            storyId,
+            story,
+            totalCostUsd: snap.totalCostUsd,
+            config,
+            defaultAgent,
+            timestamp: completionCompletedAt,
+          }),
+        );
       } else {
         // Story already has an execution-phase entry — replace cost with the aggregator
         // value if it's higher (aggregator is authoritative across all phases).

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -124,8 +124,8 @@ export interface StoryMetrics {
   startedAt: string;
   /** Timestamp when completed */
   completedAt: string;
-  /** Execution source — 'parallel' for batch dispatch, 'sequential' for single-story loop, 'rectification' for conflict resolution, 'completion-phase' for stories with only acceptance/hardening spend */
-  source?: "parallel" | "sequential" | "rectification" | "completion-phase";
+  /** Execution source — 'parallel' for batch dispatch, 'sequential' for single-story loop, 'rectification' for conflict resolution, 'completion-phase' for stories with only acceptance/hardening spend, 'execution-failed' for stories that failed in the execution stage (pipeline stopped before the completion stage that records metrics) */
+  source?: "parallel" | "sequential" | "rectification" | "completion-phase" | "execution-failed";
   /** Number of runtime crashes (RUNTIME_CRASH verify status) encountered for this story (BUG-070) */
   runtimeCrashes?: number;
   /** Whether TDD full-suite gate passed (only true for TDD strategies when gate passes) */

--- a/test/unit/execution/lifecycle/backfill-story-metrics.test.ts
+++ b/test/unit/execution/lifecycle/backfill-story-metrics.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { synthesizeBackfillMetric } from "@/execution";
+import type { StoryRouting } from "@/prd/types";
+import { makeNaxConfig, makeStory } from "../../../helpers";
+
+const TS = "2026-07-03T00:00:00.000Z";
+// Default config.models = { claude: { fast: "haiku", balanced: "sonnet", powerful: "opus" } }
+const config = makeNaxConfig();
+
+const routing = (over: Partial<StoryRouting>): StoryRouting => ({
+  modelTier: "balanced",
+  agent: "claude",
+  complexity: "complex",
+  testStrategy: "three-session-tdd-lite",
+  ...over,
+});
+
+describe("synthesizeBackfillMetric (#1296)", () => {
+  test("failed-in-execution story → real attempts/model/tier, source execution-failed", () => {
+    // Mirrors rs-stock US-001: failed in execution, agent claude @ balanced, 2 attempts.
+    const story = makeStory({ id: "US-001", status: "failed", attempts: 2, routing: routing({}) });
+    const m = synthesizeBackfillMetric({
+      storyId: "US-001",
+      story,
+      totalCostUsd: 2.15,
+      config,
+      defaultAgent: "opencode",
+      timestamp: TS,
+    });
+    expect(m.source).toBe("execution-failed");
+    expect(m.attempts).toBe(2); // NOT the corrupt 0
+    expect(m.modelUsed).toBe("sonnet"); // resolved model id, NOT the "opencode" agent name
+    expect(m.agentUsed).toBe("claude");
+    expect(m.modelTier).toBe("balanced");
+    expect(m.finalTier).toBe("balanced");
+    expect(m.success).toBe(false);
+    expect(m.cost).toBe(2.15);
+    expect(m.complexity).toBe("complex");
+  });
+
+  test("regression-failed story is also treated as an execution failure", () => {
+    const story = makeStory({
+      id: "US-2",
+      status: "regression-failed",
+      attempts: 1,
+      routing: routing({ complexity: "medium" }),
+    });
+    const m = synthesizeBackfillMetric({
+      storyId: "US-2",
+      story,
+      totalCostUsd: 1,
+      config,
+      defaultAgent: "opencode",
+      timestamp: TS,
+    });
+    expect(m.source).toBe("execution-failed");
+    expect(m.attempts).toBe(1);
+    expect(m.success).toBe(false);
+  });
+
+  test("escalated failed story → finalTier from last escalation", () => {
+    const story = makeStory({
+      id: "US-3",
+      status: "failed",
+      attempts: 1,
+      routing: routing({ modelTier: "fast" }),
+      escalations: [
+        { fromTier: "fast", toTier: "balanced", reason: "r", timestamp: TS },
+        { fromTier: "balanced", toTier: "powerful", reason: "r", timestamp: TS },
+      ],
+    });
+    const m = synthesizeBackfillMetric({
+      storyId: "US-3",
+      story,
+      totalCostUsd: 1,
+      config,
+      defaultAgent: "opencode",
+      timestamp: TS,
+    });
+    expect(m.finalTier).toBe("powerful");
+    expect(m.modelTier).toBe("fast");
+  });
+
+  test("attempts counts prior cross-tier failures + current-tier attempts", () => {
+    const story = makeStory({
+      id: "US-4",
+      status: "failed",
+      attempts: 1,
+      priorFailures: [
+        { attempt: 1, modelTier: "fast", stage: "verify", summary: "a", timestamp: TS },
+        { attempt: 2, modelTier: "balanced", stage: "verify", summary: "b", timestamp: TS },
+      ],
+      routing: routing({ complexity: "medium" }),
+    });
+    const m = synthesizeBackfillMetric({
+      storyId: "US-4",
+      story,
+      totalCostUsd: 1,
+      config,
+      defaultAgent: "opencode",
+      timestamp: TS,
+    });
+    expect(m.attempts).toBe(3); // 2 priorFailures + max(1, attempts=1)
+  });
+
+  test("model resolution falls back to the agent name when the tier is not configured", () => {
+    // agent "mystery" has no models entry and neither does the default agent "ghost".
+    const story = makeStory({ id: "US-5", status: "failed", attempts: 1, routing: routing({ agent: "mystery" }) });
+    const m = synthesizeBackfillMetric({
+      storyId: "US-5",
+      story,
+      totalCostUsd: 1,
+      config,
+      defaultAgent: "ghost",
+      timestamp: TS,
+    });
+    expect(m.agentUsed).toBe("mystery");
+    expect(m.modelUsed).toBe("mystery"); // graceful fallback, no throw
+  });
+
+  test("completion-phase-only spend (passed story) keeps the placeholder shape", () => {
+    const story = makeStory({
+      id: "US-6",
+      status: "passed",
+      attempts: 1,
+      passes: true,
+      routing: routing({ complexity: "simple" }),
+    });
+    const m = synthesizeBackfillMetric({
+      storyId: "US-6",
+      story,
+      totalCostUsd: 0.5,
+      config,
+      defaultAgent: "opencode",
+      timestamp: TS,
+    });
+    expect(m.source).toBe("completion-phase");
+    expect(m.attempts).toBe(0);
+    expect(m.modelUsed).toBe("opencode"); // defaultAgent placeholder
+    expect(m.success).toBe(true);
+  });
+
+  test("missing story → completion-phase placeholder, no crash", () => {
+    const m = synthesizeBackfillMetric({
+      storyId: "ghost",
+      story: undefined,
+      totalCostUsd: 0.1,
+      config,
+      defaultAgent: "opencode",
+      timestamp: TS,
+    });
+    expect(m.source).toBe("completion-phase");
+    expect(m.attempts).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1296.

## Problem

A story that fails in the **execution stage** makes the pipeline runner stop at its `finalAction` (`fail`/`escalate`/`pause`, `src/pipeline/runner.ts:124/134/144`) **before** the completion stage — the only place `collectStoryMetrics` runs (and marks a story passed). So a failed story has cost in the aggregator but **no execution-phase `StoryMetrics`**.

The completion-phase back-fill in `run-completion.ts` (documented for "stories whose only spend was in the completion phase") then caught these failed stories and stamped them:

```ts
modelUsed: defaultAgent,  // agent NAME, not a model id
attempts: 0,              // impossible from buildStoryMetrics (floors at >=1)
durationMs: 0,
source: "completion-phase",  // mislabels an execution-phase story
```

**Observed** (`rs-stock/tool-enabled-llmnode` US-001, ran on agent `claude`, 2 attempts, ~1.3M ms): reported in `status.json` as `{ modelUsed: "opencode", attempts: 0, durationMs: 0 }`. `attempts:0` is the tell — only this back-fill produces it (`buildStoryMetrics` floors at ≥1; `collectBatchMetrics` sets 1).

## Fix

Extract the per-story synthesis into `synthesizeBackfillMetric` (`src/execution/lifecycle/backfill-story-metrics.ts`), which distinguishes:

- **`execution-failed`** — story `status` is `failed`/`regression-failed` with `attempts > 0`. Synthesizes from the story's own `routing`/`attempts`/`escalations`: real `attempts` (prior cross-tier failures + current-tier), a **resolved model id** via `resolveModelForAgent` (not the agent name), the routed `modelTier`, `finalTier` from the last escalation, `success: false`, and a new `source: "execution-failed"`.
- **`completion-phase`** — cost incurred only after execution (acceptance/hardening/diagnosis). Unchanged placeholder.

`durationMs` stays `0` for the failed case (per-story execution duration is not persisted on the story — a known limitation, noted at the call site).

Also tightens the pre-existing `success: story?.passes ?? true` so a failed story is no longer defaulted to `success: true`.

## Tests

`test/unit/execution/lifecycle/backfill-story-metrics.test.ts` (7 cases): failed-in-execution real values, `regression-failed` handling, escalation `finalTier`, prior-failure attempt counting, model-resolution fallback, completion-phase placeholder preserved, missing-story safety.

## Verification

- `bun run typecheck` — 0 errors
- `bun run lint` — clean
- `bun test test/unit/execution/ test/unit/metrics/` — 1210 pass, 0 fail

## Context

Found during the rs-stock/tool-enabled-llmnode investigation (sibling to #1293/#1294). Independent of #1295 (closed — that was expected ladder behavior, not a bug).