### PR TITLE
fix(prd): scope out-of-scope extraction to feature-level declarations only

### DIFF
--- a/docs/architecture/spec-to-prd-pipeline.md
+++ b/docs/architecture/spec-to-prd-pipeline.md
@@ -205,17 +205,26 @@ invisible to them. `savePRD` strips the mirrored copies again
 Story-specific entries survive the strip; only exact feature-level mirrors are
 removed.
 
-### Known limitation: no story ancestry
+### Feature-level vs story-level: the extraction boundary
 
-`extractSpecOutOfScope` matches a heading or inline marker **wherever it appears**,
-with no notion of which story section contains it. So a per-story
-`### Out of scope` / `**Out of scope:**` block — which spec-writing recommends for
-deferred risk properties — is hoisted to feature level and propagated to *every*
-story. US-002's deferral then reaches US-001's implementer as a hard boundary.
+spec-writing tells authors to give risk-sensitive stories their own
+`**Out of scope:**` list under the story's AC block (guide Rule 10, for deferred
+risk properties). Those are **story**-scoped and must not become feature-level —
+hoisting them would propagate US-002's deferral onto US-001 as a hard boundary.
 
-Until the extractor models story boundaries, keep per-story deferrals in that
-story's `**Scope** — Out:` bullet, and reserve `## Out of Scope` / inline markers
-for genuinely feature-wide exclusions.
+The extractor draws the line at the first `## Stories` / `## Acceptance Criteria`
+heading:
+
+| Declaration | Feature-level? |
+|---|---|
+| `## Out of Scope` section (top-level `#`/`##`), anywhere in the document | ✅ yes |
+| `**Out of scope …:**` inline marker **before** the story sections (Summary/Design) | ✅ yes |
+| `**Out of scope:**` under a story's AC block | ❌ no — story-scoped |
+| `### Out of scope` sub-heading after the story sections begin | ❌ no — story-scoped |
+
+Story-scoped deferrals still do their job: spec-review Phase 4's adversarial-scope
+check reads them per-story, and they belong in that story's `**Scope** — Out:`
+bullet in the PRD.
 
 ### Reviewers: visible and citable, but advisory
 

--- a/src/prd/out-of-scope.ts
+++ b/src/prd/out-of-scope.ts
@@ -371,8 +371,10 @@ export function normalizeOutOfScopeList(raw: unknown): string[] | undefined {
  * Scope / assumptions (deliberate — the downstream gate warns, never fails):
  * - A sub-heading inside the section is treated as a label, not an item; its
  *   bullets are still collected.
- * - Fenced code blocks inside the section are folded as prose. Out-of-scope
- *   sections holding code are vanishingly rare; write them as bullets.
+ * - Fenced code blocks are skipped entirely, not folded — so a spec that
+ *   documents markdown by example cannot inject a fabricated exclusion. The
+ *   corollary: text written *inside* a fence is silently dropped, so exclusions
+ *   must be bullets, table rows, or prose, never fenced.
  */
 export function extractSpecOutOfScope(specContent: string): string[] {
   if (!specContent.trim()) return [];

--- a/src/prd/out-of-scope.ts
+++ b/src/prd/out-of-scope.ts
@@ -53,6 +53,12 @@ const TABLE_SEPARATOR = /^\s*\|?[\s:|-]+\|[\s:|-]*$/;
 /** A markdown table row. */
 const TABLE_ROW = /^\s*\|.*\|\s*$/;
 
+/**
+ * The heading that begins per-story decomposition. Everything after it is
+ * story-scoped territory (see {@link storyScopeBoundary}).
+ */
+const STORY_SECTION_HEADING = /^#{1,3}\s*(?:stories|acceptance\s+criteria|user\s+stories)\b/i;
+
 /** A setext underline — `===` (H1) or `---` (H2) beneath a title line. */
 const SETEXT_UNDERLINE = /^\s*(?:=+|-+)\s*$/;
 
@@ -254,9 +260,9 @@ function fencedLineIndices(lines: string[]): Set<number> {
  *   Handled explicitly because the prose fold stops at the first list item,
  *   which previously left the marker empty and the bullets claimed by nobody.
  */
-function itemsFromInlineMarkers(lines: string[], fenced: Set<number>): string[] {
+function itemsFromInlineMarkers(lines: string[], fenced: Set<number>, boundary: number): string[] {
   const items: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
+  for (let i = 0; i < boundary; i++) {
     if (fenced.has(i) || !INLINE_MARKER.test(lines[i])) continue;
 
     const remainder = lines[i].replace(INLINE_MARKER, "").trim();
@@ -319,6 +325,25 @@ function dedupeAndCap(items: string[]): string[] {
 }
 
 /**
+ * Index of the first `## Stories` / `## Acceptance Criteria` heading, or
+ * `lines.length` when the spec has none.
+ *
+ * Declarations after this point belong to a *story*, not the feature.
+ * spec-writing tells authors to give risk-sensitive stories their own
+ * `**Out of scope:**` list under the story's AC block; hoisting those to feature
+ * level propagated one story's deferral onto every other story — US-001's
+ * implementer would be told US-002's deferred work is a hard boundary.
+ *
+ * A top-level (`#`/`##`) heading is exempt: a document section named
+ * `## Out of Scope` is feature-level wherever the author placed it, including
+ * after the story sections.
+ */
+function storyScopeBoundary(lines: string[]): number {
+  const index = lines.findIndex((line) => STORY_SECTION_HEADING.test(stripEmphasis(line)));
+  return index === -1 ? lines.length : index;
+}
+
+/**
  * Coerce a raw `outOfScope` value from LLM output into a clean string list.
  *
  * Tolerant by design — this field is advisory guidance, never a gate, so a
@@ -337,12 +362,11 @@ export function normalizeOutOfScopeList(raw: unknown): string[] | undefined {
  * order: bullets (or paragraphs) under an `## Out of Scope` / `## Non-Goals`
  * heading, plus any inline `**Out of scope …:**` lead-in.
  *
- * Known limitation — no story ancestry. A heading or inline marker is matched
- * wherever it appears, so a per-story `### Out of scope` / `**Out of scope:**`
- * block (which spec-writing recommends for deferred risk properties) is hoisted
- * to feature level and propagated to EVERY story. Keep per-story deferrals in the
- * story's `Scope — Out:` bullet until this models story boundaries; see the
- * spec-to-prd-pipeline doc.
+ * Story-scoped declarations are excluded. spec-writing tells authors to give
+ * risk-sensitive stories their own `**Out of scope:**` list under the story's AC
+ * block; only declarations before the first `## Stories` / `## Acceptance
+ * Criteria` heading — or in a top-level `##` section anywhere — are feature-level
+ * (see {@link storyScopeBoundary}).
  *
  * Scope / assumptions (deliberate — the downstream gate warns, never fails):
  * - A sub-heading inside the section is treated as a label, not an item; its
@@ -355,16 +379,20 @@ export function extractSpecOutOfScope(specContent: string): string[] {
   const lines = specContent.split("\n");
 
   const fenced = fencedLineIndices(lines);
+  const boundary = storyScopeBoundary(lines);
   const items: string[] = [];
   for (let i = 0; i < lines.length; i++) {
     if (fenced.has(i)) continue;
     const level = outOfScopeHeadingLevel(lines[i], lines[i + 1]);
     if (level === null) continue;
+    // A sub-heading after story decomposition begins is that story's own
+    // deferral, not the feature's. Top-level sections stay feature-level.
+    if (level > 2 && i > boundary) continue;
     // Setext consumes its underline; ATX does not.
     const bodyStart = SETEXT_UNDERLINE.test(lines[i + 1] ?? "") ? i + 1 : i;
     items.push(...itemsFromSection(sectionLines(lines, bodyStart, level)));
   }
-  items.push(...itemsFromInlineMarkers(lines, fenced));
+  items.push(...itemsFromInlineMarkers(lines, fenced, boundary));
 
   return dedupeAndCap(items);
 }

--- a/test/unit/prd/out-of-scope.test.ts
+++ b/test/unit/prd/out-of-scope.test.ts
@@ -174,6 +174,37 @@ describe("extractSpecOutOfScope", () => {
     ]);
   });
 
+  test("ignores per-story deferrals under the Acceptance Criteria section", () => {
+    // spec-writing tells authors to give risk-sensitive stories their own
+    // `**Out of scope:**` list under the story AC block. Hoisting those to
+    // feature level propagated one story's deferral onto every other story.
+    const spec = [
+      "## Acceptance Criteria",
+      "",
+      "### US-001: Rate limiter",
+      "- [unit] increments the counter",
+      "",
+      "**Out of scope:** tenant scoping (US-003 owns it)",
+      "",
+      "### US-002: Replay store",
+      "- [unit] rejects reuse within window",
+      "",
+      "**Out of scope:** eviction policy",
+    ].join("\n");
+
+    expect(extractSpecOutOfScope(spec)).toEqual([]);
+  });
+
+  test("keeps a feature-level marker that precedes the story sections", () => {
+    const spec = "## Design\n\nstuff\n\n**Out of scope (deferred):** an Ink TUI\n\n## Stories\n\n- US-001\n";
+    expect(extractSpecOutOfScope(spec)).toEqual(["an Ink TUI"]);
+  });
+
+  test("keeps a top-level Out of Scope section placed after the story sections", () => {
+    const spec = "## Stories\n\n- US-001\n\n## Out of Scope\n\n- no Ink TUI\n";
+    expect(extractSpecOutOfScope(spec)).toEqual(["no Ink TUI"]);
+  });
+
   test("does not treat prose merely mentioning out of scope as a declaration", () => {
     const spec = "The diff rendering is out of scope for this story because nothing persists it.\n";
     expect(extractSpecOutOfScope(spec)).toEqual([]);


### PR DESCRIPTION
Follow-up to #1360. The squash merge landed at the second-to-last commit on that
branch, so this fix — pushed and CI-green before the merge — never made it in.

## The bug

`spec-writing` tells authors to give risk-sensitive stories their own
`**Out of scope:**` list under the story's AC block (guide Rule 10, for deferred
risk properties). `extractSpecOutOfScope` matched a marker **wherever it
appeared**, so those were hoisted to feature level and propagated onto *every*
story.

On `main` today:

```
## Acceptance Criteria

### US-001: Rate limiter
- [unit] increments the counter

**Out of scope:** tenant scoping (US-003 owns it)

### US-002: Replay store
- [unit] rejects reuse within window

**Out of scope:** eviction policy
```

→ `["tenant scoping (US-003 owns it)", "eviction policy"]`, both copied onto both
stories. US-001's implementer is told eviction policy is a hard boundary; US-002's
is told tenant scoping is — and a reviewer can cite either against the wrong story
with a valid `scopeIndex`.

The guide's own recommended pattern produced the bug.

## The fix

A declaration is feature-level only when it is:

- a top-level (`#`/`##`) `Out of Scope` section — anywhere in the document,
  including after the story sections; or
- an inline `**Out of scope …:**` lead-in **before** the first
  `## Stories` / `## Acceptance Criteria` heading.

Both real feature-level markers in this repo sit in Design and still extract
(`.nax/features/nax-replay/spec.md:21`, `mid-session-resume/spec.md:53` — the
story sections start at lines 84 and 229 respectively).

Also corrects the extractor docstring, which still said fenced code is "folded as
prose" — it is skipped outright, and the corollary (text inside a fence is
silently dropped) is now stated.

## Docs

`docs/architecture/spec-to-prd-pipeline.md` replaces the "Known limitation: no
story ancestry" section — added in #1360 and now obsolete — with the boundary
table. The companion `nax-spec-kit-skills` guidance is updated on that repo's
`main` (`78ba9d5`).

## Test plan

- [x] 3 new tests: per-story deferrals ignored, pre-boundary marker kept,
      top-level section after the story sections kept
- [x] `bun run test` — 10068 unit / 1090 integration / 21 UI, 0 fail, against
      latest `main`
- [x] `bun run lint` + `bun run typecheck` + contracts — clean
