### PR TITLE
feat(acceptance): polyglot import resolution for fix-diagnosis

### DIFF
--- a/docs/superpowers/plans/2026-07-18-acceptance-fix-diagnosis-polyglot.md
+++ b/docs/superpowers/plans/2026-07-18-acceptance-fix-diagnosis-polyglot.md
@@ -1,0 +1,879 @@
+# Polyglot Acceptance Fix-Diagnosis Source Loader — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the acceptance diagnosis LLM real source context for Python/Go/Rust (not just TS/JS) by making the import resolver polyglot.
+
+**Architecture:** A new module `src/acceptance/import-resolution.ts` detects the package language once (test-file extension → `detectLanguage()` → typescript default) and dispatches to a per-language regex parser + best-effort candidate-path generator. `src/acceptance/fix-diagnosis.ts` becomes a thin options-object wrapper that delegates to it. All resolution degrades to `[]` on anything unresolvable — it is context enrichment, not compilation.
+
+**Tech Stack:** Bun 1.3.7+, TypeScript strict, `bun:test`, Biome. Bun-native APIs only (`Bun.file`, `Bun.Glob`).
+
+## Global Constraints
+
+- **Bun-native only** — `Bun.file()`, `Bun.Glob().scanSync({ cwd })`; never Node.js `fs`.
+- **No `console.log`** in `src/` — not needed here (pure functions), but never add it.
+- **Barrel imports across modules** — import `detectLanguage`/`clearLanguageCache` from `../project`, `ProjectProfile` type from `../config`. Sibling files inside `src/acceptance/` may import each other by relative leaf path (existing pattern — `fix-diagnosis.ts` is itself imported by leaf path).
+- **Glob must pass `cwd` explicitly** (`monorepo-awareness.md` §6): `new Bun.Glob("*.go").scanSync({ cwd, absolute: false })`.
+- **Test placement** mirrors `src/`: `src/acceptance/import-resolution.ts` → `test/unit/acceptance/import-resolution.test.ts`.
+- **Test file I/O uses real temp dirs** via `withTempDir` from the `test/helpers` barrel — no `Bun.file` mocking.
+- **Bun test wrapper** — never run bare `bun test`; always `timeout 30 bun test <path> --timeout=5000`.
+- **Caps preserved:** `MAX_SOURCE_FILES = 5`, `MAX_FILE_LINES = 500`.
+- **Behavior contract:** first-level local imports only; no transitive/dynamic/external-dependency resolution; every unresolvable import → filtered out; no throws escape the module.
+- **Conventional commits**, one concern per commit. Never include `[run-release]`.
+
+---
+
+### Task 1: Language detection + capped file read primitives
+
+**Files:**
+- Create: `src/acceptance/import-resolution.ts`
+- Test: `test/unit/acceptance/import-resolution.test.ts`
+
+**Interfaces:**
+- Consumes: `detectLanguage(packageDir)` from `../project`; `ProjectProfile` type from `../config`.
+- Produces:
+  - `MAX_SOURCE_FILES: 5`, `MAX_FILE_LINES: 500` (exported consts)
+  - `type ResolvedLanguage = "typescript" | "javascript" | "python" | "go" | "rust"`
+  - `languageFromExtension(testFilePath: string | undefined): ProjectProfile["language"] | undefined`
+  - `resolveLanguage(opts: { testFilePath?: string; packageDir: string; language?: ProjectProfile["language"] }): Promise<ResolvedLanguage>`
+  - `readCapped(relPath: string, packageDir: string): Promise<{ path: string; content: string } | null>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/acceptance/import-resolution.test.ts`:
+
+```ts
+/**
+ * Tests for src/acceptance/import-resolution.ts — polyglot import resolution.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearLanguageCache } from "../../../src/project";
+import {
+  languageFromExtension,
+  MAX_FILE_LINES,
+  readCapped,
+  resolveLanguage,
+} from "../../../src/acceptance/import-resolution";
+import { withTempDir } from "../../helpers";
+
+afterEach(() => clearLanguageCache());
+
+describe("languageFromExtension", () => {
+  test("maps known extensions", () => {
+    expect(languageFromExtension("foo.test.ts")).toBe("typescript");
+    expect(languageFromExtension("foo_test.go")).toBe("go");
+    expect(languageFromExtension("test_foo.py")).toBe("python");
+    expect(languageFromExtension("foo_test.rs")).toBe("rust");
+    expect(languageFromExtension("foo.spec.jsx")).toBe("javascript");
+  });
+
+  test("returns undefined for no/unknown extension", () => {
+    expect(languageFromExtension(undefined)).toBeUndefined();
+    expect(languageFromExtension("Makefile")).toBeUndefined();
+    expect(languageFromExtension("foo.txt")).toBeUndefined();
+  });
+});
+
+describe("resolveLanguage", () => {
+  test("explicit language wins", async () => {
+    const lang = await resolveLanguage({ packageDir: "/tmp", language: "rust", testFilePath: "x.py" });
+    expect(lang).toBe("rust");
+  });
+
+  test("falls back to test-file extension", async () => {
+    const lang = await resolveLanguage({ packageDir: "/tmp", testFilePath: "x_test.go" });
+    expect(lang).toBe("go");
+  });
+
+  test("defaults to typescript when nothing detectable", async () => {
+    await withTempDir(async (dir) => {
+      const lang = await resolveLanguage({ packageDir: dir });
+      expect(lang).toBe("typescript");
+    });
+  });
+});
+
+describe("readCapped", () => {
+  test("reads a real file relative to packageDir", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/src/a.ts`, "export const a = 1;");
+      const result = await readCapped("src/a.ts", dir);
+      expect(result).toEqual({ path: "src/a.ts", content: "export const a = 1;" });
+    });
+  });
+
+  test("truncates to MAX_FILE_LINES", async () => {
+    await withTempDir(async (dir) => {
+      const body = Array.from({ length: MAX_FILE_LINES + 50 }, (_, i) => `line${i}`).join("\n");
+      await Bun.write(`${dir}/big.ts`, body);
+      const result = await readCapped("big.ts", dir);
+      expect(result?.content.split("\n").length).toBe(MAX_FILE_LINES);
+    });
+  });
+
+  test("returns null for a missing file", async () => {
+    await withTempDir(async (dir) => {
+      expect(await readCapped("nope.ts", dir)).toBeNull();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: FAIL — cannot resolve module `src/acceptance/import-resolution` / exports undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/acceptance/import-resolution.ts`:
+
+```ts
+/**
+ * Polyglot import resolution for acceptance fix-diagnosis.
+ *
+ * Best-effort source-context loader: parse the failing test's imports, map them
+ * to candidate local source files, load what exists (capped). NOT a compiler —
+ * every unresolvable/unreadable import degrades to a filtered-out null. Scope is
+ * first-level LOCAL imports only; language-specific parsing is gated by
+ * detected language per monorepo-awareness.md §B.
+ */
+import type { ProjectProfile } from "../config";
+import { detectLanguage } from "../project";
+
+export const MAX_SOURCE_FILES = 5;
+export const MAX_FILE_LINES = 500;
+
+export type ResolvedLanguage = "typescript" | "javascript" | "python" | "go" | "rust";
+
+const SUPPORTED = new Set<string>(["typescript", "javascript", "python", "go", "rust"]);
+
+const EXT_LANGUAGE = new Map<string, ProjectProfile["language"]>([
+  [".ts", "typescript"],
+  [".tsx", "typescript"],
+  [".mts", "typescript"],
+  [".cts", "typescript"],
+  [".js", "javascript"],
+  [".jsx", "javascript"],
+  [".mjs", "javascript"],
+  [".cjs", "javascript"],
+  [".py", "python"],
+  [".go", "go"],
+  [".rs", "rust"],
+]);
+
+export function languageFromExtension(testFilePath: string | undefined): ProjectProfile["language"] | undefined {
+  if (!testFilePath) return undefined;
+  const dot = testFilePath.lastIndexOf(".");
+  if (dot < 0) return undefined;
+  return EXT_LANGUAGE.get(testFilePath.slice(dot).toLowerCase());
+}
+
+export async function resolveLanguage(opts: {
+  testFilePath?: string;
+  packageDir: string;
+  language?: ProjectProfile["language"];
+}): Promise<ResolvedLanguage> {
+  const explicit = opts.language ?? languageFromExtension(opts.testFilePath);
+  if (explicit && SUPPORTED.has(explicit)) return explicit as ResolvedLanguage;
+  const detected = await detectLanguage(opts.packageDir);
+  if (detected && SUPPORTED.has(detected)) return detected as ResolvedLanguage;
+  return "typescript"; // historical default — preserves pre-polyglot behavior
+}
+
+export async function readCapped(
+  relPath: string,
+  packageDir: string,
+): Promise<{ path: string; content: string } | null> {
+  try {
+    const text = await Bun.file(`${packageDir}/${relPath}`).text();
+    const content = text.split("\n").slice(0, MAX_FILE_LINES).join("\n");
+    return { path: relPath, content };
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: PASS (all `languageFromExtension` / `resolveLanguage` / `readCapped` cases green).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/acceptance/import-resolution.ts test/unit/acceptance/import-resolution.test.ts
+git commit -m "feat(acceptance): language detection + capped read primitives for import resolution"
+```
+
+---
+
+### Task 2: `resolveSourceFiles` dispatch + TS/JS resolver
+
+**Files:**
+- Modify: `src/acceptance/import-resolution.ts`
+- Test: `test/unit/acceptance/import-resolution.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveLanguage`, `readCapped`, `MAX_SOURCE_FILES` (Task 1).
+- Produces:
+  - `interface ResolveSourceFilesOptions { testFileContent: string; packageDir: string; testFilePath?: string; language?: ProjectProfile["language"] }`
+  - `resolveSourceFiles(opts: ResolveSourceFilesOptions): Promise<Array<{ path: string; content: string }>>`
+  - `parseTsImports(content: string): string[]`
+  - `tsCandidates(spec: string): string[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/acceptance/import-resolution.test.ts` (add `parseTsImports`, `resolveSourceFiles` to the import from `../../../src/acceptance/import-resolution`):
+
+```ts
+describe("parseTsImports", () => {
+  test("keeps relative imports, drops bare specifiers", () => {
+    const content = `
+import { add } from "./math";
+import { z } from "zod";
+import { b } from "../lib/b.ts";
+`;
+    expect(parseTsImports(content)).toEqual(["./math", "../lib/b.ts"]);
+  });
+});
+
+describe("resolveSourceFiles — typescript", () => {
+  test("resolves an extensionless relative import", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/math.ts`, "export const add = (a: number, b: number) => a + b;");
+      const files = await resolveSourceFiles({
+        testFileContent: `import { add } from "./math";`,
+        packageDir: dir,
+        language: "typescript",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("./math.ts");
+    });
+  });
+
+  test("caps at 5 files even when 6 resolve", async () => {
+    await withTempDir(async (dir) => {
+      let content = "";
+      for (let i = 1; i <= 6; i++) {
+        await Bun.write(`${dir}/f${i}.ts`, `export const v${i} = ${i};`);
+        content += `import { v${i} } from "./f${i}.ts";\n`;
+      }
+      const files = await resolveSourceFiles({ testFileContent: content, packageDir: dir, language: "typescript" });
+      expect(files).toHaveLength(5);
+    });
+  });
+
+  test("degrades to [] when nothing resolves", async () => {
+    await withTempDir(async (dir) => {
+      const files = await resolveSourceFiles({
+        testFileContent: `import { x } from "./missing";`,
+        packageDir: dir,
+        language: "typescript",
+      });
+      expect(files).toEqual([]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: FAIL — `parseTsImports` / `resolveSourceFiles` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/acceptance/import-resolution.ts`:
+
+```ts
+export interface ResolveSourceFilesOptions {
+  testFileContent: string;
+  packageDir: string;
+  testFilePath?: string;
+  language?: ProjectProfile["language"];
+}
+
+const TS_IMPORT_RE = /import\s+(?:{[^}]+}|[^;'"]+)\s+from\s+["']([^"']+)["']/g;
+const TS_EXTS = [".ts", ".tsx", ".js", ".jsx"] as const;
+
+export function parseTsImports(content: string): string[] {
+  const specs: string[] = [];
+  for (const m of content.matchAll(TS_IMPORT_RE)) {
+    if (m[1].startsWith(".")) specs.push(m[1]);
+  }
+  return specs;
+}
+
+export function tsCandidates(spec: string): string[] {
+  if (TS_EXTS.some((e) => spec.endsWith(e))) return [spec];
+  const out: string[] = [];
+  for (const e of TS_EXTS) out.push(`${spec}${e}`);
+  for (const e of TS_EXTS) out.push(`${spec}/index${e}`);
+  return out;
+}
+
+async function collectCandidates(lang: ResolvedLanguage, opts: ResolveSourceFilesOptions): Promise<string[]> {
+  switch (lang) {
+    case "typescript":
+    case "javascript":
+      return parseTsImports(opts.testFileContent).flatMap(tsCandidates);
+    default:
+      return [];
+  }
+}
+
+async function readCandidates(
+  candidates: string[],
+  packageDir: string,
+): Promise<Array<{ path: string; content: string }>> {
+  const seen = new Set<string>();
+  const results: Array<{ path: string; content: string }> = [];
+  for (const rel of candidates) {
+    if (results.length >= MAX_SOURCE_FILES) break;
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    const file = await readCapped(rel, packageDir);
+    if (file) results.push(file);
+  }
+  return results;
+}
+
+export async function resolveSourceFiles(
+  opts: ResolveSourceFilesOptions,
+): Promise<Array<{ path: string; content: string }>> {
+  const lang = await resolveLanguage(opts);
+  const candidates = await collectCandidates(lang, opts);
+  return readCandidates(candidates, opts.packageDir);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/acceptance/import-resolution.ts test/unit/acceptance/import-resolution.test.ts
+git commit -m "feat(acceptance): resolveSourceFiles dispatch + TS/JS import resolver"
+```
+
+---
+
+### Task 3: Python resolver
+
+**Files:**
+- Modify: `src/acceptance/import-resolution.ts`
+- Test: `test/unit/acceptance/import-resolution.test.ts`
+
+**Interfaces:**
+- Consumes: `collectCandidates` switch (Task 2).
+- Produces: `parsePythonImports(content: string): string[]`, `pythonCandidates(module: string): string[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append (add `parsePythonImports` to the module import):
+
+```ts
+describe("parsePythonImports", () => {
+  test("captures from/import/as/relative forms", () => {
+    const content = `
+from foo.bar import baz
+import pkg.mod
+import other as o
+from .local import thing
+`;
+    expect(parsePythonImports(content)).toEqual(["foo.bar", "pkg.mod", "other", "local"]);
+  });
+});
+
+describe("resolveSourceFiles — python", () => {
+  test("resolves dotted module to a .py file", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/foo/bar.py`, "def baz():\n    return 1\n");
+      const files = await resolveSourceFiles({
+        testFileContent: `from foo.bar import baz`,
+        packageDir: dir,
+        language: "python",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("foo/bar.py");
+    });
+  });
+
+  test("resolves a package __init__.py", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/pkg/__init__.py`, "VALUE = 1\n");
+      const files = await resolveSourceFiles({
+        testFileContent: `import pkg`,
+        packageDir: dir,
+        language: "python",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("pkg/__init__.py");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: FAIL — `parsePythonImports` not exported; python `resolveSourceFiles` returns `[]`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append the parser/candidates to `src/acceptance/import-resolution.ts`:
+
+```ts
+// Python: `from a.b import x` and `import a.b`. Leading dots (relative imports)
+// are best-effort — stripped and mapped relative to packageDir.
+const PY_FROM_RE = /^\s*from\s+\.*([\w.]*)\s+import\s+/gm;
+const PY_IMPORT_RE = /^\s*import\s+([\w.]+(?:\s*,\s*[\w.]+)*)/gm;
+
+export function parsePythonImports(content: string): string[] {
+  const modules: string[] = [];
+  for (const m of content.matchAll(PY_FROM_RE)) {
+    if (m[1]) modules.push(m[1]); // empty for `from . import x` — skipped (ambiguous)
+  }
+  for (const m of content.matchAll(PY_IMPORT_RE)) {
+    for (const part of m[1].split(",")) {
+      const mod = part.trim().split(/\s+as\s+/)[0].trim();
+      if (mod) modules.push(mod);
+    }
+  }
+  return modules;
+}
+
+export function pythonCandidates(module: string): string[] {
+  const base = module.replace(/\./g, "/");
+  return [`${base}.py`, `${base}/__init__.py`];
+}
+```
+
+Then add a `python` case to `collectCandidates`, before `default`:
+
+```ts
+    case "python":
+      return parsePythonImports(opts.testFileContent).flatMap(pythonCandidates);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/acceptance/import-resolution.ts test/unit/acceptance/import-resolution.test.ts
+git commit -m "feat(acceptance): Python import resolver"
+```
+
+---
+
+### Task 4: Rust resolver
+
+**Files:**
+- Modify: `src/acceptance/import-resolution.ts`
+- Test: `test/unit/acceptance/import-resolution.test.ts`
+
+**Interfaces:**
+- Consumes: `collectCandidates` switch (Task 2).
+- Produces: `parseRustUses(content: string): string[]`, `rustCandidates(usePath: string): string[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append (add `parseRustUses` to the module import):
+
+```ts
+describe("parseRustUses", () => {
+  test("captures crate/super/self paths, skips external crates", () => {
+    const content = `
+use crate::math::add;
+use crate::util::{a, b};
+use super::helpers::x;
+use std::collections::HashMap;
+`;
+    expect(parseRustUses(content)).toEqual(["crate::math::add", "crate::util", "super::helpers"]);
+  });
+});
+
+describe("resolveSourceFiles — rust", () => {
+  test("resolves crate path to src/<path>.rs", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/src/math.rs`, "pub fn add(a: i32, b: i32) -> i32 { a + b }");
+      const files = await resolveSourceFiles({
+        testFileContent: `use crate::math::add;`,
+        packageDir: dir,
+        language: "rust",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("src/math.rs");
+    });
+  });
+
+  test("resolves a module directory to mod.rs", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/src/util/mod.rs`, "pub fn a() {}");
+      const files = await resolveSourceFiles({
+        testFileContent: `use crate::util::{a, b};`,
+        packageDir: dir,
+        language: "rust",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("src/util/mod.rs");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: FAIL — `parseRustUses` not exported; rust `resolveSourceFiles` returns `[]`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/acceptance/import-resolution.ts`:
+
+```ts
+// Rust: only crate-local `use` (crate/super/self roots). External crates skipped.
+// Captures the path prefix before any `{group}`. super/self are mapped like crate
+// (best-effort — no parent-dir traversal).
+const RUST_USE_RE = /^\s*use\s+((?:crate|super|self)(?:::\w+)*)/gm;
+
+export function parseRustUses(content: string): string[] {
+  const paths: string[] = [];
+  for (const m of content.matchAll(RUST_USE_RE)) paths.push(m[1]);
+  return paths;
+}
+
+export function rustCandidates(usePath: string): string[] {
+  const rest = usePath.split("::").slice(1); // drop crate/super/self
+  if (rest.length === 0) return [];
+  const base = `src/${rest.join("/")}`;
+  const parentMod = rest.length > 1 ? `src/${rest.slice(0, -1).join("/")}/mod.rs` : "src/lib.rs";
+  return [`${base}.rs`, `${base}/mod.rs`, parentMod];
+}
+```
+
+Then add a `rust` case to `collectCandidates`, before `default`:
+
+```ts
+    case "rust":
+      return parseRustUses(opts.testFileContent).flatMap(rustCandidates);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/acceptance/import-resolution.ts test/unit/acceptance/import-resolution.test.ts
+git commit -m "feat(acceptance): Rust import resolver"
+```
+
+---
+
+### Task 5: Go resolver (go.mod prefix + package directory)
+
+**Files:**
+- Modify: `src/acceptance/import-resolution.ts`
+- Test: `test/unit/acceptance/import-resolution.test.ts`
+
+**Interfaces:**
+- Consumes: `collectCandidates` switch (Task 2).
+- Produces: `parseGoImports(content: string): string[]`, `resolveGoCandidates(content: string, packageDir: string): Promise<string[]>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append (add `parseGoImports` to the module import):
+
+```ts
+describe("parseGoImports", () => {
+  test("captures single and grouped imports", () => {
+    const content = `
+import "example.com/proj/pkg/math"
+import (
+  "fmt"
+  "example.com/proj/pkg/util"
+)
+`;
+    expect(parseGoImports(content)).toEqual([
+      "example.com/proj/pkg/math",
+      "fmt",
+      "example.com/proj/pkg/util",
+    ]);
+  });
+});
+
+describe("resolveSourceFiles — go", () => {
+  test("loads local package .go files, excludes _test.go and external imports", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/go.mod`, "module example.com/proj\n\ngo 1.22\n");
+      await Bun.write(`${dir}/pkg/math/add.go`, "package math\n\nfunc Add(a, b int) int { return a + b }");
+      await Bun.write(`${dir}/pkg/math/add_test.go`, "package math\n\n// test file");
+      const files = await resolveSourceFiles({
+        testFileContent: `import (\n  "fmt"\n  "example.com/proj/pkg/math"\n)`,
+        packageDir: dir,
+        language: "go",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("pkg/math/add.go");
+    });
+  });
+
+  test("returns [] when go.mod is absent", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/pkg/math/add.go`, "package math");
+      const files = await resolveSourceFiles({
+        testFileContent: `import "example.com/proj/pkg/math"`,
+        packageDir: dir,
+        language: "go",
+      });
+      expect(files).toEqual([]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: FAIL — `parseGoImports` not exported; go `resolveSourceFiles` returns `[]`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/acceptance/import-resolution.ts`:
+
+```ts
+// Go: an import is a package path; resolving to files needs the go.mod module
+// prefix stripped, then the local directory's non-test .go files.
+const GO_SINGLE_IMPORT_RE = /^\s*import\s+"([^"]+)"/gm;
+const GO_IMPORT_BLOCK_RE = /import\s*\(([\s\S]*?)\)/g;
+const GO_BLOCK_LINE_RE = /"([^"]+)"/g;
+
+export function parseGoImports(content: string): string[] {
+  const paths: string[] = [];
+  for (const m of content.matchAll(GO_SINGLE_IMPORT_RE)) paths.push(m[1]);
+  for (const block of content.matchAll(GO_IMPORT_BLOCK_RE)) {
+    for (const line of block[1].matchAll(GO_BLOCK_LINE_RE)) paths.push(line[1]);
+  }
+  return paths;
+}
+
+async function readGoModulePrefix(packageDir: string): Promise<string | null> {
+  try {
+    const text = await Bun.file(`${packageDir}/go.mod`).text();
+    const m = text.match(/^\s*module\s+(\S+)/m);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveGoCandidates(content: string, packageDir: string): Promise<string[]> {
+  const prefix = await readGoModulePrefix(packageDir);
+  if (!prefix) return [];
+  const candidates: string[] = [];
+  for (const imp of parseGoImports(content)) {
+    if (imp !== prefix && !imp.startsWith(`${prefix}/`)) continue;
+    const relDir = imp === prefix ? "." : imp.slice(prefix.length + 1);
+    try {
+      for (const file of new Bun.Glob("*.go").scanSync({ cwd: `${packageDir}/${relDir}`, absolute: false })) {
+        if (file.endsWith("_test.go")) continue;
+        candidates.push(relDir === "." ? file : `${relDir}/${file}`);
+      }
+    } catch {
+      // directory missing — skip this import
+    }
+  }
+  return candidates;
+}
+```
+
+Then add a `go` case to `collectCandidates`, before `default`:
+
+```ts
+    case "go":
+      return resolveGoCandidates(opts.testFileContent, opts.packageDir);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 30 bun test test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/acceptance/import-resolution.ts test/unit/acceptance/import-resolution.test.ts
+git commit -m "feat(acceptance): Go import resolver (go.mod prefix + package dir)"
+```
+
+---
+
+### Task 6: Integrate into `fix-diagnosis.ts` + caller + migrate existing test
+
+**Files:**
+- Modify: `src/acceptance/fix-diagnosis.ts` (full rewrite — see Step 3)
+- Modify: `src/execution/lifecycle/acceptance-fix.ts:117`
+- Modify: `test/unit/acceptance/fix-diagnosis.test.ts:19,30,45`
+
+**Interfaces:**
+- Consumes: `resolveSourceFiles`, `ResolveSourceFilesOptions` (Task 2); `ProjectProfile` type from `../config`.
+- Produces:
+  - `interface LoadSourceFilesOptions { testFileContent: string; packageDir: string; testFilePath?: string; language?: ProjectProfile["language"] }`
+  - `loadSourceFilesForDiagnosis(opts: LoadSourceFilesOptions): Promise<Array<{ path: string; content: string }>>` (signature CHANGED from positional `(testFileContent, workdir)` to options object)
+
+- [ ] **Step 1: Update the existing test to the new options-object signature**
+
+In `test/unit/acceptance/fix-diagnosis.test.ts`, replace the three `loadSourceFilesForDiagnosis` call sites (lines ~19, ~30, ~45) with options-object calls carrying `language: "typescript"` for deterministic behavior:
+
+```ts
+// line ~19
+const result = await loadSourceFilesForDiagnosis({
+  testFileContent: 'test("x", () => {});',
+  packageDir: "/tmp",
+  language: "typescript",
+});
+expect(result).toEqual([]);
+```
+
+```ts
+// line ~30 (testContent already defined above)
+const result = await loadSourceFilesForDiagnosis({
+  testFileContent: testContent,
+  packageDir: "/tmp",
+  language: "typescript",
+});
+expect(result).toEqual([]);
+```
+
+```ts
+// line ~45 (testContent already defined above)
+const result = await loadSourceFilesForDiagnosis({
+  testFileContent: testContent,
+  packageDir: "/tmp",
+  language: "typescript",
+});
+expect(result).toEqual([]);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/acceptance/fix-diagnosis.test.ts --timeout=5000`
+Expected: FAIL — `loadSourceFilesForDiagnosis` still expects positional args / type error on object argument.
+
+- [ ] **Step 3: Rewrite `fix-diagnosis.ts` to delegate**
+
+Replace the entire contents of `src/acceptance/fix-diagnosis.ts` with:
+
+```ts
+/**
+ * Acceptance Fix Diagnosis — source-file loading for the diagnosis flow.
+ *
+ * Thin wrapper over the polyglot resolver in ./import-resolution. Kept as a
+ * named seam because the acceptance diagnosis lifecycle imports it directly.
+ */
+import type { ProjectProfile } from "../config";
+import { resolveSourceFiles } from "./import-resolution";
+
+export interface LoadSourceFilesOptions {
+  testFileContent: string;
+  packageDir: string;
+  testFilePath?: string;
+  language?: ProjectProfile["language"];
+}
+
+export async function loadSourceFilesForDiagnosis(
+  opts: LoadSourceFilesOptions,
+): Promise<Array<{ path: string; content: string }>> {
+  return resolveSourceFiles(opts);
+}
+```
+
+- [ ] **Step 4: Update the caller**
+
+In `src/execution/lifecycle/acceptance-fix.ts`, replace the line 117 call:
+
+```ts
+  const sourceFiles = await loadSourceFilesForDiagnosis({
+    testFileContent: diagnosisOpts.testFileContent,
+    packageDir: diagnosisOpts.workdir,
+    testFilePath: diagnosisOpts.acceptanceTestPath,
+  });
+```
+
+- [ ] **Step 5: Run both acceptance test files to verify they pass**
+
+Run: `timeout 30 bun test test/unit/acceptance/fix-diagnosis.test.ts test/unit/acceptance/import-resolution.test.ts --timeout=5000`
+Expected: PASS (both files green).
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors (file-size, alias, biome all pass).
+
+- [ ] **Step 7: Run the broader acceptance + lifecycle unit suites**
+
+Run: `timeout 60 bun test test/unit/acceptance/ test/unit/execution/lifecycle/ --timeout=10000`
+Expected: PASS — no regressions from the signature change.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/acceptance/fix-diagnosis.ts src/execution/lifecycle/acceptance-fix.ts test/unit/acceptance/fix-diagnosis.test.ts
+git commit -m "feat(acceptance): wire polyglot import resolution into fix-diagnosis"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (design doc §Approach):
+- New `import-resolution.ts` module → Tasks 1–5. ✓
+- Per-language table (ts/js, python, rust, go) → Tasks 2/3/4/5. ✓
+- Options-object signature + `testFilePath`/`packageDir`/`language` → Task 2 (`ResolveSourceFilesOptions`) + Task 6 (`LoadSourceFilesOptions`). ✓
+- Language detection: extension → `detectLanguage` → typescript default → Task 1 (`resolveLanguage`). ✓
+- Caller update passes `acceptanceTestPath` → Task 6 Step 4. ✓
+- Error handling: wrapped reads → null → filtered; go.mod missing → []; unknown → typescript → Tasks 1/5. ✓
+- Testing: new `import-resolution.test.ts` with real fixtures; existing `fix-diagnosis.test.ts` migrated + green → all tasks + Task 6. ✓
+- Caps 5/500 preserved → Task 1 consts, Task 2 cap test. ✓
+- Non-goals (no transitive/dynamic/external) → honored; only first-level local candidates generated. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✓
+
+**3. Type consistency:** `ResolvedLanguage`, `ResolveSourceFilesOptions`, `LoadSourceFilesOptions`, `resolveSourceFiles`, `resolveLanguage`, `readCapped`, `parseTsImports`/`tsCandidates`, `parsePythonImports`/`pythonCandidates`, `parseRustUses`/`rustCandidates`, `parseGoImports`/`resolveGoCandidates` are named identically at definition and use sites. `collectCandidates` switch grows one case per task (Tasks 2→5), each inserted before `default`. `loadSourceFilesForDiagnosis` options object matches between Task 6 definition and caller. ✓

--- a/docs/superpowers/specs/2026-07-18-acceptance-fix-diagnosis-polyglot-design.md
+++ b/docs/superpowers/specs/2026-07-18-acceptance-fix-diagnosis-polyglot-design.md
@@ -1,0 +1,104 @@
+# Design — Polyglot Acceptance Fix-Diagnosis Source Loader
+
+> Date: 2026-07-18
+> Origin: Gap Analysis 2026-07-18 §3.3 / §6 item #10 (sub-area A).
+> Scope: `src/acceptance/fix-diagnosis.ts` + new `src/acceptance/import-resolution.ts`.
+
+## Problem
+
+`loadSourceFilesForDiagnosis` loads source files referenced by a failing acceptance
+test so the LLM diagnosis op (`acceptanceDiagnoseOp`) has real source context. Its
+import parser (`parseImportStatements`) matches **only** ES `import … from "x"`
+syntax. For Python/Go/Rust packages it extracts nothing, so non-TS acceptance
+failures reach the diagnosis LLM with **zero source files** — a direct contributor
+to hallucinated-signature fixes. The sibling stub-detector in `heuristics.ts` is
+already multi-language, making this an internal inconsistency.
+
+A secondary weakness: the existing TS path is itself lossy. Resolution is a literal
+`${workdir}/${importString}` read, so an import that omits its extension
+(`./math` for `./math.ts`) silently resolves to nothing.
+
+## Contract (unchanged)
+
+Best-effort source-context enrichment, **not** a compiler:
+
+- Cap **5 files**, **500 lines** each (`MAX_SOURCE_FILES`, `MAX_FILE_LINES` preserved).
+- Every unresolvable/unreadable import degrades to `null` → filtered out. No throws.
+- First-level **local** imports only. No transitive following.
+
+## Approach
+
+Detect the package language once, then dispatch to a per-language parse+resolve
+function. Rule-conformant with `monorepo-awareness.md` §B (language-specific logic
+gated by `detectLanguage()`, documented scope, graceful empty for other languages).
+
+### Components
+
+**1. New module `src/acceptance/import-resolution.ts`** — isolates the testable
+per-language logic; keeps `fix-diagnosis.ts` a thin orchestrator. Exports
+`resolveSourceFiles(opts): Promise<Array<{ path: string; content: string }>>`.
+
+Per-language parse + candidate-path generation (all best-effort, all capped):
+
+| Lang | Parse | Candidate paths |
+|------|-------|-----------------|
+| ts/js | `import … from "x"`, relative (`.`-prefixed) only | `x`; if no source ext, try `x.{ts,tsx,js,jsx}`, `x/index.{ts,tsx,js,jsx}` |
+| python | `from a.b import …`, `import a.b` | dotted→slash: `a/b.py`, `a/b/__init__.py`; leading dots = relative parent levels |
+| rust | `use crate::a::b`, `use super::…`, `use self::…`, grouped `use a::{b, c}` (prefix path only) | `src/a/b.rs`, `src/a/b/mod.rs`, `src/a/mod.rs` |
+| go | single `import "x"` + grouped `import ( … )` block | read `go.mod` `module <prefix>`; imports under `<prefix>/` → local dir; load its non-`_test.go` `.go` files (cap-bounded) |
+
+**2. `fix-diagnosis.ts`** — `loadSourceFilesForDiagnosis` takes an options object and
+delegates to `resolveSourceFiles`:
+
+```ts
+loadSourceFilesForDiagnosis({
+  testFileContent: string;
+  packageDir: string;      // = today's workdir argument
+  testFilePath?: string;   // = acceptanceTestPath — cheap ext-based language detect
+  language?: ProjectProfile["language"];  // optional explicit override
+}): Promise<Array<{ path: string; content: string }>>
+```
+
+**3. Language detection** — cheap sync path first: infer from `testFilePath`
+extension (`.py`→python, `.rs`→rust, `.go`→go, `.ts/.tsx/.mts/.cts`→typescript,
+`.js/.jsx/.mjs/.cjs`→javascript). Fallback `detectLanguage(packageDir)` (async,
+memoized). **Undefined → typescript** (preserves historical behavior; documented).
+
+**4. Caller** (`src/execution/lifecycle/acceptance-fix.ts:117`) — pass
+`acceptanceTestPath` and `packageDir` into the new options object. `diagnosisOpts`
+already carries both (`workdir` = packageDir, `acceptanceTestPath`).
+
+### Error handling
+
+Each read wrapped, returns `null` → filtered (as today). `go.mod` missing → Go
+resolver returns `[]`. Unknown/undetected language → typescript default. No throws
+escape the module.
+
+### Testing
+
+- New `test/unit/acceptance/import-resolution.test.ts` — per language, real fixtures
+  via `withTempDir()` (real files on disk, no `Bun.file` mocking, per
+  `test-architecture.md`):
+  - resolves correct local source files from imports,
+  - respects the 5-file cap,
+  - degrades to `[]` for missing / external / stdlib imports,
+  - Go: `go.mod` module-prefix stripping + `_test.go` exclusion,
+  - `clearLanguageCache()` in teardown when `detectLanguage` fallback is exercised.
+- Existing `test/unit/acceptance/fix-diagnosis.test.ts` — updated to the
+  options-object signature; its `[]`-for-missing-files assertions still hold.
+
+## Non-goals (YAGNI)
+
+- No transitive / multi-hop import resolution.
+- No `require()` / dynamic `import()` / re-export following.
+- No external-dependency loading (`node_modules`, Go non-module imports, Python
+  site-packages, Cargo registry crates).
+- No AST parsing — regex extraction matches the existing depth and the
+  `heuristics.ts` precedent.
+
+## Sub-areas B & C (out of scope here)
+
+Gap item #10 also covers test-output parser parity (`test-runners/parser.ts`) and
+mutation-operator parity (`verification/mutation/operators.ts` — note: Python/Go
+tables are empty stubs, not just Rust-absent). Each is an independent spec, to be
+tackled separately after this ships.

--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -1,52 +1,21 @@
 /**
- * Acceptance Fix Diagnosis
+ * Acceptance Fix Diagnosis — source-file loading for the diagnosis flow.
  *
- * Provides source-file loading utilities used by the acceptance diagnosis flow.
+ * Thin wrapper over the polyglot resolver in ./import-resolution. Kept as a
+ * named seam because the acceptance diagnosis lifecycle imports it directly.
  */
+import type { ProjectProfile } from "../config";
+import { resolveSourceFiles } from "./import-resolution";
 
-const MAX_SOURCE_FILES = 5;
-const MAX_FILE_LINES = 500;
-
-function parseImportStatements(content: string): string[] {
-  const importRegex = /import\s+(?:{[^}]+}|[^;]+)\s+from\s+["']([^"']+)["']/g;
-  const imports: string[] = [];
-  const regexMatch = content.matchAll(importRegex);
-  for (const match of regexMatch) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function resolveImportPaths(imports: string[], _workdir: string): string[] {
-  const resolved: string[] = [];
-  for (const imp of imports) {
-    if (imp.startsWith(".")) {
-      resolved.push(imp);
-    }
-  }
-  return resolved.slice(0, MAX_SOURCE_FILES);
+export interface LoadSourceFilesOptions {
+  testFileContent: string;
+  packageDir: string;
+  testFilePath?: string;
+  language?: ProjectProfile["language"];
 }
 
 export async function loadSourceFilesForDiagnosis(
-  testFileContent: string,
-  workdir: string,
+  opts: LoadSourceFilesOptions,
 ): Promise<Array<{ path: string; content: string }>> {
-  const imports = parseImportStatements(testFileContent);
-  const relativeImports = resolveImportPaths(imports, workdir);
-  const results = await Promise.all(relativeImports.map((imp) => readSourceFileContent(imp, workdir)));
-  return results.filter((f): f is { path: string; content: string } => f !== null);
-}
-
-async function readSourceFileContent(
-  filePath: string,
-  workdir: string,
-): Promise<{ path: string; content: string } | null> {
-  try {
-    const fullPath = `${workdir}/${filePath}`;
-    const file = await Bun.file(fullPath).text();
-    const lines = file.split("\n").slice(0, MAX_FILE_LINES);
-    return { path: filePath, content: lines.join("\n") };
-  } catch {
-    return null;
-  }
+  return resolveSourceFiles(opts);
 }

--- a/src/acceptance/import-resolution.ts
+++ b/src/acceptance/import-resolution.ts
@@ -7,6 +7,7 @@
  * first-level LOCAL imports only; language-specific parsing is gated by
  * detected language per monorepo-awareness.md §B.
  */
+import { resolve, sep } from "node:path";
 import type { ProjectProfile } from "../config";
 import { detectLanguage } from "../project";
 
@@ -15,7 +16,7 @@ export const MAX_FILE_LINES = 500;
 
 export type ResolvedLanguage = "typescript" | "javascript" | "python" | "go" | "rust";
 
-const SUPPORTED = new Set<string>(["typescript", "javascript", "python", "go", "rust"]);
+const SUPPORTED = new Set<ResolvedLanguage>(["typescript", "javascript", "python", "go", "rust"]);
 
 const EXT_LANGUAGE = new Map<string, ProjectProfile["language"]>([
   [".ts", "typescript"],
@@ -38,15 +39,19 @@ export function languageFromExtension(testFilePath: string | undefined): Project
   return EXT_LANGUAGE.get(testFilePath.slice(dot).toLowerCase());
 }
 
+function isResolvedLanguage(lang: ProjectProfile["language"] | undefined): lang is ResolvedLanguage {
+  return lang !== undefined && SUPPORTED.has(lang as ResolvedLanguage);
+}
+
 export async function resolveLanguage(opts: {
   testFilePath?: string;
   packageDir: string;
   language?: ProjectProfile["language"];
 }): Promise<ResolvedLanguage> {
   const explicit = opts.language ?? languageFromExtension(opts.testFilePath);
-  if (explicit && SUPPORTED.has(explicit)) return explicit as ResolvedLanguage;
+  if (isResolvedLanguage(explicit)) return explicit;
   const detected = await detectLanguage(opts.packageDir);
-  if (detected && SUPPORTED.has(detected)) return detected as ResolvedLanguage;
+  if (isResolvedLanguage(detected)) return detected;
   return "typescript"; // historical default — preserves pre-polyglot behavior
 }
 
@@ -54,8 +59,13 @@ export async function readCapped(
   relPath: string,
   packageDir: string,
 ): Promise<{ path: string; content: string } | null> {
+  const resolvedPackageDir = resolve(packageDir);
+  const fullPath = resolve(resolvedPackageDir, relPath);
+  if (fullPath !== resolvedPackageDir && !fullPath.startsWith(resolvedPackageDir + sep)) {
+    return null; // escapes packageDir — not a local file, refuse to read
+  }
   try {
-    const text = await Bun.file(`${packageDir}/${relPath}`).text();
+    const text = await Bun.file(fullPath).text();
     const content = text.split("\n").slice(0, MAX_FILE_LINES).join("\n");
     return { path: relPath, content };
   } catch {
@@ -71,7 +81,10 @@ export interface ResolveSourceFilesOptions {
 }
 
 const TS_IMPORT_RE = /import\s+(?:{[^}]+}|[^;'"]+)\s+from\s+["']([^"']+)["']/g;
-const TS_EXTS = [".ts", ".tsx", ".js", ".jsx"] as const;
+// Mirrors EXT_LANGUAGE's typescript/javascript extensions so detection and
+// extensionless-import resolution stay in sync (a .mts test file must be able
+// to resolve an extensionless import to a sibling .mts source file).
+const TS_EXTS = [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"] as const;
 
 export function parseTsImports(content: string): string[] {
   const specs: string[] = [];

--- a/src/acceptance/import-resolution.ts
+++ b/src/acceptance/import-resolution.ts
@@ -104,7 +104,10 @@ export function parsePythonImports(content: string): string[] {
       if (fromModule) modules.push(fromModule); // empty for `from . import x` — skipped (ambiguous)
     } else if (importList) {
       for (const part of importList.split(",")) {
-        const mod = part.trim().split(/\s+as\s+/)[0].trim();
+        const mod = part
+          .trim()
+          .split(/\s+as\s+/)[0]
+          .trim();
         if (mod) modules.push(mod);
       }
     }

--- a/src/acceptance/import-resolution.ts
+++ b/src/acceptance/import-resolution.ts
@@ -1,0 +1,64 @@
+/**
+ * Polyglot import resolution for acceptance fix-diagnosis.
+ *
+ * Best-effort source-context loader: parse the failing test's imports, map them
+ * to candidate local source files, load what exists (capped). NOT a compiler —
+ * every unresolvable/unreadable import degrades to a filtered-out null. Scope is
+ * first-level LOCAL imports only; language-specific parsing is gated by
+ * detected language per monorepo-awareness.md §B.
+ */
+import type { ProjectProfile } from "../config";
+import { detectLanguage } from "../project";
+
+export const MAX_SOURCE_FILES = 5;
+export const MAX_FILE_LINES = 500;
+
+export type ResolvedLanguage = "typescript" | "javascript" | "python" | "go" | "rust";
+
+const SUPPORTED = new Set<string>(["typescript", "javascript", "python", "go", "rust"]);
+
+const EXT_LANGUAGE = new Map<string, ProjectProfile["language"]>([
+  [".ts", "typescript"],
+  [".tsx", "typescript"],
+  [".mts", "typescript"],
+  [".cts", "typescript"],
+  [".js", "javascript"],
+  [".jsx", "javascript"],
+  [".mjs", "javascript"],
+  [".cjs", "javascript"],
+  [".py", "python"],
+  [".go", "go"],
+  [".rs", "rust"],
+]);
+
+export function languageFromExtension(testFilePath: string | undefined): ProjectProfile["language"] | undefined {
+  if (!testFilePath) return undefined;
+  const dot = testFilePath.lastIndexOf(".");
+  if (dot < 0) return undefined;
+  return EXT_LANGUAGE.get(testFilePath.slice(dot).toLowerCase());
+}
+
+export async function resolveLanguage(opts: {
+  testFilePath?: string;
+  packageDir: string;
+  language?: ProjectProfile["language"];
+}): Promise<ResolvedLanguage> {
+  const explicit = opts.language ?? languageFromExtension(opts.testFilePath);
+  if (explicit && SUPPORTED.has(explicit)) return explicit as ResolvedLanguage;
+  const detected = await detectLanguage(opts.packageDir);
+  if (detected && SUPPORTED.has(detected)) return detected as ResolvedLanguage;
+  return "typescript"; // historical default — preserves pre-polyglot behavior
+}
+
+export async function readCapped(
+  relPath: string,
+  packageDir: string,
+): Promise<{ path: string; content: string } | null> {
+  try {
+    const text = await Bun.file(`${packageDir}/${relPath}`).text();
+    const content = text.split("\n").slice(0, MAX_FILE_LINES).join("\n");
+    return { path: relPath, content };
+  } catch {
+    return null;
+  }
+}

--- a/src/acceptance/import-resolution.ts
+++ b/src/acceptance/import-resolution.ts
@@ -89,11 +89,41 @@ export function tsCandidates(spec: string): string[] {
   return out;
 }
 
+// Python: `from a.b import x` and `import a.b`. Leading dots (relative imports)
+// are best-effort — stripped and mapped relative to packageDir. Matched as a
+// single alternation pass so results preserve source order (from/import lines
+// can be interleaved in the file).
+const PY_IMPORT_LINE_RE = /^\s*(?:from\s+\.*([\w.]*)\s+import\s+|import\s+([\w.]+(?:\s*,\s*[\w.]+)*))/gm;
+
+export function parsePythonImports(content: string): string[] {
+  const modules: string[] = [];
+  for (const m of content.matchAll(PY_IMPORT_LINE_RE)) {
+    const fromModule = m[1];
+    const importList = m[2];
+    if (fromModule !== undefined) {
+      if (fromModule) modules.push(fromModule); // empty for `from . import x` — skipped (ambiguous)
+    } else if (importList) {
+      for (const part of importList.split(",")) {
+        const mod = part.trim().split(/\s+as\s+/)[0].trim();
+        if (mod) modules.push(mod);
+      }
+    }
+  }
+  return modules;
+}
+
+export function pythonCandidates(module: string): string[] {
+  const base = module.replace(/\./g, "/");
+  return [`${base}.py`, `${base}/__init__.py`];
+}
+
 async function collectCandidates(lang: ResolvedLanguage, opts: ResolveSourceFilesOptions): Promise<string[]> {
   switch (lang) {
     case "typescript":
     case "javascript":
       return parseTsImports(opts.testFileContent).flatMap(tsCandidates);
+    case "python":
+      return parsePythonImports(opts.testFileContent).flatMap(pythonCandidates);
     default:
       return [];
   }

--- a/src/acceptance/import-resolution.ts
+++ b/src/acceptance/import-resolution.ts
@@ -117,6 +117,36 @@ export function pythonCandidates(module: string): string[] {
   return [`${base}.py`, `${base}/__init__.py`];
 }
 
+// Rust: only crate-local `use` (crate/super/self roots). External crates skipped.
+// Captures the path prefix before any `{group}`. `crate::` paths are absolute from
+// the crate root so the full segment chain is kept (candidate generation drops the
+// trailing item/module split later). `super::`/`self::` are relative and handled
+// best-effort — no parent-dir traversal — so only one segment past the root is
+// captured to avoid resolving to the wrong file.
+const RUST_USE_RE = /^\s*use\s+(crate(?:::\w+)*|(?:super|self)(?:::\w+)?)/gm;
+
+export function parseRustUses(content: string): string[] {
+  const paths: string[] = [];
+  for (const m of content.matchAll(RUST_USE_RE)) paths.push(m[1]);
+  return paths;
+}
+
+export function rustCandidates(usePath: string): string[] {
+  const rest = usePath.split("::").slice(1); // drop crate/super/self
+  if (rest.length === 0) return [];
+  const base = `src/${rest.join("/")}`;
+  const candidates = [`${base}.rs`, `${base}/mod.rs`];
+  // The trailing segment may be an item (fn/struct) rather than a module, so also
+  // try the path one level up as both a file-style and dir-style module.
+  if (rest.length > 1) {
+    const parent = `src/${rest.slice(0, -1).join("/")}`;
+    candidates.push(`${parent}.rs`, `${parent}/mod.rs`);
+  } else {
+    candidates.push("src/lib.rs");
+  }
+  return candidates;
+}
+
 async function collectCandidates(lang: ResolvedLanguage, opts: ResolveSourceFilesOptions): Promise<string[]> {
   switch (lang) {
     case "typescript":
@@ -124,6 +154,8 @@ async function collectCandidates(lang: ResolvedLanguage, opts: ResolveSourceFile
       return parseTsImports(opts.testFileContent).flatMap(tsCandidates);
     case "python":
       return parsePythonImports(opts.testFileContent).flatMap(pythonCandidates);
+    case "rust":
+      return parseRustUses(opts.testFileContent).flatMap(rustCandidates);
     default:
       return [];
   }

--- a/src/acceptance/import-resolution.ts
+++ b/src/acceptance/import-resolution.ts
@@ -147,6 +147,50 @@ export function rustCandidates(usePath: string): string[] {
   return candidates;
 }
 
+// Go: an import is a package path; resolving to files needs the go.mod module
+// prefix stripped, then the local directory's non-test .go files.
+const GO_SINGLE_IMPORT_RE = /^\s*import\s+"([^"]+)"/gm;
+const GO_IMPORT_BLOCK_RE = /import\s*\(([\s\S]*?)\)/g;
+const GO_BLOCK_LINE_RE = /"([^"]+)"/g;
+
+export function parseGoImports(content: string): string[] {
+  const paths: string[] = [];
+  for (const m of content.matchAll(GO_SINGLE_IMPORT_RE)) paths.push(m[1]);
+  for (const block of content.matchAll(GO_IMPORT_BLOCK_RE)) {
+    for (const line of block[1].matchAll(GO_BLOCK_LINE_RE)) paths.push(line[1]);
+  }
+  return paths;
+}
+
+async function readGoModulePrefix(packageDir: string): Promise<string | null> {
+  try {
+    const text = await Bun.file(`${packageDir}/go.mod`).text();
+    const m = text.match(/^\s*module\s+(\S+)/m);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveGoCandidates(content: string, packageDir: string): Promise<string[]> {
+  const prefix = await readGoModulePrefix(packageDir);
+  if (!prefix) return [];
+  const candidates: string[] = [];
+  for (const imp of parseGoImports(content)) {
+    if (imp !== prefix && !imp.startsWith(`${prefix}/`)) continue;
+    const relDir = imp === prefix ? "." : imp.slice(prefix.length + 1);
+    try {
+      for (const file of new Bun.Glob("*.go").scanSync({ cwd: `${packageDir}/${relDir}`, absolute: false })) {
+        if (file.endsWith("_test.go")) continue;
+        candidates.push(relDir === "." ? file : `${relDir}/${file}`);
+      }
+    } catch {
+      // directory missing — skip this import
+    }
+  }
+  return candidates;
+}
+
 async function collectCandidates(lang: ResolvedLanguage, opts: ResolveSourceFilesOptions): Promise<string[]> {
   switch (lang) {
     case "typescript":
@@ -156,6 +200,8 @@ async function collectCandidates(lang: ResolvedLanguage, opts: ResolveSourceFile
       return parsePythonImports(opts.testFileContent).flatMap(pythonCandidates);
     case "rust":
       return parseRustUses(opts.testFileContent).flatMap(rustCandidates);
+    case "go":
+      return resolveGoCandidates(opts.testFileContent, opts.packageDir);
     default:
       return [];
   }

--- a/src/acceptance/import-resolution.ts
+++ b/src/acceptance/import-resolution.ts
@@ -62,3 +62,63 @@ export async function readCapped(
     return null;
   }
 }
+
+export interface ResolveSourceFilesOptions {
+  testFileContent: string;
+  packageDir: string;
+  testFilePath?: string;
+  language?: ProjectProfile["language"];
+}
+
+const TS_IMPORT_RE = /import\s+(?:{[^}]+}|[^;'"]+)\s+from\s+["']([^"']+)["']/g;
+const TS_EXTS = [".ts", ".tsx", ".js", ".jsx"] as const;
+
+export function parseTsImports(content: string): string[] {
+  const specs: string[] = [];
+  for (const m of content.matchAll(TS_IMPORT_RE)) {
+    if (m[1].startsWith(".")) specs.push(m[1]);
+  }
+  return specs;
+}
+
+export function tsCandidates(spec: string): string[] {
+  if (TS_EXTS.some((e) => spec.endsWith(e))) return [spec];
+  const out: string[] = [];
+  for (const e of TS_EXTS) out.push(`${spec}${e}`);
+  for (const e of TS_EXTS) out.push(`${spec}/index${e}`);
+  return out;
+}
+
+async function collectCandidates(lang: ResolvedLanguage, opts: ResolveSourceFilesOptions): Promise<string[]> {
+  switch (lang) {
+    case "typescript":
+    case "javascript":
+      return parseTsImports(opts.testFileContent).flatMap(tsCandidates);
+    default:
+      return [];
+  }
+}
+
+async function readCandidates(
+  candidates: string[],
+  packageDir: string,
+): Promise<Array<{ path: string; content: string }>> {
+  const seen = new Set<string>();
+  const results: Array<{ path: string; content: string }> = [];
+  for (const rel of candidates) {
+    if (results.length >= MAX_SOURCE_FILES) break;
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    const file = await readCapped(rel, packageDir);
+    if (file) results.push(file);
+  }
+  return results;
+}
+
+export async function resolveSourceFiles(
+  opts: ResolveSourceFilesOptions,
+): Promise<Array<{ path: string; content: string }>> {
+  const lang = await resolveLanguage(opts);
+  const candidates = await collectCandidates(lang, opts);
+  return readCandidates(candidates, opts.packageDir);
+}

--- a/src/execution/lifecycle/acceptance-fix.ts
+++ b/src/execution/lifecycle/acceptance-fix.ts
@@ -114,7 +114,11 @@ export async function resolveAcceptanceDiagnosis(opts: ResolveAcceptanceDiagnosi
   }
 
   // Slow path: full LLM diagnosis via callOp
-  const sourceFiles = await loadSourceFilesForDiagnosis(diagnosisOpts.testFileContent, diagnosisOpts.workdir);
+  const sourceFiles = await loadSourceFilesForDiagnosis({
+    testFileContent: diagnosisOpts.testFileContent,
+    packageDir: diagnosisOpts.workdir,
+    testFilePath: diagnosisOpts.acceptanceTestPath,
+  });
   return await _diagnosisDeps.callOp(fixCallCtx(ctx), acceptanceDiagnoseOp, {
     testOutput: diagnosisOpts.testOutput,
     testFileContent: diagnosisOpts.testFileContent,

--- a/test/unit/acceptance/fix-diagnosis.test.ts
+++ b/test/unit/acceptance/fix-diagnosis.test.ts
@@ -16,7 +16,11 @@ import type { DiagnosisResult } from "../../../src/acceptance/types";
 
 describe("loadSourceFilesForDiagnosis", () => {
   test("returns empty array when test file has no imports", async () => {
-    const result = await loadSourceFilesForDiagnosis('test("x", () => {});', "/tmp");
+    const result = await loadSourceFilesForDiagnosis({
+      testFileContent: 'test("x", () => {});',
+      packageDir: "/tmp",
+      language: "typescript",
+    });
     expect(result).toEqual([]);
   });
 
@@ -27,7 +31,11 @@ import { multiply } from "./src/utils.ts";
 test("AC-1", () => { expect(add(1,2)).toBe(3); });
 `;
     // Files don't exist on disk — function gracefully returns null for missing files
-    const result = await loadSourceFilesForDiagnosis(testContent, "/tmp");
+    const result = await loadSourceFilesForDiagnosis({
+      testFileContent: testContent,
+      packageDir: "/tmp",
+      language: "typescript",
+    });
     expect(result).toEqual([]);
   });
 
@@ -42,7 +50,11 @@ import { f } from "./src/file6.ts";
 test("AC-1", () => { expect(a()).toBe(1); });
 `;
     // No files exist on disk
-    const result = await loadSourceFilesForDiagnosis(testContent, "/tmp");
+    const result = await loadSourceFilesForDiagnosis({
+      testFileContent: testContent,
+      packageDir: "/tmp",
+      language: "typescript",
+    });
     expect(result).toEqual([]);
   });
 });

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -6,6 +6,7 @@ import { clearLanguageCache } from "../../../src/project";
 import {
   languageFromExtension,
   MAX_FILE_LINES,
+  parsePythonImports,
   parseTsImports,
   readCapped,
   resolveLanguage,
@@ -120,6 +121,46 @@ describe("resolveSourceFiles — typescript", () => {
         language: "typescript",
       });
       expect(files).toEqual([]);
+    });
+  });
+});
+
+describe("parsePythonImports", () => {
+  test("captures from/import/as/relative forms", () => {
+    const content = `
+from foo.bar import baz
+import pkg.mod
+import other as o
+from .local import thing
+`;
+    expect(parsePythonImports(content)).toEqual(["foo.bar", "pkg.mod", "other", "local"]);
+  });
+});
+
+describe("resolveSourceFiles — python", () => {
+  test("resolves dotted module to a .py file", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/foo/bar.py`, "def baz():\n    return 1\n");
+      const files = await resolveSourceFiles({
+        testFileContent: `from foo.bar import baz`,
+        packageDir: dir,
+        language: "python",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("foo/bar.py");
+    });
+  });
+
+  test("resolves a package __init__.py", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/pkg/__init__.py`, "VALUE = 1\n");
+      const files = await resolveSourceFiles({
+        testFileContent: `import pkg`,
+        packageDir: dir,
+        language: "python",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("pkg/__init__.py");
     });
   });
 });

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -2,10 +2,9 @@
  * Tests for src/acceptance/import-resolution.ts — polyglot import resolution.
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { clearLanguageCache } from "../../../src/project";
 import {
-  languageFromExtension,
   MAX_FILE_LINES,
+  languageFromExtension,
   parseGoImports,
   parsePythonImports,
   parseRustUses,
@@ -14,6 +13,7 @@ import {
   resolveLanguage,
   resolveSourceFiles,
 } from "../../../src/acceptance/import-resolution";
+import { clearLanguageCache } from "../../../src/project";
 import { withTempDir } from "../../helpers";
 
 afterEach(() => clearLanguageCache());
@@ -144,7 +144,7 @@ describe("resolveSourceFiles — python", () => {
     await withTempDir(async (dir) => {
       await Bun.write(`${dir}/foo/bar.py`, "def baz():\n    return 1\n");
       const files = await resolveSourceFiles({
-        testFileContent: `from foo.bar import baz`,
+        testFileContent: "from foo.bar import baz",
         packageDir: dir,
         language: "python",
       });
@@ -157,7 +157,7 @@ describe("resolveSourceFiles — python", () => {
     await withTempDir(async (dir) => {
       await Bun.write(`${dir}/pkg/__init__.py`, "VALUE = 1\n");
       const files = await resolveSourceFiles({
-        testFileContent: `import pkg`,
+        testFileContent: "import pkg",
         packageDir: dir,
         language: "python",
       });
@@ -184,7 +184,7 @@ describe("resolveSourceFiles — rust", () => {
     await withTempDir(async (dir) => {
       await Bun.write(`${dir}/src/math.rs`, "pub fn add(a: i32, b: i32) -> i32 { a + b }");
       const files = await resolveSourceFiles({
-        testFileContent: `use crate::math::add;`,
+        testFileContent: "use crate::math::add;",
         packageDir: dir,
         language: "rust",
       });
@@ -197,7 +197,7 @@ describe("resolveSourceFiles — rust", () => {
     await withTempDir(async (dir) => {
       await Bun.write(`${dir}/src/util/mod.rs`, "pub fn a() {}");
       const files = await resolveSourceFiles({
-        testFileContent: `use crate::util::{a, b};`,
+        testFileContent: "use crate::util::{a, b};",
         packageDir: dir,
         language: "rust",
       });
@@ -216,11 +216,7 @@ import (
   "example.com/proj/pkg/util"
 )
 `;
-    expect(parseGoImports(content)).toEqual([
-      "example.com/proj/pkg/math",
-      "fmt",
-      "example.com/proj/pkg/util",
-    ]);
+    expect(parseGoImports(content)).toEqual(["example.com/proj/pkg/math", "fmt", "example.com/proj/pkg/util"]);
   });
 });
 

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -13,8 +13,8 @@ import {
   resolveLanguage,
   resolveSourceFiles,
 } from "../../../src/acceptance/import-resolution";
-import { clearLanguageCache } from "../../../src/project";
-import { withTempDir } from "../../helpers";
+import { clearLanguageCache } from "@/project";
+import { withTempDir } from "@test/helpers";
 
 afterEach(() => clearLanguageCache());
 

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -6,6 +6,7 @@ import { clearLanguageCache } from "../../../src/project";
 import {
   languageFromExtension,
   MAX_FILE_LINES,
+  parseGoImports,
   parsePythonImports,
   parseRustUses,
   parseTsImports,
@@ -202,6 +203,52 @@ describe("resolveSourceFiles — rust", () => {
       });
       expect(files).toHaveLength(1);
       expect(files[0].path).toBe("src/util/mod.rs");
+    });
+  });
+});
+
+describe("parseGoImports", () => {
+  test("captures single and grouped imports", () => {
+    const content = `
+import "example.com/proj/pkg/math"
+import (
+  "fmt"
+  "example.com/proj/pkg/util"
+)
+`;
+    expect(parseGoImports(content)).toEqual([
+      "example.com/proj/pkg/math",
+      "fmt",
+      "example.com/proj/pkg/util",
+    ]);
+  });
+});
+
+describe("resolveSourceFiles — go", () => {
+  test("loads local package .go files, excludes _test.go and external imports", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/go.mod`, "module example.com/proj\n\ngo 1.22\n");
+      await Bun.write(`${dir}/pkg/math/add.go`, "package math\n\nfunc Add(a, b int) int { return a + b }");
+      await Bun.write(`${dir}/pkg/math/add_test.go`, "package math\n\n// test file");
+      const files = await resolveSourceFiles({
+        testFileContent: `import (\n  "fmt"\n  "example.com/proj/pkg/math"\n)`,
+        packageDir: dir,
+        language: "go",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("pkg/math/add.go");
+    });
+  });
+
+  test("returns [] when go.mod is absent", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/pkg/math/add.go`, "package math");
+      const files = await resolveSourceFiles({
+        testFileContent: `import "example.com/proj/pkg/math"`,
+        packageDir: dir,
+        language: "go",
+      });
+      expect(files).toEqual([]);
     });
   });
 });

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -7,6 +7,7 @@ import {
   languageFromExtension,
   MAX_FILE_LINES,
   parsePythonImports,
+  parseRustUses,
   parseTsImports,
   readCapped,
   resolveLanguage,
@@ -161,6 +162,46 @@ describe("resolveSourceFiles — python", () => {
       });
       expect(files).toHaveLength(1);
       expect(files[0].path).toBe("pkg/__init__.py");
+    });
+  });
+});
+
+describe("parseRustUses", () => {
+  test("captures crate/super/self paths, skips external crates", () => {
+    const content = `
+use crate::math::add;
+use crate::util::{a, b};
+use super::helpers::x;
+use std::collections::HashMap;
+`;
+    expect(parseRustUses(content)).toEqual(["crate::math::add", "crate::util", "super::helpers"]);
+  });
+});
+
+describe("resolveSourceFiles — rust", () => {
+  test("resolves crate path to src/<path>.rs", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/src/math.rs`, "pub fn add(a: i32, b: i32) -> i32 { a + b }");
+      const files = await resolveSourceFiles({
+        testFileContent: `use crate::math::add;`,
+        packageDir: dir,
+        language: "rust",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("src/math.rs");
+    });
+  });
+
+  test("resolves a module directory to mod.rs", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/src/util/mod.rs`, "pub fn a() {}");
+      const files = await resolveSourceFiles({
+        testFileContent: `use crate::util::{a, b};`,
+        packageDir: dir,
+        language: "rust",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("src/util/mod.rs");
     });
   });
 });

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -76,6 +76,22 @@ describe("readCapped", () => {
       expect(await readCapped("nope.ts", dir)).toBeNull();
     });
   });
+
+  test("refuses to read a path that escapes packageDir via ../ traversal", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/secret.ts`, "export const SECRET = 1;");
+      const result = await readCapped("../secret.ts", `${dir}/pkg`);
+      expect(result).toBeNull();
+    });
+  });
+
+  test("still reads a path that stays within packageDir despite internal ..", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/pkg/a.ts`, "export const a = 1;");
+      const result = await readCapped("sub/../a.ts", `${dir}/pkg`);
+      expect(result).toEqual({ path: "sub/../a.ts", content: "export const a = 1;" });
+    });
+  });
 });
 
 describe("parseTsImports", () => {
@@ -125,6 +141,19 @@ describe("resolveSourceFiles — typescript", () => {
       expect(files).toEqual([]);
     });
   });
+
+  test("resolves an extensionless import to a .mts source file", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/math.mts`, "export const add = (a: number, b: number) => a + b;");
+      const files = await resolveSourceFiles({
+        testFileContent: `import { add } from "./math";`,
+        packageDir: dir,
+        language: "typescript",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("./math.mts");
+    });
+  });
 });
 
 describe("parsePythonImports", () => {
@@ -136,6 +165,14 @@ import other as o
 from .local import thing
 `;
     expect(parsePythonImports(content)).toEqual(["foo.bar", "pkg.mod", "other", "local"]);
+  });
+
+  test("skips the ambiguous `from . import x` form (no module name)", () => {
+    const content = `
+from . import thing
+from foo import bar
+`;
+    expect(parsePythonImports(content)).toEqual(["foo"]);
   });
 });
 
@@ -176,6 +213,13 @@ use super::helpers::x;
 use std::collections::HashMap;
 `;
     expect(parseRustUses(content)).toEqual(["crate::math::add", "crate::util", "super::helpers"]);
+  });
+
+  test("caps super/self at one segment past the root for deeper paths", () => {
+    const content = `use super::a::b::c;`;
+    // Best-effort, no parent-dir traversal: only the first segment is kept,
+    // unlike crate:: which keeps the full chain.
+    expect(parseRustUses(content)).toEqual(["super::a"]);
   });
 });
 
@@ -245,6 +289,20 @@ describe("resolveSourceFiles — go", () => {
         language: "go",
       });
       expect(files).toEqual([]);
+    });
+  });
+
+  test("resolves a bare single-line import through the full pipeline", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/go.mod`, "module example.com/proj\n\ngo 1.22\n");
+      await Bun.write(`${dir}/pkg/math/add.go`, "package math\n\nfunc Add(a, b int) int { return a + b }");
+      const files = await resolveSourceFiles({
+        testFileContent: `import "example.com/proj/pkg/math"`,
+        packageDir: dir,
+        language: "go",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("pkg/math/add.go");
     });
   });
 });

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for src/acceptance/import-resolution.ts — polyglot import resolution.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearLanguageCache } from "../../../src/project";
+import {
+  languageFromExtension,
+  MAX_FILE_LINES,
+  readCapped,
+  resolveLanguage,
+} from "../../../src/acceptance/import-resolution";
+import { withTempDir } from "../../helpers";
+
+afterEach(() => clearLanguageCache());
+
+describe("languageFromExtension", () => {
+  test("maps known extensions", () => {
+    expect(languageFromExtension("foo.test.ts")).toBe("typescript");
+    expect(languageFromExtension("foo_test.go")).toBe("go");
+    expect(languageFromExtension("test_foo.py")).toBe("python");
+    expect(languageFromExtension("foo_test.rs")).toBe("rust");
+    expect(languageFromExtension("foo.spec.jsx")).toBe("javascript");
+  });
+
+  test("returns undefined for no/unknown extension", () => {
+    expect(languageFromExtension(undefined)).toBeUndefined();
+    expect(languageFromExtension("Makefile")).toBeUndefined();
+    expect(languageFromExtension("foo.txt")).toBeUndefined();
+  });
+});
+
+describe("resolveLanguage", () => {
+  test("explicit language wins", async () => {
+    const lang = await resolveLanguage({ packageDir: "/tmp", language: "rust", testFilePath: "x.py" });
+    expect(lang).toBe("rust");
+  });
+
+  test("falls back to test-file extension", async () => {
+    const lang = await resolveLanguage({ packageDir: "/tmp", testFilePath: "x_test.go" });
+    expect(lang).toBe("go");
+  });
+
+  test("defaults to typescript when nothing detectable", async () => {
+    await withTempDir(async (dir) => {
+      const lang = await resolveLanguage({ packageDir: dir });
+      expect(lang).toBe("typescript");
+    });
+  });
+});
+
+describe("readCapped", () => {
+  test("reads a real file relative to packageDir", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/src/a.ts`, "export const a = 1;");
+      const result = await readCapped("src/a.ts", dir);
+      expect(result).toEqual({ path: "src/a.ts", content: "export const a = 1;" });
+    });
+  });
+
+  test("truncates to MAX_FILE_LINES", async () => {
+    await withTempDir(async (dir) => {
+      const body = Array.from({ length: MAX_FILE_LINES + 50 }, (_, i) => `line${i}`).join("\n");
+      await Bun.write(`${dir}/big.ts`, body);
+      const result = await readCapped("big.ts", dir);
+      expect(result?.content.split("\n").length).toBe(MAX_FILE_LINES);
+    });
+  });
+
+  test("returns null for a missing file", async () => {
+    await withTempDir(async (dir) => {
+      expect(await readCapped("nope.ts", dir)).toBeNull();
+    });
+  });
+});

--- a/test/unit/acceptance/import-resolution.test.ts
+++ b/test/unit/acceptance/import-resolution.test.ts
@@ -6,8 +6,10 @@ import { clearLanguageCache } from "../../../src/project";
 import {
   languageFromExtension,
   MAX_FILE_LINES,
+  parseTsImports,
   readCapped,
   resolveLanguage,
+  resolveSourceFiles,
 } from "../../../src/acceptance/import-resolution";
 import { withTempDir } from "../../helpers";
 
@@ -69,6 +71,55 @@ describe("readCapped", () => {
   test("returns null for a missing file", async () => {
     await withTempDir(async (dir) => {
       expect(await readCapped("nope.ts", dir)).toBeNull();
+    });
+  });
+});
+
+describe("parseTsImports", () => {
+  test("keeps relative imports, drops bare specifiers", () => {
+    const content = `
+import { add } from "./math";
+import { z } from "zod";
+import { b } from "../lib/b.ts";
+`;
+    expect(parseTsImports(content)).toEqual(["./math", "../lib/b.ts"]);
+  });
+});
+
+describe("resolveSourceFiles — typescript", () => {
+  test("resolves an extensionless relative import", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/math.ts`, "export const add = (a: number, b: number) => a + b;");
+      const files = await resolveSourceFiles({
+        testFileContent: `import { add } from "./math";`,
+        packageDir: dir,
+        language: "typescript",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe("./math.ts");
+    });
+  });
+
+  test("caps at 5 files even when 6 resolve", async () => {
+    await withTempDir(async (dir) => {
+      let content = "";
+      for (let i = 1; i <= 6; i++) {
+        await Bun.write(`${dir}/f${i}.ts`, `export const v${i} = ${i};`);
+        content += `import { v${i} } from "./f${i}.ts";\n`;
+      }
+      const files = await resolveSourceFiles({ testFileContent: content, packageDir: dir, language: "typescript" });
+      expect(files).toHaveLength(5);
+    });
+  });
+
+  test("degrades to [] when nothing resolves", async () => {
+    await withTempDir(async (dir) => {
+      const files = await resolveSourceFiles({
+        testFileContent: `import { x } from "./missing";`,
+        packageDir: dir,
+        language: "typescript",
+      });
+      expect(files).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Gives the acceptance fix-diagnosis LLM real source context for Python/Go/Rust, not just TS/JS, via a new `src/acceptance/import-resolution.ts` module that detects package language and dispatches to a per-language import parser + best-effort candidate-path resolver.
- `src/acceptance/fix-diagnosis.ts` is now a thin wrapper delegating to the new resolver; the one caller (`src/execution/lifecycle/acceptance-fix.ts`) is updated to the new options-object signature.
- Built and reviewed task-by-task via subagent-driven-development (6 tasks, each independently task-reviewed and approved), plus a final whole-branch review (approved, ready to merge).

## Test plan
- [x] `bun run test` — 9817 unit + 1090 integration + 21 ui, 0 failures
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean on all files this branch touches (one unrelated pre-existing `check:deep-relatives` baseline drift in `test/unit/ui/tui-cost.test.ts`, from an earlier unrelated commit, not part of this diff)