### PR TITLE
feat(tui): wire up "retry last failed story" (r) key

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -6,7 +6,7 @@
 
 import { Box, Text, useApp, useInput } from "ink";
 import { memo, useEffect, useRef, useState } from "react";
-import { writeQueueCommand } from "../utils/queue-writer";
+import { writeQueueCommand, writeRetryCommand } from "../utils/queue-writer";
 import { CostOverlay } from "./components/CostOverlay";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { LiveActivityPanel } from "./components/LiveActivityPanel";
@@ -189,7 +189,9 @@ export function App({
         break;
 
       case "RETRY":
-        // TODO: Implement retry logic for last failed story
+        // Retry the most recently failed story. No-op when nothing has failed
+        // or no queue file is wired (helper guards both).
+        await writeRetryCommand(queueFilePath, busState.lastFailedStoryId);
         break;
 
       default:

--- a/src/tui/hooks/usePipelineBusEvents.ts
+++ b/src/tui/hooks/usePipelineBusEvents.ts
@@ -63,6 +63,12 @@ export interface PipelineBusState {
     regression?: PostRunPhaseState;
     review?: PostRunPhaseState;
   };
+  /**
+   * Id of the most recently failed story — target for the TUI "retry last failed" (r) key.
+   * Single-slot by design: only the latest terminal failure is retryable, so in parallel
+   * mode an earlier concurrent failure is not reachable via `r`.
+   */
+  lastFailedStoryId?: string;
 }
 
 /**
@@ -97,6 +103,9 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
               }
             : s,
         ),
+        // Once the last-failed story restarts, its failure is stale — clear the
+        // retry target. A fresh failure re-arms it via the story:failed handler.
+        lastFailedStoryId: prev.lastFailedStoryId === event.storyId ? undefined : prev.lastFailedStoryId,
       }));
     });
 
@@ -114,8 +123,12 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
 
         const totalCost = newStories.reduce((sum, s) => sum + (s.cost ?? 0), 0);
         const { [event.storyId]: _removed, ...remainingSteps } = prev.storySteps;
+        // Mirror the status mapping above: a `passed:false` completion is a failure,
+        // so it arms the retry target too. In practice terminal failures arrive via
+        // `story:failed`; this branch keeps the two failure representations consistent.
+        const lastFailedStoryId = event.passed ? prev.lastFailedStoryId : event.storyId;
 
-        return { ...prev, stories: newStories, totalCost, storySteps: remainingSteps };
+        return { ...prev, stories: newStories, totalCost, storySteps: remainingSteps, lastFailedStoryId };
       });
     });
 
@@ -129,6 +142,7 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
             s.story.id === event.storyId ? { ...s, status: "failed" as const, failureReason: event.reason } : s,
           ),
           storySteps: remainingSteps,
+          lastFailedStoryId: event.storyId,
         };
       });
     });
@@ -191,6 +205,9 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
         ...prev,
         runSummary: summary,
         totalCost: event.totalCost ?? prev.totalCost,
+        // Run is over — the runner no longer polls the queue file, so a retry
+        // would be a silent no-op. Disarm the "r" key.
+        lastFailedStoryId: undefined,
       }));
     });
 

--- a/src/utils/queue-writer.ts
+++ b/src/utils/queue-writer.ts
@@ -73,3 +73,24 @@ export async function writeQueueCommand(queueFilePath: string, command: QueueCom
   });
   await next;
 }
+
+/**
+ * Write a RETRY command for a story, or do nothing when there is nothing to retry.
+ *
+ * Convenience wrapper used by the TUI "retry last failed" (r) key: it guards on
+ * both the target story id and the queue file path so callers can pass the
+ * possibly-undefined `lastFailedStoryId` / `queueFilePath` directly without their
+ * own branching.
+ *
+ * @param queueFilePath - Path to the queue file, or undefined if none is wired
+ * @param storyId - Id of the story to retry, or undefined if none has failed
+ *
+ * @example
+ * ```typescript
+ * await writeRetryCommand(queueFilePath, busState.lastFailedStoryId);
+ * ```
+ */
+export async function writeRetryCommand(queueFilePath: string | undefined, storyId: string | undefined): Promise<void> {
+  if (!queueFilePath || !storyId) return;
+  await writeQueueCommand(queueFilePath, { type: "RETRY", storyId });
+}

--- a/test/ui/tui-retry.test.tsx
+++ b/test/ui/tui-retry.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for the TUI "retry last failed story" (r) keybinding end-to-end wiring.
+ *
+ * Covers the integration point the feature exists for: pressing `r` in the TUI
+ * translates the most recently failed story (tracked in bus state) into a
+ * `RETRY <id>` queue command that the runner picks up between stories.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { render } from "ink-testing-library";
+import React, { act } from "react";
+import { PipelineEventEmitter, pipelineEventBus } from "@/pipeline";
+import { parseQueueFile } from "@/queue";
+import { App } from "@/tui/App";
+import type { StoryDisplayState } from "@/tui";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+import { waitForFile } from "../helpers/fs";
+
+function makeStory(id: string): StoryDisplayState {
+  return {
+    story: { id, title: `Story ${id}`, passes: false, workdir: ".", acceptanceCriteria: [] } as never,
+    status: "pending",
+  };
+}
+
+describe("TUI retry (r) key end-to-end", () => {
+  let tempDir: string;
+  let queueFile: string;
+
+  beforeEach(() => {
+    pipelineEventBus.clear();
+    tempDir = makeTempDir("nax-tui-retry-");
+    queueFile = join(tempDir, "queue.txt");
+  });
+
+  afterEach(() => {
+    pipelineEventBus.clear();
+    cleanupTempDir(tempDir);
+  });
+
+  test("r writes RETRY for the last failed story to the queue file", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { stdin, unmount } = render(
+      <App feature="feat" stories={[makeStory("US-001")]} events={emitter} queueFilePath={queueFile} />,
+    );
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:failed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S", status: "failed", attempts: 3 },
+        reason: "boom",
+        countsTowardEscalation: true,
+      });
+    });
+
+    act(() => {
+      stdin.write("r");
+    });
+
+    await waitForFile(queueFile, 1000);
+    const { commands } = parseQueueFile(await Bun.file(queueFile).text());
+    unmount();
+
+    expect(commands).toEqual([{ type: "RETRY", storyId: "US-001" }]);
+  });
+
+  test("r is a no-op when no story has failed", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { stdin, unmount } = render(
+      <App feature="feat" stories={[makeStory("US-001")]} events={emitter} queueFilePath={queueFile} />,
+    );
+
+    act(() => {
+      stdin.write("r");
+    });
+
+    // Give any (unexpected) async write a chance to land before asserting absence.
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    const exists = await Bun.file(queueFile).exists();
+    unmount();
+
+    expect(exists).toBe(false);
+  });
+});

--- a/test/ui/usePipelineBusEvents.test.tsx
+++ b/test/ui/usePipelineBusEvents.test.tsx
@@ -29,6 +29,13 @@ function HookOutput({ stories }: { stories: StoryDisplayState[] }) {
   );
 }
 
+// Isolated wrapper for lastFailedStoryId assertions — kept on its own line so
+// it never widens (and thus wraps) the multi-field HookOutput row.
+function LastFailedOutput({ stories }: { stories: StoryDisplayState[] }) {
+  const state = usePipelineBusEvents(stories);
+  return <Text>lastFailed:{state.lastFailedStoryId ?? "none"}</Text>;
+}
+
 beforeEach(() => pipelineEventBus.clear());
 afterEach(() => pipelineEventBus.clear());
 
@@ -141,5 +148,172 @@ describe("usePipelineBusEvents", () => {
     });
 
     expect(lastFrame()).toContain("summary:1");
+  });
+
+  test("lastFailedStoryId is none before any failure", () => {
+    const { lastFrame } = render(<LastFailedOutput stories={[makeInitialStory("US-001")]} />);
+    expect(lastFrame()).toContain("lastFailed:none");
+  });
+
+  test("story:failed records lastFailedStoryId", () => {
+    const { lastFrame } = render(<LastFailedOutput stories={[makeInitialStory("US-001")]} />);
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:failed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S", status: "failed", attempts: 3 },
+        reason: "boom",
+        countsTowardEscalation: true,
+      });
+    });
+
+    expect(lastFrame()).toContain("lastFailed:US-001");
+  });
+
+  test("story:completed with passed:false records lastFailedStoryId", () => {
+    const { lastFrame } = render(<LastFailedOutput stories={[makeInitialStory("US-001")]} />);
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:completed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S", status: "failed", attempts: 1 },
+        passed: false,
+        runElapsedMs: 5000,
+      });
+    });
+
+    expect(lastFrame()).toContain("lastFailed:US-001");
+  });
+
+  test("story:completed with passed:true does not record lastFailedStoryId", () => {
+    const { lastFrame } = render(<LastFailedOutput stories={[makeInitialStory("US-001")]} />);
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:completed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S", status: "passed", attempts: 1 },
+        passed: true,
+        runElapsedMs: 5000,
+        cost: 0.001,
+      });
+    });
+
+    expect(lastFrame()).toContain("lastFailed:none");
+  });
+
+  test("most-recent failure wins when multiple stories fail", () => {
+    const { lastFrame } = render(
+      <LastFailedOutput stories={[makeInitialStory("US-001"), makeInitialStory("US-002")]} />
+    );
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:failed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S1", status: "failed", attempts: 3 },
+        reason: "first",
+        countsTowardEscalation: true,
+      });
+    });
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:failed",
+        storyId: "US-002",
+        story: { id: "US-002", title: "S2", status: "failed", attempts: 3 },
+        reason: "second",
+        countsTowardEscalation: true,
+      });
+    });
+
+    expect(lastFrame()).toContain("lastFailed:US-002");
+  });
+
+  test("story:started clears lastFailedStoryId when the restarted story was the last failure", () => {
+    const { lastFrame } = render(<LastFailedOutput stories={[makeInitialStory("US-001")]} />);
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:failed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S", status: "failed", attempts: 3 },
+        reason: "boom",
+        countsTowardEscalation: true,
+      });
+    });
+    expect(lastFrame()).toContain("lastFailed:US-001");
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:started",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S", status: "pending", attempts: 0 },
+        workdir: ".",
+        modelTier: "balanced",
+        iteration: 2,
+      });
+    });
+
+    expect(lastFrame()).toContain("lastFailed:none");
+  });
+
+  test("run:completed clears lastFailedStoryId so retry is disarmed after the run", () => {
+    const { lastFrame } = render(<LastFailedOutput stories={[makeInitialStory("US-001")]} />);
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:failed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S", status: "failed", attempts: 3 },
+        reason: "boom",
+        countsTowardEscalation: true,
+      });
+    });
+    expect(lastFrame()).toContain("lastFailed:US-001");
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "run:completed",
+        totalStories: 1,
+        passedStories: 0,
+        failedStories: 1,
+        skippedStories: 0,
+        pausedStories: 0,
+        durationMs: 8000,
+        totalCost: 0.01,
+      });
+    });
+
+    expect(lastFrame()).toContain("lastFailed:none");
+  });
+
+  test("story:started for a different story does not clear lastFailedStoryId", () => {
+    const { lastFrame } = render(
+      <LastFailedOutput stories={[makeInitialStory("US-001"), makeInitialStory("US-002")]} />
+    );
+
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:failed",
+        storyId: "US-001",
+        story: { id: "US-001", title: "S1", status: "failed", attempts: 3 },
+        reason: "boom",
+        countsTowardEscalation: true,
+      });
+    });
+    act(() => {
+      pipelineEventBus.emit({
+        type: "story:started",
+        storyId: "US-002",
+        story: { id: "US-002", title: "S2", status: "pending", attempts: 0 },
+        workdir: ".",
+        modelTier: "balanced",
+        iteration: 1,
+      });
+    });
+
+    expect(lastFrame()).toContain("lastFailed:US-001");
   });
 });

--- a/test/unit/utils/queue-writer.test.ts
+++ b/test/unit/utils/queue-writer.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { parseQueueFile } from "@/queue";
-import { _writeChains, writeQueueCommand } from "@/utils/queue-writer";
+import { _writeChains, writeQueueCommand, writeRetryCommand } from "@/utils/queue-writer";
 import { cleanupTempDir, makeTempDir } from "@test/helpers";
 
 describe("writeQueueCommand", () => {
@@ -61,5 +61,37 @@ describe("writeQueueCommand", () => {
     await inFlight;
     // Once settled with no newer write queued, the entry is evicted.
     expect(_writeChains.has(queueFile)).toBe(false);
+  });
+});
+
+describe("writeRetryCommand", () => {
+  let tempDir: string;
+  let queueFile: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-retry-writer-");
+    queueFile = join(tempDir, "queue.txt");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  test("writes a RETRY command for the given story id", async () => {
+    await writeRetryCommand(queueFile, "US-007");
+
+    const { commands } = parseQueueFile(await Bun.file(queueFile).text());
+    expect(commands).toEqual([{ type: "RETRY", storyId: "US-007" }]);
+  });
+
+  test("no-ops when there is no story id to retry", async () => {
+    await writeRetryCommand(queueFile, undefined);
+    expect(await Bun.file(queueFile).exists()).toBe(false);
+  });
+
+  test("no-ops when there is no queue file path", async () => {
+    // Must not throw even though no path is available.
+    await writeRetryCommand(undefined, "US-007");
+    expect(await Bun.file(queueFile).exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Wires up the TUI **retry last failed story** (`r`) keybinding, which was a no-op `TODO` stub at `src/tui/App.tsx`.

## Why

The `RETRY` queue-command path already existed end-to-end — writer (`writeQueueCommand`), parser (`queue/manager`), PRD reset (`resetStoryToPending`), and the pipeline `queue-check` stage. Only the TUI wiring was missing, so pressing `r` did nothing despite the Help overlay advertising it.

## How

- **`usePipelineBusEvents`** — track `lastFailedStoryId` in bus state: set on `story:failed` and on `passed:false` `story:completed` (most-recent wins); cleared when that story restarts (`story:started`) or the run completes (`run:completed`), so a stale retry never writes to a queue file the runner no longer polls.
- **`queue-writer`** — new guarded `writeRetryCommand(queueFilePath?, storyId?)` helper that no-ops when either argument is absent.
- **`App`** — `case "RETRY"` now calls `writeRetryCommand(queueFilePath, busState.lastFailedStoryId)`.

Single-slot by design: only the latest terminal failure is retryable (an earlier concurrent failure in parallel mode is not reachable via `r`).

## Testing

- [x] Tests added/updated — bus-state tracking + clear transitions (restart, run-complete), the `writeRetryCommand` guard, and an **end-to-end App render** that emits a failure, sends `r`, and asserts a `RETRY <id>` lands in the queue file
- [x] `bun test` passes (affected suites: 103 pass / 2 pre-existing skips)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Developed test-first (RED->GREEN per unit) and code-reviewed; review warnings folded in (feature-wiring integration test added; clear-on-completion added; defensive `passed:false` branch and single-slot semantics documented). No config, no new UX surface, no keyboard-hook signature change.