### PR TITLE
fix(schedule): show live countdown in headless mode, not just JSON

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -713,7 +713,12 @@ program
       process.once("SIGINT", onSigint);
       const outcome = await waitForSchedule(scheduleGate.target, {
         label: options.feature,
-        headless: useHeadless || formatterMode === "json",
+        // --json needs countdown-free output for clean machine parsing, and a
+        // genuinely piped/redirected stdout (no TTY) would just accumulate
+        // literal \r characters instead of overwriting a line. Plain
+        // --headless with a real terminal attached still gets the live
+        // countdown, same as interactive mode.
+        quiet: formatterMode === "json" || !isTTY,
         signal: scheduleController.signal,
       });
       process.removeListener("SIGINT", onSigint);

--- a/docs/superpowers/specs/2026-07-01-scheduled-run-design.md
+++ b/docs/superpowers/specs/2026-07-01-scheduled-run-design.md
@@ -56,9 +56,12 @@ during the wait prints `Scheduled run cancelled.` and exits 0 without starting
 a run.
 
 `--schedule` composes with existing flags (`--plan`, `--parallel`, `--headless`,
-`--profile`, …); it only gates *when* `run()` is called. In `--json` / headless
-mode the countdown is suppressed — instead a single structured line is logged at
-start (`scheduled`, target ISO) so machine consumers aren't fed a redraw loop.
+`--profile`, …); it only gates *when* `run()` is called. The countdown is
+suppressed only for `--json` output and when stdout isn't a real TTY (a
+genuinely piped/redirected run) — in either case a single structured line is
+logged at start (`scheduled`, target ISO) instead, so machine consumers and
+log files aren't fed a redraw loop. Plain `--headless` with a real terminal
+attached still gets the live countdown, same as interactive mode.
 
 ## 4. Schedule Grammar
 
@@ -105,7 +108,7 @@ parseSchedule(input: string, now: Date): { target: Date } | { error: string }
 ```
 waitForSchedule(target: Date, opts: {
   label: string;
-  headless: boolean;
+  quiet: boolean;                    // true for --json output or non-TTY stdout
   render?: (line: string) => void;   // _deps: default writes/clears a TTY line
   clock?: () => number;              // _deps: default Date.now
   sleep?: (ms, signal) => Promise;   // _deps: default cancellable Bun.sleep
@@ -116,8 +119,11 @@ waitForSchedule(target: Date, opts: {
   remaining. On `≤0` resolves `"fired"`. On abort resolves `"cancelled"`.
 - **No `setInterval`.** Uses cancellable `Bun.sleep(tickMs, { signal })` per the
   Bun-native rule; the `setTimeout`+`clearTimeout` exception is unnecessary here.
-- Headless/JSON: skip the render loop, emit one structured `scheduled` log line
-  via the project logger, then a single cancellable sleep to target.
+- Quiet (`--json` output or non-TTY stdout): skip the render loop, emit one
+  structured `scheduled` log line via the project logger, then a single
+  cancellable sleep to target. Plain `--headless` with a real terminal
+  attached is *not* quiet — it renders the same live countdown as interactive
+  mode.
 - `render`/`clock`/`sleep` are injected (`_deps` pattern) so the tick loop is
   unit-tested with a fake clock and a captured render buffer — no real waiting.
 
@@ -149,7 +155,7 @@ nax run -f F --schedule 30m
   → parseSchedule("30m", now)                                          (fail fast on bad value / past time)
        → { target }  |  { error }→ print + exit 1
   → [existing setup up to just before run(): config, hooks, statusFile]
-  → waitForSchedule(target, { label:F, headless, signal })            (countdown OR structured log)
+  → waitForSchedule(target, { label:F, quiet, signal })               (countdown OR structured log)
        → "cancelled" → print notice, exit 0
        → "fired"     ↓
   → run({ prdPath, workdir, config, … })                              (UNCHANGED existing path)
@@ -175,8 +181,8 @@ Unit (`test/unit/schedule/`), following `_deps` mocking + `test.each`:
   input; boundary (`0s`, huge durations).
 - **wait.test.ts** — fake `clock` + captured `render`: countdown formats
   `HH:MM:SS` correctly; resolves `"fired"` at zero; resolves `"cancelled"` on
-  abort mid-wait; headless path emits exactly one structured line and no render
-  loop.
+  abort mid-wait; quiet path emits exactly one structured line and no render
+  loop; plain `--headless` (non-quiet) still renders the live countdown.
 - **CLI integration** (light, mock the run path): `--schedule` with a near-future
   value calls `run()` once after the gate; bad value exits 1 before `run()`;
   cancel exits 0 without `run()`. Mock `run` — do not spawn a real nax process

--- a/src/schedule/wait.ts
+++ b/src/schedule/wait.ts
@@ -33,19 +33,19 @@ const DEFAULT_DEPS: WaitDeps = {
 
 export async function waitForSchedule(
   target: Date,
-  opts: { label: string; headless: boolean; signal: AbortSignal; _deps?: Partial<WaitDeps> },
+  opts: { label: string; quiet: boolean; signal: AbortSignal; _deps?: Partial<WaitDeps> },
 ): Promise<WaitOutcome> {
   const deps: WaitDeps = { ...DEFAULT_DEPS, ...opts._deps };
   const targetMs = target.getTime();
 
-  if (opts.headless) {
+  if (opts.quiet) {
     deps.log("Scheduled run waiting", { label: opts.label, targetIso: target.toISOString() });
   }
 
   while (deps.now() < targetMs) {
     if (opts.signal.aborted) return "cancelled";
     const remaining = targetMs - deps.now();
-    if (!opts.headless) {
+    if (!opts.quiet) {
       deps.render(
         `[WAIT] Scheduled run of "${opts.label}" — starting in ${formatRemaining(remaining)}   (Ctrl-C to cancel)`,
       );
@@ -58,6 +58,6 @@ export async function waitForSchedule(
     }
   }
 
-  if (!opts.headless) deps.render("\n"); // clear the countdown line before run output
+  if (!opts.quiet) deps.render("\n"); // clear the countdown line before run output
   return "fired";
 }

--- a/test/unit/schedule/wait.test.ts
+++ b/test/unit/schedule/wait.test.ts
@@ -28,7 +28,7 @@ describe("waitForSchedule", () => {
     const target = new Date(start + 3_000);
     const outcome = await waitForSchedule(target, {
       label: "feat-x",
-      headless: false,
+      quiet: false,
       signal: new AbortController().signal,
       _deps: deps,
     });
@@ -45,19 +45,36 @@ describe("waitForSchedule", () => {
     controller.abort();
     const outcome = await waitForSchedule(new Date(start + 60_000), {
       label: "feat-x",
-      headless: false,
+      quiet: false,
       signal: controller.signal,
       _deps: deps,
     });
     expect(outcome).toBe("cancelled");
   });
 
-  test("headless emits no render lines", async () => {
+  test("headless (non-quiet) still renders a live countdown", async () => {
+    // --headless with plain/normal/verbose output still prints to the
+    // attached terminal — only --json output needs to stay countdown-free.
+    const start = 1_000_000;
+    const { lines, deps } = fakeDeps(start, 1_000);
+    const target = new Date(start + 3_000);
+    const outcome = await waitForSchedule(target, {
+      label: "feat-x",
+      quiet: false,
+      signal: new AbortController().signal,
+      _deps: deps,
+    });
+    expect(outcome).toBe("fired");
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.some((l) => /\[WAIT\].*feat-x.*Ctrl-C to cancel/.test(l))).toBe(true);
+  });
+
+  test("quiet (json) mode emits no render lines", async () => {
     const start = 1_000_000;
     const { lines, deps } = fakeDeps(start, 5_000);
     const outcome = await waitForSchedule(new Date(start + 3_000), {
       label: "feat-x",
-      headless: true,
+      quiet: true,
       signal: new AbortController().signal,
       _deps: deps,
     });
@@ -65,13 +82,13 @@ describe("waitForSchedule", () => {
     expect(lines.length).toBe(0);
   });
 
-  test("headless emits exactly one structured log line with target ISO", async () => {
+  test("quiet (json) mode emits exactly one structured log line with target ISO", async () => {
     const start = 1_000_000;
     const { lines, logs, deps } = fakeDeps(start, 5_000);
     const target = new Date(start + 3_000);
     const outcome = await waitForSchedule(target, {
       label: "feat-x",
-      headless: true,
+      quiet: true,
       signal: new AbortController().signal,
       _deps: deps,
     });


### PR DESCRIPTION
## Summary
- `waitForSchedule` suppressed the live `[WAIT] ... starting in HH:MM:SS` countdown for *any* `--headless` run, even with a real terminal attached — users only ever saw one static "Scheduled run waiting" line. Only `--json` output (and genuinely piped/non-TTY stdout) needs countdown-free output.
- Renamed the `waitForSchedule` option `headless` → `quiet`, keyed suppression on `formatterMode === "json" || !isTTY` instead of the `--headless` flag itself.
- Plain `--headless` on a real terminal now renders the same live countdown as interactive mode; `--json` and piped/redirected output still get a single structured log line.
- Updated `docs/superpowers/specs/2026-07-01-scheduled-run-design.md` to match the corrected behavior.

## Test plan
- [x] Added/updated unit tests in `test/unit/schedule/wait.test.ts` covering: interactive countdown, cancel-on-abort, headless-non-quiet still renders countdown, quiet(json) suppresses render + emits one structured log line
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` (unit + integration + UI) — all green