### PR TITLE
fix(auto-pr-plugin): stop auto-PR firing twice per run

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -133,11 +133,12 @@ export async function loadPlugins(
       const pluginLogger = createPluginLogger(autoPrPlugin.name);
       await autoPrPlugin.setup({}, pluginLogger);
     }
-    loadedPlugins.push({
-      plugin: autoPrPlugin,
-      source: { type: "builtin", path: autoPrPlugin.name },
-    });
-    pluginNames.add(autoPrPlugin.name);
+    // Side-channel action only (see PluginRegistry layout comment) — auto-pr is
+    // NOT added to `loadedPlugins`. Registering it there as well would make
+    // getPostRunActions() return the action twice (once via the `provides`
+    // filter over `plugins`, once via `builtinPostRunActions`), firing it twice
+    // per run: the first pass opens the PR, the second warns "open PR/MR already
+    // exists for branch". auto-route follows the same side-channel layout.
     const autoPrAction = autoPrPlugin.extensions.postRunAction;
     if (autoPrAction) {
       builtinPostRunActions.push(autoPrAction);

--- a/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
@@ -351,7 +351,7 @@ describe("autoPrPlugin.execute", () => {
 // ─── AC11: loader registration ──────────────────────────────────────────────
 
 describe("loadPlugins — autoPr registration", () => {
-  test("AC11 — getPostRunActions() includes 'nax-auto-pr' when not disabled", async () => {
+  test("AC11 — getPostRunActions() includes 'nax-auto-pr' exactly once when not disabled", async () => {
     const root = await mkdtemp(join(tmpdir(), "autopr-registration-"));
     const registry = await loadPlugins(
       join(root, "global"),
@@ -361,7 +361,14 @@ describe("loadPlugins — autoPr registration", () => {
       [],
     );
     const actions = registry.getPostRunActions();
-    expect(actions.some((a) => a.name === PLUGIN_NAME)).toBe(true);
+    // Regression: auto-pr must be a side-channel action only (like auto-route),
+    // never also a full plugin — otherwise getPostRunActions returns it twice
+    // and the action fires twice per run (first opens the PR, second warns
+    // "open PR/MR already exists for branch"). See registry.ts layout comment.
+    const autoPrActions = actions.filter((a) => a.name === PLUGIN_NAME);
+    expect(autoPrActions).toHaveLength(1);
+    // And it must not appear in the full plugins list (side-channel only).
+    expect(registry.plugins.some((p) => p.name === PLUGIN_NAME)).toBe(false);
   });
 
   test("autoPr is excluded from getPostRunActions() when 'nax-auto-pr' is in disabledPlugins", async () => {


### PR DESCRIPTION
## Problem

`nax-auto-pr` fired **twice within a single run**: the first pass opened the PR, the second found it and logged the warning:

> Skipping auto-PR — open PR/MR already exists for branch

## Root cause

`PluginRegistry.getPostRunActions()` returns:

```ts
return [...pluginActions, ...this.builtinPostRunActions];
//         ▲ filtered from `plugins` by `provides`   ▲ side-channel list
```

Built-in post-run actions must pick **exactly one** registration layout:

| Plugin | Layout |
|:--|:--|
| curator | full plugin in `loadedPlugins` (surfaces via the `provides` filter) |
| auto-route | side-channel only in `builtinPostRunActions` |

PR #1306 registered **auto-pr in both** lists, so `getPostRunActions()` returned the action twice and `cleanupRun` executed it twice. The registry's own layout comment (`registry.ts:30–36`) already documents auto-pr as side-channel-only.

## Fix

Drop auto-pr's `loadedPlugins.push` + `pluginNames.add` in `src/plugins/loader.ts`, keeping only the `builtinPostRunActions` registration (matching auto-route). Added a comment explaining the constraint to prevent regression.

## Test

Tightened AC11 in `auto-pr-acceptance.test.ts` from `.some(...)` (passed with 1 *or* 2) to assert auto-pr appears in `getPostRunActions()` **exactly once** and is absent from `registry.plugins`.

- **RED** before the fix: `Expected length: 1 / Received length: 2`
- **GREEN** after.

## Verification

- [x] `bun run typecheck` clean
- [x] 246 plugin + lifecycle tests pass
- [x] pre-commit gates green (biome, file-size, cwd, adapter-wrap, etc.)