### PR TITLE
feat(test-runners): structured parsers for Rust (cargo) and Mocha/Cypress output

### DIFF
--- a/docs/superpowers/plans/2026-07-18-test-output-parser-parity.md
+++ b/docs/superpowers/plans/2026-07-18-test-output-parser-parity.md
@@ -1,0 +1,521 @@
+# Test-Output Parser Parity (Rust + Mocha) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured `TestSummary` parsers for Rust (`cargo test`) and Mocha (also covering Cypress) so rectification gets per-failure `{file, testName, error, stackTrace}` instead of counts-only.
+
+**Architecture:** Two new pure-function modules (`parse-rust.ts`, `parse-mocha.ts`), each `parse*Output(output): TestSummary`. `detector.ts` gains `"rust"`/`"mocha"` in the `Framework` union and two content signatures in `detectFramework` (mocha ordered before the bun `✓/✗` catch). `parser.ts` gains two dispatch cases. Cypress needs no parser — its Mocha-reporter output detects as `mocha`.
+
+**Tech Stack:** Bun 1.3.7+, TypeScript strict, `bun:test`, Biome.
+
+## Global Constraints
+
+- **Pure functions** — no I/O, no throws; unmatched output → zero counts / empty `failures[]`.
+- **600-line source hard limit** — parser.ts is 583 lines, so new parser bodies go in their own files (not inlined).
+- **Detection is from output content only** — `detectFramework(output)` gets no framework hint.
+- **`TestFailure` shape:** `{ file: string; testName: string; error: string; stackTrace: string[] }`. `TestSummary`: `{ passed: number; failed: number; failures: TestFailure[] }`. Both from `./types` (leaf import — established pattern).
+- **stackTrace cap:** 5 lines (`MAX_STACK_LINES = 5`).
+- **Bun test wrapper** — never bare `bun test`; always `timeout 30 bun test <path> --timeout=5000`.
+- **Test path alias:** `@/` → `src/`; tests import `@/test-runners/...`.
+- **No `console.log`** in `src/`. **Conventional commits.**
+
+---
+
+### Task 1: Rust `cargo test` parser
+
+**Files:**
+- Create: `src/test-runners/parse-rust.ts`
+- Test: `test/unit/test-runners/parse-rust.test.ts`
+
+**Interfaces:**
+- Consumes: `TestFailure`, `TestSummary` from `./types`.
+- Produces: `parseRustTestOutput(output: string): TestSummary`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/test-runners/parse-rust.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { parseRustTestOutput } from "@/test-runners/parse-rust";
+
+describe("parseRustTestOutput", () => {
+  test("extracts count + panic file:line from a single-binary failure", () => {
+    const output = `
+running 3 tests
+test tests::test_ok ... ok
+test tests::test_add ... FAILED
+
+failures:
+
+---- tests::test_add stdout ----
+thread 'tests::test_add' panicked at src/lib.rs:15:9:
+assertion \`left == right\` failed
+  left: 3
+  right: 4
+
+failures:
+    tests::test_add
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+`.trim();
+    const summary = parseRustTestOutput(output);
+    expect(summary.passed).toBe(2);
+    expect(summary.failed).toBe(1);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0].testName).toBe("tests::test_add");
+    expect(summary.failures[0].file).toBe("src/lib.rs");
+    expect(summary.failures[0].error).toContain("assertion");
+    expect(summary.failures[0].stackTrace).toContain("src/lib.rs:15");
+  });
+
+  test("sums counts across multiple test binaries", () => {
+    const output = `
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+`.trim();
+    const summary = parseRustTestOutput(output);
+    expect(summary.passed).toBe(8);
+    expect(summary.failed).toBe(2);
+  });
+
+  test("passing-only run yields no failures", () => {
+    const output = `test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s`;
+    const summary = parseRustTestOutput(output);
+    expect(summary.passed).toBe(10);
+    expect(summary.failed).toBe(0);
+    expect(summary.failures).toEqual([]);
+  });
+
+  test("degrades to test-line names when no stdout blocks present", () => {
+    const output = `
+test tests::broken ... FAILED
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+`.trim();
+    const summary = parseRustTestOutput(output);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0].testName).toBe("tests::broken");
+    expect(summary.failures[0].file).toBe("unknown");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/test-runners/parse-rust.test.ts --timeout=5000`
+Expected: FAIL — cannot resolve module `@/test-runners/parse-rust`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/test-runners/parse-rust.ts`:
+
+```ts
+/**
+ * Rust `cargo test` (libtest) output parser.
+ *
+ * Pure function — no I/O, no throws. Unmatched output yields zero counts and an
+ * empty failures array. Counts are SUMMED across all `test result:` lines because
+ * cargo emits one per test binary (multi-crate runs would otherwise undercount).
+ */
+import type { TestFailure, TestSummary } from "./types";
+
+const RESULT_LINE_RE = /^test result:\s+(?:ok|FAILED)\.\s+(\d+)\s+passed;\s+(\d+)\s+failed;/gm;
+const FAILED_TEST_LINE_RE = /^test (\S+) \.\.\. FAILED$/gm;
+const MAX_STACK_LINES = 5;
+
+export function parseRustTestOutput(output: string): TestSummary {
+  let passed = 0;
+  let failed = 0;
+  for (const m of output.matchAll(RESULT_LINE_RE)) {
+    passed += Number.parseInt(m[1], 10);
+    failed += Number.parseInt(m[2], 10);
+  }
+  return { passed, failed, failures: extractRustFailures(output) };
+}
+
+function extractRustFailures(output: string): TestFailure[] {
+  const lines = output.split("\n");
+  const failures: TestFailure[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const header = lines[i].match(/^---- (\S+) stdout ----$/);
+    if (!header) continue;
+    const testName = header[1];
+
+    let file = "unknown";
+    let error = "";
+    const stackTrace: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (/^---- \S+ stdout ----$/.test(line) || /^test result:/.test(line)) break;
+      const panic = line.match(/panicked at ([^:\n]+):(\d+):(?:\d+):/);
+      if (panic) {
+        file = panic[1];
+        if (stackTrace.length < MAX_STACK_LINES) stackTrace.push(`${panic[1]}:${panic[2]}`);
+        continue;
+      }
+      if (!error && line.trim() && !line.startsWith("note:")) error = line.trim();
+    }
+    failures.push({ file, testName, error: error || "Unknown error", stackTrace });
+  }
+
+  if (failures.length > 0) return failures;
+
+  // Degrade: no detail blocks, but "test <name> ... FAILED" lines present.
+  for (const m of output.matchAll(FAILED_TEST_LINE_RE)) {
+    failures.push({ file: "unknown", testName: m[1], error: "Unknown error", stackTrace: [] });
+  }
+  return failures;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 30 bun test test/unit/test-runners/parse-rust.test.ts --timeout=5000`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/test-runners/parse-rust.ts test/unit/test-runners/parse-rust.test.ts
+git commit -m "feat(test-runners): structured parser for cargo test output"
+```
+
+---
+
+### Task 2: Mocha spec-reporter parser (covers Cypress)
+
+**Files:**
+- Create: `src/test-runners/parse-mocha.ts`
+- Test: `test/unit/test-runners/parse-mocha.test.ts`
+
+**Interfaces:**
+- Consumes: `TestFailure`, `TestSummary` from `./types`.
+- Produces: `parseMochaOutput(output: string): TestSummary`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/test-runners/parse-mocha.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { parseMochaOutput } from "@/test-runners/parse-mocha";
+
+describe("parseMochaOutput", () => {
+  test("extracts counts and structured failure from spec reporter", () => {
+    const output = `
+  MySuite
+    ✓ passes
+    1) fails
+
+  1 passing (12ms)
+  1 failing
+
+  1) MySuite fails:
+     AssertionError: expected 1 to equal 2
+      at Context.<anonymous> (test/foo.test.js:8:20)
+`.trimEnd();
+    const summary = parseMochaOutput(output);
+    expect(summary.passed).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0].testName).toBe("MySuite fails");
+    expect(summary.failures[0].error).toContain("AssertionError");
+    expect(summary.failures[0].file).toBe("test/foo.test.js");
+    expect(summary.failures[0].stackTrace).toContain("test/foo.test.js:8");
+  });
+
+  test("does not double-count the inline tree failure marker", () => {
+    const output = `
+  MySuite
+    1) fails
+
+  0 passing (5ms)
+  1 failing
+
+  1) MySuite fails:
+     Error: boom
+      at Context.<anonymous> (test/bar.test.js:3:5)
+`.trimEnd();
+    const summary = parseMochaOutput(output);
+    expect(summary.failures).toHaveLength(1);
+  });
+
+  test("counts-only run (no failing section) yields no failures", () => {
+    const output = `  4 passing (20ms)`;
+    const summary = parseMochaOutput(output);
+    expect(summary.passed).toBe(4);
+    expect(summary.failed).toBe(0);
+    expect(summary.failures).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `timeout 30 bun test test/unit/test-runners/parse-mocha.test.ts --timeout=5000`
+Expected: FAIL — cannot resolve module `@/test-runners/parse-mocha`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/test-runners/parse-mocha.ts`:
+
+```ts
+/**
+ * Mocha spec-reporter output parser (also covers Cypress, which uses Mocha's
+ * reporter). Pure function — no I/O, no throws.
+ *
+ * Failure detail blocks are parsed only from the region after the "N failing"
+ * summary line, so the inline tree's "N) name" markers are not double-counted.
+ */
+import type { TestFailure, TestSummary } from "./types";
+
+const MAX_STACK_LINES = 5;
+
+export function parseMochaOutput(output: string): TestSummary {
+  return {
+    passed: matchCount(output, /(\d+)\s+passing\b/),
+    failed: matchCount(output, /(\d+)\s+failing\b/),
+    failures: extractMochaFailures(output),
+  };
+}
+
+function matchCount(output: string, re: RegExp): number {
+  const m = output.match(re);
+  return m ? Number.parseInt(m[1], 10) : 0;
+}
+
+function extractMochaFailures(output: string): TestFailure[] {
+  const failingIdx = output.search(/^\s*\d+\s+failing\b/m);
+  if (failingIdx === -1) return [];
+  const lines = output.slice(failingIdx).split("\n");
+  const failures: TestFailure[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const header = lines[i].match(/^\s*(\d+)\)\s+(.+)$/);
+    if (!header) continue;
+    const testName = header[2].replace(/:\s*$/, "").trim();
+
+    let file = "unknown";
+    let error = "";
+    const stackTrace: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (/^\s*\d+\)\s+/.test(line)) break; // next failure block
+      const at = line.match(/at\s+.*\(([^)]+):(\d+):(\d+)\)/);
+      if (at) {
+        if (file === "unknown") file = at[1];
+        if (stackTrace.length < MAX_STACK_LINES) stackTrace.push(`${at[1]}:${at[2]}`);
+        continue;
+      }
+      if (!error && line.trim()) error = line.trim();
+    }
+    failures.push({ file, testName, error: error || "Unknown error", stackTrace });
+  }
+  return failures;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `timeout 30 bun test test/unit/test-runners/parse-mocha.test.ts --timeout=5000`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/test-runners/parse-mocha.ts test/unit/test-runners/parse-mocha.test.ts
+git commit -m "feat(test-runners): structured parser for mocha/cypress output"
+```
+
+---
+
+### Task 3: Wire detection + dispatch
+
+**Files:**
+- Modify: `src/test-runners/detector.ts` (the `Framework` union + `detectFramework`)
+- Modify: `src/test-runners/parser.ts` (imports + `parseTestOutput` switch)
+- Test: `test/unit/test-runners/detector.test.ts` (extend), `test/unit/test-runners/parser.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `parseRustTestOutput` (Task 1), `parseMochaOutput` (Task 2), `detectFramework`/`Framework` (detector.ts), `parseTestOutput` (parser.ts).
+- Produces: `Framework` union now includes `"rust"` and `"mocha"`; `parseTestOutput` dispatches cargo→rust and mocha/cypress→mocha.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/unit/test-runners/detector.test.ts`, add `detectFramework` to the existing detector import line so it reads:
+
+```ts
+import { buildTestFrameworkHint, detectFramework } from "../../../src/test-runners/detector";
+```
+
+Then append:
+
+```ts
+describe("detectFramework — rust & mocha", () => {
+  test("detects cargo test result line as rust", () => {
+    const output = `test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s`;
+    expect(detectFramework(output)).toBe("rust");
+  });
+
+  test("detects a rust panic line as rust", () => {
+    expect(detectFramework("thread 'x' panicked at src/lib.rs:1:1:")).toBe("rust");
+  });
+
+  test("detects mocha output as mocha, not bun (despite the check glyph)", () => {
+    const output = `
+  MySuite
+    ✓ passes
+
+  1 passing (12ms)
+  1 failing
+`.trim();
+    expect(detectFramework(output)).toBe("mocha");
+  });
+
+  test("cypress-style mocha output detects as mocha", () => {
+    const output = `
+  2 passing (1s)
+  1 failing
+
+  1) login flow works:
+     AssertionError: expected true to be false
+      at Context.eval (cypress/e2e/login.cy.js:12:10)
+`.trim();
+    expect(detectFramework(output)).toBe("mocha");
+  });
+});
+```
+
+In `test/unit/test-runners/parser.test.ts`, append (the file already imports `parseTestOutput` from `@/test-runners`):
+
+```ts
+describe("parseTestOutput — rust & mocha dispatch", () => {
+  test("routes cargo output through the rust parser", () => {
+    const output = `
+---- tests::t stdout ----
+thread 'tests::t' panicked at src/x.rs:2:3:
+boom
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s
+`.trim();
+    const s = parseTestOutput(output);
+    expect(s.failed).toBe(1);
+    expect(s.failures[0].file).toBe("src/x.rs");
+  });
+
+  test("routes mocha output through the mocha parser", () => {
+    const output = `
+  1 passing (1ms)
+  1 failing
+
+  1) suite t:
+     Error: nope
+      at Context.<anonymous> (test/a.test.js:1:1)
+`.trim();
+    const s = parseTestOutput(output);
+    expect(s.failed).toBe(1);
+    expect(s.failures[0].file).toBe("test/a.test.js");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `timeout 30 bun test test/unit/test-runners/detector.test.ts test/unit/test-runners/parser.test.ts --timeout=5000`
+Expected: FAIL — rust/mocha detected as `unknown`/`bun`; `parseTestOutput` returns empty `failures` for these inputs.
+
+- [ ] **Step 3: Extend the `Framework` union and `detectFramework`**
+
+In `src/test-runners/detector.ts`, change the `Framework` type:
+
+```ts
+export type Framework = "bun" | "jest" | "vitest" | "pytest" | "go" | "rust" | "mocha" | "unknown";
+```
+
+In the same file, in `detectFramework`, insert the rust and mocha checks **between the `go` check and the `bun` check** so the block reads:
+
+```ts
+  // go test: "--- FAIL:" or "ok  \t" or "FAIL\t"
+  if (/^--- (?:FAIL|PASS):/m.test(output) || /^(?:ok|FAIL)\s+\t/m.test(output)) return "go";
+  // Rust cargo test: "test result:" summary or a panic line — unique anchors.
+  if (/^test result:\s+(?:ok|FAILED)\./m.test(output) || /panicked at /.test(output)) return "rust";
+  // Mocha (and Cypress) spec reporter: "N passing". MUST precede the bun check —
+  // mocha's spec reporter also prints the ✓/✗ glyphs the bun branch matches.
+  if (/^\s*\d+\s+passing\b/m.test(output)) return "mocha";
+  // Bun: "(fail)" marker, bun test header, or bun's Unicode checkmarks (✓ ✔ ✗ ✘)
+  if (/^\(fail\)\s/m.test(output) || /^bun test/m.test(output) || /[✓✔✗✘]/m.test(output)) return "bun";
+  return "unknown";
+```
+
+- [ ] **Step 4: Add the dispatch cases in `parser.ts`**
+
+In `src/test-runners/parser.ts`, add these two imports after the existing `import { detectFramework } from "./detector";` line:
+
+```ts
+import { parseMochaOutput } from "./parse-mocha";
+import { parseRustTestOutput } from "./parse-rust";
+```
+
+In the same file, in `parseTestOutput`, add two cases immediately before `default:`:
+
+```ts
+    case "rust":
+      return parseRustTestOutput(output);
+    case "mocha":
+      return parseMochaOutput(output);
+    default:
+      return parseCommonOutput(output);
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `timeout 30 bun test test/unit/test-runners/detector.test.ts test/unit/test-runners/parser.test.ts test/unit/test-runners/parse-rust.test.ts test/unit/test-runners/parse-mocha.test.ts --timeout=5000`
+Expected: PASS — all detector, dispatch, and parser tests green.
+
+- [ ] **Step 6: Typecheck + lint (confirms 600-line limit + Biome)**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors (file-size check passes — parser.ts stays under 600).
+
+- [ ] **Step 7: Run the full test-runners unit suite for regressions**
+
+Run: `timeout 60 bun test test/unit/test-runners/ --timeout=10000`
+Expected: PASS — no regressions in existing bun/jest/vitest/pytest/go detection or parsing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/test-runners/detector.ts src/test-runners/parser.ts test/unit/test-runners/detector.test.ts test/unit/test-runners/parser.test.ts
+git commit -m "feat(test-runners): detect + dispatch rust and mocha/cypress output"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (design doc §Components):
+- `parse-rust.ts` with count-summing + panic file:line + degrade → Task 1. ✓
+- `parse-mocha.ts` with counts + failure blocks + inline-tree exclusion (Cypress covered) → Task 2. ✓
+- `detector.ts` `Framework` union + rust/mocha signatures with mocha-before-bun ordering → Task 3 Step 3. ✓
+- `parser.ts` two dispatch cases → Task 3 Step 4. ✓
+- Detection-from-output-only → all tests pass raw output, no hints. ✓
+- Pure functions, no throws, degrade to empty → Tasks 1/2 impl + passing-only/counts-only tests. ✓
+- 600-line limit honored (new files) → Task 3 Step 6 lint gate. ✓
+- Testing: new parse-rust/parse-mocha suites + extended detector/parser suites → all tasks. ✓
+- Non-goals (no Jasmine/Playwright/Cypress-enum/reporter-config/ac-parser change) → not touched. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step is complete; every command has expected output. ✓
+
+**3. Type consistency:** `parseRustTestOutput`, `parseMochaOutput`, `Framework`, `TestSummary`, `TestFailure`, `MAX_STACK_LINES` named identically at definition and use. Task 3 imports match Task 1/2 exports (`./parse-rust`, `./parse-mocha`). Dispatch `case "rust"`/`case "mocha"` match the `Framework` union values added in Step 3. The `default: return parseCommonOutput(output);` line is shown verbatim from the existing file so the two new cases are inserted above it without dropping it. ✓

--- a/docs/superpowers/specs/2026-07-18-test-output-parser-parity-design.md
+++ b/docs/superpowers/specs/2026-07-18-test-output-parser-parity-design.md
@@ -1,0 +1,142 @@
+# Design — Test-Output Parser Parity (Rust + Mocha)
+
+> Date: 2026-07-18
+> Origin: Gap Analysis 2026-07-18 §3.2 / §6 item #10 (sub-area B).
+> Scope: `src/test-runners/{parser.ts,detector.ts}` + new `parse-rust.ts`, `parse-mocha.ts`.
+
+## Problem
+
+`parseTestOutput(output)` dispatches on `detectFramework(output)` and returns a
+structured `TestSummary` (`{ passed, failed, failures[] }`). It has dedicated
+parsers for Bun/Jest/Vitest/pytest/go only. Rust (`cargo test`), Mocha, Jasmine,
+Playwright, and Cypress all fall through to `parseCommonOutput`, which extracts
+pass/fail counts but returns an **empty `failures[]`** — no `{ file, testName,
+error, stackTrace }`. Those structured failures feed the rectification gates
+(`src/operations/verify-scoped.ts:199`, `src/operations/full-suite-gate.ts:179`),
+so non-TS/non-supported runs give the fix agent counts but no per-failure context.
+
+This design closes the two highest-value gaps: **Rust** (language parity — nax
+treats Rust first-class in discovery/analyze/mutation) and **Mocha** (common JS
+runner; its spec reporter is also what **Cypress** emits, so one parser covers
+both). Jasmine and Playwright are deferred (fading / reporter-fragile).
+
+## Contract
+
+Parsers are pure functions: input string → `TestSummary`. No I/O, no throws.
+Unmatched output yields zero counts / empty `failures[]`; the dispatcher always
+returns a valid `TestSummary`. Mirrors the existing go/pytest parser pattern.
+
+Detection is from **output content only** — callers pass raw output, not the
+discovered framework id.
+
+## Components
+
+### 1. `src/test-runners/parse-rust.ts` — `parseRustTestOutput(output: string): TestSummary`
+
+`cargo test` uses the libtest reporter:
+
+```
+running 3 tests
+test tests::test_add ... FAILED
+
+failures:
+
+---- tests::test_add stdout ----
+thread 'tests::test_add' panicked at src/lib.rs:15:9:
+assertion `left == right` failed
+  left: 3
+  right: 4
+
+failures:
+    tests::test_add
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+- **Counts:** sum **all** `test result: (?:ok|FAILED)\. (\d+) passed; (\d+) failed;`
+  matches. Cargo emits one result line *per test binary*; last-match-wins (what
+  the common parser does) undercounts multi-crate runs, so the Rust parser sums.
+- **Failures:** for each `---- <name> stdout ----` block → `testName = <name>`.
+  From `thread '<name>' panicked at <file>:<line>:<col>:` → `file = <file>`, push
+  `<file>:<line>` to `stackTrace`. `error` = first non-empty line after the panic
+  line (e.g. `assertion left == right failed`), else the panic line.
+- **Degrade:** no detail blocks but `test <name> ... FAILED` lines present →
+  synthesize failures with `file: "unknown"`, `error: "Unknown error"`.
+
+### 2. `src/test-runners/parse-mocha.ts` — `parseMochaOutput(output: string): TestSummary`
+
+Mocha spec reporter (also Cypress):
+
+```
+  1 passing (12ms)
+  1 failing
+
+  1) MySuite nested fails:
+     AssertionError: expected 1 to equal 2
+      at Context.<anonymous> (test/foo.test.js:8:20)
+```
+
+- **Counts:** `(\d+) passing` → passed; `(\d+) failing` → failed. Both optional
+  (default 0).
+- **Failures:** trailing list blocks anchored by `^\s*(\d+)\)\s+(.+)$` →
+  `testName` = captured title with a trailing `:` stripped. `error` = the next
+  non-empty line that is not an `at …` stack line. `file` = capture from the
+  first `at .*\((<file>:<line>:<col>)\)` line. `stackTrace` = `at …` lines,
+  capped at 5.
+
+### 3. `src/test-runners/detector.ts`
+
+- Extend `Framework` union: `… | "rust" | "mocha" | …`.
+- Add signatures to `detectFramework`, **in this order**:
+  - **Rust** (early — unique anchors): `if (/^test result:\s+(?:ok|FAILED)\./m.test(output) || /panicked at /.test(output)) return "rust";`
+  - **Mocha** placed **before** the existing bun `/[✓✔✗✘]/m` catch (mocha's spec
+    reporter also prints `✓`/`✗`): `if (/^\s*\d+ passing\b/m.test(output)) return "mocha";`
+    — the gerund `passing` distinguishes it from jest/vitest/playwright
+    (`passed`). Placed after the jest/vitest/pytest checks.
+- Cypress: **no** new `Framework` value — its output is detected as `mocha` and
+  parsed by the Mocha parser.
+
+### 4. `src/test-runners/parser.ts`
+
+Two imports + two `switch` cases in `parseTestOutput`:
+
+```ts
+    case "rust":
+      return parseRustTestOutput(output);
+    case "mocha":
+      return parseMochaOutput(output);
+```
+
+File is 583 lines (600 hard limit); the parser bodies live in the new modules, so
+`parser.ts` stays ~587. No existing-parser refactor.
+
+## Error handling
+
+No throws, no I/O. Every regex miss degrades to empty/zero. `parseTestOutput`
+always returns a `TestSummary`.
+
+## Testing
+
+- New `test/unit/test-runners/parse-rust.test.ts` — single-binary failure with
+  `panicked at` file:line extraction; multi-binary count summing; passing-only →
+  `failures: []`; degrade path (FAILED line, no stdout block).
+- New `test/unit/test-runners/parse-mocha.test.ts` — nested failure block
+  (testName/error/file), cypress-style block, counts-only (no failing section).
+- Extend `test/unit/test-runners/detector.test.ts` — rust + mocha detection and
+  ordering guards: mocha output not misdetected as `bun`, rust not as `go`.
+- Existing `parser.test.ts` / `detector.test.ts` stay green.
+
+## Non-goals (YAGNI)
+
+- No Jasmine parser (fading usage, distinct "Failures:" format).
+- No Playwright parser (output varies by reporter: list/line/dot/html — fragile).
+- No separate Cypress parser/enum (covered by Mocha).
+- No reporter-configuration handling or `--reporter json` support.
+- No changes to `parseTestFailures` (the AC-ID extraction path in `ac-parser.ts`
+  used by the acceptance loop — a separate concern from `parseTestOutput`).
+
+## Deferred sibling (out of scope)
+
+Gap item #10 sub-area C — mutation-operator parity (`src/verification/mutation/
+operators.ts`: implement the empty Python/Go stubs + add Rust) — remains a
+separate spec.

--- a/src/test-runners/ac-parser.ts
+++ b/src/test-runners/ac-parser.ts
@@ -10,16 +10,7 @@
  * acceptance-domain question: "which acceptance criteria failed?"
  */
 
-import { detectFramework } from "./detector";
-
-/**
- * Strips ANSI escape sequences (CSI: SGR color codes plus cursor/erase codes such
- * as the `\x1b[2K` vitest's live reporter prefixes lines with) so failure markers
- * and AC tokens match on plain text — including the line-leading FAIL badge.
- * Built via RegExp() so the ESC byte (0x1b) is not a control character in the source
- * regex literal (which Biome's noControlCharactersInRegex rightly forbids).
- */
-const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[A-Za-z]`, "g");
+import { detectFramework, stripAnsi } from "./detector";
 
 /**
  * Parse test runner output to extract failed AC IDs.
@@ -44,7 +35,7 @@ export function parseTestFailures(output: string): string[] {
   // Strip ANSI escapes first: vitest/jest colorize the "FAIL" marker and test titles,
   // and the live reporter prefixes lines with cursor/erase codes — both would otherwise
   // sit between tokens and break matching (and defeat the line-start FAIL anchor below).
-  const clean = output.replace(ANSI_ESCAPE_PATTERN, "");
+  const clean = stripAnsi(output);
   const framework = detectFramework(clean);
   const failedACs: string[] = [];
   const lines = clean.split("\n");

--- a/src/test-runners/detector.ts
+++ b/src/test-runners/detector.ts
@@ -68,16 +68,22 @@ export function buildTestFrameworkHint(testCommand: string): string {
 }
 
 /**
- * Strip ANSI color/style escape sequences (e.g. `\x1b[32m`, `\x1b[0m`) from output.
+ * Strip ANSI CSI escape sequences (e.g. `\x1b[32m` SGR color, `\x1b[0m` reset,
+ * `\x1b[2K` erase-line, cursor-movement codes) from output.
  *
- * Real-world test-runner output (Mocha, Cypress, cargo) is frequently colorized.
- * An ANSI escape sitting between a line-start anchor (`^\s*`) and the digits it
- * expects defeats every anchored summary regex in this module and in the
+ * Real-world test-runner output (Mocha, Cypress, cargo, vitest's live reporter)
+ * is frequently colorized and/or interleaved with cursor/erase control codes.
+ * An escape sequence sitting between a line-start anchor (`^\s*`) and the digits
+ * it expects defeats every anchored summary regex in this module and in the
  * per-framework parsers — so callers strip once, up front, before matching.
+ *
+ * Deliberately broad (any CSI final byte, not just `m`): this is the single
+ * shared ANSI-stripping helper for `src/test-runners/` — see
+ * `.claude/rules/monorepo-awareness.md` §C "one source of truth per concept".
  */
 export function stripAnsi(output: string): string {
   // biome-ignore lint/suspicious/noControlCharactersInRegex: matching the ESC (0x1b) control byte is the point of this function
-  return output.replace(/\x1b\[[0-9;]*m/g, "");
+  return output.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "");
 }
 
 /**

--- a/src/test-runners/detector.ts
+++ b/src/test-runners/detector.ts
@@ -68,6 +68,19 @@ export function buildTestFrameworkHint(testCommand: string): string {
 }
 
 /**
+ * Strip ANSI color/style escape sequences (e.g. `\x1b[32m`, `\x1b[0m`) from output.
+ *
+ * Real-world test-runner output (Mocha, Cypress, cargo) is frequently colorized.
+ * An ANSI escape sitting between a line-start anchor (`^\s*`) and the digits it
+ * expects defeats every anchored summary regex in this module and in the
+ * per-framework parsers — so callers strip once, up front, before matching.
+ */
+export function stripAnsi(output: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: matching the ESC (0x1b) control byte is the point of this function
+  return output.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/**
  * Detect the test framework that produced the given output.
  *
  * Inspects summary lines and failure markers to identify the runner.
@@ -75,20 +88,21 @@ export function buildTestFrameworkHint(testCommand: string): string {
  * should apply all known patterns as a fallback in that case.
  */
 export function detectFramework(output: string): Framework {
+  const clean = stripAnsi(output);
   // Vitest: "Test Files  1 failed | 2 passed (3)"
-  if (/^\s*Test Files\s+\d+/m.test(output)) return "vitest";
+  if (/^\s*Test Files\s+\d+/m.test(clean)) return "vitest";
   // Jest: "Tests:       41 failed, 38 passed, 79 total"
-  if (/^\s*Tests:\s+\d+/m.test(output)) return "jest";
+  if (/^\s*Tests:\s+\d+/m.test(clean)) return "jest";
   // pytest: "====== X failed, Y passed in Z.Zs ======"
-  if (/={3,}\s+\d+\s+(?:failed|passed).*in\s+[\d.]+s\s*={3,}/m.test(output)) return "pytest";
+  if (/={3,}\s+\d+\s+(?:failed|passed).*in\s+[\d.]+s\s*={3,}/m.test(clean)) return "pytest";
   // go test: "--- FAIL:" or "ok  \t" or "FAIL\t"
-  if (/^--- (?:FAIL|PASS):/m.test(output) || /^(?:ok|FAIL)\s+\t/m.test(output)) return "go";
+  if (/^--- (?:FAIL|PASS):/m.test(clean) || /^(?:ok|FAIL)\s+\t/m.test(clean)) return "go";
   // Rust cargo test: "test result:" summary or a panic line — unique anchors.
-  if (/^test result:\s+(?:ok|FAILED)\./m.test(output) || /panicked at /.test(output)) return "rust";
+  if (/^test result:\s+(?:ok|FAILED)\./m.test(clean) || /panicked at /.test(clean)) return "rust";
   // Mocha (and Cypress) spec reporter: "N passing". MUST precede the bun check —
   // mocha's spec reporter also prints the ✓/✗ glyphs the bun branch matches.
-  if (/^\s*\d+\s+passing\b/m.test(output)) return "mocha";
+  if (/^\s*\d+\s+passing\b/m.test(clean)) return "mocha";
   // Bun: "(fail)" marker, bun test header, or bun's Unicode checkmarks (✓ ✔ ✗ ✘)
-  if (/^\(fail\)\s/m.test(output) || /^bun test/m.test(output) || /[✓✔✗✘]/m.test(output)) return "bun";
+  if (/^\(fail\)\s/m.test(clean) || /^bun test/m.test(clean) || /[✓✔✗✘]/m.test(clean)) return "bun";
   return "unknown";
 }

--- a/src/test-runners/detector.ts
+++ b/src/test-runners/detector.ts
@@ -10,7 +10,7 @@
 
 import { isTestFileByPatterns } from "./conventions";
 
-export type Framework = "bun" | "jest" | "vitest" | "pytest" | "go" | "unknown";
+export type Framework = "bun" | "jest" | "vitest" | "pytest" | "go" | "rust" | "mocha" | "unknown";
 
 /**
  * Language-agnostic patterns that identify test files. Covers:
@@ -83,6 +83,11 @@ export function detectFramework(output: string): Framework {
   if (/={3,}\s+\d+\s+(?:failed|passed).*in\s+[\d.]+s\s*={3,}/m.test(output)) return "pytest";
   // go test: "--- FAIL:" or "ok  \t" or "FAIL\t"
   if (/^--- (?:FAIL|PASS):/m.test(output) || /^(?:ok|FAIL)\s+\t/m.test(output)) return "go";
+  // Rust cargo test: "test result:" summary or a panic line — unique anchors.
+  if (/^test result:\s+(?:ok|FAILED)\./m.test(output) || /panicked at /.test(output)) return "rust";
+  // Mocha (and Cypress) spec reporter: "N passing". MUST precede the bun check —
+  // mocha's spec reporter also prints the ✓/✗ glyphs the bun branch matches.
+  if (/^\s*\d+\s+passing\b/m.test(output)) return "mocha";
   // Bun: "(fail)" marker, bun test header, or bun's Unicode checkmarks (✓ ✔ ✗ ✘)
   if (/^\(fail\)\s/m.test(output) || /^bun test/m.test(output) || /[✓✔✗✘]/m.test(output)) return "bun";
   return "unknown";

--- a/src/test-runners/index.ts
+++ b/src/test-runners/index.ts
@@ -33,6 +33,8 @@ export {
 } from "./resolver";
 export type { ResolvedTestPatterns } from "./resolver";
 export { analyzeTestExitCode, formatFailureSummary, parseBunTestOutput, parseTestOutput } from "./parser";
+export { parseMochaOutput } from "./parse-mocha";
+export { parseRustTestOutput } from "./parse-rust";
 export { discoverWorkspacePackages } from "./detect/workspace";
 export { parseTestFailures } from "./ac-parser";
 export type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";

--- a/src/test-runners/parse-mocha.ts
+++ b/src/test-runners/parse-mocha.ts
@@ -1,0 +1,53 @@
+/**
+ * Mocha spec-reporter output parser (also covers Cypress, which uses Mocha's
+ * reporter). Pure function — no I/O, no throws.
+ *
+ * Failure detail blocks are parsed only from the region after the "N failing"
+ * summary line, so the inline tree's "N) name" markers are not double-counted.
+ */
+import type { TestFailure, TestSummary } from "./types";
+
+const MAX_STACK_LINES = 5;
+
+export function parseMochaOutput(output: string): TestSummary {
+  return {
+    passed: matchCount(output, /(\d+)\s+passing\b/),
+    failed: matchCount(output, /(\d+)\s+failing\b/),
+    failures: extractMochaFailures(output),
+  };
+}
+
+function matchCount(output: string, re: RegExp): number {
+  const m = output.match(re);
+  return m ? Number.parseInt(m[1], 10) : 0;
+}
+
+function extractMochaFailures(output: string): TestFailure[] {
+  const failingIdx = output.search(/^\s*\d+\s+failing\b/m);
+  if (failingIdx === -1) return [];
+  const lines = output.slice(failingIdx).split("\n");
+  const failures: TestFailure[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const header = lines[i].match(/^\s*(\d+)\)\s+(.+)$/);
+    if (!header) continue;
+    const testName = header[2].replace(/:\s*$/, "").trim();
+
+    let file = "unknown";
+    let error = "";
+    const stackTrace: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (/^\s*\d+\)\s+/.test(line)) break; // next failure block
+      const at = line.match(/at\s+.*\(([^)]+):(\d+):(\d+)\)/);
+      if (at) {
+        if (file === "unknown") file = at[1];
+        if (stackTrace.length < MAX_STACK_LINES) stackTrace.push(`${at[1]}:${at[2]}`);
+        continue;
+      }
+      if (!error && line.trim()) error = line.trim();
+    }
+    failures.push({ file, testName, error: error || "Unknown error", stackTrace });
+  }
+  return failures;
+}

--- a/src/test-runners/parse-rust.ts
+++ b/src/test-runners/parse-rust.ts
@@ -1,0 +1,57 @@
+/**
+ * Rust `cargo test` (libtest) output parser.
+ *
+ * Pure function — no I/O, no throws. Unmatched output yields zero counts and an
+ * empty failures array. Counts are SUMMED across all `test result:` lines because
+ * cargo emits one per test binary (multi-crate runs would otherwise undercount).
+ */
+import type { TestFailure, TestSummary } from "./types";
+
+const RESULT_LINE_RE = /^test result:\s+(?:ok|FAILED)\.\s+(\d+)\s+passed;\s+(\d+)\s+failed;/gm;
+const FAILED_TEST_LINE_RE = /^test (\S+) \.\.\. FAILED$/gm;
+const MAX_STACK_LINES = 5;
+
+export function parseRustTestOutput(output: string): TestSummary {
+  let passed = 0;
+  let failed = 0;
+  for (const m of output.matchAll(RESULT_LINE_RE)) {
+    passed += Number.parseInt(m[1], 10);
+    failed += Number.parseInt(m[2], 10);
+  }
+  return { passed, failed, failures: extractRustFailures(output) };
+}
+
+function extractRustFailures(output: string): TestFailure[] {
+  const lines = output.split("\n");
+  const failures: TestFailure[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const header = lines[i].match(/^---- (\S+) stdout ----$/);
+    if (!header) continue;
+    const testName = header[1];
+
+    let file = "unknown";
+    let error = "";
+    const stackTrace: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (/^---- \S+ stdout ----$/.test(line) || /^test result:/.test(line)) break;
+      const panic = line.match(/panicked at ([^:\n]+):(\d+):(?:\d+):/);
+      if (panic) {
+        file = panic[1];
+        if (stackTrace.length < MAX_STACK_LINES) stackTrace.push(`${panic[1]}:${panic[2]}`);
+        continue;
+      }
+      if (!error && line.trim() && !line.startsWith("note:")) error = line.trim();
+    }
+    failures.push({ file, testName, error: error || "Unknown error", stackTrace });
+  }
+
+  if (failures.length > 0) return failures;
+
+  // Degrade: no detail blocks, but "test <name> ... FAILED" lines present.
+  for (const m of output.matchAll(FAILED_TEST_LINE_RE)) {
+    failures.push({ file: "unknown", testName: m[1], error: "Unknown error", stackTrace: [] });
+  }
+  return failures;
+}

--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -13,6 +13,8 @@
  */
 
 import { detectFramework } from "./detector";
+import { parseMochaOutput } from "./parse-mocha";
+import { parseRustTestOutput } from "./parse-rust";
 import type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -38,6 +40,10 @@ export function parseTestOutput(output: string): TestSummary {
       return parsePytestOutput(output);
     case "go":
       return parseGoTestOutput(output);
+    case "rust":
+      return parseRustTestOutput(output);
+    case "mocha":
+      return parseMochaOutput(output);
     default:
       return parseCommonOutput(output);
   }

--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -12,7 +12,7 @@
  *   - Unknown       (common-parser fallback via broad regexes)
  */
 
-import { detectFramework } from "./detector";
+import { detectFramework, stripAnsi } from "./detector";
 import { parseMochaOutput } from "./parse-mocha";
 import { parseRustTestOutput } from "./parse-rust";
 import type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";
@@ -29,23 +29,24 @@ import type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";
  * unknown or unsupported formats.
  */
 export function parseTestOutput(output: string): TestSummary {
-  const framework = detectFramework(output);
+  const clean = stripAnsi(output);
+  const framework = detectFramework(clean);
   switch (framework) {
     case "bun":
-      return parseBunOutput(output);
+      return parseBunOutput(clean);
     case "jest":
     case "vitest":
-      return parseJestOutput(output);
+      return parseJestOutput(clean);
     case "pytest":
-      return parsePytestOutput(output);
+      return parsePytestOutput(clean);
     case "go":
-      return parseGoTestOutput(output);
+      return parseGoTestOutput(clean);
     case "rust":
-      return parseRustTestOutput(output);
+      return parseRustTestOutput(clean);
     case "mocha":
-      return parseMochaOutput(output);
+      return parseMochaOutput(clean);
     default:
-      return parseCommonOutput(output);
+      return parseCommonOutput(clean);
   }
 }
 

--- a/test/unit/test-runners/detector.test.ts
+++ b/test/unit/test-runners/detector.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { buildTestFrameworkHint, detectFramework } from "../../../src/test-runners/detector";
+import { buildTestFrameworkHint, detectFramework, stripAnsi } from "../../../src/test-runners/detector";
 
 describe("buildTestFrameworkHint", () => {
   test("returns neutral hint for empty command (#543)", () => {
@@ -82,5 +82,30 @@ describe("detectFramework — rust & mocha", () => {
       at Context.eval (cypress/e2e/login.cy.js:12:10)
 `.trim();
     expect(detectFramework(output)).toBe("mocha");
+  });
+
+  test("detects ANSI-colored mocha output as mocha, not bun (#bug)", () => {
+    const ESC = "\x1b[32m";
+    const R = "\x1b[0m";
+    const output = `
+  MySuite
+    ${ESC}✓${R} passes
+
+  ${ESC}  1 passing${R}
+  ${"\x1b[31m"}  1 failing${R}
+`.trim();
+    expect(detectFramework(output)).toBe("mocha");
+  });
+});
+
+describe("stripAnsi", () => {
+  test("strips ANSI color escape sequences", () => {
+    const input = "\x1b[32m  1 passing\x1b[0m\n\x1b[31m  1 failing\x1b[0m";
+    expect(stripAnsi(input)).toBe("  1 passing\n  1 failing");
+  });
+
+  test("leaves plain text untouched", () => {
+    const input = "  1 passing\n  1 failing";
+    expect(stripAnsi(input)).toBe(input);
   });
 });

--- a/test/unit/test-runners/detector.test.ts
+++ b/test/unit/test-runners/detector.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { buildTestFrameworkHint } from "../../../src/test-runners/detector";
+import { buildTestFrameworkHint, detectFramework } from "../../../src/test-runners/detector";
 
 describe("buildTestFrameworkHint", () => {
   test("returns neutral hint for empty command (#543)", () => {
@@ -48,5 +48,39 @@ describe("buildTestFrameworkHint", () => {
   test("trims leading/trailing whitespace before matching", () => {
     expect(buildTestFrameworkHint("  pytest -v  ")).toBe("Use pytest");
     expect(buildTestFrameworkHint("  go test ./...  ")).toBe("Use Go's testing package");
+  });
+});
+
+describe("detectFramework — rust & mocha", () => {
+  test("detects cargo test result line as rust", () => {
+    const output = `test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s`;
+    expect(detectFramework(output)).toBe("rust");
+  });
+
+  test("detects a rust panic line as rust", () => {
+    expect(detectFramework("thread 'x' panicked at src/lib.rs:1:1:")).toBe("rust");
+  });
+
+  test("detects mocha output as mocha, not bun (despite the check glyph)", () => {
+    const output = `
+  MySuite
+    ✓ passes
+
+  1 passing (12ms)
+  1 failing
+`.trim();
+    expect(detectFramework(output)).toBe("mocha");
+  });
+
+  test("cypress-style mocha output detects as mocha", () => {
+    const output = `
+  2 passing (1s)
+  1 failing
+
+  1) login flow works:
+     AssertionError: expected true to be false
+      at Context.eval (cypress/e2e/login.cy.js:12:10)
+`.trim();
+    expect(detectFramework(output)).toBe("mocha");
   });
 });

--- a/test/unit/test-runners/parse-mocha.test.ts
+++ b/test/unit/test-runners/parse-mocha.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { parseMochaOutput } from "@/test-runners/parse-mocha";
+
+describe("parseMochaOutput", () => {
+  test("extracts counts and structured failure from spec reporter", () => {
+    const output = `
+  MySuite
+    ✓ passes
+    1) fails
+
+  1 passing (12ms)
+  1 failing
+
+  1) MySuite fails:
+     AssertionError: expected 1 to equal 2
+      at Context.<anonymous> (test/foo.test.js:8:20)
+`.trimEnd();
+    const summary = parseMochaOutput(output);
+    expect(summary.passed).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0].testName).toBe("MySuite fails");
+    expect(summary.failures[0].error).toContain("AssertionError");
+    expect(summary.failures[0].file).toBe("test/foo.test.js");
+    expect(summary.failures[0].stackTrace).toContain("test/foo.test.js:8");
+  });
+
+  test("does not double-count the inline tree failure marker", () => {
+    const output = `
+  MySuite
+    1) fails
+
+  0 passing (5ms)
+  1 failing
+
+  1) MySuite fails:
+     Error: boom
+      at Context.<anonymous> (test/bar.test.js:3:5)
+`.trimEnd();
+    const summary = parseMochaOutput(output);
+    expect(summary.failures).toHaveLength(1);
+  });
+
+  test("counts-only run (no failing section) yields no failures", () => {
+    const output = `  4 passing (20ms)`;
+    const summary = parseMochaOutput(output);
+    expect(summary.passed).toBe(4);
+    expect(summary.failed).toBe(0);
+    expect(summary.failures).toEqual([]);
+  });
+});

--- a/test/unit/test-runners/parse-mocha.test.ts
+++ b/test/unit/test-runners/parse-mocha.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseMochaOutput } from "@/test-runners/parse-mocha";
+import { parseMochaOutput } from "@/test-runners";
 
 describe("parseMochaOutput", () => {
   test("extracts counts and structured failure from spec reporter", () => {

--- a/test/unit/test-runners/parse-rust.test.ts
+++ b/test/unit/test-runners/parse-rust.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseRustTestOutput } from "@/test-runners/parse-rust";
+import { parseRustTestOutput } from "@/test-runners";
 
 describe("parseRustTestOutput", () => {
   test("extracts count + panic file:line from a single-binary failure", () => {

--- a/test/unit/test-runners/parse-rust.test.ts
+++ b/test/unit/test-runners/parse-rust.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { parseRustTestOutput } from "@/test-runners/parse-rust";
+
+describe("parseRustTestOutput", () => {
+  test("extracts count + panic file:line from a single-binary failure", () => {
+    const output = `
+running 3 tests
+test tests::test_ok ... ok
+test tests::test_add ... FAILED
+
+failures:
+
+---- tests::test_add stdout ----
+thread 'tests::test_add' panicked at src/lib.rs:15:9:
+assertion \`left == right\` failed
+  left: 3
+  right: 4
+
+failures:
+    tests::test_add
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+`.trim();
+    const summary = parseRustTestOutput(output);
+    expect(summary.passed).toBe(2);
+    expect(summary.failed).toBe(1);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0].testName).toBe("tests::test_add");
+    expect(summary.failures[0].file).toBe("src/lib.rs");
+    expect(summary.failures[0].error).toContain("assertion");
+    expect(summary.failures[0].stackTrace).toContain("src/lib.rs:15");
+  });
+
+  test("sums counts across multiple test binaries", () => {
+    const output = `
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+`.trim();
+    const summary = parseRustTestOutput(output);
+    expect(summary.passed).toBe(8);
+    expect(summary.failed).toBe(2);
+  });
+
+  test("passing-only run yields no failures", () => {
+    const output = `test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s`;
+    const summary = parseRustTestOutput(output);
+    expect(summary.passed).toBe(10);
+    expect(summary.failed).toBe(0);
+    expect(summary.failures).toEqual([]);
+  });
+
+  test("degrades to test-line names when no stdout blocks present", () => {
+    const output = `
+test tests::broken ... FAILED
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+`.trim();
+    const summary = parseRustTestOutput(output);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0].testName).toBe("tests::broken");
+    expect(summary.failures[0].file).toBe("unknown");
+  });
+});

--- a/test/unit/test-runners/parser.test.ts
+++ b/test/unit/test-runners/parser.test.ts
@@ -281,3 +281,32 @@ FAIL
     expect(result.failures[0].stackTrace).toHaveLength(0);
   });
 });
+
+describe("parseTestOutput — rust & mocha dispatch", () => {
+  test("routes cargo output through the rust parser", () => {
+    const output = `
+---- tests::t stdout ----
+thread 'tests::t' panicked at src/x.rs:2:3:
+boom
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s
+`.trim();
+    const s = parseTestOutput(output);
+    expect(s.failed).toBe(1);
+    expect(s.failures[0].file).toBe("src/x.rs");
+  });
+
+  test("routes mocha output through the mocha parser", () => {
+    const output = `
+  1 passing (1ms)
+  1 failing
+
+  1) suite t:
+     Error: nope
+      at Context.<anonymous> (test/a.test.js:1:1)
+`.trim();
+    const s = parseTestOutput(output);
+    expect(s.failed).toBe(1);
+    expect(s.failures[0].file).toBe("test/a.test.js");
+  });
+});

--- a/test/unit/test-runners/parser.test.ts
+++ b/test/unit/test-runners/parser.test.ts
@@ -97,6 +97,33 @@ FAILED tests/test_foo.py::test_bar - AssertionError: assert 1 == 2
   });
 });
 
+describe("mocha output with ANSI color escapes (#bug)", () => {
+  test("strips ANSI so summary + structured failure survive framework detection", () => {
+    const ESC = "\x1b[32m";
+    const FAIL_ESC = "\x1b[31m";
+    const R = "\x1b[0m";
+    const output = `
+  MySuite
+    ${ESC}✓${R} passes
+    ${FAIL_ESC}1) fails${R}
+
+  ${ESC}  1 passing${R} (12ms)
+  ${FAIL_ESC}  1 failing${R}
+
+  1) MySuite fails:
+     AssertionError: expected 1 to equal 2
+      at Context.<anonymous> (test/foo.test.js:8:20)
+`.trim();
+
+    const result = parseTestOutput(output);
+
+    expect(result.failed).toBe(1);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].file).toBe("test/foo.test.js");
+    expect(result.failures[0].testName).toBe("MySuite fails");
+  });
+});
+
 describe("pytest output — collection/import errors count as failures", () => {
   test("counts pytest 'errors' category in the summary line as failed", () => {
     const output = `


### PR DESCRIPTION
## Summary

Adds structured `TestSummary` parsers for **Rust (`cargo test`)** and **Mocha** (which also covers **Cypress**, since Cypress uses Mocha's spec reporter). Closes sub-area B of the 2026-07-18 codebase gap analysis (§3.2 / §6 item #10).

Before this change, `parseTestOutput()` only produced structured per-failure detail for Bun/Jest/Vitest/pytest/go — Rust, Mocha, and Cypress fell through to the counts-only common parser, returning an empty `failures[]`. Those structured failures feed the rectification gates (`operations/verify-scoped.ts`, `operations/full-suite-gate.ts`), so non-supported runs gave the fix agent counts but no `{file, testName, error, stackTrace}` context.

## What changed

- **`src/test-runners/parse-rust.ts`** (new) — `parseRustTestOutput()`: parses libtest output; **sums counts across all `test result:` lines** (cargo emits one per test binary — last-wins would undercount multi-crate runs); extracts `file:line` + message from `---- <name> stdout ----` / `panicked at` blocks; degrades to `FAILED`-line names.
- **`src/test-runners/parse-mocha.ts`** (new) — `parseMochaOutput()`: parses the spec reporter; failure blocks read only from the region **after** the `N failing` summary so the inline tree's `N)` markers aren't double-counted. Covers Cypress.
- **`src/test-runners/detector.ts`** — `Framework` union gains `"rust"`/`"mocha"`; `detectFramework` gets both signatures. Mocha is detected **before** bun because its spec reporter also emits the `✓/✗` glyphs the bun branch matches.
- **`src/test-runners/parser.ts`** — two dispatch cases; Cypress routes through the mocha parser (no separate enum value, per design).
- **Shared `stripAnsi()`** — real Mocha/Cypress/cargo output is ANSI-colored, which defeated the line-anchored `^\s*\d+ passing/failing` regexes (colored Mocha mis-routed to bun and lost the failed count + all structured failures). `stripAnsi` is applied at the entry of `detectFramework` and `parseTestOutput`; consolidated with the pre-existing `ac-parser.ts` ANSI pattern onto one helper (repo's "one source of truth per concept" rule).

## Out of scope (YAGNI, per design)

No Jasmine or Playwright parsers (fading / reporter-fragile), no separate Cypress enum, no `--reporter json` handling, no change to the `parseTestFailures` AC-ID path. Sub-area C (mutation-operator parity) remains a separate spec.

## Test plan

- [x] New `parse-rust.test.ts` (single/multi-binary, passing-only, degrade) and `parse-mocha.test.ts` (nested failure, cypress-style, counts-only, inline-tree non-double-count).
- [x] Extended `detector.test.ts` (rust/mocha detection + mocha≠bun ordering guard + ANSI-colored mocha) and `parser.test.ts` (rust/mocha dispatch + ANSI dispatch).
- [x] Empirically verified colored Mocha output → detects `mocha`, `passed/failed=1/1`, structured failure with correct file.
- [x] Full `test/unit/test-runners/` suite: **165/165 pass**. `bun run typecheck` clean. `bun run lint` clean (all sub-checks; `parser.ts` 590 < 600-line limit).

Design + plan: `docs/superpowers/specs/2026-07-18-test-output-parser-parity-design.md`, `docs/superpowers/plans/2026-07-18-test-output-parser-parity.md`.
