### PR TITLE
feat: implement INJECT mid-run queue command (#1288)

### DIFF
--- a/src/pipeline/stages/queue-check.ts
+++ b/src/pipeline/stages/queue-check.ts
@@ -5,9 +5,18 @@
  * Processes commands atomically and updates PRD accordingly.
  */
 
+import path from "node:path";
 import { clearQueueFile, readQueueFile } from "../../execution/queue-handler";
 import { getLogger } from "../../logger";
-import { markStorySkipped, resetStoryToPending, savePRD, setStoryPriority } from "../../prd";
+import {
+  injectStory,
+  markStorySkipped,
+  resetStoryToPending,
+  savePRD,
+  setStoryPriority,
+  validateInjectedStory,
+} from "../../prd";
+import { errorMessage } from "../../utils/errors";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 /**
@@ -83,6 +92,35 @@ export const queueCheckStage: PipelineStage = {
 
         const prdPath = ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/nax/features/unknown/prd.json`;
         await savePRD(ctx.prd, prdPath);
+        continue;
+      }
+
+      if (cmd.type === "INJECT") {
+        const storyFilePath = path.isAbsolute(cmd.storyFile) ? cmd.storyFile : path.join(ctx.workdir, cmd.storyFile);
+
+        try {
+          const raw: unknown = await Bun.file(storyFilePath).json();
+          const existingIds = new Set(ctx.prd.userStories.map((s) => s.id));
+          const story = validateInjectedStory(raw, existingIds);
+          injectStory(ctx.prd, story);
+
+          logger.warn("queue", "Injected new story via user request", {
+            storyId: ctx.story?.id ?? "unknown",
+            injectedStoryId: story.id,
+            storyFile: cmd.storyFile,
+          });
+
+          const prdPath = ctx.featureDir
+            ? `${ctx.featureDir}/prd.json`
+            : `${ctx.workdir}/nax/features/unknown/prd.json`;
+          await savePRD(ctx.prd, prdPath);
+        } catch (err) {
+          logger.error("queue", "Failed to inject story — skipping INJECT command", {
+            storyId: ctx.story?.id ?? "unknown",
+            storyFile: cmd.storyFile,
+            error: errorMessage(err),
+          });
+        }
         continue;
       }
 

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { existsSync, statSync } from "node:fs";
+import { NaxError } from "../errors";
 import type { FailureCategory } from "../tdd/types";
 import { saveJsonFile } from "../utils/json-file";
 import type { PRD, UserStory } from "./types";
@@ -22,6 +23,7 @@ export { extractVerbatimAcs, findMissingVerbatimAcs } from "./verbatim-fidelity"
 export { findSpecDriftViolations } from "./spec-drift";
 export type { SpecDriftViolation } from "./spec-drift";
 export type { FailureCategory } from "../tdd/types";
+export { validateInjectedStory, deriveNextStoryId } from "./inject";
 
 /** Maximum PRD file size (5MB) - reject larger PRDs to prevent memory issues */
 export const PRD_MAX_FILE_SIZE = 5 * 1024 * 1024;
@@ -334,6 +336,26 @@ export function resetStoryToPending(prd: PRD, storyId: string): void {
     };
   }
   story.escalations = [];
+}
+
+/**
+ * Add a newly validated story to the PRD (INJECT queue command).
+ * Caller must validate the story first (see {@link validateInjectedStory}).
+ * The story only becomes eligible for the next batch-selection pass — it
+ * does not join the batch currently being executed.
+ */
+export function injectStory(prd: PRD, story: UserStory): void {
+  if (prd.userStories.some((s) => s.id === story.id)) {
+    throw new NaxError(
+      `[queue] Cannot inject story: id "${story.id}" already exists in the PRD`,
+      "SCHEMA_VALIDATION_FAILED",
+      {
+        stage: "queue",
+        storyId: story.id,
+      },
+    );
+  }
+  prd.userStories.push(story);
 }
 
 /** Set a story's scheduling priority (PRIORITY queue command). Higher = more urgent. */

--- a/src/prd/inject.ts
+++ b/src/prd/inject.ts
@@ -1,0 +1,138 @@
+/**
+ * Mid-Run Story Injection (INJECT queue command)
+ *
+ * Validates and normalizes an ad hoc UserStory input for injection into an
+ * in-progress PRD. Deliberately stricter/simpler than validatePlanOutput's
+ * per-story validation: an injected story has no routing metadata yet — the
+ * routing pipeline stage classifies it (complexity/testStrategy) the first
+ * time it's picked up into a batch, same as any other pending story.
+ */
+
+import { NaxError } from "../errors";
+import type { UserStory } from "./types";
+import { validateStoryId } from "./validate";
+
+const STORY_ID_PREFIX = "US";
+
+/**
+ * Derive the next unused sequential story ID (e.g. "US-004") given the set of
+ * IDs already present in the PRD. Falls back to scanning upward from 1 so it
+ * never collides even if existing IDs have gaps.
+ */
+export function deriveNextStoryId(existingIds: ReadonlySet<string>): string {
+  let n = 1;
+  let candidate = `${STORY_ID_PREFIX}-${String(n).padStart(3, "0")}`;
+  while (existingIds.has(candidate)) {
+    n += 1;
+    candidate = `${STORY_ID_PREFIX}-${String(n).padStart(3, "0")}`;
+  }
+  return candidate;
+}
+
+/**
+ * Validate and normalize raw JSON input for the INJECT queue command into a
+ * fresh, pending UserStory.
+ *
+ * Required: title, description, acceptanceCriteria (non-empty string array).
+ * Optional: id (derived if absent), tags, dependencies (must reference
+ * existing story IDs — a brand-new story cannot introduce a dependency
+ * cycle since it can only depend on stories that already exist).
+ *
+ * @param raw - Parsed JSON object read from the INJECT target file
+ * @param existingIds - IDs of every story currently in the PRD (for
+ *   duplicate-ID rejection and dependency reference validation)
+ */
+export function validateInjectedStory(raw: unknown, existingIds: ReadonlySet<string>): UserStory {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new NaxError("[queue] INJECT story file must contain a JSON object", "SCHEMA_VALIDATION_FAILED", {
+      stage: "queue",
+    });
+  }
+  const s = raw as Record<string, unknown>;
+
+  const title = s.title;
+  if (!title || typeof title !== "string" || title.trim() === "") {
+    throw new NaxError("[queue] INJECT story.title is required and must be non-empty", "SCHEMA_VALIDATION_FAILED", {
+      stage: "queue",
+    });
+  }
+
+  const description = s.description;
+  if (!description || typeof description !== "string" || description.trim() === "") {
+    throw new NaxError(
+      "[queue] INJECT story.description is required and must be non-empty",
+      "SCHEMA_VALIDATION_FAILED",
+      { stage: "queue" },
+    );
+  }
+
+  const ac = s.acceptanceCriteria;
+  if (!Array.isArray(ac) || ac.length === 0) {
+    throw new NaxError(
+      "[queue] INJECT story.acceptanceCriteria is required and must be a non-empty array",
+      "SCHEMA_VALIDATION_FAILED",
+      { stage: "queue" },
+    );
+  }
+  for (let i = 0; i < ac.length; i++) {
+    if (typeof ac[i] !== "string") {
+      throw new NaxError(`[queue] INJECT story.acceptanceCriteria[${i}] must be a string`, "SCHEMA_VALIDATION_FAILED", {
+        stage: "queue",
+        acIndex: i,
+      });
+    }
+  }
+
+  let id: string;
+  if (s.id !== undefined && s.id !== null) {
+    if (typeof s.id !== "string" || s.id.trim() === "") {
+      throw new NaxError(
+        "[queue] INJECT story.id must be a non-empty string when present",
+        "SCHEMA_VALIDATION_FAILED",
+        {
+          stage: "queue",
+        },
+      );
+    }
+    id = s.id.trim();
+    validateStoryId(id);
+    if (existingIds.has(id)) {
+      throw new NaxError(`[queue] INJECT story.id "${id}" already exists in the PRD`, "SCHEMA_VALIDATION_FAILED", {
+        stage: "queue",
+        storyId: id,
+      });
+    }
+  } else {
+    id = deriveNextStoryId(existingIds);
+  }
+
+  const tags: string[] = Array.isArray(s.tags)
+    ? (s.tags as unknown[]).filter((t): t is string => typeof t === "string")
+    : [];
+
+  const dependencies: string[] = Array.isArray(s.dependencies)
+    ? (s.dependencies as unknown[]).filter((d): d is string => typeof d === "string")
+    : [];
+  for (const dep of dependencies) {
+    if (!existingIds.has(dep)) {
+      throw new NaxError(
+        `[queue] INJECT story.dependencies references unknown story ID "${dep}"`,
+        "SCHEMA_VALIDATION_FAILED",
+        { stage: "queue", dep },
+      );
+    }
+  }
+
+  return {
+    id,
+    title: title.trim(),
+    description: description.trim(),
+    acceptanceCriteria: ac as string[],
+    tags,
+    dependencies,
+    status: "pending",
+    passes: false,
+    attempts: 0,
+    escalations: [],
+  };
+}

--- a/src/queue/manager.ts
+++ b/src/queue/manager.ts
@@ -206,6 +206,7 @@ export class QueueManager {
  * - SKIP US-XXX: Skip a specific story
  * - RETRY US-XXX: Reset a failed/skipped story back to pending
  * - PRIORITY US-XXX <n>: Set a story's scheduling priority
+ * - INJECT <path>: Add a new story from a JSON file (path relative to workdir)
  *
  * Everything else after "--- PENDING ---" is treated as guidance text.
  */
@@ -272,6 +273,17 @@ export function parseQueueFile(content: string): QueueFileResult {
       }
     } else if (upper === "PRIORITY") {
       // PRIORITY with no arguments, treat as guidance
+      guidance.push(trimmed);
+    } else if (upper.startsWith("INJECT ")) {
+      // Extract file path after "INJECT" — take the full remainder (paths may contain spaces)
+      const storyFile = trimmed.substring(7).trim();
+      if (storyFile) {
+        commands.push({ type: "INJECT", storyFile });
+      } else {
+        guidance.push(trimmed);
+      }
+    } else if (upper === "INJECT") {
+      // INJECT with no file path, treat as guidance
       guidance.push(trimmed);
     } else {
       // Not a command, treat as guidance if in pending section

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -48,7 +48,8 @@ export type QueueCommand =
   | { type: "ABORT" }
   | { type: "SKIP"; storyId: string }
   | { type: "RETRY"; storyId: string }
-  | { type: "PRIORITY"; storyId: string; value: number };
+  | { type: "PRIORITY"; storyId: string; value: number }
+  | { type: "INJECT"; storyFile: string };
 
 /** Result of parsing a queue file */
 export interface QueueFileResult {

--- a/src/utils/queue-writer.ts
+++ b/src/utils/queue-writer.ts
@@ -48,6 +48,9 @@ export async function writeQueueCommand(queueFilePath: string, command: QueueCom
     case "PRIORITY":
       commandLine = `PRIORITY ${command.storyId} ${command.value}`;
       break;
+    case "INJECT":
+      commandLine = `INJECT ${command.storyFile}`;
+      break;
     default: {
       const _exhaustive: never = command;
       throw new Error(`Unhandled queue command: ${_exhaustive}`);

--- a/test/unit/execution/queue.test.ts
+++ b/test/unit/execution/queue.test.ts
@@ -298,4 +298,28 @@ ABORT
     expect(result.commands).toHaveLength(0);
     expect(result.guidance).toHaveLength(1);
   });
+
+  test("parses INJECT command with a story file path", () => {
+    const content = "INJECT .nax/inject/new-story.json\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0]).toEqual({ type: "INJECT", storyFile: ".nax/inject/new-story.json" });
+  });
+
+  test("parses INJECT command case-insensitive and trims path", () => {
+    const content = "inject   ./story.json   \n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0]).toEqual({ type: "INJECT", storyFile: "./story.json" });
+  });
+
+  test("handles INJECT without a file path gracefully", () => {
+    const content = "INJECT\n";
+    const result = parseQueueFile(content);
+
+    expect(result.commands).toHaveLength(0);
+    expect(result.guidance).toHaveLength(1);
+  });
 });

--- a/test/unit/pipeline/stages/queue-check.test.ts
+++ b/test/unit/pipeline/stages/queue-check.test.ts
@@ -106,3 +106,80 @@ describe("queueCheckStage — RETRY / PRIORITY", () => {
     expect(result.action).toBe("continue");
   });
 });
+
+describe("queueCheckStage — INJECT", () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    initLogger({ level: "silent" });
+    workdir = makeTempDir("nax-queue-check-inject-");
+  });
+
+  afterEach(() => {
+    resetLogger();
+    cleanupTempDir(workdir);
+  });
+
+  test("INJECT adds a validated story to the PRD and continues", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(
+      join(workdir, "new-story.json"),
+      JSON.stringify({
+        title: "Add caching layer",
+        description: "Cache expensive lookups behind a TTL.",
+        acceptanceCriteria: ["Cache hits avoid the DB call"],
+      }),
+    );
+    await Bun.write(join(workdir, ".queue.txt"), "INJECT new-story.json\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories).toHaveLength(2);
+    const injected = ctx.prd.userStories[1];
+    expect(injected.title).toBe("Add caching layer");
+    expect(injected.status).toBe("pending");
+    // Injected story is not added to the current batch — only future iterations pick it up.
+    expect(ctx.stories.map((s) => s.id)).toEqual(["US-001"]);
+  });
+
+  test("INJECT with a missing file logs and continues without crashing", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, ".queue.txt"), "INJECT does-not-exist.json\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories).toHaveLength(1);
+  });
+
+  test("INJECT with invalid story content logs and continues without crashing", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, "bad-story.json"), JSON.stringify({ title: "Missing fields" }));
+    await Bun.write(join(workdir, ".queue.txt"), "INJECT bad-story.json\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories).toHaveLength(1);
+  });
+
+  test("INJECT rejects a duplicate id and leaves the PRD unchanged", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(
+      join(workdir, "dup-story.json"),
+      JSON.stringify({
+        id: "US-001",
+        title: "Duplicate",
+        description: "Should be rejected.",
+        acceptanceCriteria: ["n/a"],
+      }),
+    );
+    await Bun.write(join(workdir, ".queue.txt"), "INJECT dup-story.json\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories).toHaveLength(1);
+  });
+});

--- a/test/unit/prd/inject.test.ts
+++ b/test/unit/prd/inject.test.ts
@@ -1,0 +1,101 @@
+/**
+ * validateInjectedStory() / deriveNextStoryId() unit tests
+ *
+ * Backs the INJECT queue command (mid-run story injection, issue #1288).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { deriveNextStoryId, validateInjectedStory } from "@/prd";
+
+describe("deriveNextStoryId()", () => {
+  test("derives US-001 for an empty PRD", () => {
+    expect(deriveNextStoryId(new Set())).toBe("US-001");
+  });
+
+  test("derives the next unused sequential ID", () => {
+    expect(deriveNextStoryId(new Set(["US-001", "US-002"]))).toBe("US-003");
+  });
+
+  test("skips over gaps to find the first unused ID", () => {
+    expect(deriveNextStoryId(new Set(["US-001", "US-003"]))).toBe("US-002");
+  });
+});
+
+describe("validateInjectedStory()", () => {
+  const validRaw = {
+    title: "Add rate limiting",
+    description: "Add a token-bucket rate limiter to the public API.",
+    acceptanceCriteria: ["Requests over the limit return 429"],
+  };
+
+  test("validates a minimal story and derives an ID", () => {
+    const story = validateInjectedStory(validRaw, new Set(["US-001"]));
+
+    expect(story.id).toBe("US-002");
+    expect(story.title).toBe("Add rate limiting");
+    expect(story.description).toBe(validRaw.description);
+    expect(story.acceptanceCriteria).toEqual(validRaw.acceptanceCriteria);
+    expect(story.status).toBe("pending");
+    expect(story.passes).toBe(false);
+    expect(story.attempts).toBe(0);
+    expect(story.escalations).toEqual([]);
+    expect(story.tags).toEqual([]);
+    expect(story.dependencies).toEqual([]);
+  });
+
+  test("accepts an explicit id when it does not collide", () => {
+    const story = validateInjectedStory({ ...validRaw, id: "US-042" }, new Set(["US-001"]));
+    expect(story.id).toBe("US-042");
+  });
+
+  test("rejects a duplicate explicit id", () => {
+    expect(() => validateInjectedStory({ ...validRaw, id: "US-001" }, new Set(["US-001"]))).toThrow(/already exists/);
+  });
+
+  test("rejects missing title", () => {
+    const { title, ...rest } = validRaw;
+    expect(() => validateInjectedStory(rest, new Set())).toThrow(/title/);
+  });
+
+  test("rejects missing description", () => {
+    const { description, ...rest } = validRaw;
+    expect(() => validateInjectedStory(rest, new Set())).toThrow(/description/);
+  });
+
+  test("rejects missing acceptanceCriteria", () => {
+    const { acceptanceCriteria, ...rest } = validRaw;
+    expect(() => validateInjectedStory(rest, new Set())).toThrow(/acceptanceCriteria/);
+  });
+
+  test("rejects empty acceptanceCriteria array", () => {
+    expect(() => validateInjectedStory({ ...validRaw, acceptanceCriteria: [] }, new Set())).toThrow(
+      /acceptanceCriteria/,
+    );
+  });
+
+  test("rejects a non-object payload", () => {
+    expect(() => validateInjectedStory("not an object", new Set())).toThrow(/JSON object/);
+    expect(() => validateInjectedStory(null, new Set())).toThrow(/JSON object/);
+    expect(() => validateInjectedStory([], new Set())).toThrow(/JSON object/);
+  });
+
+  test("accepts and passes through tags", () => {
+    const story = validateInjectedStory({ ...validRaw, tags: ["security", "api"] }, new Set());
+    expect(story.tags).toEqual(["security", "api"]);
+  });
+
+  test("accepts dependencies that reference existing story IDs", () => {
+    const story = validateInjectedStory({ ...validRaw, dependencies: ["US-001"] }, new Set(["US-001"]));
+    expect(story.dependencies).toEqual(["US-001"]);
+  });
+
+  test("rejects dependencies referencing unknown story IDs", () => {
+    expect(() => validateInjectedStory({ ...validRaw, dependencies: ["US-999"] }, new Set(["US-001"]))).toThrow(
+      /unknown story ID/,
+    );
+  });
+
+  test("rejects an invalid explicit id (path traversal)", () => {
+    expect(() => validateInjectedStory({ ...validRaw, id: "../etc" }, new Set())).toThrow();
+  });
+});

--- a/test/unit/prd/prd-queue-actions.test.ts
+++ b/test/unit/prd/prd-queue-actions.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { getNextStory, resetStoryToPending, setStoryPriority } from "@/prd";
+import { getNextStory, injectStory, resetStoryToPending, setStoryPriority } from "@/prd";
 import { makePRD, makeStory } from "@test/helpers";
 
 // ── resetStoryToPending() ───────────────────────────────────────────────────────
@@ -81,6 +81,25 @@ describe("setStoryPriority()", () => {
     const prd = makePRD({ userStories: [makeStory({ id: "US-001", priority: 3 })] });
     setStoryPriority(prd, "US-001", -1);
     expect(prd.userStories[0].priority).toBe(-1);
+  });
+});
+
+// ── injectStory() ────────────────────────────────────────────────────────────────
+
+describe("injectStory()", () => {
+  test("appends a new story to the PRD", () => {
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001" })] });
+    injectStory(prd, makeStory({ id: "US-002", title: "Injected story" }));
+
+    expect(prd.userStories).toHaveLength(2);
+    expect(prd.userStories[1].id).toBe("US-002");
+    expect(prd.userStories[1].title).toBe("Injected story");
+  });
+
+  test("throws when the story id already exists in the PRD", () => {
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001" })] });
+    expect(() => injectStory(prd, makeStory({ id: "US-001" }))).toThrow(/already exists/);
+    expect(prd.userStories).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements the fourth mid-run queue-control command deferred from the original queue-command work: `INJECT <path>`, which adds a brand-new `UserStory` to an in-progress PRD.

- `src/prd/inject.ts` (new) — `validateInjectedStory()` validates a raw JSON payload (required: `title`, `description`, `acceptanceCriteria`; optional: `id` (derived if absent via `deriveNextStoryId()`), `tags`, `dependencies`). Rejects missing required fields, duplicate story IDs, and dependencies referencing unknown story IDs. A freshly-injected story can only depend on stories that already exist in the PRD, so dependency cycles are structurally impossible.
- `src/prd/index.ts` — `injectStory()` appends a validated story to `prd.userStories` (with a duplicate-ID guard as defense in depth).
- `src/queue/types.ts` / `src/queue/manager.ts` — adds the `INJECT <path>` command to `parseQueueFile`, parsed the same way as the existing `SKIP`/`RETRY`/`PRIORITY` commands.
- `src/pipeline/stages/queue-check.ts` — reads the target JSON file (relative to `ctx.workdir`), validates, injects, and saves the PRD. Malformed INJECT commands are logged and skipped rather than failing the run.
- `src/utils/queue-writer.ts` — added the `INJECT` case to the previously-exhaustive `writeQueueCommand` switch (caught by `tsc`).

**Design decision** (open item from the issue): an injected story is appended to `prd.userStories` only, not the currently-executing batch — it becomes eligible starting the next batch-selection pass. Routing metadata (complexity/testStrategy) is intentionally left unset at injection time; it's filled in later by the existing per-story routing pipeline stage, same as any other pending story.

Closes #1288.

## Test plan

- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — full suite green (9703 unit + 1090 integration + 21 UI tests, 0 failures)
- [x] New unit tests: `test/unit/prd/inject.test.ts`, plus additions to `test/unit/execution/queue.test.ts`, `test/unit/prd/prd-queue-actions.test.ts`, `test/unit/pipeline/stages/queue-check.test.ts` covering minimal/explicit-id/duplicate-id/unknown-dependency/missing-file/malformed-content cases