### PR TITLE
feat: status-cost-json

### DIFF
--- a/.nax/features/status-cost-json/.nax-acceptance.test.ts
+++ b/.nax/features/status-cost-json/.nax-acceptance.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, mock, test } from "bun:test";
+import { calculateAggregateMetrics, getLastRun, toCostReport } from "../../../src/metrics";
+import { dispatchStatusView, emitCostReportJson } from "../../../src/cli/status";
+import type { RunMetrics, StoryMetrics } from "../../../src/metrics/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const WORKDIR = "/tmp/nax-status-cost-json-acceptance";
+
+function makeStory(overrides: Partial<StoryMetrics> = {}): StoryMetrics {
+  return {
+    storyId: "US-001",
+    complexity: "medium",
+    modelTier: "balanced",
+    modelUsed: "claude-sonnet-4.5",
+    attempts: 1,
+    finalTier: "balanced",
+    success: true,
+    cost: 0.5,
+    durationMs: 1000,
+    firstPassSuccess: true,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeRun(stories: StoryMetrics[], overrides: Partial<RunMetrics> = {}): RunMetrics {
+  return {
+    runId: "run-001",
+    feature: "test-feature",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T01:00:00.000Z",
+    totalCost: stories.reduce((s, st) => s + st.cost, 0),
+    totalStories: stories.length,
+    storiesCompleted: stories.length,
+    storiesFailed: 0,
+    totalDurationMs: 3600000,
+    stories,
+    ...overrides,
+  };
+}
+
+const REPORT_DEPS = {
+  project: "myproj",
+  now: () => "2026-01-01T00:00:00.000Z",
+};
+
+// ---------------------------------------------------------------------------
+// AC-1: toCostReport([], deps) returns object, does not throw
+// ---------------------------------------------------------------------------
+
+describe("AC-1: toCostReport with empty runs returns a non-null object", () => {
+  test("returns non-null object without throwing", () => {
+    const result = toCostReport([], REPORT_DEPS);
+    expect(typeof result === "object" && result !== null).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: schemaVersion === '1.0'
+// ---------------------------------------------------------------------------
+
+describe("AC-2: toCostReport schemaVersion is '1.0'", () => {
+  test("schemaVersion is a string equal to '1.0'", () => {
+    const result = toCostReport([], REPORT_DEPS);
+    expect(typeof result.schemaVersion).toBe("string");
+    expect(result.schemaVersion).toBe("1.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: generatedAt equals deps.now()
+// ---------------------------------------------------------------------------
+
+describe("AC-3: toCostReport.generatedAt equals deps.now()", () => {
+  test("generatedAt equals the fixed timestamp returned by deps.now", () => {
+    const result = toCostReport([], {
+      project: "any",
+      now: () => "2026-01-01T00:00:00.000Z",
+    });
+    expect(result.generatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: project equals deps.project
+// ---------------------------------------------------------------------------
+
+describe("AC-4: toCostReport.project equals deps.project", () => {
+  test("project field equals the injected project name", () => {
+    const result = toCostReport([], { project: "myproj", now: () => "2026-01-01T00:00:00.000Z" });
+    expect(result.project).toBe("myproj");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-5: empty runs → aggregate null, lastRun null, modelEfficiency []
+// ---------------------------------------------------------------------------
+
+describe("AC-5: toCostReport with empty runs has null aggregate/lastRun and empty modelEfficiency", () => {
+  test("aggregate is null, lastRun is null, modelEfficiency is []", () => {
+    const result = toCostReport([], REPORT_DEPS);
+    expect(result.aggregate).toBeNull();
+    expect(result.lastRun).toBeNull();
+    expect(Array.isArray(result.modelEfficiency)).toBe(true);
+    expect(result.modelEfficiency.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6: aggregate fields match calculateAggregateMetrics
+// ---------------------------------------------------------------------------
+
+describe("AC-6: toCostReport aggregate matches calculateAggregateMetrics", () => {
+  test("totalRuns, totalCost, avgCostPerStory equal calculateAggregateMetrics values", () => {
+    const runs = [
+      makeRun([
+        makeStory({ storyId: "US-001", cost: 1.0, modelUsed: "sonnet" }),
+        makeStory({ storyId: "US-002", cost: 2.0, modelUsed: "haiku" }),
+      ]),
+    ];
+    const expected = calculateAggregateMetrics(runs);
+    const result = toCostReport(runs, REPORT_DEPS);
+    expect(result.aggregate).not.toBeNull();
+    expect(result.aggregate!.totalRuns).toBe(expected.totalRuns);
+    expect(result.aggregate!.totalCost).toBe(expected.totalCost);
+    expect(result.aggregate!.avgCostPerStory).toBe(expected.avgCostPerStory);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-7: lastRun runId/feature match getLastRun
+// ---------------------------------------------------------------------------
+
+describe("AC-7: toCostReport lastRun matches getLastRun", () => {
+  test("lastRun.runId and lastRun.feature equal those from getLastRun(runs)", () => {
+    const runs = [
+      makeRun([makeStory()], { runId: "run-first", feature: "feature-first" }),
+      makeRun([makeStory()], { runId: "run-last", feature: "feature-last" }),
+    ];
+    const last = getLastRun(runs);
+    const result = toCostReport(runs, REPORT_DEPS);
+    expect(result.lastRun).not.toBeNull();
+    expect(result.lastRun!.runId).toBe(last!.runId);
+    expect(result.lastRun!.feature).toBe(last!.feature);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8: stories sorted desc by cost, exact keys
+// ---------------------------------------------------------------------------
+
+describe("AC-8: toCostReport lastRun stories sorted descending by cost with exact keys", () => {
+  test("stories[0].cost=0.9, stories[1].cost=0.2 with keys storyId/cost/model/attempts only", () => {
+    const runs = [
+      makeRun([
+        makeStory({ storyId: "US-001", cost: 0.2, modelUsed: "haiku", attempts: 2 }),
+        makeStory({ storyId: "US-002", cost: 0.9, modelUsed: "sonnet", attempts: 1 }),
+      ]),
+    ];
+    const result = toCostReport(runs, REPORT_DEPS);
+    expect(result.lastRun).not.toBeNull();
+    const stories = result.lastRun!.stories;
+    expect(stories.length).toBe(2);
+    expect(stories[0].cost).toBe(0.9);
+    expect(stories[1].cost).toBe(0.2);
+    expect(Object.keys(stories[0]).sort()).toEqual(["attempts", "cost", "model", "storyId"].sort());
+    expect(Object.keys(stories[1]).sort()).toEqual(["attempts", "cost", "model", "storyId"].sort());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-9: modelEfficiency sorted desc by totalCost, exact keys
+// ---------------------------------------------------------------------------
+
+describe("AC-9: toCostReport modelEfficiency sorted descending by totalCost with exact keys", () => {
+  test("modelEfficiency[0].totalCost=3.0, [1].totalCost=1.0 with keys model/attempts/passRate/avgCost/totalCost", () => {
+    const runs = [
+      makeRun([
+        makeStory({ storyId: "S-1", cost: 1.0, modelUsed: "claude-sonnet", attempts: 1, success: true }),
+        makeStory({ storyId: "S-2", cost: 1.0, modelUsed: "claude-sonnet", attempts: 1, success: true }),
+        makeStory({ storyId: "S-3", cost: 1.0, modelUsed: "claude-sonnet", attempts: 1, success: true }),
+        makeStory({ storyId: "H-1", cost: 1.0, modelUsed: "claude-haiku", attempts: 1, success: true }),
+      ]),
+    ];
+    const result = toCostReport(runs, REPORT_DEPS);
+    const models = result.modelEfficiency;
+    expect(models.length).toBe(2);
+    expect(models[0].totalCost).toBe(3.0);
+    expect(models[1].totalCost).toBe(1.0);
+    const expectedKeys = ["attempts", "avgCost", "model", "passRate", "totalCost"].sort();
+    expect(Object.keys(models[0]).sort()).toEqual(expectedKeys);
+    expect(Object.keys(models[1]).sort()).toEqual(expectedKeys);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-10: lastRun.avgCostPerStory === 0 when totalStories === 0
+// ---------------------------------------------------------------------------
+
+describe("AC-10: toCostReport lastRun.avgCostPerStory is 0 (not NaN) when totalStories is 0", () => {
+  test("avgCostPerStory equals 0 and is not NaN for a run with no stories", () => {
+    const runs = [makeRun([])];
+    const result = toCostReport(runs, REPORT_DEPS);
+    expect(result.lastRun).not.toBeNull();
+    expect(result.lastRun!.avgCostPerStory).toBe(0);
+    expect(Number.isNaN(result.lastRun!.avgCostPerStory)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-11: no internal fields in aggregate, lastRun, or lastRun.stories
+// ---------------------------------------------------------------------------
+
+describe("AC-11: internal fields do not appear in CostReportV1 output", () => {
+  test("aggregate, lastRun, and each story lack totalTokens/context/pollution/complexityAccuracy/fallback", () => {
+    const runs = [
+      makeRun([
+        makeStory({ storyId: "US-001", cost: 0.5, modelUsed: "sonnet", attempts: 1 }),
+      ]),
+    ];
+    const result = toCostReport(runs, REPORT_DEPS);
+    expect(result.aggregate).not.toBeNull();
+    expect(result.lastRun).not.toBeNull();
+    const banned = ["totalTokens", "context", "pollution", "complexityAccuracy", "fallback"];
+    for (const key of banned) {
+      expect(key in result.aggregate!).toBe(false);
+      expect(key in result.lastRun!).toBe(false);
+    }
+    for (const story of result.lastRun!.stories) {
+      for (const key of banned) {
+        expect(key in story).toBe(false);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-12: emitCostReportJson is importable from @/cli/status and is a function
+// ---------------------------------------------------------------------------
+
+describe("AC-12: emitCostReportJson is importable from @/cli/status", () => {
+  test("emitCostReportJson is a function", async () => {
+    const mod = await import("../../../src/cli/status");
+    expect(typeof mod.emitCostReportJson).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-13: stdout spy called once with JSON parseable to schemaVersion '1.0'
+// ---------------------------------------------------------------------------
+
+describe("AC-13: emitCostReportJson emits JSON with schemaVersion '1.0' to stdout", () => {
+  test("stdout called once with a JSON string whose schemaVersion is '1.0'", async () => {
+    const runs = [makeRun([makeStory()])];
+    const stdoutSpy = mock((_s: string) => {});
+    const deps = {
+      loadRuns: mock(async (_outputDir: string) => runs),
+      stdout: stdoutSpy,
+    };
+    await emitCostReportJson(WORKDIR, deps);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    expect(typeof output).toBe("string");
+    const parsed = JSON.parse(output);
+    expect(parsed.schemaVersion).toBe("1.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-14: injected toCostReport spy called with the runs from loadRuns (seam)
+// ---------------------------------------------------------------------------
+
+describe("AC-14: emitCostReportJson calls injected toCostReport with loaded runs", () => {
+  test("toCostReport spy invoked exactly once with the runs array from loadRuns", async () => {
+    const loadRunsResult = [makeRun([makeStory({ storyId: "US-seam" })])];
+    const toCostReportSpy = mock((_r: RunMetrics[]) => ({
+      schemaVersion: "1.0" as const,
+      project: "test",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      aggregate: null,
+      lastRun: null,
+      modelEfficiency: [],
+    }));
+    const deps = {
+      loadRuns: mock(async (_outputDir: string) => loadRunsResult),
+      toCostReport: toCostReportSpy,
+      stdout: mock((_s: string) => {}),
+    };
+    await emitCostReportJson(WORKDIR, deps);
+    expect(toCostReportSpy).toHaveBeenCalledTimes(1);
+    expect(toCostReportSpy).toHaveBeenCalledWith(loadRunsResult);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-15: empty loadRuns resolves without throwing, stdout emits aggregate null
+// ---------------------------------------------------------------------------
+
+describe("AC-15: emitCostReportJson with empty loadRuns resolves and emits aggregate:null", () => {
+  test("resolves to undefined, stdout emits aggregate null and empty modelEfficiency", async () => {
+    const stdoutSpy = mock((_s: string) => {});
+    const deps = {
+      loadRuns: mock(async (_outputDir: string) => [] as RunMetrics[]),
+      stdout: stdoutSpy,
+    };
+    await expect(emitCostReportJson(WORKDIR, deps)).resolves.toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(parsed.aggregate).toBeNull();
+    expect(parsed.modelEfficiency).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-16: stdout string round-trips and ends with newline
+// ---------------------------------------------------------------------------
+
+describe("AC-16: emitCostReportJson stdout round-trips and ends with newline", () => {
+  test("JSON.parse of stdout deep-equals the injected report and string ends with '\\n'", async () => {
+    const fixedReport = {
+      schemaVersion: "1.0" as const,
+      project: "test",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      aggregate: null,
+      lastRun: null,
+      modelEfficiency: [] as never[],
+    };
+    const stdoutSpy = mock((_s: string) => {});
+    const deps = {
+      loadRuns: mock(async (_outputDir: string) => [] as RunMetrics[]),
+      toCostReport: mock(async (_r: RunMetrics[]) => fixedReport),
+      stdout: stdoutSpy,
+    };
+    await emitCostReportJson(WORKDIR, deps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    expect(JSON.parse(output)).toEqual(fixedReport);
+    expect(output.endsWith("\n")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-17: dispatchStatusView({ cost: true, json: true, last: true }) → emitCostReportJson
+// ---------------------------------------------------------------------------
+
+describe("AC-17: dispatchStatusView json+cost+last routes to emitCostReportJson only", () => {
+  test("emitCostReportJson called once, displayLastRunMetrics not called", () => {
+    const emitSpy = mock(async (_w: string) => {});
+    const displayLastSpy = mock(async (_w: string) => {});
+    const _deps = {
+      emitCostReportJson: emitSpy,
+      displayLastRunMetrics: displayLastSpy,
+      displayModelEfficiency: mock(async (_w: string) => {}),
+      displayFeatureStatus: mock(async (_w: string, _opts?: unknown) => {}),
+      displayCostMetrics: mock(async (_w: string) => {}),
+    };
+    dispatchStatusView(WORKDIR, { cost: true, json: true, last: true }, _deps);
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(displayLastSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-18: dispatchStatusView({ cost: true, json: true, model: true }) → emitCostReportJson
+// ---------------------------------------------------------------------------
+
+describe("AC-18: dispatchStatusView json+cost+model routes to emitCostReportJson only", () => {
+  test("emitCostReportJson called once, displayModelEfficiency not called", () => {
+    const emitSpy = mock(async (_w: string) => {});
+    const displayModelSpy = mock(async (_w: string) => {});
+    const _deps = {
+      emitCostReportJson: emitSpy,
+      displayModelEfficiency: displayModelSpy,
+      displayLastRunMetrics: mock(async (_w: string) => {}),
+      displayFeatureStatus: mock(async (_w: string, _opts?: unknown) => {}),
+      displayCostMetrics: mock(async (_w: string) => {}),
+    };
+    dispatchStatusView(WORKDIR, { cost: true, json: true, model: true }, _deps);
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(displayModelSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-19: dispatchStatusView({ cost: false, json: true }) → displayFeatureStatus
+// ---------------------------------------------------------------------------
+
+describe("AC-19: dispatchStatusView json without cost falls through to displayFeatureStatus", () => {
+  test("displayFeatureStatus called once, emitCostReportJson not called", () => {
+    const displayFeatureSpy = mock(async (_w: string, _opts?: unknown) => {});
+    const emitSpy = mock(async (_w: string) => {});
+    const _deps = {
+      emitCostReportJson: emitSpy,
+      displayFeatureStatus: displayFeatureSpy,
+      displayCostMetrics: mock(async (_w: string) => {}),
+      displayLastRunMetrics: mock(async (_w: string) => {}),
+      displayModelEfficiency: mock(async (_w: string) => {}),
+    };
+    dispatchStatusView(WORKDIR, { cost: false, json: true }, _deps);
+    expect(displayFeatureSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-20: emitCostReportJson propagates loadRuns I/O error
+// ---------------------------------------------------------------------------
+
+describe("AC-20: emitCostReportJson propagates loadRuns I/O errors", () => {
+  test("rejects with the same error when loadRuns rejects", async () => {
+    const ioError = new Error("ENOENT: run archive not found");
+    const deps = {
+      loadRuns: mock(async (_outputDir: string) => {
+        throw ioError;
+      }),
+      stdout: mock((_s: string) => {}),
+    };
+    await expect(emitCostReportJson(WORKDIR, deps)).rejects.toThrow(ioError);
+  });
+});

--- a/.nax/features/status-cost-json/.nax-acceptance.test.ts
+++ b/.nax/features/status-cost-json/.nax-acceptance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { calculateAggregateMetrics, getLastRun, toCostReport } from "../../../src/metrics";
-import { dispatchStatusView, emitCostReportJson } from "../../../src/cli/status";
+import { dispatchStatusView } from "../../../src/cli/status-dispatch";
+import { emitCostReportJson } from "../../../src/cli/status";
 import type { RunMetrics, StoryMetrics } from "../../../src/metrics/types";
 
 // ---------------------------------------------------------------------------
@@ -259,6 +260,8 @@ describe("AC-13: emitCostReportJson emits JSON with schemaVersion '1.0' to stdou
     const stdoutSpy = mock((_s: string) => {});
     const deps = {
       loadRuns: mock(async (_outputDir: string) => runs),
+      toCostReport,
+      now: () => "2026-01-01T00:00:00.000Z",
       stdout: stdoutSpy,
     };
     await emitCostReportJson(WORKDIR, deps);
@@ -288,11 +291,16 @@ describe("AC-14: emitCostReportJson calls injected toCostReport with loaded runs
     const deps = {
       loadRuns: mock(async (_outputDir: string) => loadRunsResult),
       toCostReport: toCostReportSpy,
+      now: () => "2026-01-01T00:00:00.000Z",
       stdout: mock((_s: string) => {}),
     };
     await emitCostReportJson(WORKDIR, deps);
     expect(toCostReportSpy).toHaveBeenCalledTimes(1);
-    expect(toCostReportSpy).toHaveBeenCalledWith(loadRunsResult);
+    expect(toCostReportSpy.mock.calls[0][0]).toEqual(loadRunsResult);
+    expect(toCostReportSpy.mock.calls[0][1]).toMatchObject({
+      now: deps.now,
+      project: expect.any(String),
+    });
   });
 });
 
@@ -305,6 +313,8 @@ describe("AC-15: emitCostReportJson with empty loadRuns resolves and emits aggre
     const stdoutSpy = mock((_s: string) => {});
     const deps = {
       loadRuns: mock(async (_outputDir: string) => [] as RunMetrics[]),
+      toCostReport,
+      now: () => "2026-01-01T00:00:00.000Z",
       stdout: stdoutSpy,
     };
     await expect(emitCostReportJson(WORKDIR, deps)).resolves.toBeUndefined();
@@ -332,7 +342,8 @@ describe("AC-16: emitCostReportJson stdout round-trips and ends with newline", (
     const stdoutSpy = mock((_s: string) => {});
     const deps = {
       loadRuns: mock(async (_outputDir: string) => [] as RunMetrics[]),
-      toCostReport: mock(async (_r: RunMetrics[]) => fixedReport),
+      toCostReport: mock((_r: RunMetrics[], _d: { now: () => string; project: string }) => fixedReport),
+      now: () => "2026-01-01T00:00:00.000Z",
       stdout: stdoutSpy,
     };
     await emitCostReportJson(WORKDIR, deps);

--- a/.nax/features/status-cost-json/acceptance-meta.json
+++ b/.nax/features/status-cost-json/acceptance-meta.json
@@ -1,0 +1,7 @@
+{
+  "generatedAt": "2026-07-10T09:28:24.691Z",
+  "acFingerprint": "sha256:4fb4f2f304e55c2140f7fcbcbf2ac40d0d7b15d39c3a313a476df1e935d78f37",
+  "storyCount": 2,
+  "acCount": 20,
+  "generator": "nax"
+}

--- a/.nax/features/status-cost-json/acceptance-refined.json
+++ b/.nax/features/status-cost-json/acceptance-refined.json
@@ -1,0 +1,142 @@
+[
+  {
+    "acId": "AC-1",
+    "original": "Given `toCostReport` imported from `@/metrics`, when it is called as `toCostReport([], deps)`, then it returns an object and does not throw.",
+    "refined": "Assert that calling `toCostReport([], deps)` returns a value where `typeof result === 'object' && result !== null` and does not throw any error.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-2",
+    "original": "Given any deps object, when `toCostReport([], deps)` returns, then `schemaVersion` equals the string `\"1.0\"`.",
+    "refined": "Assert that `typeof result.schemaVersion === 'string'` and `result.schemaVersion === '1.0'`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-3",
+    "original": "Given `deps.now` returning `\"2026-01-01T00:00:00.000Z\"`, when `toCostReport([], deps)` returns, then `generatedAt` equals `\"2026-01-01T00:00:00.000Z\"`.",
+    "refined": "Assert that `result.generatedAt === '2026-01-01T00:00:00.000Z'`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-4",
+    "original": "Given `deps.project` equal to `\"myproj\"`, when `toCostReport(runs, deps)` returns, then `project` equals `\"myproj\"`.",
+    "refined": "Assert that `result.project === 'myproj'`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-5",
+    "original": "Given an empty runs array, when `toCostReport([], deps)` returns, then `aggregate === null`, `lastRun === null`, and `modelEfficiency` deep-equals `[]`.",
+    "refined": "Assert that `result.aggregate === null && result.lastRun === null && Array.isArray(result.modelEfficiency) && result.modelEfficiency.length === 0`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-6",
+    "original": "Given a non-empty `runs` array, when `toCostReport(runs, deps)` returns, then `aggregate.totalRuns`, `aggregate.totalCost`, and `aggregate.avgCostPerStory` equal the corresponding fields from `calculateAggregateMetrics(runs)`.",
+    "refined": "Assert that `result.aggregate` is not null and `result.aggregate.totalRuns === calculateAggregateMetrics(runs).totalRuns && result.aggregate.totalCost === calculateAggregateMetrics(runs).totalCost && result.aggregate.avgCostPerStory === calculateAggregateMetrics(runs).avgCostPerStory`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-7",
+    "original": "Given a non-empty `runs` array, when `toCostReport(runs, deps)` returns, then `lastRun.runId` and `lastRun.feature` equal the fields on `getLastRun(runs)`.",
+    "refined": "Assert that `result.lastRun` is not null and `result.lastRun.runId === getLastRun(runs).runId && result.lastRun.feature === getLastRun(runs).feature`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-8",
+    "original": "Given the last run contains two stories with costs `0.2` and `0.9`, when `toCostReport(runs, deps)` returns, then `lastRun.stories` is ordered by `cost` descending as `[0.9, 0.2]` and each entry exposes exactly `storyId`, `cost`, `model`, and `attempts`.",
+    "refined": "Assert that `result.lastRun.stories.length === 2 && result.lastRun.stories[0].cost === 0.9 && result.lastRun.stories[1].cost === 0.2 && Object.keys(result.lastRun.stories[0]).sort() === ['attempts','cost','model','storyId'].sort() && Object.keys(result.lastRun.stories[1]).sort() === ['attempts','cost','model','storyId'].sort()`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-9",
+    "original": "Given the aggregate contains two models with `totalCost` values `1.0` and `3.0`, when `toCostReport(runs, deps)` returns, then `modelEfficiency` is ordered by `totalCost` descending as `[3.0, 1.0]` and each entry exposes exactly `model`, `attempts`, `passRate`, `avgCost`, and `totalCost`.",
+    "refined": "Assert that `result.modelEfficiency.length === 2 && result.modelEfficiency[0].totalCost === 3.0 && result.modelEfficiency[1].totalCost === 1.0 && Object.keys(result.modelEfficiency[0]).sort() === ['avgCost','attempts','model','passRate','totalCost'].sort() && Object.keys(result.modelEfficiency[1]).sort() === ['avgCost','attempts','model','passRate','totalCost'].sort()`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-10",
+    "original": "Given the selected last run has `totalStories` equal to `0`, when `toCostReport(runs, deps)` returns, then `lastRun.avgCostPerStory` equals `0` and is not `NaN`.",
+    "refined": "Assert that `result.lastRun.avgCostPerStory === 0 && Number.isNaN(result.lastRun.avgCostPerStory) === false`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-11",
+    "original": "Given a populated `runs` array, when `toCostReport(runs, deps)` returns, then `aggregate`, `lastRun`, and every `lastRun.stories` entry contain none of the keys `totalTokens`, `context`, `pollution`, `complexityAccuracy`, or `fallback`.",
+    "refined": "Assert that `!('totalTokens' in result.aggregate) && !('context' in result.aggregate) && !('pollution' in result.aggregate) && !('complexityAccuracy' in result.aggregate) && !('fallback' in result.aggregate) && !('totalTokens' in result.lastRun) && !('context' in result.lastRun) && !('pollution' in result.lastRun) && !('complexityAccuracy' in result.lastRun) && !('fallback' in result.lastRun) && result.lastRun.stories.every(s => !('totalTokens' in s) && !('context' in s) && !('pollution' in s) && !('complexityAccuracy' in s) && !('fallback' in s))`.",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-12",
+    "original": "Given `emitCostReportJson` imported from `@/cli/status`, when `typeof emitCostReportJson` is evaluated, then it equals `\"function\"`.",
+    "refined": "const { emitCostReportJson } = await import('@/cli/status'); expect(typeof emitCostReportJson).toBe('function');",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-13",
+    "original": "Given injected deps where `loadRuns` resolves to a non-empty runs array and `stdout` is a spy, when `emitCostReportJson(workdir, deps)` resolves, then `stdout` is called exactly once with a string whose `JSON.parse` result has `schemaVersion === \"1.0\"`.",
+    "refined": "const stdoutSpy = _deps.stdout as jest.Mock; await emitCostReportJson(workdir, _deps); expect(stdoutSpy).toHaveBeenCalledTimes(1); const output = stdoutSpy.mock.calls[0][0] as string; expect(typeof output).toBe('string'); const parsed = JSON.parse(output); expect(parsed.schemaVersion).toBe('1.0');",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-14",
+    "original": "Given injected deps where `toCostReport` is a spy returning a fixed report, when `emitCostReportJson(workdir, deps)` resolves, then `toCostReport` is invoked exactly once with the runs array returned by the injected `loadRuns`.",
+    "refined": "const loadRunsResult = [{ id: 'run-1', cost: 100 }]; _deps.loadRuns = async () => loadRunsResult; const toCostReportSpy = _deps.toCostReport as jest.Mock; await emitCostReportJson(workdir, _deps); expect(toCostReportSpy).toHaveBeenCalledTimes(1); expect(toCostReportSpy).toHaveBeenCalledWith(loadRunsResult);",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-15",
+    "original": "Given injected deps where `loadRuns` resolves to `[]`, when `emitCostReportJson(workdir, deps)` resolves, then it does not throw and the single `stdout` string parses to an object with `aggregate === null` and `modelEfficiency` deep-equal to `[]`.",
+    "refined": "_deps.loadRuns = async () => []; const stdoutSpy = _deps.stdout as jest.Mock; await expect(emitCostReportJson(workdir, _deps)).resolves.toBeUndefined(); expect(stdoutSpy).toHaveBeenCalledTimes(1); const parsed = JSON.parse(stdoutSpy.mock.calls[0][0]); expect(parsed.aggregate).toBeNull(); expect(parsed.modelEfficiency).toEqual([]);",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-16",
+    "original": "Given injected deps where `toCostReport` returns a report object, when `emitCostReportJson(workdir, deps)` resolves, then `JSON.parse` of the single `stdout` string deep-equals that report object and the string contains a newline.",
+    "refined": "const fixedReport = { schemaVersion: '1.0', project: 'test', aggregate: null, lastRun: null, modelEfficiency: [] }; _deps.toCostReport = async () => fixedReport; const stdoutSpy = _deps.stdout as jest.Mock; await emitCostReportJson(workdir, _deps); const output = stdoutSpy.mock.calls[0][0] as string; expect(JSON.parse(output)).toEqual(fixedReport); expect(output.endsWith('\\n')).toBe(true);",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-17",
+    "original": "Given `dispatchStatusView` deps with spies for every view function and `options = { cost: true, json: true, last: true }`, when `dispatchStatusView(workdir, options, deps)` runs, then it invokes `deps.emitCostReportJson` and does not invoke `deps.displayLastRunMetrics` (JSON mode wins over --last).",
+    "refined": "const emitSpy = _deps.emitCostReportJson as jest.Mock; const displaySpy = _deps.displayLastRunMetrics as jest.Mock; dispatchStatusView(workdir, { cost: true, json: true, last: true }, _deps); expect(emitSpy).toHaveBeenCalledTimes(1); expect(displaySpy).not.toHaveBeenCalled();",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-18",
+    "original": "Given `dispatchStatusView` deps with spies for every view function and `options = { cost: true, json: true, model: true }`, when `dispatchStatusView(workdir, options, deps)` runs, then it invokes `deps.emitCostReportJson` and does not invoke `deps.displayModelEfficiency` (JSON mode wins over --model).",
+    "refined": "const emitSpy = _deps.emitCostReportJson as jest.Mock; const displaySpy = _deps.displayModelEfficiency as jest.Mock; dispatchStatusView(workdir, { cost: true, json: true, model: true }, _deps); expect(emitSpy).toHaveBeenCalledTimes(1); expect(displaySpy).not.toHaveBeenCalled();",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-19",
+    "original": "Given `dispatchStatusView` deps with spies for every view function and `options = { cost: false, json: true }`, when `dispatchStatusView(workdir, options, deps)` runs, then it invokes `deps.displayFeatureStatus` with the feature-status options and does not invoke `deps.emitCostReportJson`.",
+    "refined": "const emitSpy = _deps.emitCostReportJson as jest.Mock; const displaySpy = _deps.displayFeatureStatus as jest.Mock; dispatchStatusView(workdir, { cost: false, json: true }, _deps); expect(displaySpy).toHaveBeenCalledTimes(1); expect(emitSpy).not.toHaveBeenCalled();",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-20",
+    "original": "Given injected deps where `loadRuns` rejects with an I/O error, when `emitCostReportJson(workdir, deps)` is awaited, then it rejects with the same error instead of swallowing or replacing it.",
+    "refined": "const ioError = new Error('ENOENT: run archive not found'); _deps.loadRuns = async () => { throw ioError; }; await expect(emitCostReportJson(workdir, _deps)).rejects.toThrow(ioError);",
+    "testable": true,
+    "storyId": "US-002"
+  }
+]

--- a/.nax/features/status-cost-json/prd-fidelity-report.md
+++ b/.nax/features/status-cost-json/prd-fidelity-report.md
@@ -1,0 +1,78 @@
+# Spec-Review Phase 9 — PRD Fidelity: status-cost-json
+
+**Spec:** `.nax/features/status-cost-json/spec.md`
+**PRD:** `.nax/features/status-cost-json/prd.json`
+**Reviewed against:** `projects/nax/repos/nax` @ `fe711dfc`
+**Date:** 2026-07-10
+**Verdict:** ✅ RESOLVED (2026-07-10) — the major (AC6/7/8) was resolved by user decision "Accept & extract dispatcher"; spec + PRD now aligned. Original findings retained below for the record.
+
+## Resolution (2026-07-10)
+
+User chose to **accept and embrace** the planner's expansion. Actions taken:
+- Spec updated: status routing extracted into a new exported `dispatchStatusView(workdir,
+  options, deps)` (`src/cli/status-dispatch.ts`); `bin/nax.ts` `.action()` delegates to
+  it; US-002 ACs 6–8 rewritten to assert dispatch via spied deps; AC9 (I/O propagation)
+  kept.
+- PRD aligned (no re-plan, per the "keep 9 ACs" decision): US-002 AC6/7/8 rephrased to
+  `dispatchStatusView`; `expectedFiles` gained `src/cli/status-dispatch.ts` +
+  `test/unit/cli/status-dispatch.test.ts`.
+- Result: spec 20 ACs (US-001 11 + US-002 9) ↔ PRD 20 ACs, 1:1; `Creates` ↔
+  `expectedFiles` match; `dispatchStatusView` is a directly-tested seam (ACs 6–8) and
+  also the seam for `emitCostReportJson`. Only untested residue = the one-line
+  `bin/nax.ts` `--json` registration + delegation, routed to the build/typecheck gate.
+
+---
+
+## Story & AC mapping
+
+| Story | Spec ACs | PRD ACs | Mapping |
+|---|---|---|---|
+| US-001 | 11 | 11 | 1:1, all faithful, behavioral, same symbols/inputs/outputs (reworded to Given/When/Then). No drift. |
+| US-002 | 5 | 9 | Spec AC1–5 → PRD AC1–5 faithful. PRD **AC9** = faithful materialization of spec Failure-Handling prose (good). PRD **AC6/AC7/AC8** = drift (see major below). |
+
+## Major — PRD AC6/AC7/AC8 promote spec build-gate wiring into runtime ACs against an untested layer
+
+**Spec reference:** US-002 "Verification note (US-002 wiring)" + Design § Flag interactions. The spec **deliberately routed** the `bin/nax.ts` `--json` flag registration and the `if (options.cost && options.json)` route to the **build/typecheck gate**, explicitly stating "commander action handlers are not unit-tested in this repo."
+
+**PRD reality:** `nax plan` converted that flag-interaction prose into three runtime ACs:
+- AC6 — `--cost --json --last` → status action calls `emitCostReportJson`, not `displayLastRunMetrics`.
+- AC7 — `--cost --json --model` → status action calls `emitCostReportJson`, not `displayModelEfficiency`.
+- AC8 — `json:true, cost:false` → status action calls `displayFeatureStatus`, not `emitCostReportJson`.
+
+**Codebase reality (substantiated):** the status routing is an **un-exported inline** `.action(async (options) => { ... })` closure in `bin/nax.ts:1308`. The existing `test/unit/cli/cli-status.test.ts` tests the **exported `displayFeatureStatus` directly** (calls `displayFeatureStatus({dir})`); it never imports `bin/nax.ts` nor exercises the commander closure. There is no established way to unit-test "the status action dispatches to X" in this repo.
+
+**Consequence:** making AC6/7/8 green forces extracting the status command routing out of the `bin/nax.ts` closure into an exported, testable dispatcher — real scope expansion beyond the spec's "thin inline guard in bin" design, and it overrides the spec's explicit verification-routing decision.
+
+**Recommended fix — pick one:**
+1. **Accept & embrace (better design):** extract status routing into an exported `dispatchStatus(options, deps)` (or similar); AC6/7/8 become implementable and the routing gains test coverage. Grows US-002 modestly. Update the spec to match.
+2. **Relax to spec intent:** edit `prd.json` to drop AC6/7/8 and restore the build/typecheck-gate verification note. US-002 → 6 ACs (spec AC1–5 + I/O AC9). **Note:** the planner's `normalizeCreatedContextFiles`/candidate-merge would not re-strip these, but re-running `nax plan` may re-promote them from the spec prose — if relaxing, also soften the spec's Flag-interactions wording so a re-plan doesn't re-derive them.
+
+This is a **major, not a blocker**: AC6/7/8 are traceable to spec prose (not pure scope-bleed) and are implementable *if* the routing is extracted — but they contradict the spec's stated verification routing and expand scope, so the user should choose the direction before US-002 runs.
+
+## Minor — PRD AC1 slightly weaker than spec AC1
+
+**Spec:** "`emitCostReportJson` … usable as a function." **PRD AC1:** `typeof emitCostReportJson === "function"`. The behavioral "usable" intent narrowed to a typeof check. Still runtime, still valid; the fuller behavior is covered by AC2–5. No action needed.
+
+## Minor — spec's "existing status-cost unit test" was inaccurate; PRD corrected it (fidelity *improvement*)
+
+**Spec:** US-002 "Creates: (none — extends … the existing status-cost unit test)."
+**Codebase reality:** there is **no** `test/unit/cli/status-cost.test.ts`. The PRD correctly sets US-002 `expectedFiles = ["test/unit/cli/status-cost.test.ts"]` — a **new** mirrored test file (per `test-architecture.md`: one test file per source file, `src/cli/status-cost.ts` → `test/unit/cli/status-cost.test.ts`). This is the planner fixing a spec inaccuracy, not a fidelity loss. **Recommend:** update the spec's US-002 `Creates` to list the new test file so the two agree.
+
+## Minor — US-001 helpful contextFiles additions
+
+PRD US-001 `contextFiles` adds `src/metrics/index.ts` (the barrel this story edits — legitimate read) and `test/unit/replay/json.test.ts` (pattern reference). Both are existing files and helpful context (§4d), not findings.
+
+## File-role checks (§4) — clean
+
+- **US-001** `expectedFiles = [report.ts, report.test.ts]` matches spec `Creates`. ✅
+- **US-002** `expectedFiles = [status-cost.test.ts]` — new file, correctly in `expectedFiles` (see minor above). ✅
+- **US-002** `contextFiles` includes `src/metrics/report.ts` — created by upstream US-001, correctly kept in the consumer's `contextFiles` (exists at US-002's runtime; §4c). ✅
+- No self-created file mis-placed in `contextFiles`. ✅
+
+## Meta-AC survival (§5)
+
+The spec's single meta/verification-note (bin wiring → build-gate) was **not preserved as a note** — it was promoted into runtime AC6/7/8. That promotion is the subject of the major above.
+
+## Bottom line
+
+US-001 is clean and ready. US-002's 5 spec ACs plus the I/O-propagation AC9 are faithful and ready. The only decision blocking US-002 is **AC6/7/8**: accept the testable-dispatcher expansion (option 1) or relax back to the build-gate note (option 2).

--- a/.nax/features/status-cost-json/prd.json
+++ b/.nax/features/status-cost-json/prd.json
@@ -3,7 +3,7 @@
   "feature": "status-cost-json",
   "branchName": "feat/status-cost-json",
   "createdAt": "2026-07-10T08:49:26Z",
-  "updatedAt": "2026-07-10T08:52:42.326Z",
+  "updatedAt": "2026-07-10T09:28:24.801Z",
   "userStories": [
     {
       "id": "US-001",
@@ -42,7 +42,9 @@
         "profileModelTier": "balanced",
         "initialAgent": "opencode",
         "initialProfileId": "opencode-medium",
-        "initialModelTier": "balanced"
+        "initialModelTier": "balanced",
+        "initialComplexity": "medium",
+        "modelTier": "balanced"
       },
       "contextFiles": [
         "src/metrics/types.ts",
@@ -54,7 +56,11 @@
       "expectedFiles": [
         "src/metrics/report.ts",
         "test/unit/metrics/report.test.ts"
-      ]
+      ],
+      "priorErrors": [],
+      "priorFailures": [],
+      "storyPoints": 1,
+      "storyGitRef": "518ea8af9d42071b0cb169f32fcc7c49176f7eec"
     },
     {
       "id": "US-002",
@@ -106,7 +112,10 @@
         "test/unit/cli/status-cost.test.ts",
         "src/cli/status-dispatch.ts",
         "test/unit/cli/status-dispatch.test.ts"
-      ]
+      ],
+      "priorErrors": [],
+      "priorFailures": [],
+      "storyPoints": 1
     }
   ],
   "analysis": "This feature extends the existing `status` CLI cost-reporting path with a stable machine-readable surface instead of changing the current human logger views. The current cost views live in `src/cli/status-cost.ts:13-177`; `resolveOutputDir()` derives `projectKey` from `config?.name?.trim() || basename(workdir)` and resolves the metrics directory via `projectOutputDir()` (`src/cli/status-cost.ts:13-17`). `displayCostMetrics()` loads runs and logs aggregate human fields only (`src/cli/status-cost.ts:29-50`), `displayLastRunMetrics()` logs the most recent run plus top stories and currently computes `avgCostPerStory` as `lastRun.totalCost / lastRun.totalStories` without a zero guard (`src/cli/status-cost.ts:77-101`), and `displayModelEfficiency()` logs sorted model stats plus complexity accuracy (`src/cli/status-cost.ts:129-177`). There is no JSON emit path in this module today, and the barrel `src/cli/status.ts:1-13` only re-exports the three human cost functions. The top-level CLI wiring in `bin/nax.ts:1300-1334` exposes `--cost`, `--last`, and `--model`, and routes directly to those human functions; there is no `--json` option on `status` yet. `bin/nax.ts:42-60` imports those functions through the broader CLI barrel, so the new export must remain reachable through `src/cli/status.ts` and then `src/cli/index.ts:11-17`.\n\nThe internal metrics seam already exists and should be reused rather than recomputed. `RunMetrics` and `AggregateMetrics` are defined in `src/metrics/types.ts:235-311`; `RunMetrics` contains the run-level fields the spec wants (`runId`, `feature`, `startedAt`, `completedAt`, `totalCost`, `totalStories`, `storiesCompleted`, `storiesFailed`, `totalDurationMs`, `stories`) plus internal-only `totalTokens` and optional `fallback` that must not leak into the public contract. `StoryMetrics` includes `modelUsed`, `attempts`, optional `context`, and optional `fallback` (`src/metrics/types.ts:98-201`), which is why the mapper has to curate fields instead of exporting internal objects directly. `calculateAggregateMetrics()` already returns the aggregate and per-model stats, including `modelEfficiency` and internal-only `complexityAccuracy` (`src/metrics/aggregator.ts:29-167`), and `getLastRun()` already encapsulates the last-run selection (`src/metrics/aggregator.ts:184-191`). The public metrics barrel at `src/metrics/index.ts:7-21` currently exports types plus `loadRunMetrics`, `calculateAggregateMetrics`, `deriveRunFallbackAggregates`, and `getLastRun`; adding `CostReportV1` and `toCostReport` here preserves the repo’s barrel-import convention and keeps consumers on `@/metrics` rather than leaf imports.\n\nThe strongest implementation precedent is the existing replay JSON design. `ReplayCommandDeps` in `src/commands/replay.ts:41-51` exposes swappable `stdout`, `stderr`, and mapper dependencies; `_replayCmdDeps` wires defaults with `process.stdout.write` and `toReplayJson` (`src/commands/replay.ts:95-105`); and `runReplay()` switches between human and JSON output by serializing a pure mapper result with `JSON.stringify(..., null, 2)` and a trailing newline (`src/commands/replay.ts:115-158`). The replay tests show the project’s preferred testing pattern for this seam: pure mapper tests in `test/unit/replay/json.test.ts:1-103`, and orchestrator/CLI-deps tests in `test/unit/commands/replay.test.ts:102-258` that inject spies for `toReplayJson` and `stdout` and assert the exact wiring behavior. That precedent should be mirrored for `toCostReport` and `emitCostReportJson`.\n\nExisting tests cover the underlying metrics helpers but not the new public report surface. `test/unit/metrics/metrics.test.ts:1-276` already verifies empty aggregates, aggregate math, model efficiency, and `getLastRun()`, and `test/unit/metrics/aggregator.test.ts:1-164` covers `complexityAccuracy` behavior. These tests reduce risk when the mapper composes existing helpers instead of reimplementing them. There does not appear to be an existing `status-cost` unit test file in `test/unit/cli`; searches for `displayCostMetrics`, `displayLastRunMetrics`, `displayModelEfficiency`, and `status-cost` returned no matches in tests, while `test/unit/cli` currently contains feature-status and project-level status tests only. That means US-002 likely needs to create a new CLI-focused test file even though the spec text says it extends an existing one. This is a spec/codebase mismatch to note for implementers, not a reason to change scope.\n\nImpact area summary: `src/metrics/index.ts` must gain the new public exports; a new pure mapper module should live under `src/metrics/report.ts`; `src/cli/status-cost.ts` must gain the JSON emitter while leaving the human `display*` functions behaviorally unchanged; `src/cli/status.ts` must re-export the emitter; and `bin/nax.ts` must register `--json` on the `status` command and route `options.cost && options.json` before `--last` or `--model`. Because `bin/nax.ts` imports from the broader CLI barrel, no separate import path should bypass the `src/cli/status.ts` seam. The likely new tests are `test/unit/metrics/report.test.ts` for the pure mapper and a new `test/unit/cli/status-cost.test.ts` for injected deps around `emitCostReportJson`, alongside possible small import/export assertions through `@/metrics` and `@/cli/status`.\n\nPrimary risks: exposing internal metrics types directly would freeze internal structure and leak fields the spec explicitly excludes (`totalTokens`, `context`, `pollution`, `complexityAccuracy`, `fallback`), so the mapper must construct fresh plain objects rather than pass through `RunMetrics` or `StoryMetrics`; JSON mode must not accidentally emit logger lines because the existing cost code is logger-driven and downstream consumers require stdout to contain only parseable JSON; the last-run average must explicitly guard `totalStories === 0` to avoid `NaN`; model and story ordering must be deterministic (`totalCost` desc for models, `cost` desc for stories); and project naming must reuse the exact `resolveOutputDir` project-key logic so the exported `project` field matches the metrics directory resolution. Backward compatibility is favorable: this is additive CLI functionality gated behind `--cost --json`, existing human `--cost`, `--cost --last`, and `--cost --model` output stays intact, and the public contract is versioned as `schemaVersion: \"1.0\"` to preserve future migration space. Migration path is therefore minimal: downstream scripts can opt into `nax status --cost --json` immediately, while existing human consumers continue unchanged. Error-handling expectations are also explicit from the spec and current design: empty metrics should still return valid JSON with null/empty sections, and I/O failures from `loadRunMetrics` should continue to propagate rather than being swallowed.",

--- a/.nax/features/status-cost-json/prd.json
+++ b/.nax/features/status-cost-json/prd.json
@@ -3,7 +3,7 @@
   "feature": "status-cost-json",
   "branchName": "feat/status-cost-json",
   "createdAt": "2026-07-10T08:49:26Z",
-  "updatedAt": "2026-07-10T09:43:24.518Z",
+  "updatedAt": "2026-07-10T10:40:35.614Z",
   "userStories": [
     {
       "id": "US-001",
@@ -86,8 +86,8 @@
       "dependencies": [
         "US-001"
       ],
-      "status": "pending",
-      "passes": false,
+      "status": "passed",
+      "passes": true,
       "attempts": 0,
       "escalations": [],
       "routing": {

--- a/.nax/features/status-cost-json/prd.json
+++ b/.nax/features/status-cost-json/prd.json
@@ -3,7 +3,7 @@
   "feature": "status-cost-json",
   "branchName": "feat/status-cost-json",
   "createdAt": "2026-07-10T08:49:26Z",
-  "updatedAt": "2026-07-10T09:28:24.801Z",
+  "updatedAt": "2026-07-10T09:43:24.518Z",
   "userStories": [
     {
       "id": "US-001",
@@ -29,8 +29,8 @@
         "cli"
       ],
       "dependencies": [],
-      "status": "pending",
-      "passes": false,
+      "status": "passed",
+      "passes": true,
       "attempts": 0,
       "escalations": [],
       "routing": {
@@ -99,7 +99,9 @@
         "profileModelTier": "balanced",
         "initialAgent": "opencode",
         "initialProfileId": "opencode-medium",
-        "initialModelTier": "balanced"
+        "initialModelTier": "balanced",
+        "initialComplexity": "medium",
+        "modelTier": "balanced"
       },
       "contextFiles": [
         "src/cli/status-cost.ts",
@@ -115,7 +117,8 @@
       ],
       "priorErrors": [],
       "priorFailures": [],
-      "storyPoints": 1
+      "storyPoints": 1,
+      "storyGitRef": "38be1d518fea73b74e663905b20c6e0bcab15033"
     }
   ],
   "analysis": "This feature extends the existing `status` CLI cost-reporting path with a stable machine-readable surface instead of changing the current human logger views. The current cost views live in `src/cli/status-cost.ts:13-177`; `resolveOutputDir()` derives `projectKey` from `config?.name?.trim() || basename(workdir)` and resolves the metrics directory via `projectOutputDir()` (`src/cli/status-cost.ts:13-17`). `displayCostMetrics()` loads runs and logs aggregate human fields only (`src/cli/status-cost.ts:29-50`), `displayLastRunMetrics()` logs the most recent run plus top stories and currently computes `avgCostPerStory` as `lastRun.totalCost / lastRun.totalStories` without a zero guard (`src/cli/status-cost.ts:77-101`), and `displayModelEfficiency()` logs sorted model stats plus complexity accuracy (`src/cli/status-cost.ts:129-177`). There is no JSON emit path in this module today, and the barrel `src/cli/status.ts:1-13` only re-exports the three human cost functions. The top-level CLI wiring in `bin/nax.ts:1300-1334` exposes `--cost`, `--last`, and `--model`, and routes directly to those human functions; there is no `--json` option on `status` yet. `bin/nax.ts:42-60` imports those functions through the broader CLI barrel, so the new export must remain reachable through `src/cli/status.ts` and then `src/cli/index.ts:11-17`.\n\nThe internal metrics seam already exists and should be reused rather than recomputed. `RunMetrics` and `AggregateMetrics` are defined in `src/metrics/types.ts:235-311`; `RunMetrics` contains the run-level fields the spec wants (`runId`, `feature`, `startedAt`, `completedAt`, `totalCost`, `totalStories`, `storiesCompleted`, `storiesFailed`, `totalDurationMs`, `stories`) plus internal-only `totalTokens` and optional `fallback` that must not leak into the public contract. `StoryMetrics` includes `modelUsed`, `attempts`, optional `context`, and optional `fallback` (`src/metrics/types.ts:98-201`), which is why the mapper has to curate fields instead of exporting internal objects directly. `calculateAggregateMetrics()` already returns the aggregate and per-model stats, including `modelEfficiency` and internal-only `complexityAccuracy` (`src/metrics/aggregator.ts:29-167`), and `getLastRun()` already encapsulates the last-run selection (`src/metrics/aggregator.ts:184-191`). The public metrics barrel at `src/metrics/index.ts:7-21` currently exports types plus `loadRunMetrics`, `calculateAggregateMetrics`, `deriveRunFallbackAggregates`, and `getLastRun`; adding `CostReportV1` and `toCostReport` here preserves the repo’s barrel-import convention and keeps consumers on `@/metrics` rather than leaf imports.\n\nThe strongest implementation precedent is the existing replay JSON design. `ReplayCommandDeps` in `src/commands/replay.ts:41-51` exposes swappable `stdout`, `stderr`, and mapper dependencies; `_replayCmdDeps` wires defaults with `process.stdout.write` and `toReplayJson` (`src/commands/replay.ts:95-105`); and `runReplay()` switches between human and JSON output by serializing a pure mapper result with `JSON.stringify(..., null, 2)` and a trailing newline (`src/commands/replay.ts:115-158`). The replay tests show the project’s preferred testing pattern for this seam: pure mapper tests in `test/unit/replay/json.test.ts:1-103`, and orchestrator/CLI-deps tests in `test/unit/commands/replay.test.ts:102-258` that inject spies for `toReplayJson` and `stdout` and assert the exact wiring behavior. That precedent should be mirrored for `toCostReport` and `emitCostReportJson`.\n\nExisting tests cover the underlying metrics helpers but not the new public report surface. `test/unit/metrics/metrics.test.ts:1-276` already verifies empty aggregates, aggregate math, model efficiency, and `getLastRun()`, and `test/unit/metrics/aggregator.test.ts:1-164` covers `complexityAccuracy` behavior. These tests reduce risk when the mapper composes existing helpers instead of reimplementing them. There does not appear to be an existing `status-cost` unit test file in `test/unit/cli`; searches for `displayCostMetrics`, `displayLastRunMetrics`, `displayModelEfficiency`, and `status-cost` returned no matches in tests, while `test/unit/cli` currently contains feature-status and project-level status tests only. That means US-002 likely needs to create a new CLI-focused test file even though the spec text says it extends an existing one. This is a spec/codebase mismatch to note for implementers, not a reason to change scope.\n\nImpact area summary: `src/metrics/index.ts` must gain the new public exports; a new pure mapper module should live under `src/metrics/report.ts`; `src/cli/status-cost.ts` must gain the JSON emitter while leaving the human `display*` functions behaviorally unchanged; `src/cli/status.ts` must re-export the emitter; and `bin/nax.ts` must register `--json` on the `status` command and route `options.cost && options.json` before `--last` or `--model`. Because `bin/nax.ts` imports from the broader CLI barrel, no separate import path should bypass the `src/cli/status.ts` seam. The likely new tests are `test/unit/metrics/report.test.ts` for the pure mapper and a new `test/unit/cli/status-cost.test.ts` for injected deps around `emitCostReportJson`, alongside possible small import/export assertions through `@/metrics` and `@/cli/status`.\n\nPrimary risks: exposing internal metrics types directly would freeze internal structure and leak fields the spec explicitly excludes (`totalTokens`, `context`, `pollution`, `complexityAccuracy`, `fallback`), so the mapper must construct fresh plain objects rather than pass through `RunMetrics` or `StoryMetrics`; JSON mode must not accidentally emit logger lines because the existing cost code is logger-driven and downstream consumers require stdout to contain only parseable JSON; the last-run average must explicitly guard `totalStories === 0` to avoid `NaN`; model and story ordering must be deterministic (`totalCost` desc for models, `cost` desc for stories); and project naming must reuse the exact `resolveOutputDir` project-key logic so the exported `project` field matches the metrics directory resolution. Backward compatibility is favorable: this is additive CLI functionality gated behind `--cost --json`, existing human `--cost`, `--cost --last`, and `--cost --model` output stays intact, and the public contract is versioned as `schemaVersion: \"1.0\"` to preserve future migration space. Migration path is therefore minimal: downstream scripts can opt into `nax status --cost --json` immediately, while existing human consumers continue unchanged. Error-handling expectations are also explicit from the spec and current design: empty metrics should still return valid JSON with null/empty sections, and I/O failures from `loadRunMetrics` should continue to propagate rather than being swallowed.",

--- a/.nax/features/status-cost-json/prd.json
+++ b/.nax/features/status-cost-json/prd.json
@@ -1,0 +1,114 @@
+{
+  "project": "@nathapp/nax",
+  "feature": "status-cost-json",
+  "branchName": "feat/status-cost-json",
+  "createdAt": "2026-07-10T08:49:26Z",
+  "updatedAt": "2026-07-10T08:52:42.326Z",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Cost Report Schema And Pure Mapper",
+      "description": "**Goal** — Introduce the stable public `CostReportV1` contract and a pure `toCostReport` mapper that converts internal run metrics into a curated JSON-safe export.\n\n**Motivation** — Internal types would leak if exposed naively. `AggregateMetrics` / `RunMetrics` / `StoryMetrics` are internal shapes that evolve. Exporting them directly would couple every internal refactor to the public contract — the exact coupling §1.4 exists to remove. A curated `CostReportV1` behind a mapper is the seam.\n\n**Approach** — Introduce the public `CostReportV1` contract and the pure `toCostReport` mapper in a new `src/metrics/report.ts`, exported from the `src/metrics` barrel. Pure, no I/O, no logger; composes the existing `calculateAggregateMetrics` and `getLastRun` helpers.\n\n**Scope** — In: `src/metrics/report.ts`, `src/metrics/index.ts`, and mapper-focused unit coverage for the stable export shape. Out: CLI flag wiring, stdout emission, logger behavior, and any changes to the existing human cost views.\n\n**Interface**\n```typescript\ninterface CostReportV1 {\n  schemaVersion: \"1.0\";\n  project: string;        // resolved projectKey (config.name || basename(workdir))\n  generatedAt: string;    // ISO timestamp, injected via deps.now\n  aggregate: CostAggregate | null;      // null when there are no runs\n  lastRun: CostRunSummary | null;       // null when there are no runs\n  modelEfficiency: CostModelStat[];     // sorted desc by totalCost; [] when none\n}\n\ninterface CostAggregate {\n  totalRuns: number;\n  totalStories: number;\n  totalCost: number;\n  avgCostPerStory: number;\n  avgCostPerFeature: number;\n  firstPassRate: number;\n  escalationRate: number;\n}\n\ninterface CostRunSummary {\n  runId: string;\n  feature: string;\n  startedAt: string;\n  completedAt: string;\n  durationMs: number;         // from RunMetrics.totalDurationMs\n  totalStories: number;\n  storiesCompleted: number;\n  storiesFailed: number;\n  totalCost: number;\n  avgCostPerStory: number;    // totalCost / totalStories, 0 when totalStories === 0\n  stories: CostStory[];       // every story in the last run, sorted desc by cost\n}\n\ninterface CostStory {\n  storyId: string;\n  cost: number;\n  model: string;              // from StoryMetrics.modelUsed\n  attempts: number;\n}\n\ninterface CostModelStat {\n  model: string;              // the modelEfficiency record key\n  attempts: number;\n  passRate: number;\n  avgCost: number;\n  totalCost: number;\n}\n```",
+      "acceptanceCriteria": [
+        "Given `toCostReport` imported from `@/metrics`, when it is called as `toCostReport([], deps)`, then it returns an object and does not throw.",
+        "Given any deps object, when `toCostReport([], deps)` returns, then `schemaVersion` equals the string `\"1.0\"`.",
+        "Given `deps.now` returning `\"2026-01-01T00:00:00.000Z\"`, when `toCostReport([], deps)` returns, then `generatedAt` equals `\"2026-01-01T00:00:00.000Z\"`.",
+        "Given `deps.project` equal to `\"myproj\"`, when `toCostReport(runs, deps)` returns, then `project` equals `\"myproj\"`.",
+        "Given an empty runs array, when `toCostReport([], deps)` returns, then `aggregate === null`, `lastRun === null`, and `modelEfficiency` deep-equals `[]`.",
+        "Given a non-empty `runs` array, when `toCostReport(runs, deps)` returns, then `aggregate.totalRuns`, `aggregate.totalCost`, and `aggregate.avgCostPerStory` equal the corresponding fields from `calculateAggregateMetrics(runs)`.",
+        "Given a non-empty `runs` array, when `toCostReport(runs, deps)` returns, then `lastRun.runId` and `lastRun.feature` equal the fields on `getLastRun(runs)`.",
+        "Given the last run contains two stories with costs `0.2` and `0.9`, when `toCostReport(runs, deps)` returns, then `lastRun.stories` is ordered by `cost` descending as `[0.9, 0.2]` and each entry exposes exactly `storyId`, `cost`, `model`, and `attempts`.",
+        "Given the aggregate contains two models with `totalCost` values `1.0` and `3.0`, when `toCostReport(runs, deps)` returns, then `modelEfficiency` is ordered by `totalCost` descending as `[3.0, 1.0]` and each entry exposes exactly `model`, `attempts`, `passRate`, `avgCost`, and `totalCost`.",
+        "Given the selected last run has `totalStories` equal to `0`, when `toCostReport(runs, deps)` returns, then `lastRun.avgCostPerStory` equals `0` and is not `NaN`.",
+        "Given a populated `runs` array, when `toCostReport(runs, deps)` returns, then `aggregate`, `lastRun`, and every `lastRun.stories` entry contain none of the keys `totalTokens`, `context`, `pollution`, `complexityAccuracy`, or `fallback`."
+      ],
+      "tags": [
+        "feature",
+        "metrics",
+        "json",
+        "cli"
+      ],
+      "dependencies": [],
+      "status": "pending",
+      "passes": false,
+      "attempts": 0,
+      "escalations": [],
+      "routing": {
+        "complexity": "medium",
+        "testStrategy": "tdd-simple",
+        "reasoning": "Adds a new mapper module, public types, barrel exports, and focused unit coverage while reusing existing aggregate helpers without changing runtime CLI wiring.",
+        "agentProfileId": "opencode-medium",
+        "agent": "opencode",
+        "profileModelTier": "balanced",
+        "initialAgent": "opencode",
+        "initialProfileId": "opencode-medium",
+        "initialModelTier": "balanced"
+      },
+      "contextFiles": [
+        "src/metrics/types.ts",
+        "src/metrics/aggregator.ts",
+        "src/metrics/index.ts",
+        "src/commands/replay.ts",
+        "test/unit/replay/json.test.ts"
+      ],
+      "expectedFiles": [
+        "src/metrics/report.ts",
+        "test/unit/metrics/report.test.ts"
+      ]
+    },
+    {
+      "id": "US-002",
+      "title": "CLI JSON Emit And Status Flag Wiring",
+      "description": "**Goal** — Add `nax status --cost --json` so the CLI emits one stable pretty-printed `CostReportV1` object to stdout through an injected output seam.\n\n**Motivation** — No machine-readable cost surface. `src/cli/status-cost.ts` emits via `logger.info`; there is no `--json` flag on `status`. A dashboard, CI spend gate, or spend-report script must parse formatted log output.\n\n**Approach** — Add `emitCostReportJson(workdir, deps?)` to `src/cli/status-cost.ts` (re-exported from `src/cli/status.ts`) that loads run metrics, resolves the project key, maps via the injected `toCostReport`, and writes pretty JSON through the injected `stdout`. Wire the `--json` option and its route into the `bin/nax.ts` `status` command.\n\n**Scope** — In: JSON emit orchestration in `src/cli/status-cost.ts`, barrel re-export wiring, status command option/branch wiring in `bin/nax.ts`, and CLI-deps tests for the emit seam. Out: changes to the human logger-based `displayCostMetrics`, `displayLastRunMetrics`, and `displayModelEfficiency` behavior beyond leaving them untouched.\n\n**Interface**\n```typescript\ninterface CostReportV1 {\n  schemaVersion: \"1.0\";\n  project: string;        // resolved projectKey (config.name || basename(workdir))\n  generatedAt: string;    // ISO timestamp, injected via deps.now\n  aggregate: CostAggregate | null;      // null when there are no runs\n  lastRun: CostRunSummary | null;       // null when there are no runs\n  modelEfficiency: CostModelStat[];     // sorted desc by totalCost; [] when none\n}\n```\n\n**Design Notes** — `stdout` must receive exactly `JSON.stringify(report, null, 2)` plus a trailing newline. In JSON mode `--last` and `--model` are ignored because the report always includes aggregate, last-run, and model-efficiency sections. `emitCostReportJson` should follow the `ReplayCommandDeps` pattern from `src/commands/replay.ts`, inject `loadRuns`, `toCostReport`, `now`, and `stdout`, and let I/O failures from `loadRunMetrics` propagate unchanged.",
+      "acceptanceCriteria": [
+        "Given `emitCostReportJson` imported from `@/cli/status`, when `typeof emitCostReportJson` is evaluated, then it equals `\"function\"`.",
+        "Given injected deps where `loadRuns` resolves to a non-empty runs array and `stdout` is a spy, when `emitCostReportJson(workdir, deps)` resolves, then `stdout` is called exactly once with a string whose `JSON.parse` result has `schemaVersion === \"1.0\"`.",
+        "Given injected deps where `toCostReport` is a spy returning a fixed report, when `emitCostReportJson(workdir, deps)` resolves, then `toCostReport` is invoked exactly once with the runs array returned by the injected `loadRuns`.",
+        "Given injected deps where `loadRuns` resolves to `[]`, when `emitCostReportJson(workdir, deps)` resolves, then it does not throw and the single `stdout` string parses to an object with `aggregate === null` and `modelEfficiency` deep-equal to `[]`.",
+        "Given injected deps where `toCostReport` returns a report object, when `emitCostReportJson(workdir, deps)` resolves, then `JSON.parse` of the single `stdout` string deep-equals that report object and the string contains a newline.",
+        "Given `dispatchStatusView` deps with spies for every view function and `options = { cost: true, json: true, last: true }`, when `dispatchStatusView(workdir, options, deps)` runs, then it invokes `deps.emitCostReportJson` and does not invoke `deps.displayLastRunMetrics` (JSON mode wins over --last).",
+        "Given `dispatchStatusView` deps with spies for every view function and `options = { cost: true, json: true, model: true }`, when `dispatchStatusView(workdir, options, deps)` runs, then it invokes `deps.emitCostReportJson` and does not invoke `deps.displayModelEfficiency` (JSON mode wins over --model).",
+        "Given `dispatchStatusView` deps with spies for every view function and `options = { cost: false, json: true }`, when `dispatchStatusView(workdir, options, deps)` runs, then it invokes `deps.displayFeatureStatus` with the feature-status options and does not invoke `deps.emitCostReportJson`.",
+        "Given injected deps where `loadRuns` rejects with an I/O error, when `emitCostReportJson(workdir, deps)` is awaited, then it rejects with the same error instead of swallowing or replacing it."
+      ],
+      "tags": [
+        "feature",
+        "cli",
+        "metrics",
+        "json"
+      ],
+      "dependencies": [
+        "US-001"
+      ],
+      "status": "pending",
+      "passes": false,
+      "attempts": 0,
+      "escalations": [],
+      "routing": {
+        "complexity": "medium",
+        "testStrategy": "tdd-simple",
+        "reasoning": "Extends existing CLI modules and commander wiring, introduces injected emit dependencies, and likely creates a new CLI test file because no existing status-cost test file is present.",
+        "agentProfileId": "opencode-medium",
+        "agent": "opencode",
+        "profileModelTier": "balanced",
+        "initialAgent": "opencode",
+        "initialProfileId": "opencode-medium",
+        "initialModelTier": "balanced"
+      },
+      "contextFiles": [
+        "src/cli/status-cost.ts",
+        "src/cli/status.ts",
+        "bin/nax.ts",
+        "src/commands/replay.ts",
+        "src/metrics/report.ts"
+      ],
+      "expectedFiles": [
+        "test/unit/cli/status-cost.test.ts",
+        "src/cli/status-dispatch.ts",
+        "test/unit/cli/status-dispatch.test.ts"
+      ]
+    }
+  ],
+  "analysis": "This feature extends the existing `status` CLI cost-reporting path with a stable machine-readable surface instead of changing the current human logger views. The current cost views live in `src/cli/status-cost.ts:13-177`; `resolveOutputDir()` derives `projectKey` from `config?.name?.trim() || basename(workdir)` and resolves the metrics directory via `projectOutputDir()` (`src/cli/status-cost.ts:13-17`). `displayCostMetrics()` loads runs and logs aggregate human fields only (`src/cli/status-cost.ts:29-50`), `displayLastRunMetrics()` logs the most recent run plus top stories and currently computes `avgCostPerStory` as `lastRun.totalCost / lastRun.totalStories` without a zero guard (`src/cli/status-cost.ts:77-101`), and `displayModelEfficiency()` logs sorted model stats plus complexity accuracy (`src/cli/status-cost.ts:129-177`). There is no JSON emit path in this module today, and the barrel `src/cli/status.ts:1-13` only re-exports the three human cost functions. The top-level CLI wiring in `bin/nax.ts:1300-1334` exposes `--cost`, `--last`, and `--model`, and routes directly to those human functions; there is no `--json` option on `status` yet. `bin/nax.ts:42-60` imports those functions through the broader CLI barrel, so the new export must remain reachable through `src/cli/status.ts` and then `src/cli/index.ts:11-17`.\n\nThe internal metrics seam already exists and should be reused rather than recomputed. `RunMetrics` and `AggregateMetrics` are defined in `src/metrics/types.ts:235-311`; `RunMetrics` contains the run-level fields the spec wants (`runId`, `feature`, `startedAt`, `completedAt`, `totalCost`, `totalStories`, `storiesCompleted`, `storiesFailed`, `totalDurationMs`, `stories`) plus internal-only `totalTokens` and optional `fallback` that must not leak into the public contract. `StoryMetrics` includes `modelUsed`, `attempts`, optional `context`, and optional `fallback` (`src/metrics/types.ts:98-201`), which is why the mapper has to curate fields instead of exporting internal objects directly. `calculateAggregateMetrics()` already returns the aggregate and per-model stats, including `modelEfficiency` and internal-only `complexityAccuracy` (`src/metrics/aggregator.ts:29-167`), and `getLastRun()` already encapsulates the last-run selection (`src/metrics/aggregator.ts:184-191`). The public metrics barrel at `src/metrics/index.ts:7-21` currently exports types plus `loadRunMetrics`, `calculateAggregateMetrics`, `deriveRunFallbackAggregates`, and `getLastRun`; adding `CostReportV1` and `toCostReport` here preserves the repo’s barrel-import convention and keeps consumers on `@/metrics` rather than leaf imports.\n\nThe strongest implementation precedent is the existing replay JSON design. `ReplayCommandDeps` in `src/commands/replay.ts:41-51` exposes swappable `stdout`, `stderr`, and mapper dependencies; `_replayCmdDeps` wires defaults with `process.stdout.write` and `toReplayJson` (`src/commands/replay.ts:95-105`); and `runReplay()` switches between human and JSON output by serializing a pure mapper result with `JSON.stringify(..., null, 2)` and a trailing newline (`src/commands/replay.ts:115-158`). The replay tests show the project’s preferred testing pattern for this seam: pure mapper tests in `test/unit/replay/json.test.ts:1-103`, and orchestrator/CLI-deps tests in `test/unit/commands/replay.test.ts:102-258` that inject spies for `toReplayJson` and `stdout` and assert the exact wiring behavior. That precedent should be mirrored for `toCostReport` and `emitCostReportJson`.\n\nExisting tests cover the underlying metrics helpers but not the new public report surface. `test/unit/metrics/metrics.test.ts:1-276` already verifies empty aggregates, aggregate math, model efficiency, and `getLastRun()`, and `test/unit/metrics/aggregator.test.ts:1-164` covers `complexityAccuracy` behavior. These tests reduce risk when the mapper composes existing helpers instead of reimplementing them. There does not appear to be an existing `status-cost` unit test file in `test/unit/cli`; searches for `displayCostMetrics`, `displayLastRunMetrics`, `displayModelEfficiency`, and `status-cost` returned no matches in tests, while `test/unit/cli` currently contains feature-status and project-level status tests only. That means US-002 likely needs to create a new CLI-focused test file even though the spec text says it extends an existing one. This is a spec/codebase mismatch to note for implementers, not a reason to change scope.\n\nImpact area summary: `src/metrics/index.ts` must gain the new public exports; a new pure mapper module should live under `src/metrics/report.ts`; `src/cli/status-cost.ts` must gain the JSON emitter while leaving the human `display*` functions behaviorally unchanged; `src/cli/status.ts` must re-export the emitter; and `bin/nax.ts` must register `--json` on the `status` command and route `options.cost && options.json` before `--last` or `--model`. Because `bin/nax.ts` imports from the broader CLI barrel, no separate import path should bypass the `src/cli/status.ts` seam. The likely new tests are `test/unit/metrics/report.test.ts` for the pure mapper and a new `test/unit/cli/status-cost.test.ts` for injected deps around `emitCostReportJson`, alongside possible small import/export assertions through `@/metrics` and `@/cli/status`.\n\nPrimary risks: exposing internal metrics types directly would freeze internal structure and leak fields the spec explicitly excludes (`totalTokens`, `context`, `pollution`, `complexityAccuracy`, `fallback`), so the mapper must construct fresh plain objects rather than pass through `RunMetrics` or `StoryMetrics`; JSON mode must not accidentally emit logger lines because the existing cost code is logger-driven and downstream consumers require stdout to contain only parseable JSON; the last-run average must explicitly guard `totalStories === 0` to avoid `NaN`; model and story ordering must be deterministic (`totalCost` desc for models, `cost` desc for stories); and project naming must reuse the exact `resolveOutputDir` project-key logic so the exported `project` field matches the metrics directory resolution. Backward compatibility is favorable: this is additive CLI functionality gated behind `--cost --json`, existing human `--cost`, `--cost --last`, and `--cost --model` output stays intact, and the public contract is versioned as `schemaVersion: \"1.0\"` to preserve future migration space. Migration path is therefore minimal: downstream scripts can opt into `nax status --cost --json` immediately, while existing human consumers continue unchanged. Error-handling expectations are also explicit from the spec and current design: empty metrics should still return valid JSON with null/empty sections, and I/O failures from `loadRunMetrics` should continue to propagate rather than being swallowed.",
+  "routingProfile": "cross-agent"
+}

--- a/.nax/features/status-cost-json/progress.txt
+++ b/.nax/features/status-cost-json/progress.txt
@@ -1,0 +1,1 @@
+[2026-07-10T09:43:21.072Z] US-001 — PASSED — Cost Report Schema And Pure Mapper — Cost: $1.8239

--- a/.nax/features/status-cost-json/progress.txt
+++ b/.nax/features/status-cost-json/progress.txt
@@ -1,1 +1,2 @@
 [2026-07-10T09:43:21.072Z] US-001 — PASSED — Cost Report Schema And Pure Mapper — Cost: $1.8239
+[2026-07-10T10:40:35.612Z] US-002 — PASSED — CLI JSON Emit And Status Flag Wiring — Cost: $3.4296

--- a/.nax/features/status-cost-json/spec.md
+++ b/.nax/features/status-cost-json/spec.md
@@ -58,13 +58,23 @@ Verified integration points (signatures confirmed against HEAD):
   untouched. `emitCostReportJson` resolves the same `projectKey` `resolveOutputDir`
   derives and passes it to `toCostReport`.
 - **`src/cli/status.ts`** barrel — re-exports `displayCostMetrics` etc.;
-  `emitCostReportJson` is added to this re-export so `bin/nax.ts` imports it from
-  `./status` like its siblings.
-- **`bin/nax.ts`** `status` command (currently `.option("--cost")` / `--last` / `--model`
-  with an inline `if (options.cost) { ... }` router) — gains
-  `.option("--json", "Emit machine-readable cost JSON to stdout (requires --cost)", false)`
-  and, as the first branch inside `if (options.cost)`, `if (options.json) { await
-  emitCostReportJson(workdir); return; }` so JSON mode runs before any human view.
+  `emitCostReportJson` and the new `dispatchStatusView` are added to this re-export so
+  `bin/nax.ts` imports them from `./status` like its siblings.
+- **`src/cli/status-dispatch.ts`** (new) — exports `dispatchStatusView(workdir, options,
+  deps?)`, the status-command routing extracted from the `bin/nax.ts` `.action()` closure
+  so the dispatch decisions become unit-testable. `deps` (injectable, real defaults)
+  carries `emitCostReportJson`, `displayCostMetrics`, `displayLastRunMetrics`,
+  `displayModelEfficiency`, `displayFeatureStatus`. Routing: when `options.cost` — JSON
+  mode (`options.json`) wins first (→ `emitCostReportJson`), else `--last` →
+  `displayLastRunMetrics`, `--model` → `displayModelEfficiency`, otherwise
+  `displayCostMetrics`; when `!options.cost` → `displayFeatureStatus` (JSON without
+  `--cost` falls through to the human feature-status view). Mirrors the existing inline
+  router's precedence, with `--json` inserted as the first cost branch.
+- **`bin/nax.ts`** `status` command — gains `.option("--json", "Emit machine-readable
+  cost JSON to stdout (requires --cost)", false)`; its `.action()` keeps the directory
+  validation / `findProjectDir` guard (CLI entry) and then delegates all view selection
+  to `await dispatchStatusView(workdir, options)`, replacing the inline
+  `if (options.cost) { ... }` block.
 
 ### CLI Behavior
 
@@ -75,9 +85,11 @@ Verified integration points (signatures confirmed against HEAD):
 - **Exit code:** `0` on success, including the empty-metrics case.
 - **Flag precedence:** in JSON mode `--last` and `--model` are ignored — the report
   always carries all three sections, so consumers never juggle which flag produced which
-  shape.
-- **`--json` without `--cost`:** out of scope; falls through to the existing human
-  feature-status view unchanged (a future feature-status JSON export is a separate spec).
+  shape. `dispatchStatusView` enforces this by checking `options.json` as the first cost
+  branch.
+- **`--json` without `--cost`:** out of scope; `dispatchStatusView` falls through to the
+  existing human feature-status view unchanged (a future feature-status JSON export is a
+  separate spec).
 
 ### File Format — `CostReportV1`
 
@@ -210,18 +222,22 @@ logger; composes the existing `calculateAggregateMetrics` and `getLastRun` helpe
 - **Also modifies:** `src/metrics/index.ts` (barrel export of `CostReportV1` +
   `toCostReport`).
 
-### US-002 — CLI JSON emit and `--json` wiring
+### US-002 — CLI JSON emit, testable dispatch, and `--json` wiring
 
 Add `emitCostReportJson(workdir, deps?)` to `src/cli/status-cost.ts` (re-exported from
 `src/cli/status.ts`) that loads run metrics, resolves the project key, maps via the
-injected `toCostReport`, and writes pretty JSON through the injected `stdout`. Wire the
-`--json` option and its route into the `bin/nax.ts` `status` command.
+injected `toCostReport`, and writes pretty JSON through the injected `stdout`. Extract
+the status-command view selection into a new exported `dispatchStatusView(workdir,
+options, deps?)` (`src/cli/status-dispatch.ts`) so routing is unit-testable, register the
+`--json` option on the `bin/nax.ts` `status` command, and make its `.action()` delegate
+to `dispatchStatusView`.
 
 - **Depends on:** US-001 (`toCostReport` / `CostReportV1` from `@/metrics`).
-- **Context Files (reads):** `src/cli/status-cost.ts`, `src/cli/status.ts`,
+- **Context Files (reads):** `src/cli/status-cost.ts`, `src/cli/status.ts`, `bin/nax.ts`,
   `src/commands/replay.ts` (deps pattern), `src/metrics/report.ts` — created by US-001,
   consumed here.
-- **Creates:** (none — extends existing files and the existing `status-cost` unit test).
+- **Creates:** `src/cli/status-dispatch.ts`, `test/unit/cli/status-cost.test.ts`,
+  `test/unit/cli/status-dispatch.test.ts`.
 
 ### Seams
 
@@ -230,6 +246,11 @@ injected `toCostReport`, and writes pretty JSON through the injected `stdout`. W
   that injects a spy `toCostReport` via `emitCostReportJson`'s deps, triggers the emit
   path, and asserts the spy was invoked with the loaded runs array — proving the call
   site exists and is wired, not merely that the name appears.
+- **`emitCostReportJson` (US-002 internal seam).** `dispatchStatusView` routes to
+  `emitCostReportJson` in JSON mode. US-002 declares seam ACs that inject spies for the
+  view functions via `dispatchStatusView`'s deps and assert, for each flag combination,
+  that the correct view (`emitCostReportJson` / `displayFeatureStatus`) is invoked and the
+  others are not — proving the dispatch wiring, not just that the functions exist.
 
 ## Acceptance Criteria
 
@@ -283,10 +304,23 @@ injected `toCostReport`, and writes pretty JSON through the injected `stdout`. W
 5. `[integration]` The string passed to `stdout` by `emitCostReportJson` round-trips:
    `JSON.parse` of it deep-equals the report object returned by the injected
    `toCostReport`, and the string contains a newline (pretty-printed, not minified).
+6. `[unit]` Given `dispatchStatusView` deps with spies for every view function and
+   `options = { cost: true, json: true, last: true }`, `dispatchStatusView(workdir,
+   options, deps)` invokes `deps.emitCostReportJson` and does not invoke
+   `deps.displayLastRunMetrics` (JSON mode wins over `--last`).
+7. `[unit]` Given the same spied deps and `options = { cost: true, json: true, model:
+   true }`, `dispatchStatusView(workdir, options, deps)` invokes `deps.emitCostReportJson`
+   and does not invoke `deps.displayModelEfficiency` (JSON mode wins over `--model`).
+8. `[unit]` Given the same spied deps and `options = { cost: false, json: true }`,
+   `dispatchStatusView(workdir, options, deps)` invokes `deps.displayFeatureStatus` with
+   the feature-status options and does not invoke `deps.emitCostReportJson` (`--json`
+   without `--cost` falls through to feature status).
+9. `[integration]` Given `emitCostReportJson` deps whose `loadRuns` rejects with an I/O
+   error, awaiting `emitCostReportJson(workdir, deps)` rejects with that same error
+   (the error is propagated, not swallowed or replaced).
 
-**Verification note (US-002 wiring):** the `bin/nax.ts` `--json` option registration and
-the `if (options.cost && options.json) { await emitCostReportJson(workdir); return; }`
-route are thin CLI wiring over the behaviour covered by ACs above; they are verified by
-the build/typecheck gate (`bun run build` / `bun run typecheck`) and manual
-`nax status --cost --json`, not by a runtime AC (commander action handlers are not unit
--tested in this repo).
+**Verification note (US-002 wiring):** the only untested residue is `bin/nax.ts`
+registering the `--json` option and its `.action()` delegating to `dispatchStatusView`
+— thin CLI wiring verified by the build/typecheck gate (`bun run build` /
+`bun run typecheck`) and manual `nax status --cost --json`. All view-selection behaviour
+now lives in the unit-tested `dispatchStatusView` (ACs 6-8).

--- a/.nax/features/status-cost-json/spec.md
+++ b/.nax/features/status-cost-json/spec.md
@@ -1,0 +1,292 @@
+# SPEC: `nax status --cost --json` — stable cost export
+
+<!-- spec-writing: completed-through-phase-5 -->
+
+## Summary
+
+Add a stable, versioned JSON export to `nax status --cost`. Today the cost views
+(`--cost`, `--cost --last`, `--cost --model`) render through the structured logger as
+human lines only; no downstream tool can consume nax cost data without scraping log
+text. This feature introduces a curated public contract — `CostReportV1` — produced by
+a pure mapper `toCostReport`, and emits it to stdout when `--json` accompanies `--cost`.
+It is the "cheapest slice" of IMPROVEMENT-REPORT §1.4 (metrics export).
+
+## Motivation
+
+- **No machine-readable cost surface.** `src/cli/status-cost.ts` emits via
+  `logger.info`; there is no `--json` flag on `status`. A dashboard, CI spend gate, or
+  spend-report script must parse formatted log output.
+- **Internal types would leak if exposed naively.** `AggregateMetrics` / `RunMetrics` /
+  `StoryMetrics` are internal shapes that evolve. Exporting them directly would couple
+  every internal refactor to the public contract — the exact coupling §1.4 exists to
+  remove. A curated `CostReportV1` behind a mapper is the seam.
+
+## Design
+
+### Approach
+
+Curated stable schema behind a pure mapper, mirroring the established
+`nax replay --json` pattern in `src/commands/replay.ts` (a `ReplayCommandDeps` object
+with an injectable `stdout` and the mapper `toReplayJson` itself injected). A dedicated
+`CostReportV1` type plus a pure `toCostReport(runs, deps)` mapper form the seam;
+internal metrics types change freely behind it. Chosen over a thin passthrough of
+internal types, which would re-couple the contract to internals.
+
+### Integration (extends existing code)
+
+Verified integration points (signatures confirmed against HEAD):
+
+- **`src/metrics` barrel** (`src/metrics/index.ts`) — currently re-exports the metrics
+  types and `loadRunMetrics`, `calculateAggregateMetrics`, `getLastRun`. The new
+  `CostReportV1` type and `toCostReport` mapper are exported from this barrel.
+  Consumers import from `@/metrics`, never the leaf (`project-conventions.md` barrel
+  rule).
+- **`calculateAggregateMetrics(runs: RunMetrics[]): AggregateMetrics`** and
+  **`getLastRun(runs: RunMetrics[]): RunMetrics | null`** (`src/metrics/aggregator.ts`) —
+  the mapper composes these two existing helpers; it does not recompute metrics.
+- **`RunMetrics`** fields used: `runId`, `feature`, `startedAt`, `completedAt`,
+  `totalDurationMs`, `totalStories`, `storiesCompleted`, `storiesFailed`, `totalCost`,
+  `stories`. **`StoryMetrics`** fields used: `storyId`, `cost`, `modelUsed`, `attempts`.
+  **`AggregateMetrics`** fields used: `totalRuns`, `totalStories`, `totalCost`,
+  `avgCostPerStory`, `avgCostPerFeature`, `firstPassRate`, `escalationRate`,
+  `modelEfficiency` (a `Record<string, {attempts, successes, passRate, avgCost, totalCost}>`).
+- **`src/cli/status-cost.ts`** — currently holds `displayCostMetrics`,
+  `displayLastRunMetrics`, `displayModelEfficiency` plus private `resolveOutputDir`
+  (which loads config, derives `projectKey = config?.name?.trim() || basename(workdir)`,
+  and calls `projectOutputDir`) and imports `loadRunMetrics`. A new
+  `emitCostReportJson(workdir, deps?)` is added here; the three `display*` functions are
+  untouched. `emitCostReportJson` resolves the same `projectKey` `resolveOutputDir`
+  derives and passes it to `toCostReport`.
+- **`src/cli/status.ts`** barrel — re-exports `displayCostMetrics` etc.;
+  `emitCostReportJson` is added to this re-export so `bin/nax.ts` imports it from
+  `./status` like its siblings.
+- **`bin/nax.ts`** `status` command (currently `.option("--cost")` / `--last` / `--model`
+  with an inline `if (options.cost) { ... }` router) — gains
+  `.option("--json", "Emit machine-readable cost JSON to stdout (requires --cost)", false)`
+  and, as the first branch inside `if (options.cost)`, `if (options.json) { await
+  emitCostReportJson(workdir); return; }` so JSON mode runs before any human view.
+
+### CLI Behavior
+
+- **Invocation:** `nax status --cost --json`.
+- **stdout:** exactly the pretty-printed (`JSON.stringify(report, null, 2)`) JSON of one
+  `CostReportV1` object, followed by a trailing newline. Nothing else on stdout.
+- **stderr:** unused on the success path (no human logger lines in JSON mode).
+- **Exit code:** `0` on success, including the empty-metrics case.
+- **Flag precedence:** in JSON mode `--last` and `--model` are ignored — the report
+  always carries all three sections, so consumers never juggle which flag produced which
+  shape.
+- **`--json` without `--cost`:** out of scope; falls through to the existing human
+  feature-status view unchanged (a future feature-status JSON export is a separate spec).
+
+### File Format — `CostReportV1`
+
+```ts
+interface CostReportV1 {
+  schemaVersion: "1.0";
+  project: string;        // resolved projectKey (config.name || basename(workdir))
+  generatedAt: string;    // ISO timestamp, injected via deps.now
+  aggregate: CostAggregate | null;      // null when there are no runs
+  lastRun: CostRunSummary | null;       // null when there are no runs
+  modelEfficiency: CostModelStat[];     // sorted desc by totalCost; [] when none
+}
+
+interface CostAggregate {
+  totalRuns: number;
+  totalStories: number;
+  totalCost: number;
+  avgCostPerStory: number;
+  avgCostPerFeature: number;
+  firstPassRate: number;
+  escalationRate: number;
+}
+
+interface CostRunSummary {
+  runId: string;
+  feature: string;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;         // from RunMetrics.totalDurationMs
+  totalStories: number;
+  storiesCompleted: number;
+  storiesFailed: number;
+  totalCost: number;
+  avgCostPerStory: number;    // totalCost / totalStories, 0 when totalStories === 0
+  stories: CostStory[];       // every story in the last run, sorted desc by cost
+}
+
+interface CostStory {
+  storyId: string;
+  cost: number;
+  model: string;              // from StoryMetrics.modelUsed
+  attempts: number;
+}
+
+interface CostModelStat {
+  model: string;              // the modelEfficiency record key
+  attempts: number;
+  passRate: number;
+  avgCost: number;
+  totalCost: number;
+}
+```
+
+Concrete example (populated, one run, two models):
+
+```json
+{
+  "schemaVersion": "1.0",
+  "project": "nax",
+  "generatedAt": "2026-07-10T12:00:00.000Z",
+  "aggregate": {
+    "totalRuns": 3, "totalStories": 12, "totalCost": 4.87,
+    "avgCostPerStory": 0.406, "avgCostPerFeature": 1.623,
+    "firstPassRate": 0.75, "escalationRate": 0.25
+  },
+  "lastRun": {
+    "runId": "run_abc123", "feature": "status-cost-json",
+    "startedAt": "2026-07-10T11:40:00.000Z", "completedAt": "2026-07-10T11:52:00.000Z",
+    "durationMs": 720000, "totalStories": 2, "storiesCompleted": 2, "storiesFailed": 0,
+    "totalCost": 1.42, "avgCostPerStory": 0.71,
+    "stories": [
+      { "storyId": "US-001", "cost": 0.9, "model": "claude-sonnet-4.5", "attempts": 1 },
+      { "storyId": "US-002", "cost": 0.52, "model": "claude-haiku-4.5", "attempts": 2 }
+    ]
+  },
+  "modelEfficiency": [
+    { "model": "claude-sonnet-4.5", "attempts": 8, "passRate": 0.875, "avgCost": 0.45, "totalCost": 3.6 },
+    { "model": "claude-haiku-4.5", "attempts": 4, "passRate": 0.75, "avgCost": 0.32, "totalCost": 1.27 }
+  ]
+}
+```
+
+Empty example (no runs yet):
+
+```json
+{
+  "schemaVersion": "1.0",
+  "project": "nax",
+  "generatedAt": "2026-07-10T12:00:00.000Z",
+  "aggregate": null,
+  "lastRun": null,
+  "modelEfficiency": []
+}
+```
+
+Internal-only fields (`totalTokens`, per-story `context`/pollution, run `fallback`
+aggregates, `complexityAccuracy`) are intentionally excluded from v1. Additive fields
+can land under a future `schemaVersion` without breaking `1.0` consumers.
+
+### Failure Handling
+
+- **Fail-open on empty metrics.** No runs → `toCostReport` returns a valid report with
+  `aggregate: null`, `lastRun: null`, `modelEfficiency: []`; `emitCostReportJson` prints
+  it and returns normally (exit 0). No exception, no non-JSON "no data" line — a
+  consuming script always parses valid JSON.
+- **Divide-by-zero.** `avgCostPerStory` in `lastRun` is `0` when `totalStories === 0`
+  (never `NaN` in the JSON).
+- **I/O errors** from `loadRunMetrics` propagate exactly as on the human path today —
+  no new swallow, no new catch.
+- **No `console.*` in `src/`.** stdout is written through the injected `deps.stdout`
+  seam (the `deps.stdout` pattern from `src/commands/replay.ts`), keeping the emit
+  testable and out of the structured logger. `emitCostReportJson`'s dependencies —
+  `loadRuns`, `toCostReport`, `now`, `stdout` — are injected via a deps parameter with
+  real defaults, mirroring `ReplayCommandDeps`.
+
+## Stories
+
+Two stories, linear dependency (US-002 depends on US-001).
+
+### US-001 — Cost report schema and pure mapper
+
+Introduce the public `CostReportV1` contract and the pure `toCostReport` mapper in a
+new `src/metrics/report.ts`, exported from the `src/metrics` barrel. Pure, no I/O, no
+logger; composes the existing `calculateAggregateMetrics` and `getLastRun` helpers.
+
+- **Depends on:** none.
+- **Context Files (reads):** `src/metrics/types.ts`, `src/metrics/aggregator.ts`,
+  `src/commands/replay.ts` (mapper/deps precedent).
+- **Creates:** `src/metrics/report.ts`, `test/unit/metrics/report.test.ts`.
+- **Also modifies:** `src/metrics/index.ts` (barrel export of `CostReportV1` +
+  `toCostReport`).
+
+### US-002 — CLI JSON emit and `--json` wiring
+
+Add `emitCostReportJson(workdir, deps?)` to `src/cli/status-cost.ts` (re-exported from
+`src/cli/status.ts`) that loads run metrics, resolves the project key, maps via the
+injected `toCostReport`, and writes pretty JSON through the injected `stdout`. Wire the
+`--json` option and its route into the `bin/nax.ts` `status` command.
+
+- **Depends on:** US-001 (`toCostReport` / `CostReportV1` from `@/metrics`).
+- **Context Files (reads):** `src/cli/status-cost.ts`, `src/cli/status.ts`,
+  `src/commands/replay.ts` (deps pattern), `src/metrics/report.ts` — created by US-001,
+  consumed here.
+- **Creates:** (none — extends existing files and the existing `status-cost` unit test).
+
+### Seams
+
+- **`toCostReport` (US-001 → US-002).** US-001 exports `toCostReport` from the
+  `@/metrics` barrel; US-002's `emitCostReportJson` calls it. US-002 declares a seam AC
+  that injects a spy `toCostReport` via `emitCostReportJson`'s deps, triggers the emit
+  path, and asserts the spy was invoked with the loaded runs array — proving the call
+  site exists and is wired, not merely that the name appears.
+
+## Acceptance Criteria
+
+### US-001 — Cost report schema and pure mapper
+
+1. `[unit]` `toCostReport` is importable from `@/metrics` and is usable as a function
+   (calling it with `([], deps)` returns an object, does not throw).
+2. `[unit]` `toCostReport([], deps)` returns an object whose `schemaVersion` equals the
+   string `"1.0"`.
+3. `[unit]` Given `deps.now` returning `"2026-01-01T00:00:00.000Z"`,
+   `toCostReport([], deps).generatedAt` equals `"2026-01-01T00:00:00.000Z"` (clock is
+   injected, not read from the real system clock).
+4. `[unit]` Given `deps.project` equal to `"myproj"`, `toCostReport(runs, deps).project`
+   equals `"myproj"`.
+5. `[unit]` `toCostReport([], deps)` returns `aggregate === null`, `lastRun === null`,
+   and `modelEfficiency` deep-equals `[]` (empty-metrics report).
+6. `[unit]` For a `runs` array of length ≥1, `toCostReport(runs, deps).aggregate` has
+   `totalRuns`, `totalCost`, and `avgCostPerStory` equal to the corresponding fields of
+   `calculateAggregateMetrics(runs)`.
+7. `[unit]` For a non-empty `runs` array, `toCostReport(runs, deps).lastRun.runId` and
+   `.feature` equal those of the run returned by `getLastRun(runs)`.
+8. `[unit]` In a last run with two stories of costs `0.2` and `0.9`,
+   `toCostReport(runs, deps).lastRun.stories` is ordered `[0.9, 0.2]` by `cost`
+   (descending), and each entry exposes exactly `storyId`, `cost`, `model`, `attempts`
+   (with `model` taken from `StoryMetrics.modelUsed`).
+9. `[unit]` When the aggregate has two models with `totalCost` `1.0` and `3.0`,
+   `toCostReport(runs, deps).modelEfficiency` is ordered `[3.0, 1.0]` by `totalCost`
+   (descending), and each entry exposes exactly `model`, `attempts`, `passRate`,
+   `avgCost`, `totalCost`.
+10. `[unit]` For a last run whose `totalStories` is `0`,
+    `toCostReport(runs, deps).lastRun.avgCostPerStory` equals `0` (not `NaN`).
+11. `[unit]` For a populated `runs` array, the returned `aggregate`, `lastRun`, and each
+    `lastRun.stories` entry contain none of the keys `totalTokens`, `context`,
+    `pollution`, `complexityAccuracy`, or `fallback` (internal fields do not leak).
+
+### US-002 — CLI JSON emit and `--json` wiring
+
+1. `[unit]` `emitCostReportJson` is importable from `@/cli/status` and is usable as a
+   function.
+2. `[integration]` Given injected deps where `loadRuns` resolves to a non-empty runs
+   array and `stdout` is a spy, `emitCostReportJson(workdir, deps)` calls `stdout`
+   exactly once with a string that `JSON.parse`s to an object whose `schemaVersion`
+   equals `"1.0"`.
+3. `[integration]` (seam) Given injected deps whose `toCostReport` is a spy returning a
+   fixed report, `emitCostReportJson(workdir, deps)` invokes that spy exactly once with
+   the runs array returned by the injected `loadRuns`.
+4. `[integration]` Given injected deps where `loadRuns` resolves to `[]`,
+   `emitCostReportJson(workdir, deps)` resolves without throwing and its single `stdout`
+   string `JSON.parse`s to an object with `aggregate === null` and `modelEfficiency`
+   deep-equal to `[]`.
+5. `[integration]` The string passed to `stdout` by `emitCostReportJson` round-trips:
+   `JSON.parse` of it deep-equals the report object returned by the injected
+   `toCostReport`, and the string contains a newline (pretty-printed, not minified).
+
+**Verification note (US-002 wiring):** the `bin/nax.ts` `--json` option registration and
+the `if (options.cost && options.json) { await emitCostReportJson(workdir); return; }`
+route are thin CLI wiring over the behaviour covered by ACs above; they are verified by
+the build/typecheck gate (`bun run build` / `bun run typecheck`) and manual
+`nax status --cost --json`, not by a runtime AC (commander action handlers are not unit
+-tested in this repo).

--- a/.nax/features/status-cost-json/status.json
+++ b/.nax/features/status-cost-json/status.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "run": {
+    "id": "run-2026-07-10T09-19-51-819Z",
+    "feature": "status-cost-json",
+    "startedAt": "2026-07-10T09:19:51.819Z",
+    "status": "completed",
+    "dryRun": false,
+    "pid": 64473
+  },
+  "progress": {
+    "total": 2,
+    "passed": 2,
+    "failed": 0,
+    "paused": 0,
+    "blocked": 0,
+    "pending": 0
+  },
+  "cost": {
+    "spent": 5.30355488,
+    "limit": 50
+  },
+  "current": null,
+  "iterations": 3,
+  "updatedAt": "2026-07-10T10:42:44.494Z",
+  "durationMs": 4972675,
+  "postRun": {
+    "acceptance": {
+      "status": "passed",
+      "lastRunAt": "2026-07-10T10:42:12.511Z"
+    },
+    "regression": {
+      "status": "passed",
+      "lastRunAt": "2026-07-10T10:42:43.288Z"
+    }
+  }
+}

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -68,6 +68,7 @@ import {
 } from "../src/cli/config-profile";
 import { resolveFeatureSpec } from "../src/cli/features-resolve";
 import { generateCommand } from "../src/cli/generate";
+import { registerStatusCommand } from "../src/cli/status-dispatch";
 import { dispatchStatusView } from "../src/cli/status-dispatch";
 import { detectCommand } from "../src/commands/detect";
 import { logsCommand } from "../src/commands/logs";
@@ -1294,40 +1295,7 @@ routingCmd
   });
 
 // ── status ───────────────────────────────────────────
-program
-  .command("status")
-  .description("Show current run status")
-  .option("-f, --feature <name>", "Feature name")
-  .option("-d, --dir <path>", "Project directory", process.cwd())
-  .option("--cost", "Show cost metrics across all runs", false)
-  .option("--last", "Show last run metrics (requires --cost)", false)
-  .option("--model", "Show per-model efficiency (requires --cost)", false)
-  .option("-j, --json", "Emit cost report as JSON (requires --cost)", false)
-  .action(async (options) => {
-    // Validate directory path
-    let workdir: string;
-    try {
-      workdir = validateDirectory(options.dir);
-    } catch (err) {
-      console.error(chalk.red(`Invalid directory: ${(err as Error).message}`));
-      process.exit(1);
-    }
-
-    const naxDir = findProjectDir(workdir);
-    if (!naxDir) {
-      console.error(chalk.red("nax not initialized."));
-      process.exit(1);
-    }
-
-    await dispatchStatusView(workdir, {
-      cost: Boolean(options.cost),
-      json: Boolean(options.json),
-      last: Boolean(options.last),
-      model: Boolean(options.model),
-      feature: options.feature as string | undefined,
-      dir: options.dir as string | undefined,
-    });
-  });
+registerStatusCommand(program);
 
 // ── logs ─────────────────────────────────────────────
 program

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -43,10 +43,6 @@ import {
   acceptCommand,
   agentsListCommand,
   contextInspectCommand,
-  displayCostMetrics,
-  displayFeatureStatus,
-  displayLastRunMetrics,
-  displayModelEfficiency,
   exportPromptCommand,
   planCommand,
   planDecomposeCommand,
@@ -72,6 +68,7 @@ import {
 } from "../src/cli/config-profile";
 import { resolveFeatureSpec } from "../src/cli/features-resolve";
 import { generateCommand } from "../src/cli/generate";
+import { dispatchStatusView } from "../src/cli/status-dispatch";
 import { detectCommand } from "../src/commands/detect";
 import { logsCommand } from "../src/commands/logs";
 import { precheckCommand } from "../src/commands/precheck";
@@ -1305,6 +1302,7 @@ program
   .option("--cost", "Show cost metrics across all runs", false)
   .option("--last", "Show last run metrics (requires --cost)", false)
   .option("--model", "Show per-model efficiency (requires --cost)", false)
+  .option("-j, --json", "Emit cost report as JSON (requires --cost)", false)
   .action(async (options) => {
     // Validate directory path
     let workdir: string;
@@ -1321,22 +1319,13 @@ program
       process.exit(1);
     }
 
-    // Handle cost metrics flags
-    if (options.cost) {
-      if (options.last) {
-        await displayLastRunMetrics(workdir);
-      } else if (options.model) {
-        await displayModelEfficiency(workdir);
-      } else {
-        await displayCostMetrics(workdir);
-      }
-      return;
-    }
-
-    // Default status: show feature progress (new implementation with active run detection)
-    await displayFeatureStatus({
-      feature: options.feature,
-      dir: options.dir,
+    await dispatchStatusView(workdir, {
+      cost: Boolean(options.cost),
+      json: Boolean(options.json),
+      last: Boolean(options.last),
+      model: Boolean(options.model),
+      feature: options.feature as string | undefined,
+      dir: options.dir as string | undefined,
     });
   });
 

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -69,7 +69,6 @@ import {
 import { resolveFeatureSpec } from "../src/cli/features-resolve";
 import { generateCommand } from "../src/cli/generate";
 import { registerStatusCommand } from "../src/cli/status-dispatch";
-import { dispatchStatusView } from "../src/cli/status-dispatch";
 import { detectCommand } from "../src/commands/detect";
 import { logsCommand } from "../src/commands/logs";
 import { precheckCommand } from "../src/commands/precheck";

--- a/docs/superpowers/specs/2026-07-10-status-cost-json-design.md
+++ b/docs/superpowers/specs/2026-07-10-status-cost-json-design.md
@@ -1,0 +1,185 @@
+# Design: `nax status --cost --json` — stable cost export
+
+> Date: 2026-07-10
+> Source: IMPROVEMENT-REPORT §1.4 (Dashboard / metrics export), "cheapest slice."
+> Scope: stabilize and machine-expose the cost metrics `nax status --cost` already
+> computes. OTel/Prometheus export and feature-status JSON are explicitly deferred.
+
+## Problem
+
+`nax status --cost` (and its `--last` / `--model` sub-views) render metrics through
+`logger.info` as human-formatted lines. There is no stable, machine-readable export,
+so no downstream tool (dashboard, CI gate, spend report) can consume nax cost data
+without scraping log text. IMPROVEMENT-REPORT §1.4 names `nax status --cost --json`
+schema stabilization as the cheapest first step toward a metrics-export surface.
+
+## Goals
+
+- Emit a **stable, versioned** JSON contract for cost metrics to stdout.
+- Decouple the public contract from internal metrics types so internal refactors do
+  not silently break consumers.
+- Zero behavioural change to the existing human `--cost` / `--last` / `--model` views.
+
+## Non-goals (YAGNI)
+
+- OTel / Prometheus exporter (the deferred second half of §1.4).
+- `nax status --json` for feature/story status (a separate, larger surface).
+- Any new computed metric. This slice exposes only what `--cost` already computes.
+
+## Approach
+
+Curated stable schema behind a pure mapper — mirroring the established
+`nax replay --json` pattern (`src/replay/json.ts` `toReplayJson` → `deps.stdout`).
+A dedicated public `CostReportV1` type plus a pure `toCostReport` mapper form the
+seam; internal `AggregateMetrics` / `RunMetrics` / `StoryMetrics` can change freely
+behind it. Chosen over a thin passthrough of internal types precisely because a
+passthrough would couple every internal metrics-type change to the public contract —
+the coupling §1.4 exists to avoid.
+
+## Components
+
+Three pieces, smallest layer that fits:
+
+1. **`src/metrics/report.ts`** (new, pure) — public `CostReportV1` type + a pure
+   mapper `toCostReport(runs, deps)`. No I/O, no logger. `deps = { now: () => string }`
+   is the injected ISO-timestamp seam (defaults to `() => new Date().toISOString()` at
+   the boundary). Total function: never throws on empty input — returns nulls.
+   Exported from the `src/metrics` barrel (`src/metrics/index.ts`).
+
+2. **`src/cli/status-cost.ts`** (extend) — add `emitCostReportJson(workdir, deps)`.
+   Reuses the existing private `resolveOutputDir` + `loadRunMetrics`, calls
+   `toCostReport`, and writes `JSON.stringify(report, null, 2)` to stdout via an
+   injected `deps.stdout` (default `(s) => process.stdout.write(s)`). The three existing
+   `display*` human functions are untouched.
+
+3. **`bin/nax.ts`** (wire) — add `.option("--json", "Emit machine-readable cost JSON to
+   stdout (requires --cost)", false)` to the `status` command. When
+   `options.cost && options.json`, route to `emitCostReportJson` and `return` before any
+   human view or logger line runs.
+
+## Schema — `CostReportV1`
+
+```ts
+interface CostReportV1 {
+  schemaVersion: "1.0";
+  project: string;        // resolved projectKey
+  generatedAt: string;    // ISO timestamp, injected via deps.now
+  aggregate: CostAggregate | null;
+  lastRun: CostRunSummary | null;
+  modelEfficiency: CostModelStat[];   // sorted desc by totalCost; [] when none
+}
+
+interface CostAggregate {
+  totalRuns: number;
+  totalStories: number;
+  totalCost: number;
+  avgCostPerStory: number;
+  avgCostPerFeature: number;
+  firstPassRate: number;
+  escalationRate: number;
+}
+
+interface CostRunSummary {
+  runId: string;
+  feature: string;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  totalStories: number;
+  storiesCompleted: number;
+  storiesFailed: number;
+  totalCost: number;
+  avgCostPerStory: number;
+  stories: CostStory[];   // all stories in the last run, sorted desc by cost
+}
+
+interface CostStory {
+  storyId: string;
+  cost: number;
+  model: string;
+  attempts: number;
+}
+
+interface CostModelStat {
+  model: string;
+  attempts: number;
+  passRate: number;
+  avgCost: number;
+  totalCost: number;
+}
+```
+
+Curated fields only. Every field maps from an existing metrics field
+(`AggregateMetrics`, `RunMetrics`, `StoryMetrics`, `AggregateMetrics.modelEfficiency`).
+Internal-only fields (token usage, context pollution, fallback aggregates, complexity
+accuracy) are intentionally excluded from v1 — additive fields can land in a future
+`schemaVersion` without breaking `1.0` consumers.
+
+`avgCostPerStory` in `lastRun` = `totalCost / totalStories`, guarded for
+`totalStories === 0` → `0` (avoid NaN in the JSON).
+
+## Data flow
+
+`nax status --cost --json`
+→ `resolveOutputDir(workdir)`
+→ `loadRunMetrics(outputDir)` → `RunMetrics[]`
+→ `toCostReport(runs, { now })`
+→ `JSON.stringify(report, null, 2)`
+→ `deps.stdout(...)`
+→ exit 0.
+
+`aggregate` / `modelEfficiency` derive from `calculateAggregateMetrics(runs)`;
+`lastRun` derives from `getLastRun(runs)`. The mapper is the single place these three
+existing helpers are composed into the public shape.
+
+## Empty state
+
+When `loadRunMetrics` returns `[]`, `toCostReport` emits a **valid** report:
+`aggregate: null`, `lastRun: null`, `modelEfficiency: []`, with `schemaVersion`,
+`project`, and `generatedAt` present. **Exit 0.** A consuming script always gets
+parseable JSON and never has to special-case a non-JSON "no data" line or a nonzero
+exit. This is the deliberate contrast with the human path, which logs "No metrics data
+available yet".
+
+## Flag interactions
+
+- `--cost --json` → unified `CostReportV1` (all three sections). `--last` / `--model`
+  are **ignored** in JSON mode — the report always carries all sections, so consumers
+  never juggle which flag produced which shape.
+- `--json` **without** `--cost` → out of scope for this slice; falls through to the
+  existing human feature-status view unchanged. A future feature-status JSON export is
+  a separate design.
+
+## Error handling
+
+- `toCostReport` is total — returns nulls on empty, never throws.
+- `avgCostPerStory` guards divide-by-zero → `0`.
+- I/O errors from `loadRunMetrics` propagate exactly as they do for the human path
+  today (no new swallow).
+- No `console.log` / `console.error` in `src/` — stdout goes through the injected
+  `deps.stdout` seam (the `deps.stdout` pattern from `src/commands/replay.ts`),
+  keeping the emit testable and out of the structured logger.
+
+## Testing
+
+- **`test/unit/metrics/report.test.ts`** (new) — `toCostReport` with injected `now`:
+  - populated runs → correct curated shape, `schemaVersion === "1.0"`,
+    `modelEfficiency` sorted desc by `totalCost`, `lastRun.stories` sorted desc by cost.
+  - empty `[]` → valid empty report (nulls + `[]` + envelope), `generatedAt` from
+    injected `now`.
+  - assert no internal-only fields (tokens, pollution, complexityAccuracy) leak into
+    the output.
+  - `totalStories === 0` in last run → `avgCostPerStory === 0`, no NaN.
+- **`status-cost` JSON emit** (add to existing `status-cost` unit test) — injected
+  `stdout` + `now` deps assert the exact JSON string emitted; empty-state path writes a
+  valid report and does not throw.
+
+Deterministic via DI (`now`, `stdout`); no real clock, no snapshot fragility.
+
+## Convention compliance
+
+- Bun-native, no Node fs/process APIs in new logic; stdout via injected dep.
+- `_deps` DI pattern for `now` and `stdout` (nax `_deps` convention).
+- Barrel export from `src/metrics`; consumers import from `@/metrics`, never the leaf.
+- File sizes well under limits; `status-cost.ts` gains one small function.
+- Conventional commits, one concern per commit.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,8 @@ export {
   displayCostMetrics,
   displayLastRunMetrics,
   displayModelEfficiency,
+  emitCostReportJson,
+  type CostReportEmitDeps,
   displayFeatureStatus,
   type FeatureStatusOptions,
 } from "./status";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,16 @@ export {
   displayFeatureStatus,
   type FeatureStatusOptions,
 } from "./status";
-export { dispatchStatusView, _statusViewDeps, type StatusViewDeps, type StatusViewOptions } from "./status-dispatch";
+export {
+  dispatchStatusView,
+  registerStatusCommand,
+  runStatusAction,
+  _statusViewDeps,
+  _statusCommandActionDeps,
+  type StatusCommandActionDeps,
+  type StatusViewDeps,
+  type StatusViewOptions,
+} from "./status-dispatch";
 export {
   runsListCommand,
   runsShowCommand,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ export {
   displayFeatureStatus,
   type FeatureStatusOptions,
 } from "./status";
+export { dispatchStatusView, _statusViewDeps, type StatusViewDeps, type StatusViewOptions } from "./status-dispatch";
 export {
   runsListCommand,
   runsShowCommand,

--- a/src/cli/status-cost.ts
+++ b/src/cli/status-cost.ts
@@ -7,8 +7,15 @@
 import { basename } from "node:path";
 import { loadConfig } from "../config";
 import { getLogger } from "../logger";
-import { calculateAggregateMetrics, getLastRun, loadRunMetrics } from "../metrics";
+import { calculateAggregateMetrics, getLastRun, loadRunMetrics, toCostReport } from "../metrics";
+import type { CostReportV1 } from "../metrics";
+import type { RunMetrics } from "../metrics/types";
 import { projectOutputDir } from "../runtime";
+
+async function resolveProjectKey(workdir: string): Promise<string> {
+  const config = await loadConfig(workdir).catch(() => null);
+  return config?.name?.trim() || basename(workdir);
+}
 
 async function resolveOutputDir(workdir: string): Promise<string> {
   const config = await loadConfig(workdir).catch(() => null);
@@ -174,4 +181,44 @@ export async function displayModelEfficiency(workdir: string): Promise<void> {
       mismatchRate: stats.mismatchRate,
     })),
   });
+}
+
+/**
+ * Injectable dependencies for `emitCostReportJson`.
+ *
+ * Mirrors the `ReplayCommandDeps` pattern: production callers get the
+ * filesystem-backed defaults via `_costReportEmitDeps`; tests inject spies.
+ */
+export interface CostReportEmitDeps {
+  loadRuns: (outputDir: string) => Promise<RunMetrics[]>;
+  resolveProject: (workdir: string) => Promise<string>;
+  toCostReport: (runs: RunMetrics[], reportDeps: { now: () => string; project: string }) => CostReportV1;
+  now: () => string;
+  stdout: (text: string) => void;
+}
+
+export const _costReportEmitDeps: CostReportEmitDeps = {
+  loadRuns: (outputDir: string) => loadRunMetrics(outputDir),
+  resolveProject: resolveProjectKey,
+  toCostReport,
+  now: () => new Date().toISOString(),
+  stdout: (text: string) => process.stdout.write(text),
+};
+
+/**
+ * Emit a stable pretty-printed `CostReportV1` object to stdout.
+ *
+ * I/O failures from `loadRuns` propagate unchanged so callers can surface them.
+ * The report always includes aggregate, last-run, and model-efficiency sections,
+ * which is why `--last` and `--model` are ignored when `--json` is set.
+ */
+export async function emitCostReportJson(
+  workdir: string,
+  deps: CostReportEmitDeps = _costReportEmitDeps,
+): Promise<void> {
+  const outputDir = await resolveOutputDir(workdir);
+  const runs = await deps.loadRuns(outputDir);
+  const project = await deps.resolveProject(workdir);
+  const report = deps.toCostReport(runs, { now: deps.now, project });
+  deps.stdout(`${JSON.stringify(report, null, 2)}\n`);
 }

--- a/src/cli/status-cost.ts
+++ b/src/cli/status-cost.ts
@@ -12,15 +12,11 @@ import type { CostReportV1 } from "../metrics";
 import type { RunMetrics } from "../metrics/types";
 import { projectOutputDir } from "../runtime";
 
-async function resolveProjectKey(workdir: string): Promise<string> {
+async function resolveProject(workdir: string): Promise<{ project: string; outputDir: string }> {
   const config = await loadConfig(workdir).catch(() => null);
-  return config?.name?.trim() || basename(workdir);
-}
-
-async function resolveOutputDir(workdir: string): Promise<string> {
-  const config = await loadConfig(workdir).catch(() => null);
-  const projectKey = config?.name?.trim() || basename(workdir);
-  return projectOutputDir(projectKey, config?.outputDir);
+  const project = config?.name?.trim() || basename(workdir);
+  const outputDir = projectOutputDir(project, config?.outputDir);
+  return { project, outputDir };
 }
 
 /**
@@ -35,7 +31,7 @@ async function resolveOutputDir(workdir: string): Promise<string> {
  */
 export async function displayCostMetrics(workdir: string): Promise<void> {
   const logger = getLogger();
-  const outputDir = await resolveOutputDir(workdir);
+  const { outputDir } = await resolveProject(workdir);
   const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
@@ -68,7 +64,7 @@ export async function displayCostMetrics(workdir: string): Promise<void> {
  */
 export async function displayLastRunMetrics(workdir: string): Promise<void> {
   const logger = getLogger();
-  const outputDir = await resolveOutputDir(workdir);
+  const { outputDir } = await resolveProject(workdir);
   const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
@@ -135,7 +131,7 @@ export async function displayLastRunMetrics(workdir: string): Promise<void> {
  */
 export async function displayModelEfficiency(workdir: string): Promise<void> {
   const logger = getLogger();
-  const outputDir = await resolveOutputDir(workdir);
+  const { outputDir } = await resolveProject(workdir);
   const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
@@ -188,10 +184,12 @@ export async function displayModelEfficiency(workdir: string): Promise<void> {
  *
  * Mirrors the `ReplayCommandDeps` pattern: production callers get the
  * filesystem-backed defaults via `_costReportEmitDeps`; tests inject spies.
+ * The project key and metrics directory are derived in one consistent path
+ * (see `resolveProject`) so the JSON `project` field cannot drift from the
+ * source the runs were loaded from.
  */
 export interface CostReportEmitDeps {
   loadRuns: (outputDir: string) => Promise<RunMetrics[]>;
-  resolveProject: (workdir: string) => Promise<string>;
   toCostReport: (runs: RunMetrics[], reportDeps: { now: () => string; project: string }) => CostReportV1;
   now: () => string;
   stdout: (text: string) => void;
@@ -199,7 +197,6 @@ export interface CostReportEmitDeps {
 
 export const _costReportEmitDeps: CostReportEmitDeps = {
   loadRuns: (outputDir: string) => loadRunMetrics(outputDir),
-  resolveProject: resolveProjectKey,
   toCostReport,
   now: () => new Date().toISOString(),
   stdout: (text: string) => process.stdout.write(text),
@@ -216,9 +213,8 @@ export async function emitCostReportJson(
   workdir: string,
   deps: CostReportEmitDeps = _costReportEmitDeps,
 ): Promise<void> {
-  const outputDir = await resolveOutputDir(workdir);
+  const { project, outputDir } = await resolveProject(workdir);
   const runs = await deps.loadRuns(outputDir);
-  const project = await deps.resolveProject(workdir);
   const report = deps.toCostReport(runs, { now: deps.now, project });
   deps.stdout(`${JSON.stringify(report, null, 2)}\n`);
 }

--- a/src/cli/status-dispatch.ts
+++ b/src/cli/status-dispatch.ts
@@ -1,0 +1,87 @@
+/**
+ * Status View Dispatch
+ *
+ * Routes `nax status` flag combinations to the right view function. JSON mode
+ * (`--cost --json`) wins over `--last` and `--model` because the JSON report
+ * always includes aggregate, last-run, and model-efficiency sections.
+ *
+ * Pure routing logic — every view function is injected so tests can assert
+ * the exact call shape without touching the filesystem or stdout.
+ */
+
+import type { FeatureStatusOptions } from "./status-features";
+
+/** CLI options parsed from commander for `nax status`. */
+export interface StatusViewOptions {
+  cost?: boolean;
+  json?: boolean;
+  last?: boolean;
+  model?: boolean;
+  feature?: string;
+  dir?: string;
+}
+
+/** Swappable view functions — keeps the dispatcher hermetic for tests. */
+export interface StatusViewDeps {
+  displayCostMetrics: (workdir: string) => Promise<void>;
+  displayLastRunMetrics: (workdir: string) => Promise<void>;
+  displayModelEfficiency: (workdir: string) => Promise<void>;
+  emitCostReportJson: (workdir: string) => Promise<void>;
+  displayFeatureStatus: (options: FeatureStatusOptions) => Promise<void>;
+}
+
+export const _statusViewDeps: StatusViewDeps = {
+  displayCostMetrics: async (workdir: string) => {
+    const { displayCostMetrics } = await import("./status-cost");
+    await displayCostMetrics(workdir);
+  },
+  displayLastRunMetrics: async (workdir: string) => {
+    const { displayLastRunMetrics } = await import("./status-cost");
+    await displayLastRunMetrics(workdir);
+  },
+  displayModelEfficiency: async (workdir: string) => {
+    const { displayModelEfficiency } = await import("./status-cost");
+    await displayModelEfficiency(workdir);
+  },
+  emitCostReportJson: async (workdir: string) => {
+    const { emitCostReportJson } = await import("./status-cost");
+    await emitCostReportJson(workdir);
+  },
+  displayFeatureStatus: async (options: FeatureStatusOptions) => {
+    const { displayFeatureStatus } = await import("./status-features");
+    await displayFeatureStatus(options);
+  },
+};
+
+/**
+ * Route `nax status` flags to the appropriate view function. JSON mode wins
+ * over `--last`/`--model`; otherwise the cost-mode flags branch into the
+ * human view functions; otherwise the feature-status view runs.
+ */
+export async function dispatchStatusView(
+  workdir: string,
+  options: StatusViewOptions,
+  deps: StatusViewDeps = _statusViewDeps,
+): Promise<void> {
+  if (options.cost && options.json) {
+    await deps.emitCostReportJson(workdir);
+    return;
+  }
+  if (options.cost) {
+    if (options.last) {
+      await deps.displayLastRunMetrics(workdir);
+      return;
+    }
+    if (options.model) {
+      await deps.displayModelEfficiency(workdir);
+      return;
+    }
+    await deps.displayCostMetrics(workdir);
+    return;
+  }
+  const featureOpts: FeatureStatusOptions = {
+    ...(options.feature !== undefined ? { feature: options.feature } : {}),
+    ...(options.dir !== undefined ? { dir: options.dir } : {}),
+  };
+  await deps.displayFeatureStatus(featureOpts);
+}

--- a/src/cli/status-dispatch.ts
+++ b/src/cli/status-dispatch.ts
@@ -9,6 +9,9 @@
  * the exact call shape without touching the filesystem or stdout.
  */
 
+import chalk from "chalk";
+import type { Command } from "commander";
+import { findProjectDir, validateDirectory } from "../config";
 import type { FeatureStatusOptions } from "./status-features";
 
 /** CLI options parsed from commander for `nax status`. */
@@ -84,4 +87,92 @@ export async function dispatchStatusView(
     ...(options.dir !== undefined ? { dir: options.dir } : {}),
   };
   await deps.displayFeatureStatus(featureOpts);
+}
+
+/**
+ * Status command action dependencies. The action calls into the dispatcher
+ * with a stable `StatusViewOptions` shape and forwards failures to stderr +
+ * exit(1). The action is injectable so commander-level tests can assert the
+ * exact dispatch behavior without touching the filesystem or `process.exit`.
+ */
+export interface StatusCommandActionDeps {
+  validateDirectory: (dir: string) => string;
+  findProjectDir: (workdir: string) => string | null;
+  dispatchStatusView: typeof dispatchStatusView;
+}
+
+export const _statusCommandActionDeps: StatusCommandActionDeps = {
+  validateDirectory,
+  findProjectDir,
+  dispatchStatusView,
+};
+
+/**
+ * Run the `status` subcommand action against the dispatcher. Extracted so
+ * commander-level tests can exercise the real bin/nax.ts wiring (including
+ * the new `--json` option) without spinning up a child process.
+ */
+export async function runStatusAction(
+  options: {
+    cost?: boolean;
+    json?: boolean;
+    last?: boolean;
+    model?: boolean;
+    feature?: string;
+    dir?: string;
+  },
+  deps: StatusCommandActionDeps = _statusCommandActionDeps,
+): Promise<void> {
+  const workdir = deps.validateDirectory(options.dir ?? process.cwd());
+  const naxDir = deps.findProjectDir(workdir);
+  if (!naxDir) {
+    process.stderr.write(`${chalk.red("nax not initialized.")}\n`);
+    process.exit(1);
+  }
+  await deps.dispatchStatusView(workdir, {
+    cost: options.cost === true,
+    json: options.json === true,
+    last: options.last === true,
+    model: options.model === true,
+    ...(options.feature !== undefined ? { feature: options.feature } : {}),
+    ...(options.dir !== undefined ? { dir: options.dir } : {}),
+  });
+}
+
+/**
+ * Register the `status` subcommand on a commander `Command` instance.
+ *
+ * The option surface mirrors what `bin/nax.ts` exposes; the action delegates
+ * to `runStatusAction` so the routing logic is independently testable.
+ */
+export function registerStatusCommand(
+  program: Command,
+  deps: StatusCommandActionDeps = _statusCommandActionDeps,
+): void {
+  program
+    .command("status")
+    .description("Show current run status")
+    .option("-f, --feature <name>", "Feature name")
+    .option("-d, --dir <path>", "Project directory", process.cwd())
+    .option("--cost", "Show cost metrics across all runs", false)
+    .option("--last", "Show last run metrics (requires --cost)", false)
+    .option("--model", "Show per-model efficiency (requires --cost)", false)
+    .option("-j, --json", "Emit cost report as JSON (requires --cost)", false)
+    .action(
+      async (options: {
+        cost?: boolean;
+        json?: boolean;
+        last?: boolean;
+        model?: boolean;
+        feature?: string;
+        dir?: string;
+      }) => {
+        try {
+          await runStatusAction(options, deps);
+        } catch (err) {
+          process.stderr.write(`${chalk.red(`Error: ${(err as Error).message}`)}\n`);
+          process.exit(1);
+        }
+      },
+    );
 }

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -7,7 +7,13 @@
  */
 
 // Cost metrics
-export { displayCostMetrics, displayLastRunMetrics, displayModelEfficiency } from "./status-cost";
+export {
+  displayCostMetrics,
+  displayLastRunMetrics,
+  displayModelEfficiency,
+  emitCostReportJson,
+  type CostReportEmitDeps,
+} from "./status-cost";
 
 // Feature display
 export { displayFeatureStatus, type FeatureStatusOptions } from "./status-features";

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -19,3 +19,12 @@ export {
   loadRunMetrics,
 } from "./tracker";
 export { calculateAggregateMetrics, deriveRunFallbackAggregates, getLastRun } from "./aggregator";
+export {
+  toCostReport,
+  type CostAggregate,
+  type CostModelStat,
+  type CostReportDeps,
+  type CostReportV1,
+  type CostRunSummary,
+  type CostStory,
+} from "./report";

--- a/src/metrics/report.ts
+++ b/src/metrics/report.ts
@@ -11,7 +11,7 @@
 
 import { NaxError } from "../errors";
 import { calculateAggregateMetrics, getLastRun } from "./aggregator";
-import type { RunMetrics } from "./types";
+import type { AggregateMetrics, RunMetrics } from "./types";
 
 /**
  * Public stable report shape. Versioned via `schemaVersion` so downstream
@@ -85,9 +85,10 @@ const FORBIDDEN_INTERNAL_KEYS = ["totalTokens", "context", "pollution", "complex
  * internal fields never leak into the contract.
  */
 export function toCostReport(runs: RunMetrics[], deps: CostReportDeps): CostReportV1 {
-  const aggregate = buildAggregate(runs);
+  const metrics = runs.length === 0 ? null : calculateAggregateMetrics(runs);
+  const aggregate = buildAggregate(metrics);
   const lastRun = buildLastRun(runs);
-  const modelEfficiency = buildModelEfficiency(runs);
+  const modelEfficiency = buildModelEfficiency(metrics);
 
   const report: CostReportV1 = {
     schemaVersion: SCHEMA_VERSION,
@@ -101,17 +102,16 @@ export function toCostReport(runs: RunMetrics[], deps: CostReportDeps): CostRepo
   return stripInternalFields(report);
 }
 
-function buildAggregate(runs: RunMetrics[]): CostAggregate | null {
-  if (runs.length === 0) return null;
-  const a = calculateAggregateMetrics(runs);
+function buildAggregate(metrics: AggregateMetrics | null): CostAggregate | null {
+  if (!metrics) return null;
   return {
-    totalRuns: a.totalRuns,
-    totalStories: a.totalStories,
-    totalCost: a.totalCost,
-    avgCostPerStory: a.avgCostPerStory,
-    avgCostPerFeature: a.avgCostPerFeature,
-    firstPassRate: a.firstPassRate,
-    escalationRate: a.escalationRate,
+    totalRuns: metrics.totalRuns,
+    totalStories: metrics.totalStories,
+    totalCost: metrics.totalCost,
+    avgCostPerStory: metrics.avgCostPerStory,
+    avgCostPerFeature: metrics.avgCostPerFeature,
+    firstPassRate: metrics.firstPassRate,
+    escalationRate: metrics.escalationRate,
   };
 }
 
@@ -147,10 +147,9 @@ function buildLastRun(runs: RunMetrics[]): CostRunSummary | null {
   };
 }
 
-function buildModelEfficiency(runs: RunMetrics[]): CostModelStat[] {
-  if (runs.length === 0) return [];
-  const a = calculateAggregateMetrics(runs);
-  return Object.entries(a.modelEfficiency)
+function buildModelEfficiency(metrics: AggregateMetrics | null): CostModelStat[] {
+  if (!metrics) return [];
+  return Object.entries(metrics.modelEfficiency)
     .map(([model, stat]) => ({
       model,
       attempts: stat.attempts,

--- a/src/metrics/report.ts
+++ b/src/metrics/report.ts
@@ -1,0 +1,189 @@
+/**
+ * Cost Report Mapper
+ *
+ * Pure, side-effect-free mapper that converts internal run metrics into the
+ * stable public `CostReportV1` contract. No I/O, no logger, no Date.now.
+ *
+ * The contract deliberately strips internal fields (`totalTokens`, `context`,
+ * `pollution`, `complexityAccuracy`, `fallback`) so consumers can rely on the
+ * shape independent of internal refactors.
+ */
+
+import { NaxError } from "../errors";
+import { calculateAggregateMetrics, getLastRun } from "./aggregator";
+import type { RunMetrics } from "./types";
+
+/**
+ * Public stable report shape. Versioned via `schemaVersion` so downstream
+ * consumers can branch on contract changes.
+ */
+export interface CostReportV1 {
+  schemaVersion: "1.0";
+  project: string;
+  generatedAt: string;
+  aggregate: CostAggregate | null;
+  lastRun: CostRunSummary | null;
+  modelEfficiency: CostModelStat[];
+}
+
+export interface CostAggregate {
+  totalRuns: number;
+  totalStories: number;
+  totalCost: number;
+  avgCostPerStory: number;
+  avgCostPerFeature: number;
+  firstPassRate: number;
+  escalationRate: number;
+}
+
+export interface CostRunSummary {
+  runId: string;
+  feature: string;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  totalStories: number;
+  storiesCompleted: number;
+  storiesFailed: number;
+  totalCost: number;
+  avgCostPerStory: number;
+  stories: CostStory[];
+}
+
+export interface CostStory {
+  storyId: string;
+  cost: number;
+  model: string;
+  attempts: number;
+}
+
+export interface CostModelStat {
+  model: string;
+  attempts: number;
+  passRate: number;
+  avgCost: number;
+  totalCost: number;
+}
+
+/**
+ * Injectable dependencies for the pure mapper. Callers can supply a frozen
+ * `now()` for deterministic timestamps.
+ */
+export interface CostReportDeps {
+  now: () => string;
+  project: string;
+}
+
+const SCHEMA_VERSION = "1.0" as const;
+const FORBIDDEN_INTERNAL_KEYS = ["totalTokens", "context", "pollution", "complexityAccuracy", "fallback"] as const;
+
+/**
+ * Convert internal run metrics into the public `CostReportV1` shape.
+ *
+ * Composition-only: aggregates via `calculateAggregateMetrics`, picks the
+ * last run via `getLastRun`, and curates a fresh plain-object tree so
+ * internal fields never leak into the contract.
+ */
+export function toCostReport(runs: RunMetrics[], deps: CostReportDeps): CostReportV1 {
+  const aggregate = buildAggregate(runs);
+  const lastRun = buildLastRun(runs);
+  const modelEfficiency = buildModelEfficiency(runs);
+
+  const report: CostReportV1 = {
+    schemaVersion: SCHEMA_VERSION,
+    project: deps.project,
+    generatedAt: deps.now(),
+    aggregate,
+    lastRun,
+    modelEfficiency,
+  };
+
+  return stripInternalFields(report);
+}
+
+function buildAggregate(runs: RunMetrics[]): CostAggregate | null {
+  if (runs.length === 0) return null;
+  const a = calculateAggregateMetrics(runs);
+  return {
+    totalRuns: a.totalRuns,
+    totalStories: a.totalStories,
+    totalCost: a.totalCost,
+    avgCostPerStory: a.avgCostPerStory,
+    avgCostPerFeature: a.avgCostPerFeature,
+    firstPassRate: a.firstPassRate,
+    escalationRate: a.escalationRate,
+  };
+}
+
+function buildLastRun(runs: RunMetrics[]): CostRunSummary | null {
+  const last = getLastRun(runs);
+  if (!last) return null;
+
+  const totalStories = last.totalStories;
+  const totalCost = last.totalCost;
+  const avgCostPerStory = totalStories === 0 ? 0 : totalCost / totalStories;
+
+  const stories = [...last.stories]
+    .sort((a, b) => b.cost - a.cost)
+    .map((s) => ({
+      storyId: s.storyId,
+      cost: s.cost,
+      model: s.modelUsed,
+      attempts: s.attempts,
+    }));
+
+  return {
+    runId: last.runId,
+    feature: last.feature,
+    startedAt: last.startedAt,
+    completedAt: last.completedAt,
+    durationMs: last.totalDurationMs,
+    totalStories,
+    storiesCompleted: last.storiesCompleted,
+    storiesFailed: last.storiesFailed,
+    totalCost,
+    avgCostPerStory,
+    stories,
+  };
+}
+
+function buildModelEfficiency(runs: RunMetrics[]): CostModelStat[] {
+  if (runs.length === 0) return [];
+  const a = calculateAggregateMetrics(runs);
+  return Object.entries(a.modelEfficiency)
+    .map(([model, stat]) => ({
+      model,
+      attempts: stat.attempts,
+      passRate: stat.passRate,
+      avgCost: stat.avgCost,
+      totalCost: stat.totalCost,
+    }))
+    .sort((x, y) => y.totalCost - x.totalCost);
+}
+
+function stripInternalFields(report: CostReportV1): CostReportV1 {
+  // Defense in depth: the curated shapes above already exclude internal
+  // fields, but ASSERT that forbidden keys never appear in the contract.
+  // This guards against future internal refactors that silently leak.
+  assertNoInternalFields(report, "<root>");
+  if (report.aggregate) assertNoInternalFields(report.aggregate, "aggregate");
+  if (report.lastRun) {
+    assertNoInternalFields(report.lastRun, "lastRun");
+    for (const story of report.lastRun.stories) {
+      assertNoInternalFields(story, "lastRun.stories[]");
+    }
+  }
+  return report;
+}
+
+function assertNoInternalFields<T extends object>(value: T, path: string): void {
+  for (const key of FORBIDDEN_INTERNAL_KEYS) {
+    if (key in (value as Record<string, unknown>)) {
+      throw new NaxError(
+        `[metrics/report] forbidden internal field "${key}" leaked at ${path}`,
+        "COST_REPORT_LEAKED_INTERNAL_FIELD",
+        { path, field: key },
+      );
+    }
+  }
+}

--- a/test/unit/cli/status-cost.test.ts
+++ b/test/unit/cli/status-cost.test.ts
@@ -22,6 +22,7 @@ import { join } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 import { emitCostReportJson, type CostReportEmitDeps } from "@/cli";
 import type { CostReportV1 } from "@/metrics";
+import { projectOutputDir } from "@/runtime";
 
 const FIXED_REPORT: CostReportV1 = {
   schemaVersion: "1.0",
@@ -57,7 +58,6 @@ const FIXED_REPORT: CostReportV1 = {
 function makeDeps(overrides: Partial<CostReportEmitDeps> = {}): CostReportEmitDeps {
   return {
     loadRuns: mock(async () => []),
-    resolveProject: mock(async () => "myproj"),
     toCostReport: mock(() => FIXED_REPORT),
     now: () => "2026-01-01T00:00:00.000Z",
     stdout: mock(() => {}),
@@ -95,13 +95,20 @@ describe("emitCostReportJson — AC1: export shape", () => {
 describe("emitCostReportJson — AC2: stdout payload schemaVersion", () => {
   test("AC2: with non-empty runs and stdout spy, stdout is called once with a string whose JSON.parse has schemaVersion === '1.0'", async () => {
     const stdout = mock(() => {});
+    const loadRuns = mock(async () => [{ runId: "r1", feature: "f1" }] as never);
     const deps = makeDeps({
-      loadRuns: mock(async () => [{ runId: "r1", feature: "f1" }] as never),
+      loadRuns,
       stdout,
     });
 
     await emitCostReportJson("/tmp/workdir", deps);
 
+    // loadRuns must be invoked exactly once with the metrics dir derived
+    // from the same workdir that drives the project field — guards against
+    // a regression that splits the project/outputDir resolution.
+    expect(loadRuns.mock.calls).toHaveLength(1);
+    const loadRunsArg = loadRuns.mock.calls[0]?.[0];
+    expect(loadRunsArg).toBe(projectOutputDir("workdir"));
     expect(stdout.mock.calls).toHaveLength(1);
     const out = stdout.mock.calls[0]?.[0];
     expect(typeof out).toBe("string");
@@ -111,22 +118,28 @@ describe("emitCostReportJson — AC2: stdout payload schemaVersion", () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC-3: toCostReport receives runs array from loadRuns
+// AC-3: toCostReport receives runs array from loadRuns and project/now from seams
 // ---------------------------------------------------------------------------
 
-describe("emitCostReportJson — AC3: toCostReport receives injected runs", () => {
-  test("AC3: toCostReport is invoked exactly once with the runs array returned by loadRuns", async () => {
+describe("emitCostReportJson — AC3: toCostReport receives injected runs + seam wiring", () => {
+  test("AC3: toCostReport is invoked exactly once with the runs array returned by loadRuns, plus { now, project } where now is from deps.now and project is derived from the workdir via the canonical resolveProject path", async () => {
     const injectedRuns = [{ runId: "r1", feature: "f1" }, { runId: "r2", feature: "f2" }] as never;
     const toCostReport = mock(() => FIXED_REPORT);
     const deps = makeDeps({
       loadRuns: mock(async () => injectedRuns),
       toCostReport,
+      now: () => "2026-01-01T12:34:56.000Z",
     });
 
-    await emitCostReportJson("/tmp/workdir", deps);
+    await emitCostReportJson("/tmp/proj-x", deps);
 
     expect(toCostReport.mock.calls).toHaveLength(1);
     expect(toCostReport.mock.calls[0]?.[0]).toBe(injectedRuns);
+    const reportDeps = toCostReport.mock.calls[0]?.[1] as { now: () => string; project: string };
+    expect(reportDeps.now()).toBe("2026-01-01T12:34:56.000Z");
+    // project is derived from the workdir via the same resolveProject path
+    // used to compute outputDir — no separate seam to override.
+    expect(reportDeps.project).toBe("proj-x");
   });
 });
 

--- a/test/unit/cli/status-cost.test.ts
+++ b/test/unit/cli/status-cost.test.ts
@@ -1,0 +1,183 @@
+/**
+ * emitCostReportJson — CLI JSON orchestration (US-002)
+ *
+ * AC-1: emitCostReportJson is exported from @/cli/status as a function.
+ * AC-2: with non-empty runs and a stdout spy, stdout is called exactly once
+ *       with a string whose JSON.parse result has schemaVersion === "1.0".
+ * AC-3: when toCostReport is a spy returning a fixed report, toCostReport is
+ *       invoked exactly once with the runs array returned by the injected
+ *       loadRuns.
+ * AC-4: with loadRuns resolving to [], emitCostReportJson does not throw and
+ *       the single stdout string parses to an object with aggregate === null
+ *       and modelEfficiency deep-equal to [].
+ * AC-5: when toCostReport returns a report object, JSON.parse of the single
+ *       stdout string deep-equals that report object and the string contains
+ *       a newline.
+ * AC-9: when loadRuns rejects with an I/O error, emitCostReportJson awaits
+ *       and rejects with the same error.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { emitCostReportJson, type CostReportEmitDeps } from "@/cli/status";
+import type { CostReportV1 } from "@/metrics";
+
+const FIXED_REPORT: CostReportV1 = {
+  schemaVersion: "1.0",
+  project: "myproj",
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  aggregate: {
+    totalRuns: 1,
+    totalStories: 1,
+    totalCost: 0.5,
+    avgCostPerStory: 0.5,
+    avgCostPerFeature: 0.5,
+    firstPassRate: 1,
+    escalationRate: 0,
+  },
+  lastRun: {
+    runId: "run-1",
+    feature: "feat-x",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:00:10.000Z",
+    durationMs: 10000,
+    totalStories: 1,
+    storiesCompleted: 1,
+    storiesFailed: 0,
+    totalCost: 0.5,
+    avgCostPerStory: 0.5,
+    stories: [{ storyId: "US-001", cost: 0.5, model: "claude-sonnet-4-5", attempts: 1 }],
+  },
+  modelEfficiency: [
+    { model: "claude-sonnet-4-5", attempts: 1, passRate: 1, avgCost: 0.5, totalCost: 0.5 },
+  ],
+};
+
+function makeDeps(overrides: Partial<CostReportEmitDeps> = {}): CostReportEmitDeps {
+  return {
+    loadRuns: mock(async () => []),
+    resolveProject: mock(async () => "myproj"),
+    toCostReport: mock(() => FIXED_REPORT),
+    now: () => "2026-01-01T00:00:00.000Z",
+    stdout: mock(() => {}),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC-1: exported function
+// ---------------------------------------------------------------------------
+
+describe("emitCostReportJson — AC1: export shape", () => {
+  test("AC1: emitCostReportJson imported from @/cli/status is a function", () => {
+    expect(typeof emitCostReportJson).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: stdout receives exactly one JSON string with schemaVersion === "1.0"
+// ---------------------------------------------------------------------------
+
+describe("emitCostReportJson — AC2: stdout payload schemaVersion", () => {
+  test("AC2: with non-empty runs and stdout spy, stdout is called once with a string whose JSON.parse has schemaVersion === '1.0'", async () => {
+    const stdout = mock(() => {});
+    const deps = makeDeps({
+      loadRuns: mock(async () => [{ runId: "r1", feature: "f1" }] as never),
+      stdout,
+    });
+
+    await emitCostReportJson("/tmp/workdir", deps);
+
+    expect(stdout.mock.calls).toHaveLength(1);
+    const out = stdout.mock.calls[0]?.[0];
+    expect(typeof out).toBe("string");
+    const parsed = JSON.parse(out as string);
+    expect(parsed.schemaVersion).toBe("1.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: toCostReport receives runs array from loadRuns
+// ---------------------------------------------------------------------------
+
+describe("emitCostReportJson — AC3: toCostReport receives injected runs", () => {
+  test("AC3: toCostReport is invoked exactly once with the runs array returned by loadRuns", async () => {
+    const injectedRuns = [{ runId: "r1", feature: "f1" }, { runId: "r2", feature: "f2" }] as never;
+    const toCostReport = mock(() => FIXED_REPORT);
+    const deps = makeDeps({
+      loadRuns: mock(async () => injectedRuns),
+      toCostReport,
+    });
+
+    await emitCostReportJson("/tmp/workdir", deps);
+
+    expect(toCostReport.mock.calls).toHaveLength(1);
+    expect(toCostReport.mock.calls[0]?.[0]).toBe(injectedRuns);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: empty runs → aggregate=null, modelEfficiency=[]
+// ---------------------------------------------------------------------------
+
+describe("emitCostReportJson — AC4: empty runs safety", () => {
+  test("AC4: with loadRuns resolving to [], does not throw and stdout string parses to { aggregate: null, modelEfficiency: [] }", async () => {
+    const stdout = mock(() => {});
+    // Real toCostReport — the orchestrator must let the mapper handle empty
+    // runs without swallowing them into a fake non-null aggregate.
+    const { toCostReport: realToCostReport } = await import("@/metrics/report");
+    const deps = makeDeps({
+      loadRuns: mock(async () => []),
+      toCostReport: realToCostReport as CostReportEmitDeps["toCostReport"],
+      stdout,
+    });
+
+    await expect(emitCostReportJson("/tmp/workdir", deps)).resolves.toBeUndefined();
+
+    expect(stdout.mock.calls).toHaveLength(1);
+    const parsed = JSON.parse(stdout.mock.calls[0]?.[0] as string);
+    expect(parsed.aggregate).toBeNull();
+    expect(parsed.modelEfficiency).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-5: stdout string deep-equals the report + contains a newline
+// ---------------------------------------------------------------------------
+
+describe("emitCostReportJson — AC5: stdout deep-equals report", () => {
+  test("AC5: JSON.parse(stdout) deep-equals the report returned by toCostReport and the string contains a newline", async () => {
+    const stdout = mock(() => {});
+    const deps = makeDeps({
+      loadRuns: mock(async () => [{ runId: "r1" }] as never),
+      toCostReport: mock(() => FIXED_REPORT),
+      stdout,
+    });
+
+    await emitCostReportJson("/tmp/workdir", deps);
+
+    expect(stdout.mock.calls).toHaveLength(1);
+    const out = stdout.mock.calls[0]?.[0] as string;
+    expect(out.includes("\n")).toBe(true);
+    expect(JSON.parse(out)).toEqual(FIXED_REPORT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-9: loadRuns I/O error propagates
+// ---------------------------------------------------------------------------
+
+describe("emitCostReportJson — AC9: I/O error propagation", () => {
+  test("AC9: when loadRuns rejects with an I/O error, emitCostReportJson rejects with the same error", async () => {
+    const ioError = new Error("EACCES: permission denied, open '/x/metrics.json'");
+    const stdout = mock(() => {});
+    const deps = makeDeps({
+      loadRuns: mock(async () => {
+        throw ioError;
+      }),
+      stdout,
+    });
+
+    await expect(emitCostReportJson("/tmp/workdir", deps)).rejects.toBe(ioError);
+    expect(stdout.mock.calls).toHaveLength(0);
+  });
+});

--- a/test/unit/cli/status-cost.test.ts
+++ b/test/unit/cli/status-cost.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
-import { emitCostReportJson, type CostReportEmitDeps } from "@/cli/status";
+import { emitCostReportJson, type CostReportEmitDeps } from "@/cli";
 import type { CostReportV1 } from "@/metrics";
 
 const FIXED_REPORT: CostReportV1 = {
@@ -124,7 +124,7 @@ describe("emitCostReportJson — AC4: empty runs safety", () => {
     const stdout = mock(() => {});
     // Real toCostReport — the orchestrator must let the mapper handle empty
     // runs without swallowing them into a fake non-null aggregate.
-    const { toCostReport: realToCostReport } = await import("@/metrics/report");
+    const { toCostReport: realToCostReport } = await import("@/metrics");
     const deps = makeDeps({
       loadRuns: mock(async () => []),
       toCostReport: realToCostReport as CostReportEmitDeps["toCostReport"],

--- a/test/unit/cli/status-cost.test.ts
+++ b/test/unit/cli/status-cost.test.ts
@@ -17,6 +17,8 @@
  *       and rejects with the same error.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 import { emitCostReportJson, type CostReportEmitDeps } from "@/cli";
 import type { CostReportV1 } from "@/metrics";
@@ -64,12 +66,25 @@ function makeDeps(overrides: Partial<CostReportEmitDeps> = {}): CostReportEmitDe
 }
 
 // ---------------------------------------------------------------------------
-// AC-1: exported function
+// AC-1: exported function via the @/cli/status barrel
+//
+// The repo's check:alias-internals gate forbids `from "@/cli/status"` because
+// @/cli has its own barrel; importing through @/cli would not catch a
+// regression that drops the symbol from the @/cli/status re-export barrel.
+// To prove AC-1's actual contract — that the symbol is reachable through the
+// @/cli/status barrel — this test inspects src/cli/status.ts directly and
+// asserts it re-exports emitCostReportJson from ./status-cost.
 // ---------------------------------------------------------------------------
 
 describe("emitCostReportJson — AC1: export shape", () => {
-  test("AC1: emitCostReportJson imported from @/cli/status is a function", () => {
+  test("AC1: emitCostReportJson is a function and is re-exported from the @/cli/status barrel", () => {
     expect(typeof emitCostReportJson).toBe("function");
+
+    const barrelSrc = readFileSync(
+      join(import.meta.dir, "../../../src/cli/status.ts"),
+      "utf8",
+    );
+    expect(barrelSrc).toMatch(/export\s*\{[\s\S]*?\bemitCostReportJson\b[\s\S]*?\}\s*from\s+["']\.\/status-cost["']/);
   });
 });
 

--- a/test/unit/cli/status-dispatch.test.ts
+++ b/test/unit/cli/status-dispatch.test.ts
@@ -64,11 +64,14 @@ describe("dispatchStatusView — AC7: --cost --json --model", () => {
 describe("dispatchStatusView — AC8: --json without --cost", () => {
   test("AC8: with { cost: false, json: true }, invokes displayFeatureStatus with the feature-status options and does NOT invoke emitCostReportJson", async () => {
     const deps = makeDeps();
-    const options = { cost: false, json: true };
+    const options = { cost: false, json: true, feature: "feat-x", dir: "/tmp/workdir" };
 
     await dispatchStatusView("/tmp/workdir", options, deps);
 
     expect((deps.displayFeatureStatus as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
     expect((deps.emitCostReportJson as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
+    const forwarded = (deps.displayFeatureStatus as ReturnType<typeof mock>).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(forwarded.feature).toBe("feat-x");
+    expect(forwarded.dir).toBe("/tmp/workdir");
   });
 });

--- a/test/unit/cli/status-dispatch.test.ts
+++ b/test/unit/cli/status-dispatch.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
-import { dispatchStatusView, type StatusViewDeps } from "@/cli/status-dispatch";
+import { dispatchStatusView, type StatusViewDeps } from "@/cli";
 
 function makeDeps(): StatusViewDeps {
   return {

--- a/test/unit/cli/status-dispatch.test.ts
+++ b/test/unit/cli/status-dispatch.test.ts
@@ -1,0 +1,74 @@
+/**
+ * dispatchStatusView — Status command view routing (US-002)
+ *
+ * AC-6: dispatchStatusView with { cost: true, json: true, last: true } invokes
+ *       deps.emitCostReportJson and does NOT invoke deps.displayLastRunMetrics
+ *       (JSON mode wins over --last).
+ * AC-7: dispatchStatusView with { cost: true, json: true, model: true } invokes
+ *       deps.emitCostReportJson and does NOT invoke deps.displayModelEfficiency
+ *       (JSON mode wins over --model).
+ * AC-8: dispatchStatusView with { cost: false, json: true } invokes
+ *       deps.displayFeatureStatus with the feature-status options and does NOT
+ *       invoke deps.emitCostReportJson.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { dispatchStatusView, type StatusViewDeps } from "@/cli/status-dispatch";
+
+function makeDeps(): StatusViewDeps {
+  return {
+    displayCostMetrics: mock(async () => {}),
+    displayLastRunMetrics: mock(async () => {}),
+    displayModelEfficiency: mock(async () => {}),
+    emitCostReportJson: mock(async () => {}),
+    displayFeatureStatus: mock(async () => {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC-6: --cost --json --last → JSON mode wins
+// ---------------------------------------------------------------------------
+
+describe("dispatchStatusView — AC6: --cost --json --last", () => {
+  test("AC6: with { cost: true, json: true, last: true }, invokes emitCostReportJson and does NOT invoke displayLastRunMetrics", async () => {
+    const deps = makeDeps();
+    const options = { cost: true, json: true, last: true };
+
+    await dispatchStatusView("/tmp/workdir", options, deps);
+
+    expect((deps.emitCostReportJson as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((deps.displayLastRunMetrics as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-7: --cost --json --model → JSON mode wins
+// ---------------------------------------------------------------------------
+
+describe("dispatchStatusView — AC7: --cost --json --model", () => {
+  test("AC7: with { cost: true, json: true, model: true }, invokes emitCostReportJson and does NOT invoke displayModelEfficiency", async () => {
+    const deps = makeDeps();
+    const options = { cost: true, json: true, model: true };
+
+    await dispatchStatusView("/tmp/workdir", options, deps);
+
+    expect((deps.emitCostReportJson as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((deps.displayModelEfficiency as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8: --json without --cost → feature status path
+// ---------------------------------------------------------------------------
+
+describe("dispatchStatusView — AC8: --json without --cost", () => {
+  test("AC8: with { cost: false, json: true }, invokes displayFeatureStatus with the feature-status options and does NOT invoke emitCostReportJson", async () => {
+    const deps = makeDeps();
+    const options = { cost: false, json: true };
+
+    await dispatchStatusView("/tmp/workdir", options, deps);
+
+    expect((deps.displayFeatureStatus as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((deps.emitCostReportJson as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
+  });
+});

--- a/test/unit/cli/status-dispatch.test.ts
+++ b/test/unit/cli/status-dispatch.test.ts
@@ -10,10 +10,19 @@
  * AC-8: dispatchStatusView with { cost: false, json: true } invokes
  *       deps.displayFeatureStatus with the feature-status options and does NOT
  *       invoke deps.emitCostReportJson.
+ *
+ * Plus commander-level wiring coverage so `status --json` is exercised end-to-end.
  */
 
 import { describe, expect, mock, test } from "bun:test";
-import { dispatchStatusView, type StatusViewDeps } from "@/cli";
+import {
+  type StatusCommandActionDeps,
+  type StatusViewDeps,
+  dispatchStatusView,
+  registerStatusCommand,
+  runStatusAction,
+} from "@/cli";
+import { Command } from "commander";
 
 function makeDeps(): StatusViewDeps {
   return {
@@ -70,8 +79,66 @@ describe("dispatchStatusView — AC8: --json without --cost", () => {
 
     expect((deps.displayFeatureStatus as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
     expect((deps.emitCostReportJson as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
-    const forwarded = (deps.displayFeatureStatus as ReturnType<typeof mock>).mock.calls[0]?.[0] as Record<string, unknown>;
+    const forwarded = (deps.displayFeatureStatus as ReturnType<typeof mock>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
     expect(forwarded.feature).toBe("feat-x");
     expect(forwarded.dir).toBe("/tmp/workdir");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Commander-level wiring: status subcommand registers --json and routes
+// to dispatchStatusView via runStatusAction (extracted from bin/nax.ts).
+// ---------------------------------------------------------------------------
+
+describe("registerStatusCommand — commander wiring for --json", () => {
+  test("registers a subcommand named 'status' that exposes --json, --cost, --last, and --model", () => {
+    const program = new Command();
+    registerStatusCommand(program);
+
+    const sub = program.commands.find((c) => c.name() === "status");
+    expect(sub).toBeDefined();
+    if (!sub) throw new Error("status subcommand not registered");
+    const help = sub.helpInformation();
+    expect(help).toContain("--json");
+    expect(help).toContain("--cost");
+    expect(help).toContain("--last");
+    expect(help).toContain("--model");
+  });
+});
+
+function makeActionDeps(viewDeps: StatusViewDeps = makeDeps()): StatusCommandActionDeps {
+  return {
+    validateDirectory: (dir: string) => dir,
+    findProjectDir: () => "/tmp/.nax",
+    dispatchStatusView: mock(async (_workdir: string, opts: Parameters<typeof dispatchStatusView>[1]) => {
+      await dispatchStatusView(_workdir, opts, viewDeps);
+    }) as StatusCommandActionDeps["dispatchStatusView"],
+  };
+}
+
+describe("runStatusAction — --cost --json --last routes through JSON mode", () => {
+  test("with --cost --json --last, dispatches to emitCostReportJson and skips displayLastRunMetrics", async () => {
+    const viewDeps = makeDeps();
+    const actionDeps = makeActionDeps(viewDeps);
+
+    await runStatusAction({ cost: true, json: true, last: true, dir: "/tmp/workdir" }, actionDeps);
+
+    expect((viewDeps.emitCostReportJson as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((viewDeps.displayLastRunMetrics as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
+  });
+});
+
+describe("runStatusAction — --json without --cost falls back to feature status", () => {
+  test("with --json only, invokes displayFeatureStatus and does NOT invoke emitCostReportJson", async () => {
+    const viewDeps = makeDeps();
+    const actionDeps = makeActionDeps(viewDeps);
+
+    await runStatusAction({ json: true, feature: "feat-x", dir: "/tmp/workdir" }, actionDeps);
+
+    expect((viewDeps.displayFeatureStatus as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((viewDeps.emitCostReportJson as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
   });
 });

--- a/test/unit/metrics/report.test.ts
+++ b/test/unit/metrics/report.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, test } from "bun:test";
 import { toCostReport } from "@/metrics";
 import type { CostReportDeps, CostReportV1 } from "@/metrics";
 import type { RunMetrics, StoryMetrics } from "@/metrics";
+import { calculateAggregateMetrics, getLastRun } from "@/metrics";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -133,7 +134,7 @@ describe("toCostReport — empty runs", () => {
 // ---------------------------------------------------------------------------
 
 describe("toCostReport — aggregate mirrors calculateAggregateMetrics", () => {
-  test("AC6: aggregate.totalRuns, totalCost, avgCostPerStory match calculateAggregateMetrics", () => {
+  test("AC6: aggregate.totalRuns, totalCost, avgCostPerStory equal calculateAggregateMetrics(runs)", () => {
     const stories = [
       makeStoryMetrics({ storyId: "US-001", cost: 0.4 }),
       makeStoryMetrics({ storyId: "US-002", cost: 0.6, modelUsed: "claude-opus-4-5" }),
@@ -141,11 +142,12 @@ describe("toCostReport — aggregate mirrors calculateAggregateMetrics", () => {
     const runs = [makeRun(stories, { runId: "run-a" })];
 
     const result = toCostReport(runs, fixedDeps);
+    const expected = calculateAggregateMetrics(runs);
 
     expect(result.aggregate).not.toBeNull();
-    expect(result.aggregate?.totalRuns).toBe(1);
-    expect(result.aggregate?.totalCost).toBeCloseTo(1.0, 6);
-    expect(result.aggregate?.avgCostPerStory).toBeCloseTo(0.5, 6);
+    expect(result.aggregate?.totalRuns).toBe(expected.totalRuns);
+    expect(result.aggregate?.totalCost).toBeCloseTo(expected.totalCost, 10);
+    expect(result.aggregate?.avgCostPerStory).toBeCloseTo(expected.avgCostPerStory, 10);
   });
 });
 
@@ -154,7 +156,7 @@ describe("toCostReport — aggregate mirrors calculateAggregateMetrics", () => {
 // ---------------------------------------------------------------------------
 
 describe("toCostReport — lastRun mirrors getLastRun", () => {
-  test("AC7: lastRun.runId and lastRun.feature equal getLastRun(runs).runId/feature", () => {
+  test("AC7: lastRun.runId and lastRun.feature equal getLastRun(runs)", () => {
     const older = makeRun([makeStoryMetrics({ storyId: "US-OLD" })], {
       runId: "run-old",
       feature: "feat-old",
@@ -167,10 +169,12 @@ describe("toCostReport — lastRun mirrors getLastRun", () => {
     });
 
     const result = toCostReport([older, newer], fixedDeps);
+    const last = getLastRun([older, newer]);
 
+    expect(last).not.toBeNull();
     expect(result.lastRun).not.toBeNull();
-    expect(result.lastRun?.runId).toBe("run-new");
-    expect(result.lastRun?.feature).toBe("feat-new");
+    expect(result.lastRun?.runId).toBe(last?.runId);
+    expect(result.lastRun?.feature).toBe(last?.feature);
   });
 });
 

--- a/test/unit/metrics/report.test.ts
+++ b/test/unit/metrics/report.test.ts
@@ -1,0 +1,330 @@
+/**
+ * toCostReport — Stable public cost report contract (US-001)
+ *
+ * AC-1: importable from @/metrics
+ * AC-2: schemaVersion equals "1.0"
+ * AC-3: generatedAt equals deps.now()
+ * AC-4: project equals deps.project
+ * AC-5: empty runs → aggregate=null, lastRun=null, modelEfficiency=[]
+ * AC-6: aggregate fields equal calculateAggregateMetrics
+ * AC-7: lastRun.runId/feature equal getLastRun
+ * AC-8: lastRun.stories sorted by cost desc; entries expose exactly storyId/cost/model/attempts
+ * AC-9: modelEfficiency sorted by totalCost desc; entries expose exactly model/attempts/passRate/avgCost/totalCost
+ * AC-10: lastRun.totalStories=0 → avgCostPerStory===0 (not NaN)
+ * AC-11: no internal fields leaked (totalTokens, context, pollution, complexityAccuracy, fallback)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { toCostReport } from "@/metrics";
+import type { CostReportDeps, CostReportV1 } from "@/metrics";
+import type { RunMetrics, StoryMetrics } from "@/metrics";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStoryMetrics(overrides: Partial<StoryMetrics> & { storyId: string }): StoryMetrics {
+  return {
+    storyId: overrides.storyId,
+    complexity: "medium",
+    modelTier: "balanced",
+    modelUsed: "claude-sonnet-4-5",
+    attempts: 1,
+    finalTier: "balanced",
+    success: true,
+    cost: 0.1,
+    durationMs: 5000,
+    firstPassSuccess: true,
+    startedAt: "2026-01-01T00:00:00Z",
+    completedAt: "2026-01-01T00:00:05Z",
+    ...overrides,
+  };
+}
+
+function makeRun(stories: StoryMetrics[], overrides: Partial<RunMetrics> = {}): RunMetrics {
+  return {
+    runId: "run-001",
+    feature: "test-feature",
+    startedAt: "2026-01-01T00:00:00Z",
+    completedAt: "2026-01-01T00:01:00Z",
+    totalCost: stories.reduce((sum, s) => sum + s.cost, 0),
+    totalStories: stories.length,
+    storiesCompleted: stories.filter((s) => s.success).length,
+    storiesFailed: stories.filter((s) => !s.success).length,
+    totalDurationMs: 60000,
+    stories,
+    ...overrides,
+  };
+}
+
+const fixedDeps: CostReportDeps = {
+  now: () => "2026-01-01T00:00:00.000Z",
+  project: "myproj",
+};
+
+// ---------------------------------------------------------------------------
+// AC-1: importable + safe with empty runs
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — module + empty runs safety", () => {
+  test("AC1: toCostReport is exported from @/metrics as a function", () => {
+    expect(typeof toCostReport).toBe("function");
+  });
+
+  test("AC1: toCostReport([], deps) returns an object and does not throw", () => {
+    const result = toCostReport([], fixedDeps);
+    expect(typeof result).toBe("object");
+    expect(result).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2/3/4: top-level scalar fields
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — schemaVersion / generatedAt / project", () => {
+  test("AC2: schemaVersion equals '1.0' regardless of input", () => {
+    const result = toCostReport([], fixedDeps);
+    expect(result.schemaVersion).toBe("1.0");
+  });
+
+  test("AC3: generatedAt equals the ISO string returned by deps.now", () => {
+    const deps: CostReportDeps = {
+      now: () => "2026-01-01T00:00:00.000Z",
+      project: "any",
+    };
+    const result = toCostReport([], deps);
+    expect(result.generatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("AC4: project equals deps.project (e.g. 'myproj')", () => {
+    const deps: CostReportDeps = {
+      now: () => "2026-01-01T00:00:00.000Z",
+      project: "myproj",
+    };
+    const result = toCostReport([], deps);
+    expect(result.project).toBe("myproj");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-5: empty runs → aggregate=null, lastRun=null, modelEfficiency=[]
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — empty runs", () => {
+  test("AC5: aggregate is null when runs array is empty", () => {
+    const result = toCostReport([], fixedDeps);
+    expect(result.aggregate).toBeNull();
+  });
+
+  test("AC5: lastRun is null when runs array is empty", () => {
+    const result = toCostReport([], fixedDeps);
+    expect(result.lastRun).toBeNull();
+  });
+
+  test("AC5: modelEfficiency deep-equals [] when runs array is empty", () => {
+    const result = toCostReport([], fixedDeps);
+    expect(result.modelEfficiency).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6: aggregate fields mirror calculateAggregateMetrics
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — aggregate mirrors calculateAggregateMetrics", () => {
+  test("AC6: aggregate.totalRuns, totalCost, avgCostPerStory match calculateAggregateMetrics", () => {
+    const stories = [
+      makeStoryMetrics({ storyId: "US-001", cost: 0.4 }),
+      makeStoryMetrics({ storyId: "US-002", cost: 0.6, modelUsed: "claude-opus-4-5" }),
+    ];
+    const runs = [makeRun(stories, { runId: "run-a" })];
+
+    const result = toCostReport(runs, fixedDeps);
+
+    expect(result.aggregate).not.toBeNull();
+    expect(result.aggregate?.totalRuns).toBe(1);
+    expect(result.aggregate?.totalCost).toBeCloseTo(1.0, 6);
+    expect(result.aggregate?.avgCostPerStory).toBeCloseTo(0.5, 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-7: lastRun.runId / lastRun.feature mirror getLastRun
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — lastRun mirrors getLastRun", () => {
+  test("AC7: lastRun.runId and lastRun.feature equal getLastRun(runs).runId/feature", () => {
+    const older = makeRun([makeStoryMetrics({ storyId: "US-OLD" })], {
+      runId: "run-old",
+      feature: "feat-old",
+      startedAt: "2025-12-01T00:00:00Z",
+    });
+    const newer = makeRun([makeStoryMetrics({ storyId: "US-NEW" })], {
+      runId: "run-new",
+      feature: "feat-new",
+      startedAt: "2026-01-01T00:00:00Z",
+    });
+
+    const result = toCostReport([older, newer], fixedDeps);
+
+    expect(result.lastRun).not.toBeNull();
+    expect(result.lastRun?.runId).toBe("run-new");
+    expect(result.lastRun?.feature).toBe("feat-new");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8: lastRun.stories sorted by cost desc + exact field set
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — lastRun.stories ordering + shape", () => {
+  test("AC8: lastRun.stories is ordered by cost desc (0.9 then 0.2)", () => {
+    const stories = [
+      makeStoryMetrics({ storyId: "US-A", cost: 0.2, modelUsed: "claude-haiku-4-5" }),
+      makeStoryMetrics({ storyId: "US-B", cost: 0.9, modelUsed: "claude-opus-4-5" }),
+    ];
+    const runs = [makeRun(stories)];
+
+    const result = toCostReport(runs, fixedDeps);
+
+    expect(result.lastRun).not.toBeNull();
+    const costs = result.lastRun?.stories.map((s) => s.cost);
+    expect(costs).toEqual([0.9, 0.2]);
+  });
+
+  test("AC8: each lastRun.stories entry exposes exactly storyId, cost, model, attempts", () => {
+    const stories = [makeStoryMetrics({ storyId: "US-A", cost: 0.3, modelUsed: "claude-opus-4-5", attempts: 2 })];
+    const runs = [makeRun(stories)];
+
+    const result = toCostReport(runs, fixedDeps);
+    const entry = result.lastRun?.stories[0];
+
+    expect(entry).toBeDefined();
+    const keys = Object.keys(entry ?? {}).sort();
+    expect(keys).toEqual(["attempts", "cost", "model", "storyId"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-9: modelEfficiency ordering + exact field set
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — modelEfficiency ordering + shape", () => {
+  test("AC9: modelEfficiency sorted by totalCost desc ([3.0, 1.0])", () => {
+    const stories = [
+      makeStoryMetrics({ storyId: "US-A", cost: 1.0, modelUsed: "model-A" }),
+      makeStoryMetrics({ storyId: "US-B", cost: 3.0, modelUsed: "model-B" }),
+    ];
+    const runs = [makeRun(stories)];
+
+    const result = toCostReport(runs, fixedDeps);
+
+    expect(result.modelEfficiency.length).toBe(2);
+    expect(result.modelEfficiency[0].totalCost).toBeCloseTo(3.0, 6);
+    expect(result.modelEfficiency[1].totalCost).toBeCloseTo(1.0, 6);
+  });
+
+  test("AC9: each modelEfficiency entry exposes exactly model, attempts, passRate, avgCost, totalCost", () => {
+    const stories = [makeStoryMetrics({ storyId: "US-A", cost: 0.5, modelUsed: "model-A", attempts: 1 })];
+    const runs = [makeRun(stories)];
+
+    const result = toCostReport(runs, fixedDeps);
+    const entry = result.modelEfficiency[0];
+
+    expect(entry).toBeDefined();
+    const keys = Object.keys(entry).sort();
+    expect(keys).toEqual(["attempts", "avgCost", "model", "passRate", "totalCost"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-10: avgCostPerStory zero-guard
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — avgCostPerStory zero guard", () => {
+  test("AC10: when lastRun.totalStories===0, lastRun.avgCostPerStory is 0 and not NaN", () => {
+    const emptyRun: RunMetrics = {
+      runId: "run-empty",
+      feature: "feat-empty",
+      startedAt: "2026-01-01T00:00:00Z",
+      completedAt: "2026-01-01T00:00:10Z",
+      totalCost: 0,
+      totalStories: 0,
+      storiesCompleted: 0,
+      storiesFailed: 0,
+      totalDurationMs: 10000,
+      stories: [],
+    };
+
+    const result = toCostReport([emptyRun], fixedDeps);
+
+    expect(result.lastRun).not.toBeNull();
+    expect(result.lastRun?.totalStories).toBe(0);
+    const avg = result.lastRun?.avgCostPerStory;
+    expect(avg).toBe(0);
+    expect(Number.isNaN(avg ?? Number.NaN)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-11: no internal fields leak
+// ---------------------------------------------------------------------------
+
+describe("toCostReport — no internal fields leak", () => {
+  test("AC11: aggregate / lastRun / lastRun.stories entries expose none of totalTokens, context, pollution, complexityAccuracy, fallback", () => {
+    const stories = [
+      makeStoryMetrics({
+        storyId: "US-A",
+        cost: 0.5,
+        modelUsed: "claude-opus-4-5",
+        attempts: 2,
+        context: {
+          providers: {
+            tmp: { tokensProduced: 1, chunksProduced: 1, chunksKept: 1, wallClockMs: 1, timedOut: false, failed: false },
+          },
+          pollution: {
+            droppedBelowMinScore: 0,
+            staleChunksInjected: 0,
+            contradictedChunks: 0,
+            ignoredChunks: 0,
+            pollutionRatio: 0,
+          },
+        },
+        fallback: { hops: [] },
+        tokens: { inputTokens: 10, outputTokens: 20 },
+      }),
+    ];
+    const runs = [
+      makeRun(stories, {
+        totalTokens: { inputTokens: 10, outputTokens: 20 },
+        fallback: {
+          totalHops: 0,
+          perPair: {},
+          exhaustedStories: [],
+          totalWastedCostUsd: 0,
+        },
+      }),
+    ];
+
+    const result: CostReportV1 = toCostReport(runs, fixedDeps);
+
+    const forbidden = ["totalTokens", "context", "pollution", "complexityAccuracy", "fallback"];
+
+    const aggregateKeys = result.aggregate ? Object.keys(result.aggregate) : [];
+    for (const k of forbidden) {
+      expect(aggregateKeys).not.toContain(k);
+    }
+
+    const lastRunKeys = result.lastRun ? Object.keys(result.lastRun) : [];
+    for (const k of forbidden) {
+      expect(lastRunKeys).not.toContain(k);
+    }
+
+    for (const story of result.lastRun?.stories ?? []) {
+      for (const k of forbidden) {
+        expect(Object.keys(story)).not.toContain(k);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a stable, versioned JSON export to `nax status --cost`. Introduces the curated
`CostReportV1` contract, a pure `toCostReport` mapper (`src/metrics/report.ts`), and
wires `nax status --cost --json` to emit it to stdout — plus extracts status-command
routing into a unit-testable `dispatchStatusView`.

## Why

Today `nax status --cost` renders through the structured logger as human-readable
lines only — no downstream tool (dashboard, CI spend gate, spend-report script) can
consume nax cost data without scraping log text. This is the "cheapest slice" of
IMPROVEMENT-REPORT §1.4 (metrics export).

## How

- **US-001** — `CostReportV1` type + pure `toCostReport(runs, deps)` mapper in
  `src/metrics/report.ts`, composing the existing `calculateAggregateMetrics` /
  `getLastRun` helpers (no recomputation), barrel-exported from `src/metrics`.
  Strips internal-only fields (`totalTokens`, `context`, `pollution`, etc.) with a
  runtime assertion so future internal refactors can't leak into the public contract.
- **US-002** — `emitCostReportJson(workdir, deps?)` in `src/cli/status-cost.ts`
  (deps-injected, mirroring `ReplayCommandDeps`); new `dispatchStatusView` in
  `src/cli/status-dispatch.ts` extracts status-command view selection out of
  `bin/nax.ts`'s inline `.action()` closure so routing is unit-testable; `--json`
  registered on the `status` command, winning over `--last`/`--model` when combined
  with `--cost`.

## Testing

- [x] Tests added/updated (20 acceptance tests + unit/integration coverage for all
      20 ACs across both stories)
- [x] `bun run test` passes (9676 unit + 1088 integration + 21 UI, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [x] Feature acceptance suite green (`.nax/features/status-cost-json/.nax-acceptance.test.ts` — 20/20)

## Notes

Reviewed via `post-impl-review` in two phases (spec, then quality on the stabilized
diff) — both **ALIGNED**, zero critical/high findings. Two LOW findings were fixed
during triage: an unused `dispatchStatusView` import left over from the
`bin/nax.ts` extraction, and a redundant double-computation of
`calculateAggregateMetrics` in `toCostReport` (now computed once and threaded into
both `buildAggregate`/`buildModelEfficiency`). One LOW quality note was left
as-is by design: `nax status --json` without `--cost` silently falls through to
the human feature-status view (matches spec's explicit out-of-scope note — a
future feature-status JSON export is a separate spec).