### PR TITLE
fix(auto-pr-plugin): push feature branch to origin before creating PR

### DIFF
--- a/src/plugins/builtin/auto-pr/index.ts
+++ b/src/plugins/builtin/auto-pr/index.ts
@@ -4,7 +4,9 @@
  * After a successful run, opens a draft PR/MR on GitHub or GitLab for the
  * feature branch. Reads `ctx.config.autoPr` for opt-in config, detects the
  * forge from the git remote URL, looks for an existing open PR/MR to skip
- * duplicates, and shells out to `gh` / `glab` to create the draft.
+ * duplicates, pushes the feature branch to `origin` (required — forges can
+ * only resolve a head ref that already exists on the remote), and shells out
+ * to `gh` / `glab` to create the draft.
  *
  * Fail-open: a failed PR open never fails the run. The post-run driver in
  * `run-cleanup.ts` already swallows thrown exceptions and logs `{ success: false }`
@@ -170,6 +172,14 @@ const autoPrAction: IPostRunAction = {
       const forge = _autoPrDeps.detectForge(remoteUrl);
       if (!forge) {
         return { success: false, message: "Remote host is not GitHub or GitLab" };
+      }
+
+      const pushResult = await _autoPrDeps.run(["git", "push", "-u", "origin", context.branch], {
+        cwd: context.workdir,
+      });
+      if (pushResult.exitCode !== 0) {
+        const message = pushResult.stderr.trim() || `git push exited with code ${pushResult.exitCode}`;
+        return { success: false, message: `Failed to push branch "${context.branch}" to origin: ${message}` };
       }
 
       const template = await _autoPrDeps.findPrTemplate(context.workdir, forge, {

--- a/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
@@ -227,6 +227,48 @@ describe("autoPrPlugin.execute", () => {
     expect(captured[0]?.draft).toBe(true);
   });
 
+  test("AC8b — pushes the branch to origin before calling openDraft", async () => {
+    const pushCalls: string[][] = [];
+    const openDraftCalls: string[] = [];
+    _autoPrDeps.run = (async (cmd: string[]) => {
+      pushCalls.push(cmd);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }) as typeof _autoPrDeps.run;
+    _autoPrDeps.openDraft = (async () => {
+      openDraftCalls.push("called");
+      return { success: true, message: "ok" };
+    }) as typeof _autoPrDeps.openDraft;
+
+    const ctx = makeContext();
+    const result = await autoPrPlugin.extensions.postRunAction!.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(pushCalls).toContainEqual(["git", "push", "-u", "origin", ctx.branch]);
+    expect(openDraftCalls).toEqual(["called"]);
+  });
+
+  test("AC8c — returns { success: false } and never calls openDraft when git push fails", async () => {
+    _autoPrDeps.run = (async (cmd: string[]) => {
+      if (cmd[0] === "git" && cmd[1] === "push") {
+        return { exitCode: 1, stdout: "", stderr: "remote: Permission denied" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }) as typeof _autoPrDeps.run;
+    let openDraftCalled = false;
+    _autoPrDeps.openDraft = (async () => {
+      openDraftCalled = true;
+      return { success: true, message: "ok" };
+    }) as typeof _autoPrDeps.openDraft;
+
+    const ctx = makeContext();
+    const result = await autoPrPlugin.extensions.postRunAction!.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain(ctx.branch);
+    expect(result.message).toContain("Permission denied");
+    expect(openDraftCalled).toBe(false);
+  });
+
   test("AC9 — returns { success: false } when openDraft reports forge failure and does not throw", async () => {
     _autoPrDeps.openDraft = (async () => ({
       success: false,


### PR DESCRIPTION
## Summary
- The built-in auto-PR post-run plugin called `gh pr create` / `glab mr create` without ever pushing the feature branch to `origin`, so the forge had no ref to resolve — surfacing as `GraphQL: Head sha can't be blank, Base sha can't be blank, no commit between main and feat/<feature>, Head must be a branch`.
- `execute()` now runs `git push -u origin <branch>` before calling `openDraft`, and returns `{ success: false, message }` early with a clear error if the push fails, instead of ever shelling out to `gh`/`glab` with an unpublished branch.

## Test plan
- [x] `timeout 30 bun test test/unit/plugins/builtin/ test/unit/config/auto-pr-config.test.ts --timeout=5000` — 172 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Added `AC8b`/`AC8c` tests covering push-then-create ordering and push-failure short-circuit