### PR TITLE
fix(execution): route source adversarial findings to implementer in blocking three-session cycle (#1333)

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -216,7 +216,18 @@ export async function buildPlanForStrategy(
       // Single-session strategies (tdd-simple / test-after / no-test) have no
       // separate test-writer session — the one warm implementer session authored
       // both source and tests. Route adversarial-review findings to that
-      // implementer instead of spinning up a fresh, context-less test-writer.
+      // implementer (blanket) instead of spinning up a fresh, context-less
+      // test-writer.
+      //
+      // Three-session TDD DOES have a test-writer session, so split adversarial
+      // findings by fixTarget instead of handing them all to the test-writer: the
+      // implementer owns SOURCE-targeted adversarial findings (category ∈
+      // BLOCKING_CATEGORIES → fixTarget "source", e.g. error-path), the test-writer
+      // owns test-targeted ones. Without this, a source-correctness adversarial
+      // finding was claimed ONLY by the test-writer — which is forbidden from
+      // editing source — so it could never be fixed and burned the entire
+      // rectification budget before failing the story. Mirrors the `triage`
+      // non-blocking scope below. See #1333.
       //
       // Note: AC-HOOK / AC-ERROR sentinel findings (test-runner, fixTarget=test)
       // are intentionally NOT re-routed here — they are owned by the acceptance
@@ -225,14 +236,19 @@ export async function buildPlanForStrategy(
       strategies.push(
         makeAutofixImplementerStrategy(story, config, sink, {
           includeAdversarialReview: !isThreeSession,
+          ...(isThreeSession ? { adversarialReviewByFixTarget: "source" as const } : {}),
         }) as FixStrategy<Finding, unknown, unknown, unknown>,
       );
-      // The autofix-test-writer strategy only belongs to three-session TDD,
-      // where the test-writer phase itself exists (see gating above where
-      // addTestWriter is conditioned on isThreeSession).
+      // The autofix-test-writer strategy only belongs to three-session TDD, where
+      // the test-writer phase itself exists (see gating above where addTestWriter
+      // is conditioned on isThreeSession). Disable its blanket adversarial clause
+      // so it claims ONLY test-targeted adversarial findings — source-targeted
+      // findings now go to the implementer above (#1333).
       if (isThreeSession) {
         strategies.push(
-          makeAutofixTestWriterStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
+          makeAutofixTestWriterStrategy(story, config, sink, {
+            includeAdversarialReview: false,
+          }) as FixStrategy<Finding, unknown, unknown, unknown>,
         );
       }
     }

--- a/test/e2e/agent-fix.e2e.test.ts
+++ b/test/e2e/agent-fix.e2e.test.ts
@@ -204,4 +204,82 @@ describe("E2E: agent-fix", () => {
       "adversarial-review",
     ]);
   });
+
+  test("adversarial(error-path=source) -> autofix-implementer, NOT autofix-test-writer (#1333)", async () => {
+    // Regression lock for #1333: in three-session TDD, a SOURCE-targeted adversarial
+    // finding (category error-path ∈ BLOCKING_CATEGORIES → fixTarget "source" after the
+    // real adversarialReviewOp normalizes it) must be claimed by autofix-implementer,
+    // which can edit source — NOT autofix-test-writer, which is forbidden from touching
+    // source. Prior to #1333 the test-writer's blanket clause claimed it, so the source
+    // bug could never be fixed and rectification exhausted (repro: rs-stock
+    // tier3-analytics-tools US-002). This test would fire autofix-test-writer on the old
+    // code. Compare with the test-gap (fixTarget=test) sibling above.
+    const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
+    const verifier = () => ({ output: PASSING_VERDICT });
+    let advAttempt = 0;
+
+    // Mirrors the test-gap sibling exactly (same severity/threshold/evidence path so
+    // substantiation keeps the finding blocking) — the ONLY change is the category,
+    // which flips fixTarget test→source and therefore the fix lane test-writer→implementer.
+    const failingAdversarial = JSON.stringify({
+      passed: false,
+      findings: [{
+        severity: "warning",
+        category: "error-path",
+        file: "src/a.ts",
+        line: 1,
+        issue: "unaligned variance check bypasses the near-zero guard on shared dates",
+        suggestion: "compute variance on the aligned window before applying the threshold",
+        verifiedBy: { file: "src/a.ts", observed: "bm_var = benchmark_returns.var()" },
+      }],
+    });
+    const passingAdversarial = JSON.stringify({ passed: true, findings: [] });
+
+    const { result, phaseLog, strategiesFired } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      config: { review: { blockingThreshold: "warning" } } as unknown as Partial<NaxConfig>,
+      agent: {
+        "test-writer": tw,
+        implementer: impl,
+        verifier,
+        "reviewer-semantic": PASS_REVIEW,
+        // attempt 0 → failing source-category finding; attempt 1+ → passing.
+        "reviewer-adversarial": () => ({ output: advAttempt++ === 0 ? failingAdversarial : passingAdversarial }),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    // #1333 lock: the SOURCE finding routes to the implementer, never the test-writer.
+    expect(strategiesFired).toContain("autofix-implementer");
+    expect(strategiesFired).not.toContain("autofix-test-writer");
+
+    // adversarial-review runs twice (fail → fix → pass).
+    expect(phaseLog.filter((p) => p === "adversarial-review").length).toBe(2);
+    // Orthogonal routing signal: autofix-implementer's revalidation set INCLUDES
+    // semantic-review (runs twice), whereas autofix-test-writer EXCLUDES it (would run
+    // once). Two semantic-review phases prove the implementer lane handled the finding.
+    expect(phaseLog.filter((p) => p === "semantic-review").length).toBe(2);
+    // verifier is a once-per-story phase, not in either revalidation set.
+    expect(phaseLog.filter((p) => p === "verifier").length).toBe(1);
+
+    // Full observed sequence: main loop fails at adversarial-review → autofix-implementer
+    // fires → revalidation in canonical order (full-suite-gate, lint, typecheck,
+    // semantic, adversarial).
+    expect(phaseLog).toEqual([
+      "test-writer",
+      "greenfield-gate",
+      "implementer",
+      "full-suite-gate",
+      "verifier",
+      "lint-check",
+      "typecheck-check",
+      "semantic-review",
+      "adversarial-review",
+      "full-suite-gate",
+      "lint-check",
+      "typecheck-check",
+      "semantic-review",
+      "adversarial-review",
+    ]);
+  });
 });

--- a/test/integration/pipeline/gating-preservation.test.ts
+++ b/test/integration/pipeline/gating-preservation.test.ts
@@ -318,13 +318,17 @@ describe("single-session adversarial-review routing", () => {
   let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
   let runtime: NaxRuntime;
 
+  // A blocking adversarial finding as the real adversarialReviewOp would emit it:
+  // normalized with a concrete fixTarget (category error-path ∈ BLOCKING_CATEGORIES
+  // → fixTarget "source"). See #1333.
   const adversarialFinding: Finding = {
     source: "adversarial-review",
     severity: "error",
-    category: "",
+    category: "error-path",
     message: "AC11 not propagated",
     file: "src/foo.ts",
     line: 1,
+    fixTarget: "source",
   };
 
   beforeEach(() => {
@@ -404,7 +408,7 @@ describe("single-session adversarial-review routing", () => {
     expect(matching.map((s) => s.name)).toEqual(["autofix-implementer"]);
   });
 
-  test("three-session-tdd: adversarial-review still routes to autofix-test-writer (unchanged)", async () => {
+  test("three-session-tdd: source-targeted adversarial finding routes to autofix-implementer, not test-writer (#1333)", async () => {
     const story = makeStory({ attempts: 1 });
     const config = makeNaxConfig({
       quality: { autofix: { enabled: true } },
@@ -414,11 +418,21 @@ describe("single-session adversarial-review routing", () => {
     const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
 
+    // Both strategies are assembled in three-session mode...
     const names = (capturedCycle?.strategies ?? []).map((s) => s.name);
+    expect(names).toContain("autofix-implementer");
     expect(names).toContain("autofix-test-writer");
 
+    // ...but a SOURCE-targeted adversarial finding is claimed only by the
+    // implementer (which can edit source), not the test-writer. Prior to #1333
+    // the test-writer's blanket clause claimed it and it could never be fixed.
     const matching = (capturedCycle?.strategies ?? []).filter((s) => s.appliesTo(adversarialFinding));
-    expect(matching.map((s) => s.name)).toEqual(["autofix-test-writer"]);
+    expect(matching.map((s) => s.name)).toEqual(["autofix-implementer"]);
+
+    // A TEST-targeted adversarial finding still routes to the test-writer.
+    const testFinding: Finding = { ...adversarialFinding, category: "convention", fixTarget: "test" };
+    const matchingTest = (capturedCycle?.strategies ?? []).filter((s) => s.appliesTo(testFinding));
+    expect(matchingTest.map((s) => s.name)).toEqual(["autofix-test-writer"]);
   });
 });
 

--- a/test/unit/execution/build-plan-for-strategy-triage-predicates.test.ts
+++ b/test/unit/execution/build-plan-for-strategy-triage-predicates.test.ts
@@ -208,7 +208,7 @@ describe("buildPlanForStrategy — AC5/AC6: default-preserving factory options +
     expect(testWriter.appliesTo(finding)).toBe(true);
   });
 
-  test("AC6: blocking three-session set → test-writer.appliesTo=true and implementer.appliesTo=false for adversarial source finding (driven through plan)", async () => {
+  test("AC6 (#1333): blocking three-session set → implementer claims adversarial SOURCE finding, test-writer claims adversarial TEST finding (driven through plan)", async () => {
     const capturedStrategySets: Array<Array<import("@/findings").FixStrategy<import("@/findings").Finding, any, any, any>>> = [];
     const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
     const origCallOp = _storyOrchestratorDeps.callOp;
@@ -260,15 +260,29 @@ describe("buildPlanForStrategy — AC5/AC6: default-preserving factory options +
       const testWriter = mainRectSet.find((strategy) => strategy.name === "autofix-test-writer");
       expect(implementer).toBeDefined();
       expect(testWriter).toBeDefined();
-      const finding: import("@/findings").Finding = {
+      // Source-targeted adversarial finding (category ∈ BLOCKING_CATEGORIES) must
+      // go to the implementer, which can edit source — NOT the test-writer, which
+      // is forbidden from touching source. Prior to #1333 this was inverted and
+      // such findings could never be fixed.
+      const sourceFinding: import("@/findings").Finding = {
         source: "adversarial-review",
-        severity: "warning",
-        category: "input",
-        message: "advisory finding",
+        severity: "error",
+        category: "error-path",
+        message: "source correctness bug",
         fixTarget: "source",
       };
-      expect(testWriter!.appliesTo(finding)).toBe(true);
-      expect(implementer!.appliesTo(finding)).toBe(false);
+      expect(implementer!.appliesTo(sourceFinding)).toBe(true);
+      expect(testWriter!.appliesTo(sourceFinding)).toBe(false);
+      // Test-targeted adversarial finding still goes to the test-writer.
+      const testFinding: import("@/findings").Finding = {
+        source: "adversarial-review",
+        severity: "warning",
+        category: "convention",
+        message: "missing coverage",
+        fixTarget: "test",
+      };
+      expect(testWriter!.appliesTo(testFinding)).toBe(true);
+      expect(implementer!.appliesTo(testFinding)).toBe(false);
     } finally {
       _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
       _storyOrchestratorDeps.callOp = origCallOp;


### PR DESCRIPTION
## Summary

Fixes #1333. In the **blocking** rectification cycle for **three-session TDD** stories, a source-correctness adversarial finding (category ∈ `BLOCKING_CATEGORIES` → `fixTarget: "source"`) was claimed **only** by `autofix-test-writer`, which is forbidden from editing source. `autofix-implementer` had `includeAdversarialReview: false` in three-session mode and never claimed it, so the source bug could never be fixed — rectification exhausted and the story failed after burning the whole fix budget.

This is a latent gap, not a recent regression: the `triage` non-blocking-fix scope and the single-session path (#1278) already route source-targeted adversarial findings to the implementer; that routing was simply never applied to the blocking three-session cycle.

## Repro

`rs-stock` / `tier3-analytics-tools` / **US-002**, nax **v0.73.1**. A blocking `error-path` adversarial finding (AC-10, `GetCorrelationMatrix` pruning bug) was routed to `autofix-test-writer` for 3 iterations (`outcome: "regressed"` 1→1), ~$3.40 wasted, then `rectificationExhausted`. Prompt audit confirmed the test-writer was told "Do NOT modify source implementation files… let the implementer fix the source" — but no implementer was ever dispatched.

## Fix

Mirror the `triage` scope in the blocking three-session cycle (`build-plan-for-strategy.ts`):
- `autofix-implementer` → `adversarialReviewByFixTarget: "source"` (claims `fixTarget:"source"` adversarial findings even in three-session).
- `autofix-test-writer` → `includeAdversarialReview: false` (claims only `fixTarget:"test"`).

Single-session behavior is unchanged (`!isThreeSession` still gives the implementer the blanket clause).

### No stranding
Every blocking adversarial finding entering the cycle is normalized via `toAdversarialReviewFindings` → `fixTarget ∈ {source, test}` (`adversarial-review.ts:500`); the orchestrator consumes `normalizedFindings` (`phase-eval.ts:85`). The split covers both lanes, so coverage is preserved (parity with the old blanket).

## Tests

- **Updated 2 predicate tests** that had codified the inverted behavior (`build-plan-for-strategy-triage-predicates.test.ts` AC6, `gating-preservation.test.ts`).
- **Added an e2e regression lock** (`agent-fix.e2e.test.ts`): a real three-session run where adversarial review emits an `error-path` (source) finding, asserting `strategiesFired` contains `autofix-implementer` and **not** `autofix-test-writer`, plus the orthogonal signal that `semantic-review` runs twice (in the implementer revalidation set, excluded from the test-writer's). **Verified it fails on the pre-fix code** with `strategiesFired = ["autofix-test-writer"]` — reproducing the exact bug.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test` (unit + integration + ui) — all phases passed, 0 fail
- `bun run test:e2e` — 25 pass, 0 fail (+1 new regression lock)
