### PR TITLE
fix: expose explicit cwd on acceptance groups, fix {{FILE}} splitting

### DIFF
--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -48,12 +48,18 @@ export function buildAcceptanceRunCommand(
   packageDir?: string,
 ): string[] {
   if (commandOverride) {
-    // Support {{files}}, {{file}}, {{FILE}} — all resolve to the single acceptance test path
-    const resolved = commandOverride
-      .replace(/\{\{files\}\}/g, testPath)
-      .replace(/\{\{file\}\}/g, testPath)
-      .replace(/\{\{FILE\}\}/g, testPath);
-    return resolved.trim().split(/\s+/);
+    // Split on whitespace BEFORE substitution so a testPath containing spaces stays
+    // a single argv element instead of being torn apart by the split below.
+    // Support {{files}}, {{file}}, {{FILE}} — all resolve to the single acceptance test path.
+    return commandOverride
+      .trim()
+      .split(/\s+/)
+      .map((part) =>
+        part
+          .replace(/\{\{files\}\}/g, testPath)
+          .replace(/\{\{file\}\}/g, testPath)
+          .replace(/\{\{FILE\}\}/g, testPath),
+      );
   }
 
   switch (testFramework?.toLowerCase()) {

--- a/src/cli/features-acceptance.ts
+++ b/src/cli/features-acceptance.ts
@@ -6,7 +6,16 @@ import { getSafeLogger } from "../logger";
 import { loadPRD } from "../prd";
 import { errorMessage } from "../utils/errors";
 
-/** One resolved acceptance test target — a single package the feature touches. */
+/**
+ * One resolved acceptance test target — a single package the feature touches.
+ *
+ * Reproducing the runtime invocation: spawn `command` with `cwd` as the working
+ * directory, substituting any `{{FILE}}` placeholder in `command` with `testPath`
+ * made relative to `cwd` (both are repo-root-relative, so a plain `path.relative(cwd,
+ * testPath)` suffices). Do NOT spawn from repo root with the repo-root-relative
+ * `testPath` substituted verbatim — `command` is resolved per-package and is only
+ * valid when run from `cwd`.
+ */
 export interface AcceptanceGroupResult {
   /** Package directory relative to repo root; "" for the root package. */
   packageDir: string;
@@ -16,6 +25,11 @@ export interface AcceptanceGroupResult {
   exists: boolean;
   /** Resolved acceptance command (per-package override else root); may contain a {{FILE}} placeholder. */
   command?: string;
+  /**
+   * Working directory `command` must be spawned from, relative to repo root
+   * (equal to `packageDir` — see the interface doc for the full reconstruction contract).
+   */
+  cwd: string;
   /** Per-package detected language (drives the test-file extension). */
   language?: string;
 }
@@ -83,6 +97,7 @@ export async function resolveFeatureAcceptance(featureName: string, workdir: str
           testPath: relative(repoRoot, g.testPath),
           exists: await Bun.file(g.testPath).exists(),
           command,
+          cwd: packageDir,
           language: g.language,
         };
       }),

--- a/test/unit/acceptance/generator-core.test.ts
+++ b/test/unit/acceptance/generator-core.test.ts
@@ -56,6 +56,11 @@ describe("buildAcceptanceRunCommand", () => {
     const cmd = buildAcceptanceRunCommand("/pkg/.nax-acceptance.test.ts", undefined, override);
     expect(cmd).toEqual(["bun", "test", "/pkg/.nax-acceptance.test.ts"]);
   });
+
+  test("keeps a substituted path containing spaces as a single argv element", () => {
+    const cmd = buildAcceptanceRunCommand("/pkg with spaces/.nax-acceptance.test.ts", undefined, "bun test {{FILE}}");
+    expect(cmd).toEqual(["bun", "test", "/pkg with spaces/.nax-acceptance.test.ts"]);
+  });
 });
 
 describe("parseAcceptanceCriteria", () => {

--- a/test/unit/cli/features-acceptance.test.ts
+++ b/test/unit/cli/features-acceptance.test.ts
@@ -144,6 +144,7 @@ describe("single-package", () => {
     expect(group.testPath).toBe(".nax/features/feat/.nax-acceptance.test.ts");
     expect(group.exists).toBe(false);
     expect(group.command).toBeUndefined();
+    expect(group.cwd).toBe("");
   });
 
   test("exists=true when the acceptance test file is present on disk", async () => {
@@ -194,6 +195,8 @@ describe("monorepo", () => {
     expect(Object.keys(byPkg).sort()).toEqual(["packages/api", "packages/core"]);
     expect(byPkg["packages/core"].testPath).toBe("packages/core/.nax/features/feat/.nax-acceptance.test.ts");
     expect(byPkg["packages/api"].testPath).toBe("packages/api/.nax/features/feat/.nax-acceptance.test.ts");
+    expect(byPkg["packages/core"].cwd).toBe("packages/core");
+    expect(byPkg["packages/api"].cwd).toBe("packages/api");
   });
 
   test("per-package acceptance.command override beats the root command", async () => {


### PR DESCRIPTION
## Summary
- `nax features resolve --json` mixed reference frames: `packageDir`/`testPath` were repo-root-relative, but the per-package `command` override is only valid when run from the package directory — an unstated fact. Adds an explicit `cwd` field per acceptance group (equal to `packageDir`, documented as the required spawn cwd) so consumers can reconstruct the actual runtime invocation instead of guessing and getting it wrong 5/6 of the time (per the issue's measurement).
- Fixes the related nit in `buildAcceptanceRunCommand`: it substituted `{{FILE}}` before splitting the command string on whitespace, so a test path containing spaces would be torn into multiple argv elements. Now splits the override template first, then substitutes per-token.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (full suite: unit/integration/ui, 0 failures)
- [x] Added unit coverage: `cwd` field assertions in `test/unit/cli/features-acceptance.test.ts`, space-safety case in `test/unit/acceptance/generator-core.test.ts`

Fixes #1328