### PR TITLE
fix: stop emitting findings no fix strategy can claim (unclaimable autofix mint + single-session test re-tag)

### DIFF
--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -609,7 +609,17 @@ and stashed on `ctx.testEditDeclarations` by the implementer strategy's
 fresh findings: each declaration whose `PRD_QUOTE` is verbatim-present in the
 story description or AC text causes a finding on the declared file to be
 re-tagged from `fixTarget: "source"` to `"test"`. The test-writer strategy
-claims the re-tagged finding on the next iteration. Declarations with fabricated
+claims the re-tagged finding on the next iteration.
+
+The re-tag is gated on `isThreeSession` (`allowTestRetag`). `fixTarget: "test"`
+exists to hand a finding to the test-writer, and `autofix-test-writer` — its only
+claimer — is registered only for three-session strategies. A single-session
+implementer (`tdd-simple` / `test-after` / `no-test`) owns both source and tests,
+so there is no handoff to make: the declaration is informational and the finding
+stays `fixTarget: "source"` for the implementer to claim and edit the test
+itself. Re-tagging there would strand it with no claimer (#1330).
+
+Declarations with fabricated
 PRD quotes do not re-tag, and are reported as a `prd_quote_mismatch`
 `DeclarationDiagnostic` that the `postValidate` caller logs at warn — never as a
 finding. The non-re-tag *is* the enforcement; a diagnostic carries no fix, and

--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -610,8 +610,14 @@ fresh findings: each declaration whose `PRD_QUOTE` is verbatim-present in the
 story description or AC text causes a finding on the declared file to be
 re-tagged from `fixTarget: "source"` to `"test"`. The test-writer strategy
 claims the re-tagged finding on the next iteration. Declarations with fabricated
-PRD quotes inject a `prd_quote_mismatch` advisory finding (severity=warning) and
-do not re-tag.
+PRD quotes do not re-tag, and are reported as a `prd_quote_mismatch`
+`DeclarationDiagnostic` that the `postValidate` caller logs at warn — never as a
+finding. The non-re-tag *is* the enforcement; a diagnostic carries no fix, and
+the findings stream is the cycle's work queue, so every entry in it must be
+claimable by some strategy's `appliesTo`. An unclaimable finding makes
+`selectActiveStrategies` return `[]` and the cycle exit `no-strategy`, failing a
+story whose gates all passed (#1327). The same rule applies to invalid
+`mock_structure` handoffs.
 
 The test-writer strategy's `maxAttempts` is set to `2` to allow exactly one
 re-fire after the initial source-bug-error attempt.

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -23,6 +23,7 @@ import type { TestStrategy } from "../config/schema-types";
 import type { FixCycleContext } from "../findings/cycle-types";
 import type { FixStrategy } from "../findings/cycle-types";
 import type { Finding } from "../findings/types";
+import { getSafeLogger } from "../logger";
 import {
   applyTestEditDeclarations,
   makeAutofixImplementerStrategy,
@@ -32,7 +33,7 @@ import {
   makeMechanicalLintFixStrategy,
   validateMockStructureFiles,
 } from "../operations";
-import type { TestEditDeclaration } from "../operations";
+import type { DeclarationDiagnostic, TestEditDeclaration } from "../operations";
 import { shouldRunRectification } from "../operations/execution-gates";
 import { makeFullSuiteRectifyStrategy } from "../operations/full-suite-rectify";
 import type { CallContext } from "../operations/types";
@@ -51,6 +52,29 @@ import { type ExecutionPlan, type RectificationPhaseOptions, StoryOrchestratorBu
  */
 export function requiresInitialRefCapture(strategy: TestStrategy): boolean {
   return isThreeSessionStrategy(strategy);
+}
+
+/**
+ * Warn about test-edit declarations the implementer made that failed validation.
+ *
+ * These are deliberately not findings: the fix cycle's findings stream is a work
+ * queue, and a rejected declaration has no fix to apply — its enforcement already
+ * happened (see apply-test-edit-declarations.ts). Injecting them as findings made
+ * green stories exit the cycle "no-strategy" (#1327). Logging keeps the signal
+ * greppable without gating the story.
+ */
+function logRejectedDeclarations(diagnostics: DeclarationDiagnostic[], ctx: FixCycleContext): void {
+  if (diagnostics.length === 0) return;
+  const logger = getSafeLogger();
+  for (const d of diagnostics) {
+    logger?.warn("findings.cycle", "test-edit declaration rejected — ignoring declaration", {
+      storyId: ctx.storyId,
+      packageDir: ctx.packageDir,
+      reason: d.reason,
+      file: d.file,
+      detail: d.detail,
+    });
+  }
 }
 
 /**
@@ -213,7 +237,7 @@ export async function buildPlanForStrategy(
       }
     }
 
-    const postValidate = async (findings: Finding[], _validateCtx: FixCycleContext): Promise<Finding[]> => {
+    const postValidate = async (findings: Finding[], validateCtx: FixCycleContext): Promise<Finding[]> => {
       if (sink.testEdits.length === 0 && sink.mockHandoffs.length === 0) return findings;
 
       // Wrap mock handoffs as TestEditDeclaration shape for validateMockStructureFiles.
@@ -232,7 +256,9 @@ export async function buildPlanForStrategy(
       const allDeclarations = [...sink.testEdits, ...valid];
       sink.testEdits = []; // consumed
 
-      return applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+      const applied = applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+      logRejectedDeclarations(applied.diagnostics, validateCtx);
+      return applied.findings;
     };
 
     const rectOpts: RectificationPhaseOptions = {
@@ -317,7 +343,7 @@ export async function buildPlanForStrategy(
     );
 
     // Mirror the main rectification postValidate but bound to nbSink (#1227).
-    const nbPostValidate = async (findings: Finding[], _validateCtx: FixCycleContext): Promise<Finding[]> => {
+    const nbPostValidate = async (findings: Finding[], validateCtx: FixCycleContext): Promise<Finding[]> => {
       if (nbSink.testEdits.length === 0 && nbSink.mockHandoffs.length === 0) return findings;
 
       const pendingMock: TestEditDeclaration[] = nbSink.mockHandoffs.map((h) => ({
@@ -334,7 +360,9 @@ export async function buildPlanForStrategy(
       const allDeclarations = [...nbSink.testEdits, ...valid];
       nbSink.testEdits = [];
 
-      return applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+      const applied = applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+      logRejectedDeclarations(applied.diagnostics, validateCtx);
+      return applied.findings;
     };
 
     builder.addNonBlockingFix(nbf, nbStrategies, nbPostValidate);

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -256,7 +256,13 @@ export async function buildPlanForStrategy(
       const allDeclarations = [...sink.testEdits, ...valid];
       sink.testEdits = []; // consumed
 
-      const applied = applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+      const applied = applyTestEditDeclarations(findings, allDeclarations, story, {
+        invalidMockStructure: invalid,
+        // Only three-session registers autofix-test-writer (the sole claimer of
+        // fixTarget "test") — see the gate above. Re-tagging in single-session
+        // would strand the finding with no claimer (#1330).
+        allowTestRetag: isThreeSession,
+      });
       logRejectedDeclarations(applied.diagnostics, validateCtx);
       return applied.findings;
     };
@@ -360,7 +366,13 @@ export async function buildPlanForStrategy(
       const allDeclarations = [...nbSink.testEdits, ...valid];
       nbSink.testEdits = [];
 
-      const applied = applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+      const applied = applyTestEditDeclarations(findings, allDeclarations, story, {
+        invalidMockStructure: invalid,
+        // Mirrors the main cycle: the nbf strategy set only registers
+        // autofix-test-writer under isThreeSession (see the !isThreeSession
+        // carve-out above, which routes everything to the implementer).
+        allowTestRetag: isThreeSession,
+      });
       logRejectedDeclarations(applied.diagnostics, validateCtx);
       return applied.findings;
     };

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -359,9 +359,12 @@ export async function decideStageAction(
     // Advisory-only escape: if NONE of the remaining unfixed findings meet the
     // run's blocking threshold, the story is functionally green — do not fail it
     // on sub-blocking leftovers. This covers findings that no fix strategy can
-    // claim (e.g. `source:"autofix"` declaration diagnostics) which would
+    // claim (e.g. `source:"plugin"`, which no `appliesTo` matches) which would
     // otherwise force a `no-strategy` cycle exit into a hard story failure even
     // though every gate (tests/lint/typecheck/semantic/adversarial) passed.
+    // Note this escape is threshold-relative: it does not fire when a project
+    // sets `review.blockingThreshold` at or below the leftover's severity, so it
+    // is a backstop — not a licence to mint findings no strategy can claim.
     // Missing severity is treated as "error" (blocking) so a real defect is
     // never silently swallowed. Mirrors the severity-based blocking/advisory
     // partition used by the review layer (isBlockingSeverity).

--- a/src/findings/types.ts
+++ b/src/findings/types.ts
@@ -36,8 +36,7 @@ export type FindingSource =
   | "acceptance-diagnose"
   | "tdd-verifier"
   | "plugin"
-  | "implementer-handoff"
-  | "autofix";
+  | "implementer-handoff";
 
 /**
  * Severity scale. Standardised on "warning" (not "warn") to align with

--- a/src/operations/apply-test-edit-declarations.ts
+++ b/src/operations/apply-test-edit-declarations.ts
@@ -1,14 +1,47 @@
 /**
  * Apply test-edit declarations emitted by the implementer rectification agent
  * to findings, re-tagging source→test on valid prd_contract declarations and
- * appending advisory findings for invalid quotes or invalid mock-structure refs.
+ * reporting rejected declarations as diagnostics.
  *
- * Pure function — never mutates inputs.
+ * Rejected declarations are NOT injected into the findings stream. The findings
+ * stream is the fix cycle's work queue: every entry must be claimable by some
+ * FixStrategy's `appliesTo`, or the cycle exits "no-strategy" and fails an
+ * otherwise-green story (#1327). A rejected declaration carries no work — the
+ * enforcement has already happened by the time it is reported (an invalid quote
+ * means the finding was not re-tagged; invalid mock files are stripped from the
+ * handoff before the test-writer sees them). Callers log these instead.
+ *
+ * Pure function — never mutates inputs, never logs.
  */
 import type { Finding } from "@/findings";
 import type { UserStory } from "@/prd";
 import { validatePrdQuote } from "./test-edit-declaration";
 import type { TestEditDeclaration } from "./test-edit-declaration";
+
+/** Why a declaration was rejected. */
+export type DeclarationDiagnosticReason = "prd_quote_mismatch" | "mock_structure_invalid_files";
+
+/**
+ * A rejected declaration, reported for logging rather than fixing.
+ *
+ * Diagnostics describe a *declaration* the implementer made, not a defect in
+ * the code — there is nothing for a fix strategy to act on.
+ */
+export interface DeclarationDiagnostic {
+  reason: DeclarationDiagnosticReason;
+  /** The declaration's primary file. */
+  file: string;
+  /** Human-readable explanation, suitable as a log message. */
+  detail: string;
+}
+
+/** Result of applying declarations: re-tagged findings plus rejection diagnostics. */
+export interface TestEditDeclarationResult {
+  /** The findings, with valid prd_contract re-tags applied. Never appended to. */
+  findings: Finding[];
+  /** Declarations that failed validation. Empty when everything validated. */
+  diagnostics: DeclarationDiagnostic[];
+}
 
 /**
  * Apply declarations to the findings array.
@@ -17,16 +50,16 @@ import type { TestEditDeclaration } from "./test-edit-declaration";
  * @param declarations - Parsed TEST_EDIT_REASON declarations from the implementer.
  * @param story - The user story (used to validate prd_contract quotes).
  * @param invalidMockStructure - Mock-structure declarations that failed file/pattern validation.
- * @returns New findings array with re-tags and advisory findings applied.
+ * @returns Re-tagged findings and diagnostics for any rejected declaration.
  */
 export function applyTestEditDeclarations(
   findings: Finding[],
   declarations: TestEditDeclaration[],
   story: UserStory,
   invalidMockStructure?: TestEditDeclaration[],
-): Finding[] {
+): TestEditDeclarationResult {
   let result: Finding[] = [...findings];
-  const advisories: Finding[] = [];
+  const diagnostics: DeclarationDiagnostic[] = [];
 
   for (const d of declarations) {
     if (d.reason === "prd_contract") {
@@ -53,32 +86,28 @@ export function applyTestEditDeclarations(
           return f;
         });
       } else {
-        advisories.push({
-          source: "autofix",
-          severity: "warning",
-          category: "prd_quote_mismatch",
-          message: `PRD quote not found verbatim in story text for file: ${d.file}`,
+        // Rejection is already enforced above: without a valid quote the
+        // findings for this file keep their original fixTarget.
+        diagnostics.push({
+          reason: "prd_quote_mismatch",
           file: d.file,
-          fixTarget: "source",
+          detail: `PRD quote not found verbatim in story text for file: ${d.file}`,
         });
       }
     }
     // lint_only and sibling_scope: passthrough — no changes to findings
   }
 
-  // Advisory findings for invalid mock_structure declarations
-  if (invalidMockStructure && invalidMockStructure.length > 0) {
-    for (const d of invalidMockStructure) {
-      const fileList = (d.files ?? [d.file]).join(", ");
-      advisories.push({
-        source: "autofix",
-        severity: "warning",
-        category: "mock_structure_invalid_files",
-        message: `Mock structure handoff references file that does not exist or is not a test file: ${fileList}`,
-        fixTarget: "source",
-      });
-    }
+  // Invalid mock_structure declarations are stripped from the handoff by the
+  // caller before the test-writer consumes it; report them for visibility.
+  for (const d of invalidMockStructure ?? []) {
+    const fileList = (d.files ?? [d.file]).join(", ");
+    diagnostics.push({
+      reason: "mock_structure_invalid_files",
+      file: d.file,
+      detail: `Mock structure handoff references file that does not exist or is not a test file: ${fileList}`,
+    });
   }
 
-  return [...result, ...advisories];
+  return { findings: result, diagnostics };
 }

--- a/src/operations/apply-test-edit-declarations.ts
+++ b/src/operations/apply-test-edit-declarations.ts
@@ -11,6 +11,9 @@
  * means the finding was not re-tagged; invalid mock files are stripped from the
  * handoff before the test-writer sees them). Callers log these instead.
  *
+ * The same invariant governs the re-tag: `fixTarget: "test"` is only claimable
+ * where a test-writer exists, so it is gated behind `allowTestRetag` (#1330).
+ *
  * Pure function — never mutates inputs, never logs.
  */
 import type { Finding } from "@/findings";
@@ -43,21 +46,45 @@ export interface TestEditDeclarationResult {
   diagnostics: DeclarationDiagnostic[];
 }
 
+/** Options for {@link applyTestEditDeclarations}. */
+export interface ApplyTestEditDeclarationsOptions {
+  /** Mock-structure declarations that failed file/pattern validation. */
+  invalidMockStructure?: TestEditDeclaration[];
+  /**
+   * Whether a valid prd_contract declaration may re-tag a finding to
+   * `fixTarget: "test"`. Pass `isThreeSession`.
+   *
+   * `fixTarget: "test"` exists to hand a finding from the implementer to the
+   * test-writer, and only three-session strategies have a test-writer session
+   * (`autofix-test-writer` is the sole claimer of that fixTarget and registers
+   * only under `isThreeSession`). A single-session implementer owns both source
+   * and tests, so there is no handoff to make: the declaration is informational
+   * and the finding stays `fixTarget: "source"` for the implementer to claim.
+   * Re-tagging anyway strands the finding with no claimer, exiting the cycle
+   * "no-strategy" (#1330).
+   *
+   * (default: true — preserves the three-session behavior for callers that
+   * cannot produce a single-session cycle)
+   */
+  allowTestRetag?: boolean;
+}
+
 /**
  * Apply declarations to the findings array.
  *
  * @param findings - Current findings from the fix cycle.
  * @param declarations - Parsed TEST_EDIT_REASON declarations from the implementer.
  * @param story - The user story (used to validate prd_contract quotes).
- * @param invalidMockStructure - Mock-structure declarations that failed file/pattern validation.
+ * @param opts - See {@link ApplyTestEditDeclarationsOptions}.
  * @returns Re-tagged findings and diagnostics for any rejected declaration.
  */
 export function applyTestEditDeclarations(
   findings: Finding[],
   declarations: TestEditDeclaration[],
   story: UserStory,
-  invalidMockStructure?: TestEditDeclaration[],
+  opts: ApplyTestEditDeclarationsOptions = {},
 ): TestEditDeclarationResult {
+  const { invalidMockStructure, allowTestRetag = true } = opts;
   let result: Finding[] = [...findings];
   const diagnostics: DeclarationDiagnostic[] = [];
 
@@ -66,7 +93,15 @@ export function applyTestEditDeclarations(
       const prdQuote = d.prdQuote ?? "";
       const valid = validatePrdQuote(prdQuote, story);
 
-      if (valid) {
+      if (!valid) {
+        // Rejection is already enforced by not re-tagging: the findings for this
+        // file keep their original fixTarget.
+        diagnostics.push({
+          reason: "prd_quote_mismatch",
+          file: d.file,
+          detail: `PRD quote not found verbatim in story text for file: ${d.file}`,
+        });
+      } else if (allowTestRetag) {
         // Re-tag matching findings: same file, fixTarget was "source" OR finding
         // is a test-runner failed-test with no fixTarget (AC4: failing-test findings
         // carry no fixTarget but are re-tag-eligible when source === "test-runner").
@@ -85,15 +120,10 @@ export function applyTestEditDeclarations(
           }
           return f;
         });
-      } else {
-        // Rejection is already enforced above: without a valid quote the
-        // findings for this file keep their original fixTarget.
-        diagnostics.push({
-          reason: "prd_quote_mismatch",
-          file: d.file,
-          detail: `PRD quote not found verbatim in story text for file: ${d.file}`,
-        });
       }
+      // valid && !allowTestRetag: single-session. The quote is fine, but there is
+      // no test-writer to hand off to — the implementer edits the test itself, so
+      // the declaration is informational and the finding keeps fixTarget "source".
     }
     // lint_only and sibling_scope: passthrough — no changes to findings
   }

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -93,6 +93,7 @@ export { makeAutofixImplementerStrategy } from "./autofix-implementer-strategy";
 export { makeAutofixTestWriterStrategy } from "./autofix-test-writer-strategy";
 export { applyTestEditDeclarations } from "./apply-test-edit-declarations";
 export type {
+  ApplyTestEditDeclarationsOptions,
   DeclarationDiagnostic,
   DeclarationDiagnosticReason,
   TestEditDeclarationResult,

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -92,6 +92,11 @@ export type { FullSuiteRectifyInput, FullSuiteRectifyOutput } from "./full-suite
 export { makeAutofixImplementerStrategy } from "./autofix-implementer-strategy";
 export { makeAutofixTestWriterStrategy } from "./autofix-test-writer-strategy";
 export { applyTestEditDeclarations } from "./apply-test-edit-declarations";
+export type {
+  DeclarationDiagnostic,
+  DeclarationDiagnosticReason,
+  TestEditDeclarationResult,
+} from "./apply-test-edit-declarations";
 export { validateMockStructureFiles } from "./validate-mock-structure-files";
 export { setupGenerateOp, MAX_SETUP_LLM_ATTEMPTS } from "./setup-generate";
 export type { SetupPlan, MonoPackageConfig, RawSetupPlan } from "./setup-generate";

--- a/test/integration/execution/fullsuite-rectify-declaration.test.ts
+++ b/test/integration/execution/fullsuite-rectify-declaration.test.ts
@@ -4,7 +4,8 @@
  * AC8: full-suite-rectify strategy (with sink) pushes mock_structure declarations to
  *      sink.mockHandoffs; after postValidate validates the files, autofix-test-writer
  *      picks up the handoff.
- * AC9: invalid mock_structure files → advisory finding with category mock_structure_invalid_files.
+ * AC9: invalid mock_structure files → reported as a log diagnostic, never as a finding;
+ *      postValidate's output stays fully claimable by the cycle's strategies (#1327).
  * AC11: single-session story with mock_structure output → cycle completes without throwing,
  *       no autofix-test-writer strategy dispatched.
  */
@@ -187,12 +188,12 @@ describe("AC8: full-suite-rectify sink integration — test-writer receives mock
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC9: invalid mock_structure files → advisory finding appended
+// AC9: invalid mock_structure files → no unclaimable finding minted (#1327)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("AC9: invalid mock_structure files → advisory with category mock_structure_invalid_files", () => {
+describe("AC9: invalid mock_structure files → diagnostic only, no unclaimable finding", () => {
   test(
-    "AC9: postValidate appends advisory when mock_structure files do not exist or do not match test patterns",
+    "AC9: postValidate mints no finding when mock_structure files do not exist or do not match test patterns",
     async () => {
       // Use a packageDir where the declared test file does not exist.
       const packageDir = "/tmp/nax-test-ac9-nonexistent-dir";
@@ -247,6 +248,16 @@ describe("AC9: invalid mock_structure files → advisory with category mock_stru
       const mockInput: FullSuiteRectifyInput = { story, findings: [] };
       await fullSuiteStrategy!.extractApplied!(invalidMockOutput as any, mockInput as any);
 
+      const testWriterStrategy = capturedCycle!.strategies.find((s) => s.name === "autofix-test-writer");
+      expect(testWriterStrategy).toBeDefined();
+      const dummyFinding: Finding = { source: "lint", severity: "error", category: "style", message: "dummy" };
+
+      // Precondition: extractApplied populated the sink, so the test-writer's
+      // `sink.mockHandoffs.length > 0` clause claims. Without this, the
+      // assertions below would also hold on the `postValidate` early-return
+      // path (empty sink → returns findings untouched) and prove nothing.
+      expect(testWriterStrategy!.appliesTo(dummyFinding)).toBe(true);
+
       // Set up callOp for validate re-run.
       _storyOrchestratorDeps.callOp = mock(async () => ({ success: true })) as typeof _storyOrchestratorDeps.callOp;
 
@@ -258,11 +269,16 @@ describe("AC9: invalid mock_structure files → advisory with category mock_stru
 
       const findings = Array.isArray(validateResult) ? validateResult : validateResult.findings;
 
-      // AC9: postValidate appends advisory finding for invalid mock_structure files.
-      const hasAdvisory = (findings as Finding[]).some(
-        (f) => f.category === "mock_structure_invalid_files",
-      );
-      expect(hasAdvisory).toBe(true);
+      // postValidate reached the validation branch and rejected the handoff: the
+      // sink is now drained, so the test-writer no longer claims. This is the
+      // positive artifact that the invalid-declaration path actually ran.
+      expect(testWriterStrategy!.appliesTo(dummyFinding)).toBe(false);
+
+      // AC9 (#1327): every phase passed, so validate yields no findings — and the
+      // rejected handoff must not add one. It is reported as a log diagnostic
+      // instead. An appended advisory here is claimed by no strategy's appliesTo,
+      // so the cycle would exit "no-strategy" and fail this green story.
+      expect(findings).toEqual([]);
     },
   );
 });

--- a/test/integration/execution/nbf-rectify-declaration.test.ts
+++ b/test/integration/execution/nbf-rectify-declaration.test.ts
@@ -5,7 +5,8 @@
  *          applied via nbPostValidate — autofix-test-writer picks up the handoff.
  * AC-NBF2: nbSink is drained by nbPostValidate; the main sink (empty at this point)
  *          is not double-drained.
- * AC-NBF3: invalid mock_structure files in the nbf cycle → advisory finding appended.
+ * AC-NBF3: invalid mock_structure files in the nbf cycle → reported as a log diagnostic,
+ *          never as a finding; nbPostValidate's output stays claimable (#1327).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -288,12 +289,12 @@ describe("AC-NBF2: nbf cycle validate uses nbPostValidate bound to nbSink", () =
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC-NBF3: invalid mock_structure in nbf cycle → advisory finding appended
+// AC-NBF3: invalid mock_structure in nbf cycle → no unclaimable finding minted (#1327)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("AC-NBF3: invalid mock_structure in nbf cycle → advisory with category mock_structure_invalid_files", () => {
+describe("AC-NBF3: invalid mock_structure in nbf cycle → diagnostic only, no unclaimable finding", () => {
   test(
-    "AC-NBF3: nbPostValidate appends advisory when declared test file does not exist",
+    "AC-NBF3: nbPostValidate mints no finding when declared test file does not exist",
     async () => {
       const packageDir = "/tmp/nax-test-nbf-ac3-nonexistent";
       const story = makeStory({ id: "US-nbf3", attempts: 1 });
@@ -344,6 +345,16 @@ describe("AC-NBF3: invalid mock_structure in nbf cycle → advisory with categor
       const mockInput: FullSuiteRectifyInput = { story, findings: [] };
       await fullSuiteStrategy!.extractApplied!(invalidOutput as any, mockInput as any);
 
+      const testWriterStrategy = capturedCycle!.strategies.find((s) => s.name === "autofix-test-writer");
+      expect(testWriterStrategy).toBeDefined();
+      const dummyFinding: Finding = { source: "lint", severity: "error", category: "style", message: "dummy" };
+
+      // Precondition: extractApplied populated nbSink, so the test-writer claims
+      // via its `sink.mockHandoffs.length > 0` clause. This also proves the
+      // captured cycle is the nbf one (it shares nbSink). Without it, the
+      // assertions below would also hold on nbPostValidate's early-return path.
+      expect(testWriterStrategy!.appliesTo(dummyFinding)).toBe(true);
+
       _storyOrchestratorDeps.callOp = mock(async () => ({ success: true })) as typeof _storyOrchestratorDeps.callOp;
 
       const validateResult = await capturedCycle!.validate(capturedCycleCtx!, {
@@ -352,8 +363,15 @@ describe("AC-NBF3: invalid mock_structure in nbf cycle → advisory with categor
       });
 
       const findings = Array.isArray(validateResult) ? validateResult : validateResult.findings;
-      const hasAdvisory = (findings as Finding[]).some((f) => f.category === "mock_structure_invalid_files");
-      expect(hasAdvisory).toBe(true);
+
+      // nbPostValidate reached the validation branch and rejected the handoff:
+      // nbSink is drained, so the test-writer no longer claims.
+      expect(testWriterStrategy!.appliesTo(dummyFinding)).toBe(false);
+
+      // AC-NBF3 (#1327): the rejected handoff is reported as a log diagnostic, not
+      // appended as a finding. An appended advisory is claimed by no nbf strategy,
+      // so the cycle would exit "no-strategy" on a story whose every phase passed.
+      expect(findings).toEqual([]);
     },
   );
 });

--- a/test/unit/execution/_post-run-fixtures.ts
+++ b/test/unit/execution/_post-run-fixtures.ts
@@ -55,14 +55,17 @@ export const SEMANTIC_REVIEW_FINDING: Finding = {
   category: "ac-coverage",
   fixTarget: "source",
 };
-// Advisory leftover that no fix strategy's `appliesTo` claims (source "autofix",
-// severity below the default "error" blocking threshold). Regression fixture for
-// the advisory-only exhaustion escape — see the event-bus-idempotency-dlq US-004
-// no-strategy failure where a green story was failed on exactly this shape.
-export const AUTOFIX_ADVISORY_FINDING: Finding = {
-  source: "autofix",
+// Advisory leftover that no fix strategy's `appliesTo` claims — "plugin" is
+// claimed by no strategy, and the severity is below the default "error" blocking
+// threshold. Regression fixture for the advisory-only exhaustion escape: see the
+// event-bus-idempotency-dlq US-004 no-strategy failure where a green story was
+// failed on exactly this shape. That case was a `source:"autofix"` declaration
+// diagnostic; #1327 removed those at the mint site, but sources like "plugin"
+// can still orphan, so the escape stays.
+export const ADVISORY_LEFTOVER_FINDING: Finding = {
+  source: "plugin",
   severity: "warning",
-  message: "mock structure handoff references file that is not a test file",
-  category: "mock_structure_invalid_files",
+  message: "plugin check reported a non-blocking issue",
+  category: "plugin-advisory",
   fixTarget: "source",
 };

--- a/test/unit/execution/post-run-inspection-exhaustion.test.ts
+++ b/test/unit/execution/post-run-inspection-exhaustion.test.ts
@@ -13,7 +13,7 @@ import type { Finding } from "@/findings/types";
 import { fullSuiteGateOp, implementerOp, testWriterOp, verifierOp } from "@/operations";
 import { makeTestContext } from "@test/helpers";
 import {
-  AUTOFIX_ADVISORY_FINDING,
+  ADVISORY_LEFTOVER_FINDING,
   LINT_FINDING,
   SEMANTIC_REVIEW_FINDING,
   TEST_RUNNER_FINDING,
@@ -267,9 +267,11 @@ describe("AC8: mechanicalFailedOnly — non-mechanical source present → escala
 // ─────────────────────────────────────────────────────────────────────────────
 // Advisory-only rectification exhaustion → continue (not escalate/fail).
 // A green story (all gates passed) must not be failed on leftover findings that
-// are below the run's blocking threshold — e.g. `source:"autofix"` declaration
-// diagnostics that no fix strategy can claim, which drive a `no-strategy` cycle
-// exit. Regression guard for the event-bus-idempotency-dlq US-004 failure.
+// are below the run's blocking threshold — e.g. a `source:"plugin"` advisory that
+// no fix strategy can claim, which drives a `no-strategy` cycle exit. Regression
+// guard for the event-bus-idempotency-dlq US-004 failure (that one was a
+// `source:"autofix"` declaration diagnostic; #1327 removed those at the mint
+// site, but other unclaimed sources keep this escape necessary).
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("advisory-only rectification exhaustion → continue", () => {
@@ -292,12 +294,12 @@ describe("advisory-only rectification exhaustion → continue", () => {
     _postRunDeps.failAndClose = origFailClose;
   });
 
-  test("rectificationExhausted + only advisory autofix finding → continue", async () => {
+  test("rectificationExhausted + only advisory unclaimed finding → continue", async () => {
     const ctx = makeTestContext();
     const planResult = makePlanResult({
       success: false,
       rectificationExhausted: true,
-      unfixedFindings: [AUTOFIX_ADVISORY_FINDING],
+      unfixedFindings: [ADVISORY_LEFTOVER_FINDING],
     });
     const opts = makeInspectionOpts();
     const inspection = await applyPostRunInspection(ctx, planResult, opts);
@@ -305,12 +307,12 @@ describe("advisory-only rectification exhaustion → continue", () => {
     expect(result.action).toBe("continue");
   });
 
-  test("rectificationExhausted + advisory autofix + blocking semantic finding → escalate", async () => {
+  test("rectificationExhausted + advisory unclaimed + blocking semantic finding → escalate", async () => {
     const ctx = makeTestContext();
     const planResult = makePlanResult({
       success: false,
       rectificationExhausted: true,
-      unfixedFindings: [AUTOFIX_ADVISORY_FINDING, SEMANTIC_REVIEW_FINDING],
+      unfixedFindings: [ADVISORY_LEFTOVER_FINDING, SEMANTIC_REVIEW_FINDING],
     });
     const opts = makeInspectionOpts();
     const inspection = await applyPostRunInspection(ctx, planResult, opts);
@@ -323,7 +325,7 @@ describe("advisory-only rectification exhaustion → continue", () => {
     // No `severity` field: must default to "error" (blocking) so a real defect is
     // never silently swallowed by the advisory-only escape.
     const noSeverityFinding = {
-      source: "autofix",
+      source: "plugin",
       message: "unknown-severity finding",
       category: "unknown",
       fixTarget: "source",
@@ -341,7 +343,7 @@ describe("advisory-only rectification exhaustion → continue", () => {
 
   test("advisory-only escape respects a stricter blockingThreshold:'info'", async () => {
     // Under blockingThreshold "info" every finding blocks (info < warning < error),
-    // so a "warning" autofix advisory is now blocking → escalate, not continue.
+    // so a "warning" advisory is now blocking → escalate, not continue.
     const ctx = makeTestContext();
     ctx.config = {
       ...ctx.config,
@@ -350,7 +352,7 @@ describe("advisory-only rectification exhaustion → continue", () => {
     const planResult = makePlanResult({
       success: false,
       rectificationExhausted: true,
-      unfixedFindings: [AUTOFIX_ADVISORY_FINDING],
+      unfixedFindings: [ADVISORY_LEFTOVER_FINDING],
     });
     const opts = makeInspectionOpts();
     const inspection = await applyPostRunInspection(ctx, planResult, opts);

--- a/test/unit/operations/apply-test-edit-declarations.test.ts
+++ b/test/unit/operations/apply-test-edit-declarations.test.ts
@@ -233,7 +233,7 @@ describe("applyTestEditDeclarations", () => {
         reasonDetail: "Mock setup is wrong",
       };
 
-      const { findings: result, diagnostics } = applyTestEditDeclarations(findings, [], story, [invalidDecl]);
+      const { findings: result, diagnostics } = applyTestEditDeclarations(findings, [], story, { invalidMockStructure: [invalidDecl] });
 
       // The invalid handoff is already stripped by the caller before the
       // test-writer sees it — there is no fix to queue here (#1327).
@@ -252,7 +252,7 @@ describe("applyTestEditDeclarations", () => {
         reasonDetail: "needs mock",
       };
 
-      const { diagnostics } = applyTestEditDeclarations([], [], story, [invalidDecl]);
+      const { diagnostics } = applyTestEditDeclarations([], [], story, { invalidMockStructure: [invalidDecl] });
 
       expect(diagnostics[0]!.detail).toContain("test/unit/a.test.ts");
       expect(diagnostics[0]!.detail).toContain("test/unit/b.test.ts");
@@ -266,7 +266,7 @@ describe("applyTestEditDeclarations", () => {
         reasonDetail: "only file",
       };
 
-      const { diagnostics } = applyTestEditDeclarations([], [], story, [invalidDecl]);
+      const { diagnostics } = applyTestEditDeclarations([], [], story, { invalidMockStructure: [invalidDecl] });
 
       expect(diagnostics[0]!.detail).toContain("test/unit/only.test.ts");
     });
@@ -278,10 +278,76 @@ describe("applyTestEditDeclarations", () => {
         { reason: "mock_structure", file: "test/unit/b.test.ts", reasonDetail: "b" },
       ];
 
-      const { findings: result, diagnostics } = applyTestEditDeclarations([], [], story, invalid);
+      const { findings: result, diagnostics } = applyTestEditDeclarations([], [], story, { invalidMockStructure: invalid });
 
       expect(result).toHaveLength(0);
       expect(diagnostics.map((d) => d.file)).toEqual(["test/unit/a.test.ts", "test/unit/b.test.ts"]);
+    });
+  });
+
+  describe("allowTestRetag — single-session gate (#1330)", () => {
+    // fixTarget "test" hands a finding to the test-writer, and only three-session
+    // registers one. A single-session implementer edits both source and tests, so
+    // the declaration is informational and the finding must stay claimable by it.
+    const story = () => makeStory({ description: "The function getThing() must return a Thing" });
+    const decl: TestEditDeclaration = {
+      reason: "prd_contract",
+      file: "test/unit/foo.test.ts",
+      prdQuote: "getThing()",
+      testBefore: "old",
+      testAfter: "new",
+    };
+
+    test("allowTestRetag: false → valid quote does NOT re-tag to test", () => {
+      const findings: Finding[] = [makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" })];
+
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story(), {
+        allowTestRetag: false,
+      });
+
+      expect(result[0]!.fixTarget).toBe("source");
+      expect(result[0]!.meta?.prdContractDeclaration).toBeUndefined();
+    });
+
+    test("allowTestRetag: false → a valid quote is NOT reported as a quote mismatch", () => {
+      // The quote is genuine; only the handoff is unavailable. Emitting a
+      // prd_quote_mismatch here would accuse the agent of fabricating it.
+      const findings: Finding[] = [makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" })];
+
+      const { diagnostics } = applyTestEditDeclarations(findings, [decl], story(), { allowTestRetag: false });
+
+      expect(diagnostics).toEqual([]);
+    });
+
+    test("allowTestRetag: false → finding stays claimable by autofix-implementer", () => {
+      const findings: Finding[] = [makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" })];
+
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story(), {
+        allowTestRetag: false,
+      });
+
+      const implementer = makeAutofixImplementerStrategy(story(), makeNaxConfig(), makeDeclarationSink());
+      expect(result.map((f) => implementer.appliesTo(f))).toEqual([true]);
+    });
+
+    test("allowTestRetag: false → an invalid quote still reports a diagnostic", () => {
+      const findings: Finding[] = [makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" })];
+      const badDecl: TestEditDeclaration = { ...decl, prdQuote: "nonExistentFunction()" };
+
+      const { findings: result, diagnostics } = applyTestEditDeclarations(findings, [badDecl], story(), {
+        allowTestRetag: false,
+      });
+
+      expect(result[0]!.fixTarget).toBe("source");
+      expect(diagnostics.map((d) => d.reason)).toEqual(["prd_quote_mismatch"]);
+    });
+
+    test("allowTestRetag defaults to true → valid quote re-tags", () => {
+      const findings: Finding[] = [makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" })];
+
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story());
+
+      expect(result[0]!.fixTarget).toBe("test");
     });
   });
 
@@ -304,7 +370,7 @@ describe("applyTestEditDeclarations", () => {
         reasonDetail: "bad handoff",
       };
 
-      const { findings: result, diagnostics } = applyTestEditDeclarations([], [decl], story, [invalidDecl]);
+      const { findings: result, diagnostics } = applyTestEditDeclarations([], [decl], story, { invalidMockStructure: [invalidDecl] });
 
       expect(result).toHaveLength(0);
       expect(diagnostics).toHaveLength(2);

--- a/test/unit/operations/apply-test-edit-declarations.test.ts
+++ b/test/unit/operations/apply-test-edit-declarations.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { applyTestEditDeclarations } from "@/operations";
+import { applyTestEditDeclarations, makeAutofixImplementerStrategy, makeDeclarationSink } from "@/operations";
 import type { Finding } from "@/findings";
 import type { TestEditDeclaration } from "@/operations";
-import { makeStory } from "@test/helpers";
+import { makeNaxConfig, makeStory } from "@test/helpers";
 
 // Helper to create a basic source-targeted finding
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
@@ -32,7 +32,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new line",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result).toHaveLength(1);
       expect(result[0]!.fixTarget).toBe("test");
@@ -51,7 +51,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "after",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result[0]!.meta?.prdContractDeclaration).toEqual(decl);
     });
@@ -73,7 +73,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result[0]!.meta?.existingKey).toBe("existingValue");
       expect(result[0]!.meta?.prdContractDeclaration).toEqual(decl);
@@ -92,7 +92,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result[0]!.fixTarget).toBe("source");
       expect(result[0]!.meta?.prdContractDeclaration).toBeUndefined();
@@ -111,7 +111,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       // fixTarget was already "test", meta should still be set
       expect(result[0]!.fixTarget).toBe("test");
@@ -119,7 +119,7 @@ describe("applyTestEditDeclarations", () => {
   });
 
   describe("prd_contract — invalid quote", () => {
-    test("appends advisory finding when quote not found in story", () => {
+    test("reports a diagnostic without adding a finding when quote not found in story", () => {
       const story = makeStory({ description: "This is a story about widgets" });
       const findings: Finding[] = [
         makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" }),
@@ -132,18 +132,37 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result, diagnostics } = applyTestEditDeclarations(findings, [decl], story);
 
-      // Original finding unchanged
+      // Original finding unchanged, and nothing appended: a rejected declaration
+      // is not a defect, and an unclaimable finding dead-ends the cycle (#1327).
+      expect(result).toHaveLength(1);
       expect(result[0]!.fixTarget).toBe("source");
-      // Advisory appended
-      expect(result).toHaveLength(2);
-      const advisory = result[1]!;
-      expect(advisory.source).toBe("autofix");
-      expect(advisory.severity).toBe("warning");
-      expect(advisory.category).toBe("prd_quote_mismatch");
-      expect(advisory.message).toContain("test/unit/foo.test.ts");
-      expect(advisory.fixTarget).toBe("source");
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]!.reason).toBe("prd_quote_mismatch");
+      expect(diagnostics[0]!.file).toBe("test/unit/foo.test.ts");
+      expect(diagnostics[0]!.detail).toContain("test/unit/foo.test.ts");
+    });
+
+    test("rejected quote leaves the finding claimable by autofix-implementer", () => {
+      // The rejection IS the enforcement: fixTarget stays "source", so the
+      // implementer still claims the finding. Asserted against the real strategy
+      // predicate rather than restating the field, so a change to either side of
+      // the contract fails here.
+      const story = makeStory({ description: "This is a story about widgets" });
+      const findings: Finding[] = [makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" })];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "nonExistentFunction()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
+
+      const implementer = makeAutofixImplementerStrategy(story, makeNaxConfig(), makeDeclarationSink());
+      expect(result.map((f) => implementer.appliesTo(f))).toEqual([true]);
     });
 
     test("does not re-tag finding when quote is invalid", () => {
@@ -159,7 +178,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result[0]!.fixTarget).toBe("source");
     });
@@ -177,7 +196,7 @@ describe("applyTestEditDeclarations", () => {
         finding: "no-non-null-assertion",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result).toHaveLength(1);
       expect(result[0]!.fixTarget).toBe("source");
@@ -196,7 +215,7 @@ describe("applyTestEditDeclarations", () => {
         finding: "TS2304",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result).toHaveLength(1);
       expect(result[0]!.fixTarget).toBe("source");
@@ -204,7 +223,7 @@ describe("applyTestEditDeclarations", () => {
   });
 
   describe("invalidMockStructure", () => {
-    test("appends advisory finding with category mock_structure_invalid_files", () => {
+    test("reports a diagnostic without adding a finding", () => {
       const story = makeStory();
       const findings: Finding[] = [makeFinding()];
       const invalidDecl: TestEditDeclaration = {
@@ -214,19 +233,17 @@ describe("applyTestEditDeclarations", () => {
         reasonDetail: "Mock setup is wrong",
       };
 
-      const result = applyTestEditDeclarations(findings, [], story, [invalidDecl]);
+      const { findings: result, diagnostics } = applyTestEditDeclarations(findings, [], story, [invalidDecl]);
 
-      expect(result).toHaveLength(2);
-      const advisory = result[1]!;
-      expect(advisory.source).toBe("autofix");
-      expect(advisory.severity).toBe("warning");
-      expect(advisory.category).toBe("mock_structure_invalid_files");
-      expect(advisory.message).toContain("test/unit/mock.test.ts");
-      expect(advisory.message).toContain("test/unit/other.test.ts");
-      expect(advisory.fixTarget).toBe("source");
+      // The invalid handoff is already stripped by the caller before the
+      // test-writer sees it — there is no fix to queue here (#1327).
+      expect(result).toEqual(findings);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]!.reason).toBe("mock_structure_invalid_files");
+      expect(diagnostics[0]!.file).toBe("test/unit/mock.test.ts");
     });
 
-    test("includes file names in advisory message", () => {
+    test("includes every declared file name in the diagnostic detail", () => {
       const story = makeStory();
       const invalidDecl: TestEditDeclaration = {
         reason: "mock_structure",
@@ -235,10 +252,10 @@ describe("applyTestEditDeclarations", () => {
         reasonDetail: "needs mock",
       };
 
-      const result = applyTestEditDeclarations([], [], story, [invalidDecl]);
+      const { diagnostics } = applyTestEditDeclarations([], [], story, [invalidDecl]);
 
-      expect(result[0]!.message).toContain("test/unit/a.test.ts");
-      expect(result[0]!.message).toContain("test/unit/b.test.ts");
+      expect(diagnostics[0]!.detail).toContain("test/unit/a.test.ts");
+      expect(diagnostics[0]!.detail).toContain("test/unit/b.test.ts");
     });
 
     test("uses d.file when d.files is absent", () => {
@@ -249,9 +266,48 @@ describe("applyTestEditDeclarations", () => {
         reasonDetail: "only file",
       };
 
-      const result = applyTestEditDeclarations([], [], story, [invalidDecl]);
+      const { diagnostics } = applyTestEditDeclarations([], [], story, [invalidDecl]);
 
-      expect(result[0]!.message).toContain("test/unit/only.test.ts");
+      expect(diagnostics[0]!.detail).toContain("test/unit/only.test.ts");
+    });
+
+    test("emits one diagnostic per invalid declaration", () => {
+      const story = makeStory();
+      const invalid: TestEditDeclaration[] = [
+        { reason: "mock_structure", file: "test/unit/a.test.ts", reasonDetail: "a" },
+        { reason: "mock_structure", file: "test/unit/b.test.ts", reasonDetail: "b" },
+      ];
+
+      const { findings: result, diagnostics } = applyTestEditDeclarations([], [], story, invalid);
+
+      expect(result).toHaveLength(0);
+      expect(diagnostics.map((d) => d.file)).toEqual(["test/unit/a.test.ts", "test/unit/b.test.ts"]);
+    });
+  });
+
+  describe("no unclaimable findings are ever minted (#1327)", () => {
+    test("returns an empty findings array when the only input is a rejected declaration", () => {
+      // The regression: a green story (validate returned []) had an advisory
+      // appended here, so classifyOutcome saw a new source, the cycle looped,
+      // no strategy claimed it, and the story failed "no-strategy".
+      const story = makeStory({ description: "A story that does not mention the function" });
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "nonExistentFunction()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+      const invalidDecl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/mock.test.ts",
+        reasonDetail: "bad handoff",
+      };
+
+      const { findings: result, diagnostics } = applyTestEditDeclarations([], [decl], story, [invalidDecl]);
+
+      expect(result).toHaveLength(0);
+      expect(diagnostics).toHaveLength(2);
     });
   });
 
@@ -278,7 +334,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "expect(mock).toBeCalled()",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result[0]?.fixTarget).toBe("test");
     });
@@ -303,12 +359,12 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result[0]?.fixTarget).toBeUndefined();
     });
 
-    test("AC10: test-runner finding with no fixTarget + invalid prd_quote → advisory appended", () => {
+    test("AC10: test-runner finding with no fixTarget + invalid prd_quote → diagnostic, no appended finding", () => {
       const story = makeStory({ description: "A story that does not mention the function" });
       const findings: Finding[] = [
         {
@@ -327,10 +383,10 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result, diagnostics } = applyTestEditDeclarations(findings, [decl], story);
 
-      expect(result).toHaveLength(2);
-      expect(result[1]?.category).toBe("prd_quote_mismatch");
+      expect(result).toHaveLength(1);
+      expect(diagnostics[0]?.reason).toBe("prd_quote_mismatch");
     });
 
     test("AC10: original test-runner finding retains no fixTarget after invalid prd_quote", () => {
@@ -352,7 +408,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(findings, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(findings, [decl], story);
 
       expect(result[0]?.fixTarget).toBeUndefined();
     });
@@ -373,7 +429,7 @@ describe("applyTestEditDeclarations", () => {
         testAfter: "new",
       };
 
-      const result = applyTestEditDeclarations(original, [decl], story);
+      const { findings: result } = applyTestEditDeclarations(original, [decl], story);
 
       // Input array not mutated
       expect(original).toHaveLength(1);


### PR DESCRIPTION
Two bugs in `applyTestEditDeclarations`, same root cause: **it emitted findings into the fix cycle that no `FixStrategy.appliesTo` could ever claim.** When such a finding is the only one left, `selectActiveStrategies` returns `[]`, `runFixCycle` exits `no-strategy`, and a story whose every gate passed fails.

## What

- **#1327** — the op no longer *mints* advisory findings with `source: "autofix"`. It returns `{ findings, diagnostics }`; rejected declarations are logged at warn by the two `postValidate` callers. `"autofix"` is removed from the `FindingSource` union.
- **#1330** — the op no longer *re-tags* to `fixTarget: "test"` outside three-session, via a new `allowTestRetag` option.

## Why

Closes #1327
Closes #1330

### #1327 — the mint path

The op minted findings with `source: "autofix"` when a `prd_contract` quote failed verbatim validation or a `mock_structure` handoff referenced invalid files. No strategy claims that source.

**This op was the union member's only producer.** Grepping `src/` found exactly two mint sites, both here — `"autofix"` existed solely to feed a dead end, so the member could be deleted outright rather than policed by a test. ADR-021's canonical union never listed it, so removing it *restores* ADR conformance.

**It manufactured a false regression.** The advisories were minted in `postValidate`, which runs *after* validate. On a green story: validate returns `[]` → postValidate appends the advisory → `classifyOutcome(before=[lint], after=[autofix])` sees a source absent from `findingsBefore` and returns `regressed-different-source`, not `resolved`. The cycle loops, finds no strategy, and fails the story at the exact moment it succeeded.

**Neither advisory carried any work.** The enforcement had already happened by the time it was minted: an invalid quote means the finding was *not* re-tagged; invalid mock files are stripped from `sink.mockHandoffs` before the test-writer sees them. The finding was a breadcrumb occupying the cycle's work queue.

This takes option 1 from the issue and goes one step further by deleting the union member, making the dead end unrepresentable rather than test-enforced. Option 2 (`IMPLEMENTER_SOURCES`) would burn an LLM turn re-prompting the implementer about a bad quote while every gate is green, and it can re-declare, regenerating the advisory — the loop the issue itself flags. Option 3 (`severity: "info"`) leans on the escape below, which isn't unconditional.

### #1330 — the re-tag path (the mirror image)

Surfaced by code review on this PR. `fixTarget: "test"` exists to hand a finding from the implementer to the test-writer, and `autofix-test-writer` — its only claimer — registers only under `isThreeSession`. But `postValidate` applies the re-tag **unconditionally**, and both `testEdits` producers (`full-suite-rectify`, `autofix-implementer`) run in single-session too. So a single-session story could re-tag a finding and strand it: `autofix-implementer` requires `fixTarget` `"source"`/null, `full-suite-rectify` claims only `source: "test-runner"`, mechanical strategies only `source: "lint"`. #1326's advisory escape doesn't cover it either — `semantic-review` findings are `severity: "error"`, i.e. blocking.

Per @williamkhoo, **`fixTarget: "test"` only happening on three-session is by intent**: a single-session implementer can edit both test and source. So the fix is to not re-tag — the declaration is informational and the finding stays `fixTarget: "source"` for the implementer to claim and edit the test itself. This matches the existing carve-outs (`includeAdversarialReview: !isThreeSession`, the `isThreeSession` gate on the test-writer, AC11).

## How

- `applyTestEditDeclarations` returns `{ findings, diagnostics }` and takes `allowTestRetag` (callers pass `isThreeSession`). It stays pure and logger-free, so the caller owns the log and supplies `storyId`/`packageDir`.
- Signature moved to an options object — already at 4 positional params, over the project's 3-param convention.
- A **valid** quote under `allowTestRetag: false` is a no-op, **not** a `prd_quote_mismatch`. The quote is genuine; only the handoff is unavailable. Reporting a mismatch would accuse the agent of fabricating it.
- Both `postValidate` bodies log via `logRejectedDeclarations` at `logger.warn("findings.cycle", …)` — the same stage tag as the sibling orphaned-findings warn in `cycle.ts`, so they correlate in one grep.
- `docs/architecture/subsystems.md` updated for both — it documented the old inject-an-advisory behavior, and now records the three-session gating so the next reader doesn't "fix" it back.

**#1326's advisory-only escape is kept and still earns its keep.** `plugin` and `acceptance-diagnose` are minted but claimed by no strategy, so orphans remain possible. Its fixture retargets from `source: "autofix"` to `source: "plugin"` and now guards the general case. Worth knowing: that escape is **threshold-relative** — `post-run.ts` reads `review.blockingThreshold`, and the repo already has a test (`advisory-only escape respects a stricter blockingThreshold:'info'`) pinning that a warning-severity leftover *escalates* under a stricter threshold. So #1326 patched the default config, not the gap. Removing the emit sites is the actual fix.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes — 10,832 pass / 0 fail across unit, integration, ui
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

Beyond running them, I verified every new test is a real guard by breaking the code and confirming it fails:

- **Restoring the #1327 mint** → **8 tests fail** across all three files.
- **Removing the #1330 gate** → **2 tests fail**.

Without that check, a passing suite proves only that it's self-consistent.

**Two assertions I first wrote were vacuous and were replaced.** The integration tests originally asserted `unclaimable).toEqual([])` over a filtered array — I forced the value into a failing assertion and it printed `[]`, so the filter proved nothing. They now assert `expect(findings).toEqual([])` *plus* a positive artifact: `autofix-test-writer.appliesTo(...)` is `true` before validate (sink populated by `extractApplied`) and `false` after (postValidate rejected the handoff and drained the sink). Without that precondition both assertions would also hold on `postValidate`'s early-return path and cover nothing.

**Unit tests assert against the real predicate.** Rather than restating `fixTarget === "source"`, they invoke `makeAutofixImplementerStrategy(...).appliesTo` on the result, so a change to either side of the contract fails there.

## Notes

Two pre-existing items, both deliberately left alone:

- `implementer-handoff` is also a dead `FindingSource` member (no mints anywhere). Removing it isn't these issues' business.
- `DeclarationDiagnostic.file` can be `""` — `autofix-implementer-strategy.ts:84` guards with a truthy `decl.files` check that passes for `[]`, whereas `full-suite-rectify.ts:52` correctly checks `.length > 0`. Pre-existing, but this change promotes it from buried prose in a `message` string to a structured log field.

Specs under `docs/specs/` still describe the old advisory behavior; I read those as point-in-time records rather than living docs and left them. `docs/architecture/subsystems.md` was the living reference and is updated.
