### PR TITLE
fix(auto-pr-plugin): render PRD path repo-relative to avoid leaking local path

### DIFF
--- a/src/plugins/builtin/auto-pr/index.ts
+++ b/src/plugins/builtin/auto-pr/index.ts
@@ -13,6 +13,7 @@
  * as a non-blocking warning.
  */
 
+import * as path from "node:path";
 import type { IPostRunAction, NaxPlugin, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
 import { detectForge as _detectForge, hasOpenPr as _hasOpenPr, openDraft as _openDraft } from "./forge";
 import { type PrBodyContext, buildBody, buildTitle } from "./pr-body";
@@ -103,6 +104,18 @@ function getStorySummary(context: PostRunContext): PostRunContext["storySummary"
   return context.storySummary;
 }
 
+/**
+ * Render the PRD path repo-relative so the PR body never leaks an absolute
+ * local filesystem path (e.g. `/Users/alice/workspace/.../prd.json`). When the
+ * PRD lives outside the workdir (`..`-relative) or `prdPath` is empty, fall back
+ * to the raw value rather than emitting a misleading relative path.
+ */
+function relativePrdPath(workdir: string, prdPath: string): string {
+  if (!prdPath) return prdPath;
+  const rel = path.relative(workdir, prdPath);
+  return rel && !rel.startsWith("..") && !path.isAbsolute(rel) ? rel : prdPath;
+}
+
 /** Sub-context handed to the pure body builders (does not include `paused`). */
 function toPrBodyContext(context: PostRunContext): PrBodyContext {
   const summary = getStorySummary(context);
@@ -110,7 +123,7 @@ function toPrBodyContext(context: PostRunContext): PrBodyContext {
     feature: context.feature,
     totalCost: context.totalCost,
     totalDurationMs: context.totalDurationMs,
-    prdPath: context.prdPath,
+    prdPath: relativePrdPath(context.workdir, context.prdPath),
     storySummary: {
       completed: summary.completed,
       failed: summary.failed,

--- a/src/plugins/builtin/auto-pr/pr-body.ts
+++ b/src/plugins/builtin/auto-pr/pr-body.ts
@@ -20,7 +20,11 @@ export interface PrBodyContext {
   totalCost: number;
   /** Wall-clock run duration in milliseconds. Negative values clamp to zero. */
   totalDurationMs: number;
-  /** Absolute path to the PRD file that drove this run. */
+  /**
+   * Display path to the PRD file that drove this run. Repo-relative — the
+   * caller (`toPrBodyContext`) relativizes it against the workdir so the PR
+   * body never leaks an absolute local filesystem path.
+   */
   prdPath: string;
   /** Aggregated counts of story outcomes actually rendered by the body. */
   storySummary: {

--- a/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
@@ -20,7 +20,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import type { PostRunContext } from "@/plugins/extensions";
 import { loadPlugins } from "@/plugins";
 import { autoPrPlugin, _autoPrDeps } from "../../../../src/plugins/builtin/auto-pr";
@@ -205,12 +205,15 @@ describe("autoPrPlugin.execute", () => {
       },
       stories: ctx.stories,
     });
+    // execute() relativizes prdPath against the workdir so the PR body never
+    // leaks an absolute local path.
+    const relPrdPath = relative(ctx.workdir, ctx.prdPath);
     const expectedBody = buildBody(
       {
         feature: ctx.feature,
         totalCost: ctx.totalCost,
         totalDurationMs: ctx.totalDurationMs,
-        prdPath: ctx.prdPath,
+        prdPath: relPrdPath,
         storySummary: {
           completed: ctx.storySummary.completed,
           failed: ctx.storySummary.failed,
@@ -225,6 +228,9 @@ describe("autoPrPlugin.execute", () => {
     expect(captured[0]?.body).toBe(expectedBody);
     expect(captured[0]?.branch).toBe(ctx.branch);
     expect(captured[0]?.draft).toBe(true);
+    // Guard against absolute-path leakage in the rendered body.
+    expect(captured[0]?.body).toContain(`- PRD: ${relPrdPath}`);
+    expect(captured[0]?.body).not.toContain(`- PRD: ${ctx.prdPath}`);
   });
 
   test("AC8b — pushes the branch to origin before calling openDraft", async () => {


### PR DESCRIPTION
## Problem

The auto-PR body leaked an absolute local filesystem path in the `- PRD:` line:

```
- PRD: /Users/williamkhoo/workspace/subrina-coder/projects/stock-trading/repos/rs-stock/.nax/features/alerts-background-monitoring/prd.json
```

Since this body is published to GitHub/GitLab, it exposes the runner's local directory layout, which is incorrect.

## Fix

Relativize the PRD path against the workdir in `toPrBodyContext` before rendering:

- `<workdir>/.nax/features/<name>/prd.json` → `.nax/features/<name>/prd.json`
- Falls back to the raw value when the PRD lives outside the workdir (`..`-relative) or `prdPath` is empty, so no misleading path is emitted.
- The pure body builder stays I/O-free; relativization happens at the boundary where `workdir` is available.

Result:

```
- PRD: .nax/features/alerts-background-monitoring/prd.json
```

## Changes

- `src/plugins/builtin/auto-pr/index.ts` — added `relativePrdPath(workdir, prdPath)` and applied it in `toPrBodyContext`.
- `src/plugins/builtin/auto-pr/pr-body.ts` — updated the `prdPath` doc comment (now a repo-relative display path).
- `test/unit/plugins/builtin/auto-pr-acceptance.test.ts` — updated the AC8 body assertion and added guards that the body contains `- PRD: <relative>` and **not** the absolute path.

## Test plan

- [x] `bun test test/unit/plugins/builtin/auto-pr-acceptance.test.ts test/unit/plugins/builtin/auto-pr-pr-body.test.ts` — 28 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean