### PR TITLE
fix(execution): count oscillation as source reappearance, not first reveal (#1355)

### DIFF
--- a/src/execution/oscillation-store.ts
+++ b/src/execution/oscillation-store.ts
@@ -1,4 +1,4 @@
-import type { IterationOutcome } from "@/findings/cycle-types";
+import type { Finding, Iteration } from "@/findings";
 
 export function recordOscillations(store: Map<string, number>, storyId: string, delta: number): number {
   if (!Number.isSafeInteger(delta) || delta < 1) {
@@ -13,19 +13,51 @@ export function getOscillations(store: Map<string, number>, storyId: string): nu
   return store.get(storyId) ?? 0;
 }
 
-const OSCILLATION_OUTCOME: IterationOutcome = "regressed-different-source";
+/** Minimal iteration shape the oscillation counter needs: the finding sources before/after. */
+type OscillationIteration = Pick<Iteration, "findingsBefore" | "findingsAfter">;
+
+function sourceSet(findings: ReadonlyArray<Pick<Finding, "source">> | undefined): Set<Finding["source"]> {
+  // Defensive: this runs in the rectification hot path. A malformed or partial
+  // iteration (e.g. a carry-forward record missing its findings arrays) must
+  // degrade to "no sources", never crash the counter.
+  return new Set((Array.isArray(findings) ? findings : []).map((f) => f.source));
+}
 
 /**
- * Count how many iterations in a cycle carry the `regressed-different-source`
- * outcome — the source-agnostic oscillation signal used by the
- * circuit-breaker. Each match increments the per-story counter at the
- * increment site (one recordOscillations call per cycle is the norm, but
- * batched counts are valid too).
+ * Count genuine reviewer oscillation across a cycle's iterations — a finding
+ * source that was previously RESOLVED (present in an earlier iteration's
+ * `findingsBefore`, then absent from its `findingsAfter`) REAPPEARING in a
+ * later iteration's `findingsAfter`. That "fixed, then came back" reversal is
+ * the ping-pong the circuit-breaker exists to catch.
+ *
+ * It deliberately does NOT count a source that merely appears for the first
+ * time. Rectification revalidation short-circuits on the first failing phase
+ * (see `story-orchestrator/rectification.ts`), so downstream reviewers
+ * (semantic, then adversarial) are structurally revealed one at a time as the
+ * phases ahead of them go green. The old counter treated each first reveal as
+ * `regressed-different-source` and counted it, pausing stories that were making
+ * monotonic forward progress (issue #1355). A strictly-forward reveal chain
+ * (`typecheck → semantic → adversarial`, each once) never revisits a source and
+ * now counts zero; only a source coming back after a fix increments the count.
+ *
+ * The per-story counter accumulates across escalation attempts at the increment
+ * site (one `recordOscillations` call per cycle).
  */
-export function countOscillationOutcomes(iterations: ReadonlyArray<{ outcome: IterationOutcome }>): number {
+export function countOscillationOutcomes(iterations: ReadonlyArray<OscillationIteration>): number {
+  const resolvedSources = new Set<Finding["source"]>();
   let count = 0;
   for (const iteration of iterations) {
-    if (iteration.outcome === OSCILLATION_OUTCOME) count += 1;
+    const beforeSources = sourceSet(iteration.findingsBefore);
+    const afterSources = sourceSet(iteration.findingsAfter);
+    // A previously-resolved source reappearing after a fix is a real reversal.
+    for (const source of afterSources) {
+      if (resolvedSources.has(source)) count += 1;
+    }
+    // A source present-before and absent-after is now "resolved" — a later
+    // reappearance in `findingsAfter` will register as oscillation.
+    for (const source of beforeSources) {
+      if (!afterSources.has(source)) resolvedSources.add(source);
+    }
   }
   return count;
 }

--- a/test/unit/execution/oscillation-store.test.ts
+++ b/test/unit/execution/oscillation-store.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { getOscillations, recordOscillations } from "@/execution";
+import { countOscillationOutcomes, getOscillations, recordOscillations } from "@/execution";
+import type { Finding, Iteration } from "@/findings";
+
+/** Minimal Finding carrying only what the oscillation counter reads (source). */
+function finding(source: Finding["source"], message = source): Finding {
+  return { source, severity: "error", category: "test", message } as Finding;
+}
+
+/** Build one iteration from before/after source lists. */
+function iteration(before: Finding["source"][], after: Finding["source"][]): Iteration {
+  return {
+    iterationNum: 1,
+    findingsBefore: before.map((s) => finding(s)),
+    fixesApplied: [],
+    findingsAfter: after.map((s) => finding(s)),
+    outcome: "partial",
+    startedAt: "2026-07-21T00:00:00.000Z",
+    finishedAt: "2026-07-21T00:00:01.000Z",
+  };
+}
 
 describe("oscillation store", () => {
   test("exports callable helpers", () => {
@@ -42,5 +61,52 @@ describe("oscillation store", () => {
     recordOscillations(store, "A", 1);
     expect(getOscillations(store, "A")).toBe(3);
     expect(getOscillations(store, "B")).toBe(5);
+  });
+});
+
+describe("countOscillationOutcomes — ping-pong detection (issue #1355)", () => {
+  test("empty iteration list counts zero", () => {
+    expect(countOscillationOutcomes([])).toBe(0);
+  });
+
+  test("forward reveal chain counts zero (no false oscillation)", () => {
+    // The US-003 shape: a typecheck seed reveals semantic, then adversarial —
+    // each source appears once, none reappears after being resolved.
+    const iterations = [
+      iteration(["typecheck"], ["semantic"]),
+      iteration(["semantic"], ["semantic"]),
+      iteration(["semantic"], ["adversarial"]),
+    ];
+    expect(countOscillationOutcomes(iterations)).toBe(0);
+  });
+
+  test("a source coming back after being resolved counts as one reversal", () => {
+    // semantic resolved in iter1, then reappears in iter2's findingsAfter.
+    const iterations = [iteration(["semantic"], ["adversarial"]), iteration(["adversarial"], ["semantic"])];
+    expect(countOscillationOutcomes(iterations)).toBe(1);
+  });
+
+  test("two full round-trips count two reversals (trips default max=2)", () => {
+    // semantic ↔ adversarial ping-pong: A→B→A→B.
+    const iterations = [
+      iteration(["semantic"], ["adversarial"]),
+      iteration(["adversarial"], ["semantic"]),
+      iteration(["semantic"], ["adversarial"]),
+    ];
+    expect(countOscillationOutcomes(iterations)).toBe(2);
+  });
+
+  test("monotonic progress within a single source counts zero", () => {
+    const iterations = [iteration(["semantic"], ["semantic"]), iteration(["semantic"], [])];
+    expect(countOscillationOutcomes(iterations)).toBe(0);
+  });
+
+  test("multiple resolved sources reappearing in one iteration each count", () => {
+    const iterations = [
+      iteration(["lint"], ["semantic"]), // lint resolved
+      iteration(["semantic"], ["typecheck"]), // semantic resolved
+      iteration(["typecheck"], ["lint", "semantic"]), // both reappear
+    ];
+    expect(countOscillationOutcomes(iterations)).toBe(2);
   });
 });

--- a/test/unit/execution/rectification-oscillation-circuit-breaker.test.ts
+++ b/test/unit/execution/rectification-oscillation-circuit-breaker.test.ts
@@ -3,8 +3,11 @@
  *
  * Three concerns:
  *
- * 1. Pure outcome-count helper (AC1, AC2).
- * 2. `runRectification` records `regressed-different-source` iterations into
+ * 1. Pure source-reappearance counter (AC1, AC2). Post-#1355 the counter
+ *    counts genuine ping-pong (a resolved finding source reappearing), NOT
+ *    every `regressed-different-source` outcome — a forward reviewer-reveal
+ *    chain no longer trips the breaker.
+ * 2. `runRectification` records source-reappearance reversals into
  *    `ctx.runtime.rectificationOscillations` (AC3).
  * 3. `decideStageAction` reads the accumulated count, the
  *    `review.conflictDetection.{enabled,maxOscillations}` config, and the
@@ -16,58 +19,76 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { type DEFAULT_CONFIG, pickSelector } from "@/config";
 import {
+  StoryOrchestratorBuilder,
   _postRunDeps,
   _storyOrchestratorDeps,
   applyPostRunInspection,
   countOscillationOutcomes,
   decideStageAction,
   getOscillations,
-  StoryOrchestratorBuilder,
 } from "@/execution";
 import type { FixCycle, FixCycleContext, FixCycleExitReason, Iteration } from "@/findings/cycle-types";
 import type { Finding } from "@/findings/types";
 import type { CallContext, RunOperation } from "@/operations";
 import type { NaxRuntime, PipelineContext } from "@/runtime";
 import { makeTestContext, makeTestRuntime } from "@test/helpers";
-import { LINT_FINDING, makeInspectionOpts, makePlanResult, TEST_RUNNER_FINDING } from "./_post-run-fixtures";
+import { LINT_FINDING, TEST_RUNNER_FINDING, makeInspectionOpts, makePlanResult } from "./_post-run-fixtures";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 1. Pure outcome-count helper (AC1, AC2)
+// 1. Pure source-reappearance counter (AC1, AC2)
+//
+// Post-#1355: a "reversal" is a finding source that was resolved (present in an
+// earlier findingsBefore, absent from that iteration's findingsAfter) then
+// reappears in a later findingsAfter. A strictly-forward reveal chain
+// (typecheck → semantic → adversarial, each once) counts zero.
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("AC1: countOscillationOutcomes counts regressed-different-source outcomes", () => {
-  test("returns 2 for [regressed-different-source, partial, regressed-different-source]", () => {
-    expect(
-      countOscillationOutcomes([
-        { outcome: "regressed-different-source" },
-        { outcome: "partial" },
-        { outcome: "regressed-different-source" },
-      ]),
-    ).toBe(2);
+/** One iteration built from before/after finding sources. */
+function iterFromSources(n: number, before: Finding["source"][], after: Finding["source"][]): Iteration {
+  const f = (source: Finding["source"]): Finding => ({ source, severity: "error", category: "test", message: source });
+  return {
+    iterationNum: n,
+    findingsBefore: before.map(f),
+    fixesApplied: [],
+    findingsAfter: after.map(f),
+    outcome: "partial",
+    startedAt: new Date(0).toISOString(),
+    finishedAt: new Date(0).toISOString(),
+  };
+}
+
+/**
+ * A minimal iteration sequence producing exactly `count` genuine reversals by
+ * alternating lint ↔ test-runner. Reversals = number of swaps after the first
+ * (the first swap only resolves a source; subsequent swaps make a resolved
+ * source reappear). `reversalIterations(0)` is a single non-reversing swap.
+ */
+function reversalIterations(count: number): Iteration[] {
+  const sources: Finding["source"][] = ["lint", "test-runner"];
+  const iters: Iteration[] = [];
+  for (let i = 0; i <= count; i++) {
+    iters.push(iterFromSources(i + 1, [sources[i % 2]], [sources[(i + 1) % 2]]));
+  }
+  return iters;
+}
+
+describe("AC1: countOscillationOutcomes counts resolved-source reappearances (ping-pong)", () => {
+  test("two lint↔test-runner round-trips count 2 reversals", () => {
+    expect(countOscillationOutcomes(reversalIterations(2))).toBe(2);
   });
 
-  test("counts every regressed-different-source outcome in a longer mixed list", () => {
-    expect(
-      countOscillationOutcomes([
-        { outcome: "resolved" },
-        { outcome: "regressed-different-source" },
-        { outcome: "regressed" },
-        { outcome: "regressed-different-source" },
-        { outcome: "partial" },
-        { outcome: "regressed-different-source" },
-      ]),
-    ).toBe(3);
+  test("a single resolved source reappearing counts 1", () => {
+    expect(countOscillationOutcomes(reversalIterations(1))).toBe(1);
   });
 });
 
-describe("AC2: countOscillationOutcomes returns 0 when no regressed-different-source outcomes are present", () => {
-  test("returns 0 for [resolved, partial, regressed, unchanged]", () => {
+describe("AC2: countOscillationOutcomes returns 0 without a resolved-source reappearance", () => {
+  test("forward reveal chain (typecheck → semantic → adversarial) counts 0", () => {
     expect(
       countOscillationOutcomes([
-        { outcome: "resolved" },
-        { outcome: "partial" },
-        { outcome: "regressed" },
-        { outcome: "unchanged" },
+        iterFromSources(1, ["typecheck"], ["semantic-review"]),
+        iterFromSources(2, ["semantic-review"], ["semantic-review"]),
+        iterFromSources(3, ["semantic-review"], ["adversarial-review"]),
       ]),
     ).toBe(0);
   });
@@ -129,16 +150,9 @@ function makeCallCtx(storyId: string): CallContext {
   } as CallContext;
 }
 
-function makeIteration(n: number, outcome: Iteration["outcome"]): Iteration {
-  return {
-    iterationNum: n,
-    findingsBefore: [LINT_FINDING],
-    fixesApplied: [],
-    findingsAfter: [LINT_FINDING],
-    outcome,
-    startedAt: new Date(0).toISOString(),
-    finishedAt: new Date(0).toISOString(),
-  };
+/** A monotonic single-source sequence — no source ever reappears (count 0). */
+function monotonicIterations(): Iteration[] {
+  return [iterFromSources(1, ["lint"], ["lint"]), iterFromSources(2, ["lint"], [])];
 }
 
 function buildRectificationPlan(ctx: CallContext) {
@@ -176,24 +190,22 @@ afterEach(async () => {
   runtime = undefined as unknown as NaxRuntime;
 });
 
-describe("AC3: runRectification increments rectificationOscillations on regressed-different-source", () => {
-  test("one regressed-different-source iteration increases the per-story count by exactly 1", async () => {
+describe("AC3: runRectification increments rectificationOscillations on source reappearance", () => {
+  test("one resolved-source reappearance increases the per-story count by exactly 1", async () => {
     const storyId = "US-osc-inc-1";
     const ctx = makeCallCtx(storyId);
     const store = ctx.runtime.rectificationOscillations;
     expect(store).toBeInstanceOf(Map);
     expect(getOscillations(store, storyId)).toBe(0);
 
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => {
-        return {
-          iterations: [makeIteration(1, "regressed-different-source")],
-          finalFindings: [LINT_FINDING],
-          exitReason: "max-attempts-total" as FixCycleExitReason,
-          costUsd: 0,
-        };
-      },
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => {
+      return {
+        iterations: reversalIterations(1),
+        finalFindings: [LINT_FINDING],
+        exitReason: "max-attempts-total" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
 
     const plan = buildRectificationPlan(ctx);
     await plan.run();
@@ -201,24 +213,19 @@ describe("AC3: runRectification increments rectificationOscillations on regresse
     expect(getOscillations(store, storyId)).toBe(1);
   });
 
-  test("two regressed-different-source iterations in a single cycle increase the count by 2", async () => {
+  test("two source reappearances in a single cycle increase the count by 2", async () => {
     const storyId = "US-osc-inc-2";
     const ctx = makeCallCtx(storyId);
     const store = ctx.runtime.rectificationOscillations;
 
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => {
-        return {
-          iterations: [
-            makeIteration(1, "regressed-different-source"),
-            makeIteration(2, "regressed-different-source"),
-          ],
-          finalFindings: [LINT_FINDING],
-          exitReason: "max-attempts-total" as FixCycleExitReason,
-          costUsd: 0,
-        };
-      },
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => {
+      return {
+        iterations: reversalIterations(2),
+        finalFindings: [LINT_FINDING],
+        exitReason: "max-attempts-total" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
 
     const plan = buildRectificationPlan(ctx);
     await plan.run();
@@ -226,21 +233,19 @@ describe("AC3: runRectification increments rectificationOscillations on regresse
     expect(getOscillations(store, storyId)).toBe(2);
   });
 
-  test("non-oscillating outcomes do not increase the per-story count", async () => {
+  test("a forward reveal chain (no reappearance) does not increase the per-story count", async () => {
     const storyId = "US-osc-inc-3";
     const ctx = makeCallCtx(storyId);
     const store = ctx.runtime.rectificationOscillations;
 
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => {
-        return {
-          iterations: [makeIteration(1, "unchanged"), makeIteration(2, "partial")],
-          finalFindings: [LINT_FINDING],
-          exitReason: "max-attempts-total" as FixCycleExitReason,
-          costUsd: 0,
-        };
-      },
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => {
+      return {
+        iterations: monotonicIterations(),
+        finalFindings: [LINT_FINDING],
+        exitReason: "max-attempts-total" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
 
     const plan = buildRectificationPlan(ctx);
     await plan.run();
@@ -334,18 +339,13 @@ describe("AC4: decideStageAction returns action === 'pause' when the breaker thr
       agentName: "claude",
       storyId: "US-cb-1",
     } as CallContext;
-    const iterations: Iteration[] = [
-      makeIteration(1, "regressed-different-source"),
-      makeIteration(2, "regressed-different-source"),
-    ];
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
-        iterations,
-        finalFindings: [LINT_FINDING],
-        exitReason: "max-attempts-total" as FixCycleExitReason,
-        costUsd: 0,
-      }),
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    const iterations: Iteration[] = reversalIterations(2);
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
+      iterations,
+      finalFindings: [LINT_FINDING],
+      exitReason: "max-attempts-total" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     await buildRectificationPlan(callCtx).run();
 
     const ctx = makeTestContext({
@@ -386,18 +386,13 @@ describe("AC5/AC6: pause reason includes the count and an oscillation substring"
       agentName: "claude",
       storyId: "US-cb-2",
     } as CallContext;
-    const iterations: Iteration[] = [
-      makeIteration(1, "regressed-different-source"),
-      makeIteration(2, "regressed-different-source"),
-    ];
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
-        iterations,
-        finalFindings: [LINT_FINDING],
-        exitReason: "max-attempts-total" as FixCycleExitReason,
-        costUsd: 0,
-      }),
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    const iterations: Iteration[] = reversalIterations(2);
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
+      iterations,
+      finalFindings: [LINT_FINDING],
+      exitReason: "max-attempts-total" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     await buildRectificationPlan(callCtx).run();
 
     const ctx = makeTestContext({
@@ -443,16 +438,14 @@ describe("AC7: count below maxOscillations escalates", () => {
       agentName: "claude",
       storyId: "US-cb-3",
     } as CallContext;
-    // One regressed-different-source iteration produces a count of 1.
-    const iterations: Iteration[] = [makeIteration(1, "regressed-different-source")];
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
-        iterations,
-        finalFindings: [LINT_FINDING],
-        exitReason: "max-attempts-total" as FixCycleExitReason,
-        costUsd: 0,
-      }),
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    // One resolved-source reappearance produces a count of 1.
+    const iterations: Iteration[] = reversalIterations(1);
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
+      iterations,
+      finalFindings: [LINT_FINDING],
+      exitReason: "max-attempts-total" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     await buildRectificationPlan(callCtx).run();
     expect(getOscillations(sharedRuntime.rectificationOscillations, "US-cb-3")).toBe(1);
 
@@ -494,18 +487,13 @@ describe("AC8: conflictDetection.enabled === false escalates even when count >= 
       agentName: "claude",
       storyId: "US-cb-4",
     } as CallContext;
-    const iterations: Iteration[] = [
-      makeIteration(1, "regressed-different-source"),
-      makeIteration(2, "regressed-different-source"),
-    ];
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
-        iterations,
-        finalFindings: [LINT_FINDING],
-        exitReason: "max-attempts-total" as FixCycleExitReason,
-        costUsd: 0,
-      }),
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    const iterations: Iteration[] = reversalIterations(2);
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
+      iterations,
+      finalFindings: [LINT_FINDING],
+      exitReason: "max-attempts-total" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     await buildRectificationPlan(callCtx).run();
 
     const ctx = makeTestContext({
@@ -566,16 +554,14 @@ describe("AC10: count=0 on a normal single-source unfixable finding escalates", 
       agentName: "claude",
       storyId: "US-cb-6",
     } as CallContext;
-    // No regressed-different-source — only `unchanged` and `partial`.
-    const iterations: Iteration[] = [makeIteration(1, "unchanged"), makeIteration(2, "partial")];
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
-        iterations,
-        finalFindings: [LINT_FINDING],
-        exitReason: "max-attempts-total" as FixCycleExitReason,
-        costUsd: 0,
-      }),
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    // No source reappears — monotonic single-source progress.
+    const iterations: Iteration[] = monotonicIterations();
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
+      iterations,
+      finalFindings: [LINT_FINDING],
+      exitReason: "max-attempts-total" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     await buildRectificationPlan(callCtx).run();
     expect(getOscillations(sharedRuntime.rectificationOscillations, "US-cb-6")).toBe(0);
 
@@ -617,18 +603,13 @@ describe("AC11: pause emits a notify through the injected interaction channel", 
       agentName: "claude",
       storyId: "US-cb-7",
     } as CallContext;
-    const iterations: Iteration[] = [
-      makeIteration(1, "regressed-different-source"),
-      makeIteration(2, "regressed-different-source"),
-    ];
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
-        iterations,
-        finalFindings: [LINT_FINDING],
-        exitReason: "max-attempts-total" as FixCycleExitReason,
-        costUsd: 0,
-      }),
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    const iterations: Iteration[] = reversalIterations(2);
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
+      iterations,
+      finalFindings: [LINT_FINDING],
+      exitReason: "max-attempts-total" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     await buildRectificationPlan(callCtx).run();
 
     const sent: Array<{ type: string }> = [];
@@ -640,7 +621,11 @@ describe("AC11: pause emits a notify through the injected interaction channel", 
       configurable: true,
     });
     Object.defineProperty(ctx, "interaction", {
-      value: { send: async (req: { type: string }) => { sent.push({ type: req.type }); } },
+      value: {
+        send: async (req: { type: string }) => {
+          sent.push({ type: req.type });
+        },
+      },
       configurable: true,
     });
     ctx.config = {
@@ -676,18 +661,13 @@ describe("AC12: interaction.send() throwing does not abort the pause", () => {
       agentName: "claude",
       storyId: "US-cb-8",
     } as CallContext;
-    const iterations: Iteration[] = [
-      makeIteration(1, "regressed-different-source"),
-      makeIteration(2, "regressed-different-source"),
-    ];
-    _storyOrchestratorDeps.runFixCycle = mock(
-      async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
-        iterations,
-        finalFindings: [LINT_FINDING],
-        exitReason: "max-attempts-total" as FixCycleExitReason,
-        costUsd: 0,
-      }),
-    ) as typeof _storyOrchestratorDeps.runFixCycle;
+    const iterations: Iteration[] = reversalIterations(2);
+    _storyOrchestratorDeps.runFixCycle = mock(async (_cycle: FixCycle<Finding>, _cycleCtx: FixCycleContext) => ({
+      iterations,
+      finalFindings: [LINT_FINDING],
+      exitReason: "max-attempts-total" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     await buildRectificationPlan(callCtx).run();
 
     const ctx = makeTestContext({


### PR DESCRIPTION
Fixes #1355.

## Problem

The rectification oscillation circuit-breaker pauses stories that made **monotonic forward progress**, mistaking the *staged reveal* of downstream reviewers for genuine reviewer ping-pong.

Revalidation short-circuits on the first failing phase (`story-orchestrator/rectification.ts`), so downstream reviewers (`semantic`, then `adversarial`) are structurally revealed one at a time as the phases ahead of them go green. `classifyOutcome` labels each first reveal `regressed-different-source`, and `countOscillationOutcomes` counted every such label — so a plain `typecheck → semantic → adversarial` progression trips the default `maxOscillations: 2`.

Observed on a real run (rs-stock `backtest-sweep` US-003): seed = a typecheck finding; semantic went 2→1→0 (monotonic); adversarial failed once, for the first time. No source ever regressed back to green, yet `oscillationCount: 2` → paused. The pause also consumed the autofix budget on *unmasking* reviewers, so the real adversarial findings never got a fix pass.

## Fix

Recount from the iteration **source-transition sequence** instead of the outcome label: a source increments the count only when it was **resolved and later REAPPEARS** (genuine ping-pong). A strictly-forward reveal chain now counts **0**.

- `classifyOutcome` and the `IterationOutcome` enum are **untouched**, so adversarial iteration history, recurrence-demotion, and curator serialization are unaffected (this is why the counter — not the classifier — was the fix site).
- `sourceSet` guards non-array findings fields (`Array.isArray`) so a malformed/partial iteration degrades to "no sources" rather than crashing the rectification hot path.

### Behaviour
- Forward reveal chain (`typecheck → semantic → adversarial`, each once) → **0** (was 2 → false pause).
- Genuine `A → B → A` reappearance → counts; two round-trips → trips default `max=2`.
- Stories that previously false-paused now escalate as designed and get a real fix pass at the last reviewer's findings.

### Known limitation (not addressed here)
`recordOscillations` accumulates across escalation *attempts*, but the runtime stores only an integer, not source history — so per-cycle detection cannot see an oscillation whose round-trip spans two separate attempts. This is a pre-existing gap; the change neither closes it nor introduces new false positives. Tracking a history-based version separately.

### Naming note
`countOscillationOutcomes` is now a slight misnomer (it counts reappearances). Kept as-is to keep the change surgical (exported from the barrel, referenced by the increment site and tests); open to a rename if preferred.

## Tests
- `oscillation-store.test.ts` — added ping-pong cases: forward chain → 0, single reappearance → 1, two round-trips → 2, multi-source reappearance.
- `rectification-oscillation-circuit-breaker.test.ts` — re-baselined AC1/AC2 and replaced the outcome-driven `makeIteration` with source-driven `reversalIterations` / `monotonicIterations` across AC3–AC12.

## Verification
- Full suite green: unit 1337 pass, integration 1090 pass / 38 skip, ui 21 pass, 0 fail.
- `bun run typecheck`, `bun run lint`, and the full pre-commit gate all clean.
