### PR TITLE
feat(review): surface coverage-gap demotion count in run-end summary (closes #1339)

### DIFF
--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -284,9 +284,11 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
   // per-story debug log line and the on-disk `.nax/review-audit/` trail.
   const advisoryFindings = options.runtime?.reviewAuditor?.getAdvisoryFindings() ?? [];
   if (advisoryFindings.length > 0) {
+    const coverageGapCount = advisoryFindings.filter((f) => f.coverageGap).length;
     logger?.warn("review", `${advisoryFindings.length} non-blocking review finding(s) surfaced at run end`, {
       storyId: "_run",
       count: advisoryFindings.length,
+      coverageGapCount,
       findings: advisoryFindings,
     });
   }

--- a/src/log-format/formatter.ts
+++ b/src/log-format/formatter.ts
@@ -452,13 +452,25 @@ export function formatAdvisorySummary(
   lines.push("");
   lines.push(c.yellow("─".repeat(60)));
   lines.push(c.bold(c.yellow(`  ${EMOJI.warning} NON-BLOCKING REVIEW FINDINGS (${findings.length})`)));
+  const coverageGapCount = findings.filter((f) => f.coverageGap).length;
+  if (coverageGapCount > 0) {
+    lines.push(
+      c.gray(
+        `  ${coverageGapCount} of ${findings.length} were coverage-gap demotions (recurred past the block limit — candidate for spec/AC review)`,
+      ),
+    );
+  }
   lines.push(c.yellow("─".repeat(60)));
 
   for (const f of sorted) {
     const location = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : undefined;
-    const parts = [`[${f.severity}]`, f.storyId ?? "unknown", location, f.category].filter(
-      (v): v is string => typeof v === "string" && v.length > 0,
-    );
+    const parts = [
+      `[${f.severity}]`,
+      f.storyId ?? "unknown",
+      location,
+      f.category,
+      f.coverageGap ? "coverage-gap" : undefined,
+    ].filter((v): v is string => typeof v === "string" && v.length > 0);
     lines.push(`  ${c.gray(parts.join(" · "))}`);
     lines.push(`    ${f.issue}`);
   }

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -105,6 +105,8 @@ export interface AdvisoryFindingSummaryEntry {
   file?: string;
   line?: number;
   issue: string;
+  /** True when this advisory finding was recurrence-demoted (tagged `meta.coverageGap`). */
+  coverageGap?: boolean;
 }
 
 export interface IReviewAuditor {
@@ -202,7 +204,14 @@ export function createNoOpReviewAuditor(): IReviewAuditor {
 function toAdvisorySummaryEntries(entry: ReviewAuditDecision): AdvisoryFindingSummaryEntry[] {
   if (!entry.advisoryFindings || entry.advisoryFindings.length === 0) return [];
   return entry.advisoryFindings.map((raw) => {
-    const f = raw as { severity?: string; category?: string; file?: string; line?: number; issue?: string };
+    const f = raw as {
+      severity?: string;
+      category?: string;
+      file?: string;
+      line?: number;
+      issue?: string;
+      meta?: { coverageGap?: boolean };
+    };
     return {
       storyId: entry.storyId,
       featureName: entry.featureName,
@@ -212,6 +221,7 @@ function toAdvisorySummaryEntries(entry: ReviewAuditDecision): AdvisoryFindingSu
       file: f.file,
       line: f.line,
       issue: f.issue ?? "(no description)",
+      coverageGap: f.meta?.coverageGap === true ? true : undefined,
     };
   });
 }

--- a/test/unit/log-format/formatter.test.ts
+++ b/test/unit/log-format/formatter.test.ts
@@ -202,6 +202,21 @@ describe("formatAdvisorySummary", () => {
     expect(JSON.parse(output)).toEqual(findings);
   });
 
+  test("surfaces the coverage-gap demotion count and tags demoted findings", () => {
+    const findings = [
+      advisoryFinding({ storyId: "US-001", coverageGap: true, issue: "recurred out-of-scope" }),
+      advisoryFinding({ storyId: "US-002", issue: "ordinary advisory" }),
+    ];
+    const output = plain(formatAdvisorySummary(findings, { mode: "normal", useColor: false }));
+    expect(output).toContain("1 of 2 were coverage-gap demotions");
+    expect(output).toContain("coverage-gap");
+  });
+
+  test("omits the coverage-gap line when no finding was demoted", () => {
+    const output = plain(formatAdvisorySummary([advisoryFinding()], { mode: "normal", useColor: false }));
+    expect(output).not.toContain("coverage-gap demotions");
+  });
+
   test("includes every finding's story ID, severity, and issue text", () => {
     const findings = [
       advisoryFinding({ storyId: "US-001", severity: "warning", issue: "issue A" }),

--- a/test/unit/review/review-audit.test.ts
+++ b/test/unit/review/review-audit.test.ts
@@ -326,6 +326,32 @@ describe("ReviewAuditor.getAdvisoryFindings", () => {
     });
   });
 
+  test("preserves meta.coverageGap as a coverageGap flag on the summary entry", async () => {
+    const { deps } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-cg", "/tmp/workdir");
+
+    auditor.recordDecision({
+      reviewer: "adversarial",
+      storyId: "US-004",
+      featureName: "f",
+      parsed: true,
+      passed: true,
+      blockingThreshold: "error",
+      result: { passed: true, findings: [] },
+      advisoryFindings: [
+        { severity: "error", category: "assumption", file: "lib/s.ts", issue: "demoted", meta: { coverageGap: true } },
+        { severity: "warning", category: "correctness", file: "lib/s.ts", issue: "ordinary" },
+      ],
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    const summary = auditor.getAdvisoryFindings();
+    expect(summary.find((s) => s.issue === "demoted")?.coverageGap).toBe(true);
+    expect(summary.find((s) => s.issue === "ordinary")?.coverageGap).toBeUndefined();
+  });
+
   test("decisions with no advisory findings contribute nothing", async () => {
     const { deps } = makeDeps();
     Object.assign(_reviewAuditDeps, deps);


### PR DESCRIPTION
Closes #1339 (follow-up to #1337).

Recurrence-demoted findings are tagged `meta.coverageGap`, but the run-end advisory summary treated them like any other sub-threshold advisory. This threads the flag through so they're distinguishable at run end — the Phase-0 telemetry gate becomes visible without grepping logs / audit JSON.

**Changes**
- `AdvisoryFindingSummaryEntry` gains `coverageGap?: boolean`; `toAdvisorySummaryEntries` reads `meta.coverageGap` (`review-audit.ts`).
- `formatAdvisorySummary` prints `M of N were coverage-gap demotions (recurred past the block limit — candidate for spec/AC review)` and tags each demoted finding line `coverage-gap` (`formatter.ts`).
- Run-end warn log carries `coverageGapCount` (`runner-completion.ts`).

**Tests:** new cases in `formatter.test.ts` (count line + tag; omitted when none) and `review-audit.test.ts` (flag preserved from `meta.coverageGap`). Blast-radius suites (review + log-format + execution) 1726 pass; typecheck + lint clean.

Companion telemetry: `scripts/analyze-coverage-gap.ts` (#1340, merged) and the `nax-coverage-gap` toolkit skill for cross-run aggregation; this PR is the per-run at-a-glance view.