### PR TITLE
fix(auto-pr-plugin): remove cost from PR body

### DIFF
--- a/src/plugins/builtin/auto-pr/index.ts
+++ b/src/plugins/builtin/auto-pr/index.ts
@@ -121,7 +121,6 @@ function toPrBodyContext(context: PostRunContext): PrBodyContext {
   const summary = getStorySummary(context);
   return {
     feature: context.feature,
-    totalCost: context.totalCost,
     totalDurationMs: context.totalDurationMs,
     prdPath: relativePrdPath(context.workdir, context.prdPath),
     storySummary: {

--- a/src/plugins/builtin/auto-pr/pr-body.ts
+++ b/src/plugins/builtin/auto-pr/pr-body.ts
@@ -16,8 +16,6 @@ const MS_PER_SECOND = 1000;
 export interface PrBodyContext {
   /** Feature name — used in the title prefix and the run summary. */
   feature: string;
-  /** Total spend in USD for this run. */
-  totalCost: number;
   /** Wall-clock run duration in milliseconds. Negative values clamp to zero. */
   totalDurationMs: number;
   /**
@@ -54,10 +52,6 @@ function formatDuration(totalMs: number): string {
   return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
 }
 
-function formatCost(usd: number): string {
-  return `$${usd.toFixed(2)}`;
-}
-
 function buildSummaryLines(ctx: PrBodyContext): string[] {
   const { storySummary } = ctx;
   const passed = `${storySummary.completed} passed`;
@@ -67,7 +61,7 @@ function buildSummaryLines(ctx: PrBodyContext): string[] {
     "## Run summary",
     `- Feature: ${ctx.feature}`,
     `- Stories: ${passed} / ${failed} / ${skipped}`,
-    `- Cost: ${formatCost(ctx.totalCost)} · Duration: ${formatDuration(ctx.totalDurationMs)}`,
+    `- Duration: ${formatDuration(ctx.totalDurationMs)}`,
     `- PRD: ${ctx.prdPath}`,
     "",
   ];

--- a/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
@@ -195,7 +195,6 @@ describe("autoPrPlugin.execute", () => {
 
     const expectedTitle = buildTitle({
       feature: ctx.feature,
-      totalCost: ctx.totalCost,
       totalDurationMs: ctx.totalDurationMs,
       prdPath: ctx.prdPath,
       storySummary: {
@@ -211,7 +210,6 @@ describe("autoPrPlugin.execute", () => {
     const expectedBody = buildBody(
       {
         feature: ctx.feature,
-        totalCost: ctx.totalCost,
         totalDurationMs: ctx.totalDurationMs,
         prdPath: relPrdPath,
         storySummary: {

--- a/test/unit/plugins/builtin/auto-pr-pr-body.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-pr-body.test.ts
@@ -13,7 +13,6 @@ import { makeStory } from "@test/helpers";
 function makeContext(overrides: Partial<PrBodyContext> = {}): PrBodyContext {
   return {
     feature: "auto-pr-plugin",
-    totalCost: 0.42,
     totalDurationMs: 192_000,
     prdPath: ".nax/features/auto-pr-plugin/prd.json",
     storySummary: { completed: 4, failed: 0, skipped: 0 },
@@ -70,12 +69,12 @@ describe("buildBody (null template)", () => {
     expect(body).not.toMatch(/^---\s*$/m);
   });
 
-  test("run summary includes feature, cost, duration, and PRD path", () => {
+  test("run summary includes feature, duration, and PRD path", () => {
     const ctx = makeContext();
     const body = buildBody(ctx, null);
 
     expect(body).toContain("auto-pr-plugin");
-    expect(body).toContain("$0.42");
+    expect(body).not.toContain("Cost:");
     expect(body).toContain("3m 12s");
     expect(body).toContain(".nax/features/auto-pr-plugin/prd.json");
   });


### PR DESCRIPTION
## Summary
- Removes the `Cost: $X.XX` line from the auto-pr plugin's generated PR body run summary — cost data isn't relevant to reviewers.
- Drops `totalCost` from `PrBodyContext` since it's no longer used by `buildBody`/`buildTitle`.

## Test plan
- [x] `bun test test/unit/plugins/builtin/auto-pr-pr-body.test.ts test/unit/plugins/builtin/auto-pr-acceptance.test.ts` — 28 pass
- [x] `bun run typecheck` — clean