### PR TITLE
fix(rectify): short-circuit mock_structure handoff to test-writer (#1352)

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -208,8 +208,16 @@ export async function buildPlanForStrategy(
       Boolean(inputs.fullSuiteGate) && (isThreeSession || regressionMode === "per-story");
     const verifyScopedPhasePresent = !isThreeSession && Boolean(inputs.verifyScoped);
     if (fullSuiteGatePhasePresent || verifyScopedPhasePresent) {
+      // `isThreeSession` doubles as "an autofix-test-writer will be registered on
+      // this sink" (see the isThreeSession gate below) — the drainer that lets the
+      // mock_structure handoff short-circuit (#1352).
       strategies.push(
-        makeFullSuiteRectifyStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
+        makeFullSuiteRectifyStrategy(story, config, sink, isThreeSession) as FixStrategy<
+          Finding,
+          unknown,
+          unknown,
+          unknown
+        >,
       );
     }
     if (config.quality.autofix?.enabled !== false) {
@@ -360,8 +368,20 @@ export async function buildPlanForStrategy(
     // `source: "test-runner"` regression findings (never advisory adversarial
     // findings), and its prompt renders failing tests without a severity filter,
     // so a floor would be inert.
+    //
+    // The mock_structure short-circuit (#1352) is enabled only when an
+    // autofix-test-writer is registered on nbSink to drain the handoff: three-session
+    // "triage" and "both" scopes above register one; single-session and the
+    // three-session "source" scope do NOT — suppressing there would orphan the
+    // finding (no-strategy). Mirrors the drainer gate on the main cycle.
+    const nbHasTestWriterDrainer = isThreeSession && nbf.scope !== "source";
     nbStrategies.push(
-      makeFullSuiteRectifyStrategy(story, config, nbSink) as FixStrategy<Finding, unknown, unknown, unknown>,
+      makeFullSuiteRectifyStrategy(story, config, nbSink, nbHasTestWriterDrainer) as FixStrategy<
+        Finding,
+        unknown,
+        unknown,
+        unknown
+      >,
     );
 
     // Mirror the main rectification postValidate but bound to nbSink (#1227).

--- a/src/operations/full-suite-rectify.ts
+++ b/src/operations/full-suite-rectify.ts
@@ -21,11 +21,23 @@ import { implementerOp } from "./implement";
  * When `sink` is provided the strategy switches to `fullSuiteRectifyOp` and
  * `extractApplied` pushes parsed declarations into the shared sink for downstream
  * processing (mock_structure → mockHandoffs, others → testEdits).
+ *
+ * `hasTestWriterDrainer` (sink variant only) gates the mock-structure handoff
+ * short-circuit. When `true`, this exclusive strategy stops claiming failing-test
+ * findings while a mock_structure handoff is pending (`sink.mockHandoffs.length > 0`),
+ * so `selectExecutionGroup` falls through to the co-run `autofix-test-writer` that
+ * drains the handoff — instead of re-invoking the implementer up to its per-strategy
+ * cap to re-declare the identical handoff (#1352). The suppression is self-limiting:
+ * the test-writer drains `sink.mockHandoffs` in one iteration, after which this
+ * strategy reclaims normally. Pass `true` ONLY where an `autofix-test-writer` is
+ * registered on the same sink; otherwise suppressing here orphans the finding
+ * (`exitReason: "no-strategy"` — #1330/#1327).
  */
 export function makeFullSuiteRectifyStrategy(
   story: UserStory,
   config: NaxConfig,
   sink: DeclarationSink,
+  hasTestWriterDrainer?: boolean,
 ): FixStrategy<Finding, FullSuiteRectifyInput, FullSuiteRectifyOutput, AutofixConfig>;
 export function makeFullSuiteRectifyStrategy(
   story: UserStory,
@@ -35,13 +47,20 @@ export function makeFullSuiteRectifyStrategy(
   story: UserStory,
   config: NaxConfig,
   sink?: DeclarationSink,
+  hasTestWriterDrainer?: boolean,
 ):
   | FixStrategy<Finding, FullSuiteRectifyInput, FullSuiteRectifyOutput, AutofixConfig>
   | FixStrategy<Finding, ImplementerInput, ImplementerOutput, TddConfig> {
-  const appliesTo = (finding: Finding): boolean =>
+  const claimsFailingTest = (finding: Finding): boolean =>
     finding.source === "test-runner" && (finding.category === "failed-test" || finding.category === "execution-failed");
 
   if (sink) {
+    // While a mock_structure handoff is pending AND a test-writer is registered to
+    // drain it, stop claiming — hand selection to the co-run `autofix-test-writer`
+    // this iteration instead of re-running the implementer (#1352).
+    const appliesTo = (finding: Finding): boolean =>
+      claimsFailingTest(finding) && !(hasTestWriterDrainer === true && sink.mockHandoffs.length > 0);
+
     return {
       name: "full-suite-rectify",
       appliesTo,
@@ -76,7 +95,7 @@ export function makeFullSuiteRectifyStrategy(
 
   return {
     name: "full-suite-rectify",
-    appliesTo,
+    appliesTo: claimsFailingTest,
     fixOp: implementerOp,
     buildInput: (findings) => ({
       story,

--- a/test/unit/operations/full-suite-rectify.test.ts
+++ b/test/unit/operations/full-suite-rectify.test.ts
@@ -224,3 +224,62 @@ describe("makeFullSuiteRectifyStrategy — with DeclarationSink", () => {
     expect(result.summary).toBe("Fixed failing tests");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1352: mock_structure handoff short-circuit — the exclusive implementer must
+// stop claiming failing-test findings while a handoff is pending SO the co-run
+// autofix-test-writer is selected, but only when a test-writer drainer exists.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("makeFullSuiteRectifyStrategy — mock_structure handoff short-circuit (#1352)", () => {
+  const pushHandoff = (sink: ReturnType<typeof makeDeclarationSink>) =>
+    sink.mockHandoffs.push({ files: ["test/unit/foo.test.ts"], reasonDetail: "mock cache reuse" });
+
+  test("drainer + pending handoff → appliesTo false (hands selection to test-writer)", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink, true);
+    pushHandoff(sink);
+    expect(strategy.appliesTo(makeTestFinding())).toBe(false);
+  });
+
+  test("drainer + no pending handoff → appliesTo true (claims normally)", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink, true);
+    expect(strategy.appliesTo(makeTestFinding())).toBe(true);
+  });
+
+  test("no drainer + pending handoff → appliesTo STAYS true (no orphan when no test-writer registered)", () => {
+    // Single-session verify-scoped and three-session nbf scope:"source" register
+    // full-suite-rectify without an autofix-test-writer. Suppressing there would
+    // strand the finding (exitReason "no-strategy" — #1330/#1327).
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink, false);
+    pushHandoff(sink);
+    expect(strategy.appliesTo(makeTestFinding())).toBe(true);
+  });
+
+  test("drainer default (omitted) → treated as no drainer → appliesTo stays true with pending handoff", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink);
+    pushHandoff(sink);
+    expect(strategy.appliesTo(makeTestFinding())).toBe(true);
+  });
+
+  test("self-correcting window: suppressed while pending, reclaims after test-writer drains the sink", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink, true);
+    pushHandoff(sink);
+    expect(strategy.appliesTo(makeTestFinding())).toBe(false);
+    // autofix-test-writer.buildInput drains via splice(0); a later regression re-selects us.
+    sink.mockHandoffs.splice(0);
+    expect(strategy.appliesTo(makeTestFinding())).toBe(true);
+  });
+
+  test("suppression only relaxes claiming — non-failing-test findings are still not claimed", () => {
+    const sink = makeDeclarationSink();
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig(), sink, true);
+    pushHandoff(sink);
+    // A lint finding never matched regardless of handoff state.
+    expect(strategy.appliesTo(makeTestFinding({ source: "lint" }))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1352.

## Problem

In three-session TDD, when the implementer emits a valid `TEST_EDIT_REASON: mock_structure` handoff (Exception 4) during full-suite rectification, the handoff does **not** short-circuit to `autofix-test-writer`. The exclusive `full-suite-rectify` (implementer) strategy keeps winning `selectExecutionGroup` and is re-invoked up to `maxAttemptsPerStrategy` (default **3**) times, re-declaring the identical handoff each turn (~80–90 KB prompt each), before the test-writer finally claims the work.

Observed in `nathapp-nestjs-starter` / `sp4-mfa-step-up` / US-001: two consecutive implementer rectification turns both declared `mock_structure` for the same test files; the watchdog recycled a wedged third attempt; `autofix-test-writer` was never selected within the cap window.

### Root cause
- `applyTestEditDeclarations` only re-tags findings to `fixTarget: "test"` for `prd_contract` — `mock_structure` rides solely on the `sink.mockHandoffs` side-channel, so the finding keeps `source: "test-runner"` / `category: "failed-test"`.
- `full-suite-rectify.appliesTo` claims by `source`+`category` and is `coRun: "exclusive"`; `selectExecutionGroup(uncappedActive)` returns only the exclusive strategy while it has attempts left, so the co-run `autofix-test-writer` (guarded by `sink.mockHandoffs.length > 0`) can't run until the implementer exhausts its cap.

## Fix

Suppress `full-suite-rectify.appliesTo` for failing-test findings while a `mock_structure` handoff is pending (`sink.mockHandoffs.length > 0`), so `selectExecutionGroup` falls through to the co-run `autofix-test-writer` on the next iteration.

- **Self-limiting:** `autofix-test-writer.buildInput` drains via `sink.mockHandoffs.splice(0)`, so the suppression is live for exactly one iteration; a fresh regression from the rewrite re-selects `full-suite-rectify` normally.
- **Drainer-gated (required):** a new `hasTestWriterDrainer` arg gates the suppression. Passed `true` only where an `autofix-test-writer` is registered on the same sink — the main three-session cycle and nbf `triage`/`both` scopes. Single-session (never offered Exception 4) and three-session nbf `scope: "source"` pass `false`, so the finding is never orphaned into `exitReason: "no-strategy"` (#1330/#1327).

## Blast radius
- `src/operations/full-suite-rectify.ts` — gated `appliesTo` suppression (sink variant only; no-sink/single-session path unchanged).
- `src/execution/build-plan-for-strategy.ts` — both call sites: main cycle passes `isThreeSession`; nbf cycle passes `isThreeSession && nbf.scope !== "source"`.
- `prd_contract` / `lint_only` / `sibling_scope` paths untouched.

## Tests
6 new unit tests in `test/unit/operations/full-suite-rectify.test.ts`:
- drainer + pending handoff → `appliesTo` false (hands off to test-writer)
- drainer + no handoff → true (claims normally)
- no drainer + pending handoff → stays true (no orphan)
- drainer arg omitted → treated as no drainer
- self-correcting window: suppressed while pending, reclaims after drain
- suppression only relaxes claiming — non-failing-test findings still not claimed

## Verification
- `bun run typecheck` — clean
- `bun run lint` — clean (all ratchets hold)
- `bun run test` — all phases passed (unit + integration 1090/0 + ui 21/0); new factory tests 25/25
