### PR TITLE
fix(config): derive adversarial default from schema, not a hand-literal (closes #1338)

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -33,7 +33,7 @@ import {
   RoutingConfigSchema,
 } from "./schemas-infra";
 import { ModelMapSchema } from "./schemas-model";
-import { ReviewConfigSchema } from "./schemas-review";
+import { AdversarialReviewConfigSchema, ReviewConfigSchema } from "./schemas-review";
 
 // Re-export named schemas consumed by other modules (via config/schema.ts barrel)
 export { AcceptanceConfigSchema, PlanConfigSchema } from "./schemas-infra";
@@ -259,19 +259,13 @@ export const NaxConfigSchema = z
           ":!.nax-pids",
         ],
       },
+      // Derived from the schema's own defaults (SSOT, issue #1338) so new
+      // AdversarialReviewConfigSchema fields flow in automatically instead of
+      // being hand-copied here. `substantiation` is schema-optional (no
+      // `.default()`), so it is spread in explicitly to keep the default shape
+      // identical; consumers treat an absent value the same via `?? true` / `?? 5`.
       adversarial: {
-        model: "balanced",
-        diffMode: "ref",
-        rules: [],
-        timeoutMs: 600_000,
-        parallel: false,
-        maxConcurrentSessions: 2,
-        acRegroundOnDrop: true,
-        recurrenceDemotion: {
-          enabled: true,
-          maxBlockingRounds: 2,
-        },
-        demandInspectionTrail: true,
+        ...AdversarialReviewConfigSchema.parse({}),
         substantiation: {
           requote: true,
           maxRequotes: 5,

--- a/test/unit/config/defaults-schema-derive.test.ts
+++ b/test/unit/config/defaults-schema-derive.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { AdversarialReviewConfigSchema } from "@/config";
 import { loadConfig } from "../../../src/config/loader";
 import { DEFAULT_CONFIG, NaxConfigSchema } from "../../../src/config/schema";
 import type { NaxConfig } from "../../../src/config/schema";
@@ -75,6 +76,24 @@ describe("US-002: Derive DEFAULT_CONFIG from schema parse", () => {
       const typed = parsed as NaxConfig;
       expect(typed.execution).toBeDefined();
       expect(typed.quality).toBeDefined();
+    });
+  });
+
+  describe("issue #1338: review.adversarial default is schema-derived (no hand-copied drift)", () => {
+    test("DEFAULT_CONFIG.review.adversarial equals the schema default (aside from schema-optional substantiation)", () => {
+      const schemaDefault = AdversarialReviewConfigSchema.parse({});
+      const adv = DEFAULT_CONFIG.review?.adversarial;
+      expect(adv).toBeDefined();
+      const { substantiation, ...derived } = adv as Record<string, unknown>;
+      expect(derived).toEqual(schemaDefault);
+      // substantiation is schema-optional (no `.default()`), spread in explicitly to keep the shape.
+      expect(substantiation).toEqual({ requote: true, maxRequotes: 5 });
+    });
+
+    test("new schema defaults flow into DEFAULT_CONFIG automatically (recurrenceDemotion, not a hand-copied literal)", () => {
+      expect(DEFAULT_CONFIG.review?.adversarial?.recurrenceDemotion).toEqual(
+        AdversarialReviewConfigSchema.parse({}).recurrenceDemotion,
+      );
     });
   });
 


### PR DESCRIPTION
Closes #1338.

`NaxConfigSchema`'s `review.adversarial` default was a hand-maintained object literal that duplicated `AdversarialReviewConfigSchema`'s own `.default()` values — two sources of truth, and every new schema field had to be manually re-synced (this bit us in #1337 with `recurrenceDemotion`, per config-patterns.md's 'defaults live in the Zod schema' rule).

**Change:** replace the literal with `{ ...AdversarialReviewConfigSchema.parse({}), substantiation: { requote: true, maxRequotes: 5 } }`. Schema-defaulted fields now flow in automatically; `substantiation` is schema-optional (no `.default()`) so it's spread in explicitly to keep the default **byte-identical** (verified) — and consumers already treat an absent value the same via `?? true` / `?? 5`.

**Guard:** new test in `defaults-schema-derive.test.ts` asserts `DEFAULT_CONFIG.review.adversarial` equals the schema default (so a future hand-literal that drifts fails CI).

Scoped to adversarial only (what #1338 flagged); the semantic literal has an `excludePatterns` nuance left untouched. Byte-identical default confirmed; config + review suites 1177 pass; typecheck + lint clean.