### PR TITLE
fix: reset story.passes on regression-gate failure (#1292)

### DIFF
--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -191,6 +191,10 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
         const story = prd.userStories.find((s) => s.id === storyId);
         if (story) {
           story.status = "regression-failed";
+          // isComplete() checks `s.passes || s.status === "passed" || ...` — the `passes`
+          // clause short-circuits before status, so it must be reset here too or a
+          // regression-failed story still reads as complete (issue #1292).
+          story.passes = false;
         }
       }
       // Reflect regression gate failure in run status (RL-004)

--- a/test/unit/execution/lifecycle/run-completion-postrun.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-postrun.test.ts
@@ -418,6 +418,34 @@ describe("handleRunCompletion - AC6: sets regression failed on failure", () => {
       callOrder.indexOf("setPostRunPhase-regression-failed"),
     );
   });
+
+  test("resets story.passes to false for affected stories, not just status (issue #1292)", async () => {
+    const statusWriter = makeStatusWriter();
+
+    _runCompletionDeps.runDeferredRegression = mock(async (): Promise<DeferredRegressionResult> => ({
+      success: false,
+      failedTests: 1,
+      failedTestFiles: [],
+      passedTests: 5,
+      rectificationAttempts: 0,
+      affectedStories: ["US-001"],
+    }));
+
+    const prd = makePRD([
+      { id: "US-001", status: "passed" },
+      { id: "US-002", status: "passed" },
+    ]);
+    const config = makeConfig("deferred", "bun test");
+
+    await handleRunCompletion(makeOpts(config, prd, { statusWriter }));
+
+    const affectedStory = prd.userStories.find((s) => s.id === "US-001");
+    expect(affectedStory?.status).toBe("regression-failed");
+    expect(affectedStory?.passes).toBe(false);
+
+    const unaffectedStory = prd.userStories.find((s) => s.id === "US-002");
+    expect(unaffectedStory?.passes).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #1292: when the deferred regression gate fails, affected stories were marked `story.status = "regression-failed"` but `story.passes` was never reset, so `isComplete(prd)` (`s.passes || s.status === "passed" || s.status === "skipped"`) could still short-circuit to `true` for a story that failed regression.
- Resets `story.passes = false` alongside `story.status = "regression-failed"` in the same loop in `handleRunCompletion()` (`src/execution/lifecycle/run-completion.ts`), so `isComplete()` correctly reads the story as incomplete everywhere it's consumed (`run-completion.ts`, `runner-completion.ts`, `unified-executor.ts`) — no per-caller changes needed since they all read the same mutated `prd` object.

## Test plan
- [x] Added a regression test in `test/unit/execution/lifecycle/run-completion-postrun.test.ts` (AC6 block) asserting the affected story's `passes` flips to `false` while an unaffected story's `passes` stays `true`; confirmed it fails without the fix and passes with it.
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` (unit + integration + ui) — all green, 0 failures
- [x] Independent code review (agent) — approved, no changes requested