### PR TITLE
fix(review): honour blockingThreshold in semantic verdict (#1347)

### DIFF
--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -361,7 +361,13 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
     const { accepted, dropped } = filterByAcGroundingMinimal(substantiated, input.story.acceptanceCriteria);
 
     const blocking = accepted.filter((f) => isBlockingSeverity(f.severity, threshold));
-    const passed = parsed.passed && blocking.length === 0;
+    // Honour blockingThreshold: the verdict fails only when a blocking finding
+    // survives. The model's raw `passed:false` must NOT fail the review when every
+    // surviving finding is advisory (sub-threshold) — that was nax#1347. The
+    // `accepted.length > 0` clause preserves the fail-closed guard for the distinct
+    // case where the model claims failure but all findings were dropped as
+    // ungrounded (accepted empty): there we still respect the model's `passed` flag.
+    const passed = blocking.length === 0 && (parsed.passed || accepted.length > 0);
 
     return {
       ...parsed,

--- a/test/unit/operations/semantic-review-verify.test.ts
+++ b/test/unit/operations/semantic-review-verify.test.ts
@@ -252,7 +252,11 @@ describe("semanticReviewOp.verify() — filter pipeline (AC1 semantic)", () => {
     });
   });
 
-  test("blocking/advisory split preserves passed:false when only advisory findings remain", async () => {
+  test("#1347: advisory-only findings pass the verdict even when the model reports passed:false", async () => {
+    // Regression for nax#1347. When the model emits only sub-threshold (advisory)
+    // findings but sets passed:false, the verdict must honour blockingThreshold —
+    // there are no blocking findings, so the review passes. The advisory findings
+    // are still surfaced (they are not silently dropped), just non-blocking.
     return withTempDir(async (workdir) => {
       const ctx = makeVerifyCtx();
       const input: SemanticReviewInput = {
@@ -263,7 +267,6 @@ describe("semanticReviewOp.verify() — filter pipeline (AC1 semantic)", () => {
       const parsed = makeOutput({
         passed: false,
         findings: [
-          // Only advisory finding — no blocking findings survive
           {
             severity: "warning",
             file: "src/auth.ts",
@@ -277,8 +280,41 @@ describe("semanticReviewOp.verify() — filter pipeline (AC1 semantic)", () => {
       });
       const result = await semanticReviewOp.verify!(parsed, input, ctx);
       expect(result).not.toBeNull();
-      expect(result!.passed).toBe(false);
-      expect(result!.normalizedFindings).toHaveLength(0);
+      expect(result!.passed).toBe(true); // no blocking findings → pass
+      expect(result!.findings).toHaveLength(1); // advisory finding still surfaced
+      expect(result!.normalizedFindings).toHaveLength(0); // but not blocking
+    });
+  });
+
+  test("#1347: fail-closed guard preserved — model passed:false with all findings dropped stays failing", async () => {
+    // The advisory-pass fix must NOT weaken the fail-closed guard: when the model
+    // claims failure but every finding is dropped as ungrounded (accepted empty),
+    // the verdict stays false so an ungrounded-but-real blocker can't slip through.
+    return withTempDir(async (workdir) => {
+      const ctx = makeVerifyCtx();
+      const input: SemanticReviewInput = {
+        ...BASE_INPUT,
+        workdir,
+        mode: "embedded",
+      };
+      const parsed = makeOutput({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            file: "src/auth.ts",
+            line: 1,
+            issue: "Ungrounded blocker",
+            suggestion: "Fix it",
+            acIndex: 99, // out of range → dropped from accepted
+          },
+        ],
+        normalizedFindings: [],
+      });
+      const result = await semanticReviewOp.verify!(parsed, input, ctx);
+      expect(result).not.toBeNull();
+      expect(result!.findings).toHaveLength(0); // all dropped
+      expect(result!.passed).toBe(false); // fail-closed preserved
     });
   });
 

--- a/test/unit/review/orchestrator-wrapper-parity.test.ts
+++ b/test/unit/review/orchestrator-wrapper-parity.test.ts
@@ -135,7 +135,7 @@ describe("Semantic op verify() parity with wrapper consumer (AC10, AC11)", () =>
     });
   });
 
-  test("advisory-only run: passed:false is preserved and normalizedFindings is empty", async () => {
+  test("advisory-only run: verdict passes (nax#1347) with empty normalizedFindings", async () => {
     return withTempDir(async (workdir) => {
       const ctx = makeVerifyCtx();
       const input: SemanticReviewInput = {
@@ -171,8 +171,11 @@ describe("Semantic op verify() parity with wrapper consumer (AC10, AC11)", () =>
       const result = await semanticReviewOp.verify!(parsed, input, ctx);
       expect(result).not.toBeNull();
 
-      // verify() preserves the LLM's passed:false even when only advisory findings remain.
-      expect(result!.passed).toBe(false);
+      // nax#1347: with only advisory (sub-threshold) findings surviving, the verdict
+      // honours blockingThreshold and passes — the LLM's raw passed:false no longer
+      // fails the review when nothing is blocking. The advisory finding is still surfaced.
+      expect(result!.passed).toBe(true);
+      expect(result!.findings).toHaveLength(1);
       expect(result!.normalizedFindings).toHaveLength(0);
     });
   });


### PR DESCRIPTION
## Summary

Fixes #1347. A story could be paused by a semantic review whose every finding is **below `blockingThreshold`**. The semantic op verdict folded the model's raw `passed` flag into the pass/fail decision, so advisory-only (sub-threshold) findings failed the story despite nothing being blocking.

## Root cause

The story-orchestrator reads the semantic verdict from the **op output** via `src/execution/story-orchestrator/review-decision.ts:41` (`passed: record.passed`) — not `semantic.ts`'s threshold-gated branches. That value came from `src/operations/semantic-review.ts:364`:

```ts
const passed = parsed.passed && blocking.length === 0;
```

When the model emitted only advisory findings but set `passed:false`, `blocking.length === 0` yet `parsed.passed === false` → verdict `false` → `phaseSignals.semantic-review.passed:false` → story pauses. This also explains the contradictory persisted audit (`passed:false` with only warning/info findings) reported in #1347 — it's written from the op output.

## Fix

```ts
const passed = blocking.length === 0 && (parsed.passed || accepted.length > 0);
```

The verdict is now driven by blocking severity. The `accepted.length > 0` clause preserves the fail-closed guard for the distinct case where the model claims failure but every finding was dropped as ungrounded (accepted empty), so an ungrounded-but-real blocker can't slip through.

| Case | Before | After |
|:--|:--|:--|
| Advisory-only + model `passed:false` | ❌ fail (bug) | ✅ pass |
| Blocking finding present | fail | fail |
| Model `passed:false`, all findings dropped as ungrounded | fail-closed | fail-closed |

Adversarial review (`adversarial-review.ts:522`) already uses an equivalent severity-driven formula, so this is scoped to semantic.

## Tests

- Added `#1347` regression test (advisory-only passes) + a fail-closed-guard test to `test/unit/operations/semantic-review-verify.test.ts`.
- Updated the two tests that codified the old behavior (`semantic-review-verify.test.ts`, `orchestrator-wrapper-parity.test.ts`).
- Confirmed the failing test reproduced the bug **before** the fix, then went green after.

## Verification

- `bun run typecheck`: exit 0, 0 errors
- `bun run lint` + all pre-commit gates: clean
- 589 review/orchestrator/acceptance tests + 1326 operations/pipeline tests: 0 failures
