### PR TITLE
fix: address P1/P2 findings from code review report

### DIFF
--- a/CODE_REVIEW_REPORT.md
+++ b/CODE_REVIEW_REPORT.md
@@ -1,0 +1,50 @@
+# Code Review Report
+
+**Repository:** `@nathapp/nax`  
+**Reviewed revision:** `main` at `ca202ba0`  
+**Review scope:** Current repository snapshot, with focused inspection of recent checkpoint/resume and queue-injection changes.  
+**Working tree:** Clean at review time.
+
+## Findings
+
+### P1 — Multi-story resume drops checkpoints for later stories
+
+**Locations:**
+
+- `src/execution/checkpoint/reader.ts:96-104`
+- `src/execution/story-orchestrator/execution-plan.ts:53-72`
+
+`loadCheckpoints()` retains records only for the lexically newest `runId`. On a resumed run, the first story loads checkpoints from the previous run and re-records its skipped phases with the current run ID. When the next story starts, it reloads the same checkpoint file, now selects the current run ID as newest, and discards the previous-run checkpoints that apply to that next story.
+
+**Impact:** A resume involving multiple incomplete stories can resume only the first story correctly; later stories rerun phases that were already green.
+
+**Recommendation:** Preserve checkpoint state per story across runs, or load one checkpoint snapshot at run start and retain it for the duration of the run. Add an integration test that resumes two stories with checkpoints from a prior run.
+
+### P2 — INJECT can read paths outside the workspace
+
+**Location:** `src/pipeline/stages/queue-check.ts:99-102`
+
+The `INJECT` command accepts absolute paths and joins relative paths without validating realpath containment. A queue-file writer can therefore cause the process to parse JSON from any readable path, including a path reached through traversal or a symlink outside `ctx.workdir`.
+
+**Impact:** If an external file has compatible JSON fields, its content can become an injected story and later enter agent prompts. This violates the project’s path-containment conventions.
+
+**Recommendation:** Reject absolute paths and use a realpath-based containment check before reading the file. Add tests for absolute paths, `..` traversal, and symlink escapes.
+
+### P2 — Checkpoint writing performs quadratic I/O and transient allocations
+
+**Location:** `src/execution/checkpoint/writer.ts:42-47`
+
+For every checkpoint record, the writer reads the complete JSONL file into memory, concatenates the new record, writes the complete content to a temporary file, then renames it. The per-writer queue prevents concurrent lost updates, but does not avoid repeatedly copying the full history.
+
+**Impact:** Long runs incur O(records²) total disk I/O and repeatedly allocate increasingly large strings. This is the primary confirmed memory/performance risk found in the reviewed paths.
+
+**Recommendation:** Use a durable append primitive where available, or store a bounded checkpoint snapshot and periodically compact it. Add a benchmark or regression test for a large number of checkpoint records.
+
+## Memory-Leak Review
+
+No confirmed timer, event-listener, or subprocess-lifecycle memory leak was found in the reviewed execution paths. The checkpoint rewrite behavior above causes transient memory growth and increasing I/O cost, rather than an unbounded retained-object leak.
+
+## Verification
+
+- `bun run typecheck` — passed
+- Focused tests — passed: 44 tests across checkpoint reader, runner resume dependencies, INJECT validation, and queue-check behavior.

--- a/src/execution/checkpoint/index.ts
+++ b/src/execution/checkpoint/index.ts
@@ -5,7 +5,7 @@
  * orchestrator skip-state after a crash or abort. See:
  *   - `types.ts`  — CheckpointRecord, StoryCheckpoint, TreeState
  *   - `writer.ts` — CheckpointWriter.recordGreen (durable append)
- *   - `reader.ts` — loadCheckpoints (longest-valid-prefix + latest-runId filter)
+ *   - `reader.ts` — loadCheckpoints (longest-valid-prefix + per-story latest-runId filter)
  *   - `resume-hydrate.ts` — captureTreeState / hydrateFromResumePlan /
  *     buildCheckpointLogData (US-003 resume-integration helpers)
  */

--- a/src/execution/checkpoint/reader.ts
+++ b/src/execution/checkpoint/reader.ts
@@ -4,10 +4,16 @@
  * Recovery semantics:
  * - Parse line-by-line and keep the LONGEST VALID PREFIX: a torn final line
  *   from a crash mid-append is dropped silently (it is not fatal).
- * - Keep only records whose `runId` equals the newest `runId` present in the
- *   file. Records from earlier runs are ignored — a fresh run starts clean.
- * - Group remaining records by `storyId` and order each story's `greenPhases`
- *   by canonical phase index so callers can compare against `CANONICAL_ORDER`.
+ * - Group records by `storyId` first, then keep only the records whose
+ *   `runId` equals the newest `runId` present **for that story** (not the
+ *   newest runId in the whole file). Filtering globally by file-wide newest
+ *   runId discards other stories' checkpoints the moment any single story
+ *   re-records a phase under the current run's id — on a resume involving
+ *   multiple incomplete stories, only the first story to touch the file
+ *   would resume correctly. Per-story filtering keeps a story's checkpoints
+ *   until that same story records something under a newer run.
+ * - Order each story's `greenPhases` by canonical phase index so callers can
+ *   compare against `CANONICAL_ORDER`.
  * - Skip lines that fail JSON.parse or that are missing a required field; a
  *   single bad line must not abort the parse of the rest.
  * - A missing or unreadable file yields an empty `Map` rather than throwing.
@@ -93,25 +99,29 @@ export async function loadCheckpoints(
     }
   }
 
-  // Newest runId (lexical max — same shape used everywhere else in the project).
-  let latestRunId: string | undefined;
-  for (const r of validRecords) {
-    latestRunId = maxRunId(latestRunId, r.runId);
-  }
-  if (latestRunId === undefined) return new Map();
-
-  // Keep only records from the latest runId.
-  const latest = validRecords.filter((r) => r.runId === latestRunId);
-
-  // Group by storyId, preserving insertion order on first-seen.
+  // Group by storyId first, preserving insertion order on first-seen.
   const grouped = new Map<string, CheckpointRecord[]>();
-  for (const r of latest) {
+  for (const r of validRecords) {
     const list = grouped.get(r.storyId);
     if (list) {
       list.push(r);
     } else {
       grouped.set(r.storyId, [r]);
     }
+  }
+
+  // Within each story, keep only records from that story's own newest runId
+  // (lexical max — same shape used everywhere else in the project). This is
+  // deliberately per-story, not file-wide: see module docstring.
+  for (const [storyId, records] of grouped) {
+    let latestRunId: string | undefined;
+    for (const r of records) {
+      latestRunId = maxRunId(latestRunId, r.runId);
+    }
+    grouped.set(
+      storyId,
+      records.filter((r) => r.runId === latestRunId),
+    );
   }
 
   const result = new Map<string, StoryCheckpoint>();

--- a/src/execution/checkpoint/writer.ts
+++ b/src/execution/checkpoint/writer.ts
@@ -9,7 +9,13 @@
  * or an equivalent O_APPEND-safe write).
  */
 
-import { rename } from "node:fs/promises";
+// node:fs/promises exception: Bun has no native atomic-append equivalent —
+// Bun.write() truncates, and reusing a `writer()` FileSink across the whole
+// run would destroy checkpoint history from a prior run before
+// `loadCheckpoints` ever gets to read it. `appendFile` uses O_APPEND, which
+// the POSIX write(2) syscall guarantees is atomic for writes up to PIPE_BUF
+// (same precedent as `src/session/scratch-writer.ts`, `src/logger/logger.ts`).
+import { appendFile } from "node:fs/promises";
 import { NaxError } from "@/errors";
 import { errorMessage } from "@/utils/errors";
 import type { PhaseKind } from "../story-orchestrator";
@@ -22,29 +28,15 @@ export interface CheckpointWriterOptions {
 }
 
 /**
- * Default on-disk append — Bun-native content write (no `writer()` FileSink,
- * which opens truncated: reusing it across the whole run would destroy any
- * checkpoint history from a prior run before `loadCheckpoints` ever gets to
- * read it). Reads existing content (if any) and rewrites the file with the
- * new line appended, so a fresh writer never truncates a checkpoint another
- * story is still relying on for resume.
- *
- * The rewrite itself is made atomic via write-to-`.tmp` + `rename()`: a
- * direct `Bun.write(filePath, ...)` truncates the destination before writing
- * the new bytes, so a crash mid-write can corrupt or shorten a file that
- * already held durable history for prior green phases — exactly the crash
- * this feature exists to survive. `rename()` is atomic on POSIX filesystems,
- * so a crash during the write leaves either the old file intact or the full
- * new file, never a partial one. `rename` has no Bun-native equivalent, so
- * it's imported from `node:fs/promises` (same precedent as
- * `src/execution/status-file.ts`).
+ * Default on-disk append. A prior implementation read the complete file,
+ * concatenated the new line, and rewrote it via write-to-`.tmp` + `rename()`
+ * for every single record — O(records²) total disk I/O and repeatedly
+ * allocating increasingly large strings over a long run. `appendFile` with
+ * O_APPEND writes only the new line and is atomic at the syscall level, so
+ * a crash mid-write can never corrupt or shorten prior durable history.
  */
 async function defaultAppend(filePath: string, line: string): Promise<void> {
-  const file = Bun.file(filePath);
-  const existing = (await file.exists()) ? await file.text() : "";
-  const tmpPath = `${filePath}.tmp`;
-  await Bun.write(tmpPath, existing + line);
-  await rename(tmpPath, filePath);
+  await appendFile(filePath, line, "utf8");
 }
 
 /** Construct a `CheckpointWriter` bound to the real Bun-native append. */
@@ -57,15 +49,16 @@ export class CheckpointWriter {
   private readonly runId: string;
   private readonly deps: CheckpointWriterDeps;
   /**
-   * Serializes `_deps.append` calls. `defaultAppend` is a read-modify-write
-   * (no true O_APPEND primitive is exposed for `Bun.file`), so two concurrent
-   * `recordGreen` calls — from two stories running in parallel mode via the
-   * same shared writer — could each read the file before either writes back,
-   * silently losing one story's record. Chaining every append onto this
-   * promise forces them to run one at a time regardless of caller concurrency.
-   * Always resolves (errors are swallowed here) so one failed write does not
-   * permanently wedge the queue for subsequent calls; the failure is still
-   * propagated to that call's own caller below.
+   * Serializes `_deps.append` calls. O_APPEND writes are atomic at the
+   * syscall level for a single write, but two concurrent `recordGreen`
+   * calls — from two stories running in parallel mode via the same shared
+   * writer — could still interleave their underlying `write()` calls out of
+   * program order or (for injected test `_deps`) use a non-atomic append.
+   * Chaining every append onto this promise forces them to run one at a
+   * time regardless of caller concurrency. Always resolves (errors are
+   * swallowed here) so one failed write does not permanently wedge the
+   * queue for subsequent calls; the failure is still propagated to that
+   * call's own caller below.
    */
   private queue: Promise<void> = Promise.resolve();
 

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -60,13 +60,14 @@ export class ExecutionPlan {
     // skipped in the main loop below never reaches the `recordGreen` call at
     // its old position (the skip guard's `continue` bypasses it), so it would
     // keep only the checkpoint record from the run that originally recorded
-    // it. `loadCheckpoints` retains records from only the single newest
-    // `runId` present in the file — so a second consecutive resume (which
-    // mints its own new `runId`) would see that older record filtered out
-    // and re-run work that was already green two runs ago. Re-recording each
-    // seeded phase here, under the tree already confirmed to match by
-    // `buildResumePlan`, keeps every still-green phase alive across repeated
-    // resumes.
+    // it. `loadCheckpoints` now filters per-story (see `reader.ts`), so an
+    // untouched story's older-run records already survive repeated resumes
+    // on their own — this re-recording is a cheap consolidation, not a
+    // correctness requirement: it advances this story's own checkpoint
+    // history to the current `runId` under the tree state already confirmed
+    // to match by `buildResumePlan`, so every still-green phase for THIS
+    // story shares one consistent runId rather than accumulating one stale
+    // record per resume.
     if (this.ctx.storyId) {
       for (const skippedPhase of plan.skipPhases) {
         await _storyOrchestratorDeps.recordGreen(this.ctx.storyId, skippedPhase, tree);

--- a/src/pipeline/stages/queue-check.ts
+++ b/src/pipeline/stages/queue-check.ts
@@ -6,6 +6,9 @@
  */
 
 import path from "node:path";
+import { validateFilePath } from "@/config";
+import { NaxError } from "@/errors";
+import { errorMessage } from "@/utils/errors";
 import { clearQueueFile, readQueueFile } from "../../execution/queue-handler";
 import { getLogger } from "../../logger";
 import {
@@ -16,7 +19,6 @@ import {
   setStoryPriority,
   validateInjectedStory,
 } from "../../prd";
-import { errorMessage } from "../../utils/errors";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 /**
@@ -96,9 +98,15 @@ export const queueCheckStage: PipelineStage = {
       }
 
       if (cmd.type === "INJECT") {
-        const storyFilePath = path.isAbsolute(cmd.storyFile) ? cmd.storyFile : path.join(ctx.workdir, cmd.storyFile);
-
         try {
+          if (path.isAbsolute(cmd.storyFile)) {
+            throw new NaxError(
+              `INJECT storyFile must be a relative path within the workspace: ${cmd.storyFile}`,
+              "INJECT_PATH_ABSOLUTE",
+              { stage: "queue-check", storyId: ctx.story?.id ?? "unknown", storyFile: cmd.storyFile },
+            );
+          }
+          const storyFilePath = validateFilePath(path.join(ctx.workdir, cmd.storyFile), ctx.workdir);
           const raw: unknown = await Bun.file(storyFilePath).json();
           const existingIds = new Set(ctx.prd.userStories.map((s) => s.id));
           const story = validateInjectedStory(raw, existingIds);

--- a/test/integration/execution/checkpoint/reader.test.ts
+++ b/test/integration/execution/checkpoint/reader.test.ts
@@ -75,7 +75,8 @@ describe("loadCheckpoints integration", () => {
     await writer.recordGreen("US-001", "implementer", { headSha: "h2", dirtyDigest: "d2" });
     await writer.recordGreen("US-002", "test-writer", { headSha: "h3", dirtyDigest: "d3" });
 
-    // The atomic write's `.tmp` sidecar must never survive a successful write.
+    // defaultAppend uses O_APPEND (node:fs/promises.appendFile) directly —
+    // no temp-file + rename dance, so no `.tmp` sidecar is ever created.
     expect(existsSync(`${filePath}.tmp`)).toBe(false);
 
     const raw = readFileSync(filePath, "utf8");
@@ -103,11 +104,18 @@ describe("loadCheckpoints integration", () => {
     const lines = raw.split("\n").filter((l) => l !== "");
     expect(lines).toHaveLength(2);
 
-    // loadCheckpoints only honors the latest runId — this asserts the older
-    // run's bytes are still physically present on disk (not truncated away),
-    // even though the reader intentionally filters them out.
+    // The older run's bytes are physically present on disk (not truncated
+    // away by the fresh writer instance).
     const parsedFirst = JSON.parse(lines[0] as string) as { runId: string; storyId: string };
     expect(parsedFirst.runId).toBe("run-1");
     expect(parsedFirst.storyId).toBe("US-001");
+
+    // loadCheckpoints filters per-story (see reader.ts), not by a single
+    // file-wide newest runId — US-001's own newest (and only) runId is
+    // "run-1", so its checkpoint survives even though a newer runId
+    // ("run-2") exists elsewhere in the file for a different story.
+    const result = await loadCheckpoints(tmpDir);
+    expect(result.get("US-001")?.greenPhases).toEqual(["test-writer"]);
+    expect(result.get("US-002")?.greenPhases).toEqual(["test-writer"]);
   });
 });

--- a/test/unit/execution/checkpoint/reader.test.ts
+++ b/test/unit/execution/checkpoint/reader.test.ts
@@ -84,8 +84,13 @@ describe("loadCheckpoints latest-runId filter", () => {
     expect(result.get("US-002")?.greenPhases).toEqual(["test-writer"]);
   });
 
-  test("determines the newest runId by lexical string comparison", async () => {
-    // Lexical newest: "run-2" > "run-1"
+  test("determines the newest runId by lexical string comparison, per story", async () => {
+    // Lexical newest: "run-2" > "run-1". US-001 advanced to run-2; US-002 has
+    // not been touched since run-1. The runId filter is per-story (see
+    // module docstring in reader.ts), so US-002's run-1 records must survive
+    // even though a newer runId exists elsewhere in the file — a resume
+    // involving multiple incomplete stories must resume all of them, not
+    // just the one that happens to touch the file first.
     const a = record("US-001", "test-writer", { runId: "run-1" });
     const b = record("US-001", "implementer", { runId: "run-2" });
     const c = record("US-002", "test-writer", { runId: "run-1" });
@@ -95,7 +100,24 @@ describe("loadCheckpoints latest-runId filter", () => {
     const result = await loadCheckpoints("/feature", { _deps: deps });
     const us001 = result.get("US-001");
     expect(us001?.greenPhases).toEqual(["implementer"]);
-    expect(result.has("US-002")).toBe(false);
+    expect(result.has("US-002")).toBe(true);
+    expect(result.get("US-002")?.greenPhases).toEqual(["test-writer"]);
+  });
+
+  test("does not let one story's newer runId discard another story's older-runId checkpoints", async () => {
+    // Regression for the P1 finding: a resume that re-records US-001's
+    // skipped phases under the current run must not cause US-002's
+    // still-valid prior-run checkpoints to be dropped when the reader is
+    // consulted again for US-002.
+    const resumedRunOld = record("US-001", "implementer", { runId: "run-1" });
+    const resumedRunReRecorded = record("US-001", "implementer", { runId: "run-2" });
+    const otherStoryOld = record("US-002", "test-writer", { runId: "run-1" });
+    const content = `${resumedRunOld}\n${otherStoryOld}\n${resumedRunReRecorded}\n`;
+    const deps = makeReadDep(content);
+
+    const result = await loadCheckpoints("/feature", { _deps: deps });
+    expect(result.get("US-001")?.greenPhases).toEqual(["implementer"]);
+    expect(result.get("US-002")?.greenPhases).toEqual(["test-writer"]);
   });
 });
 

--- a/test/unit/pipeline/stages/queue-check.test.ts
+++ b/test/unit/pipeline/stages/queue-check.test.ts
@@ -182,4 +182,82 @@ describe("queueCheckStage — INJECT", () => {
     expect(result.action).toBe("continue");
     expect(ctx.prd.userStories).toHaveLength(1);
   });
+
+  test("INJECT rejects an absolute path outside the workspace and leaves the PRD unchanged", async () => {
+    const ctx = makeCtx(workdir);
+    const outsideDir = makeTempDir("nax-queue-check-outside-");
+    try {
+      const outsidePath = join(outsideDir, "outside-story.json");
+      await Bun.write(
+        outsidePath,
+        JSON.stringify({
+          title: "Escaped story",
+          description: "Should never be read.",
+          acceptanceCriteria: ["n/a"],
+        }),
+      );
+      await Bun.write(join(workdir, ".queue.txt"), `INJECT ${outsidePath}\n`);
+
+      const result = await queueCheckStage.execute(ctx);
+
+      expect(result.action).toBe("continue");
+      expect(ctx.prd.userStories).toHaveLength(1);
+    } finally {
+      cleanupTempDir(outsideDir);
+    }
+  });
+
+  test("INJECT rejects a relative path that traverses outside the workspace via ..", async () => {
+    const ctx = makeCtx(workdir);
+    const outsideDir = makeTempDir("nax-queue-check-outside-");
+    try {
+      await Bun.write(
+        join(outsideDir, "traversal-story.json"),
+        JSON.stringify({
+          title: "Escaped via traversal",
+          description: "Should never be read.",
+          acceptanceCriteria: ["n/a"],
+        }),
+      );
+      // relative(workdir, outsideDir) yields a `..`-prefixed path that resolves
+      // outside workdir once joined back onto it — the traversal shape validateFilePath must reject.
+      const { relative } = await import("node:path");
+      const traversalPath = join(relative(workdir, outsideDir), "traversal-story.json");
+      await Bun.write(join(workdir, ".queue.txt"), `INJECT ${traversalPath}\n`);
+
+      const result = await queueCheckStage.execute(ctx);
+
+      expect(result.action).toBe("continue");
+      expect(ctx.prd.userStories).toHaveLength(1);
+    } finally {
+      cleanupTempDir(outsideDir);
+    }
+  });
+
+  test("INJECT rejects a symlink that resolves outside the workspace", async () => {
+    const ctx = makeCtx(workdir);
+    const outsideDir = makeTempDir("nax-queue-check-outside-");
+    try {
+      const realTarget = join(outsideDir, "symlink-target.json");
+      await Bun.write(
+        realTarget,
+        JSON.stringify({
+          title: "Escaped via symlink",
+          description: "Should never be read.",
+          acceptanceCriteria: ["n/a"],
+        }),
+      );
+      const { symlinkSync } = await import("node:fs");
+      const linkPath = join(workdir, "link.json");
+      symlinkSync(realTarget, linkPath);
+      await Bun.write(join(workdir, ".queue.txt"), "INJECT link.json\n");
+
+      const result = await queueCheckStage.execute(ctx);
+
+      expect(result.action).toBe("continue");
+      expect(ctx.prd.userStories).toHaveLength(1);
+    } finally {
+      cleanupTempDir(outsideDir);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- **P1** — `loadCheckpoints()` filtered checkpoint records by the single newest `runId` across the whole file, so on a resume touching multiple incomplete stories, one story re-recording its checkpoints under a newer `runId` silently discarded another story's still-valid older-run checkpoints. Now filters per-story.
- **P2** — the `INJECT` queue command read `cmd.storyFile` without realpath-containment validation, allowing absolute paths, `..` traversal, or symlink escapes outside `ctx.workdir`. Now rejects absolute paths and routes the resolved path through the existing `validateFilePath()` containment check.
- **P2** — `CheckpointWriter`'s `defaultAppend` did a full read-modify-write + temp-file-rename on every single record (O(records²) I/O over a long run). Replaced with `node:fs/promises.appendFile` (O_APPEND), consistent with existing precedent (`src/session/scratch-writer.ts`, `src/logger/logger.ts`).

Also fixed stale comments/test assertions elsewhere that documented the pre-fix behavior (resume re-record loop rationale, a `.tmp`-sidecar assertion that no longer applies, and a reader doc comment), and strengthened an integration test to assert both stories survive `loadCheckpoints` under the new per-story filtering.

Full findings: `CODE_REVIEW_REPORT.md` (included in this branch).

## Test plan
- [x] `bun run typecheck` — pass
- [x] `bun run lint` — pass (Biome + alias/deep-relative/NaxError/logger-storyid/log-format/file-size checks)
- [x] `bun run test` — 9708 unit + 1090 integration + 21 UI = 10,819 passing, 0 failures
- [x] New/updated tests specifically cover: per-story runId filtering (reader unit + integration), INJECT absolute-path rejection, `..` traversal rejection, symlink-escape rejection
- [x] Independent code-review pass (subagent) confirmed all three fixes correct with no correctness/security issues; follow-up doc fixes applied