### PR TITLE
fix(finish): make the nax-finish auto flow actually runnable + usage docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ test/integration/tmp/
 TEST_SUMMARY_*.md
 .nax-pids
 .nax/metrics.json
+.nax/nax-finish-result.json
 
 .nax/**/runs/
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ description: User guides, architecture references, and specs for nax
 |:------|:------------|
 | [CLI Reference](guides/cli-reference.md) | Complete `nax` CLI command reference |
 | [Configuration](guides/configuration.md) | Config file locations, key options, shell operator limitations |
+| [Autonomous Finish Flow](guides/nax-finish-autoflow.md) | `finish.autoFlow` — review, verify and open a PR after a run, incl. acpx reviewer profiles |
 | [Hooks](guides/hooks.md) | Lifecycle hooks for notifications and CI triggers |
 | [Interaction Triggers](guides/triggers.md) | Interactive pause-and-prompt configuration |
 | [Troubleshooting](guides/troubleshooting.md) | Common issues and resolutions |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -447,6 +447,9 @@ exclude: ["**/.nax-acceptance*"]
 
 ### Autonomous Finish Flow (`finish.autoFlow`)
 
+> Full walkthrough, including how to configure the acpx reviewer agent profiles:
+> [nax-finish-autoflow.md](./nax-finish-autoflow.md).
+
 After a **successful** run on a feature branch, nax can drive the whole finish
 ritual — acceptance gate, spec review, quality review, repo-root quality gates,
 PR — without a human in the terminal, as an [acpx flow](https://www.npmjs.com/package/acpx).
@@ -478,6 +481,7 @@ escalates** instead of guessing. It never merges.
 | `timeouts.acceptanceMs` | 10 min | Cap per acceptance-test group. |
 | `timeouts.gateMs` | 15 min | Cap per quality gate. |
 | `timeouts.flowMs` | 90 min | Cap on the whole `acpx flow run` subprocess. |
+| `timeouts.stepMs` | `null` | Cap per flow step (one agent turn), passed to acpx as `--timeout`. `null` keeps acpx's own 15-minute default. |
 
 **It runs only when** the run succeeded (no failed or paused stories, at least
 one completed), HEAD is not `main`/`master`, and `enabled` is true.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -444,3 +444,62 @@ exclude: ["**/.nax-acceptance*"]
 ```
 
 **Why this matters:** the acceptance test files import production code with relative paths (e.g. `./src/utils/detect-provider.ts`). They run correctly from their package directory under nax control, but should be excluded from the normal test pipeline to avoid unexpected failures or duplicate runs.
+
+### Autonomous Finish Flow (`finish.autoFlow`)
+
+After a **successful** run on a feature branch, nax can drive the whole finish
+ritual — acceptance gate, spec review, quality review, repo-root quality gates,
+PR — without a human in the terminal, as an [acpx flow](https://www.npmjs.com/package/acpx).
+It auto-fixes what it can, and on anything needing human judgment it **stops and
+escalates** instead of guessing. It never merges.
+
+**Opt-in — off by default:**
+
+```json
+{
+  "finish": {
+    "autoFlow": {
+      "enabled": true,
+      "reviewers": { "spec": "nax-spec-reviewer", "quality": "nax-quality-reviewer" },
+      "escalate": { "telegram": true },
+      "timeouts": { "acceptanceMs": 600000, "gateMs": 900000, "flowMs": 5400000 }
+    }
+  }
+}
+```
+
+| Key | Default | Meaning |
+|:---|:---|:---|
+| `enabled` | `false` | Master gate. The flow never fires unless this is true. |
+| `flowPath` | `flows/nax-finish/nax-finish.flow.ts` | Relative paths resolve against the **nax install** first, then your repo (so you can vendor a variant). Absolute paths are used as-is. |
+| `defaultAgent` | `null` | acpx `--default-agent` for nodes with no pinned profile. |
+| `reviewers.spec` / `reviewers.quality` | `null` | acpx agent profiles (from `~/.acpx/config.json`) for the two review phases — each runs in its own isolated session, so they can be different agents/models. Unset → `defaultAgent`. |
+| `escalate.telegram` | `true` | Prefer Telegram for escalations when `interaction.plugin` is `telegram` (or `NAX_TELEGRAM_TOKEN` + `NAX_TELEGRAM_CHAT_ID` are set). With no credentials it falls back to a PR/MR comment. |
+| `timeouts.acceptanceMs` | 10 min | Cap per acceptance-test group. |
+| `timeouts.gateMs` | 15 min | Cap per quality gate. |
+| `timeouts.flowMs` | 90 min | Cap on the whole `acpx flow run` subprocess. |
+
+**It runs only when** the run succeeded (no failed or paused stories, at least
+one completed), HEAD is not `main`/`master`, and `enabled` is true.
+
+**Requirements:**
+
+- `acpx` on `PATH` with flows support (`acpx flow run`), and `gh` or `glab`
+  authenticated for the PR/MR step.
+- **`quality.commands` must be configured** — the flow runs those commands at the
+  repo root as its final gate. With none configured it escalates rather than
+  opening a PR, because a green gate that verified nothing is worse than no gate.
+
+**What it does with what it finds:**
+
+| Outcome | Action |
+|:---|:---|
+| Everything green | Opens a **ready** PR/MR, or promotes the draft `autoPR` already opened. Never merges. |
+| Findings with a clear recommended fix | Applies them, re-runs acceptance / re-reviews, up to 3 attempts per phase. |
+| Spec conflicts, contradictions, design calls, or anything it can't get green | Commits and pushes what it fixed, then escalates via Telegram or a PR/MR comment. No ready PR. |
+| Branch has no commits ahead of base | Reports `nothing-to-finish` and stops. |
+
+The flow's terminal state is written to `.nax/nax-finish-result.json` (gitignored).
+
+The interactive, approval-gated `nax-finish` skill still exists for manual
+finishes — this is the autonomous path, not a replacement.

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -1,0 +1,357 @@
+# Autonomous Finish Flow (`nax-finish`)
+
+`nax-finish` takes a feature branch that a `nax run` just implemented and drives
+it to a **review-ready PR** — or to a clearly-flagged escalation — without a
+human in the terminal.
+
+It runs as an [acpx flow](https://www.npmjs.com/package/acpx) triggered by a
+built-in nax post-run plugin. It auto-fixes what it can, and on anything needing
+human judgment it **stops and escalates** rather than guessing. It never merges.
+
+> The interactive, approval-gated `nax-finish` skill still exists for manual
+> finishes. This is the autonomous path, not a replacement.
+
+---
+
+## 1. What it does
+
+```
+load_ctx          detect base branch, resolve the feature spec + acceptance groups,
+                  check the branch is ahead of base (else: nothing-to-finish)
+  ↓
+acceptance        run the feature's acceptance tests
+  ↳ fail → fix_acceptance (agent) → re-run          [max 3 attempts → escalate]
+  ↓
+review_spec       spec-relative review, isolated session, own agent profile
+  ↳ clean            → skip to review_quality
+  ↳ recommended fix  → fix_spec (agent) → re-run acceptance → re-review
+  ↳ needs judgment   → escalate
+  ↓
+review_quality    code-quality review, isolated session, own agent profile
+  ↳ clean            → skip to quality_gates
+  ↳ recommended fix  → fix_quality (agent) → re-review
+  ↳ needs judgment   → escalate
+  ↓
+quality_gates     run the repo's own quality.commands at the repo root
+  ↳ red → fix_gate (agent) → re-run                 [max 3 attempts → escalate]
+  ↳ none configured → escalate (a gate that verified nothing is not a pass)
+  ↓
+open_pr           commit + push the fixes, then open a ready PR
+                  (or promote the draft autoPR already opened)
+```
+
+Both terminal nodes (`open_pr`, `escalate`) commit and push first, so the PR — or
+the escalation — describes state a human can actually see.
+
+| Outcome | Result |
+|:---|:---|
+| All green | **Ready** PR/MR opened, or an existing draft promoted. Never merged. |
+| Fixable findings | Applied, re-verified, up to 3 attempts per phase. |
+| Spec conflict, contradiction, design call, or can't reach green | Partial fixes pushed, escalation sent, **no ready PR**. |
+| Branch not ahead of base | `nothing-to-finish`, stops. |
+
+The terminal state is written to `.nax/nax-finish-result.json`:
+
+```json
+{ "feature": "auth-hardening", "status": "promoted", "url": "https://github.com/o/r/pull/42" }
+```
+
+`status` is one of `opened`, `promoted`, `already-ready`, `escalated`,
+`nothing-to-finish`. Add it to `.gitignore`.
+
+---
+
+## 2. Prerequisites
+
+| Requirement | Check |
+|:---|:---|
+| `acpx` with flows support on `PATH` | `acpx flow run --help` |
+| At least one ACP agent working | `acpx claude 'say hi'` |
+| `gh` or `glab` authenticated | `gh auth status` / `glab auth status` |
+| `quality.commands` configured in `.nax/config.json` | see below — **required** |
+| Acceptance tests for the feature | `nax features resolve <feature> --json` |
+
+**`quality.commands` is not optional.** The flow's final gate runs those commands
+at the repo root. With none configured it escalates instead of opening a PR:
+
+```json
+{
+  "quality": {
+    "commands": {
+      "build": "bun run build",
+      "typecheck": "bun run typecheck",
+      "lint": "bun run lint",
+      "test": "bun run test"
+    }
+  }
+}
+```
+
+Commands run through `/bin/sh -c`, so `&&`, quoting and globs work as written.
+Only the repo-root `.nax/config.json` is read for this gate — per-package
+overrides don't verify the repo root.
+
+---
+
+## 3. Enable it
+
+```json
+{
+  "finish": {
+    "autoFlow": {
+      "enabled": true
+    }
+  }
+}
+```
+
+That's the minimum. It then fires after a `nax run` when **all** of these hold:
+
+- the run succeeded — at least one completed story, no failed and no paused ones
+- `HEAD` is not `main` / `master`
+- `enabled` is `true`
+
+It is off by default, and a failure inside the flow never fails your run (the
+post-run driver treats it as non-blocking and logs a warning).
+
+### Full config
+
+```json
+{
+  "finish": {
+    "autoFlow": {
+      "enabled": true,
+      "flowPath": "flows/nax-finish/nax-finish.flow.ts",
+      "defaultAgent": "claude",
+      "reviewers": {
+        "spec": "nax-spec-reviewer",
+        "quality": "nax-quality-reviewer"
+      },
+      "escalate": { "telegram": true },
+      "timeouts": {
+        "acceptanceMs": 600000,
+        "gateMs": 900000,
+        "flowMs": 5400000,
+        "stepMs": null
+      }
+    }
+  }
+}
+```
+
+| Key | Default | Meaning |
+|:---|:---|:---|
+| `enabled` | `false` | Master gate. |
+| `flowPath` | `flows/nax-finish/nax-finish.flow.ts` | Resolved against the **nax install** first, then your repo (vendor a variant by putting a file at the same relative path), then used as-is if absolute. |
+| `defaultAgent` | `null` | acpx agent for any node without a pinned profile. Unset → acpx's own `defaultAgent`. |
+| `reviewers.spec` | `null` | acpx agent profile for the spec-review phase — see §4. |
+| `reviewers.quality` | `null` | acpx agent profile for the quality-review phase. |
+| `escalate.telegram` | `true` | Prefer Telegram for escalations when credentials resolve; else PR/MR comment. |
+| `timeouts.acceptanceMs` | 600000 (10 min) | Cap per acceptance-test group. |
+| `timeouts.gateMs` | 900000 (15 min) | Cap per quality gate. |
+| `timeouts.flowMs` | 5400000 (90 min) | Cap on the whole `acpx flow run`. |
+| `timeouts.stepMs` | `null` | Cap per flow step (one agent turn), passed to acpx as `--timeout`. `null` keeps acpx's own 15-minute default — raise it if reviews of large diffs get cut off. |
+
+---
+
+## 4. Configuring the reviewer agent profiles (acpx)
+
+The two review phases run as **separate isolated acpx sessions**, so each can use
+a different agent and model — e.g. a powerful adversarial model for the spec lens
+and a cheaper one for code quality.
+
+`reviewers.spec` and `reviewers.quality` are **acpx agent names**. A name is
+either a built-in (`claude`, `codex`, `pi`, `gemini`, `opencode`, …) or a key you
+define in the `agents` map of your acpx config. The model is encoded in that
+entry's command/args — acpx has no separate model field.
+
+### Where acpx config lives
+
+acpx reads, later winning:
+
+1. global — `~/.acpx/config.json`
+2. project — `<cwd>/.acpxrc.json`
+
+Inspect the resolved result with `acpx config show`; create the global template
+with `acpx config init`.
+
+### Defining named reviewer profiles
+
+`~/.acpx/config.json`:
+
+```json
+{
+  "defaultAgent": "claude",
+  "agents": {
+    "nax-spec-reviewer": {
+      "command": "claude-agent-acp",
+      "args": ["--model", "opus"]
+    },
+    "nax-quality-reviewer": {
+      "command": "claude-agent-acp",
+      "args": ["--model", "sonnet"]
+    }
+  }
+}
+```
+
+Then in `.nax/config.json`:
+
+```json
+{
+  "finish": {
+    "autoFlow": {
+      "enabled": true,
+      "reviewers": { "spec": "nax-spec-reviewer", "quality": "nax-quality-reviewer" }
+    }
+  }
+}
+```
+
+Each entry needs a non-empty `command`; `args` is an optional array of strings
+that acpx appends (quoted) to it. Names are normalised, so `nax-spec-reviewer`
+and `Nax_Spec_Reviewer` refer to the same profile.
+
+### Mixing agents across phases
+
+Nothing requires both phases to use the same underlying agent:
+
+```json
+{
+  "agents": {
+    "spec-lens": { "command": "codex-acp", "args": ["--model", "gpt-5.2"] },
+    "quality-lens": { "command": "claude-agent-acp", "args": ["--model", "sonnet"] }
+  }
+}
+```
+
+```json
+{ "reviewers": { "spec": "spec-lens", "quality": "quality-lens" } }
+```
+
+### Overriding a built-in's command
+
+You can also redefine a built-in name — useful for a local checkout or extra env:
+
+```json
+{
+  "agents": {
+    "claude": { "command": "env ANTHROPIC_LOG=debug claude-agent-acp" }
+  }
+}
+```
+
+### Resolution order per node
+
+1. the node's pinned profile — `reviewers.spec` / `reviewers.quality`
+2. else `finish.autoFlow.defaultAgent` (passed to acpx as `--default-agent`)
+3. else acpx config `defaultAgent`
+4. else acpx's built-in fallback
+
+Fix nodes (`fix_acceptance`, `fix_spec`, `fix_quality`, `fix_gate`) are never
+pinned — they always use the default agent.
+
+Verify a profile resolves before enabling the flow:
+
+```bash
+acpx nax-spec-reviewer 'reply with OK'
+```
+
+### How the profiles reach the flow
+
+The plugin passes them as the env vars `NAX_FINISH_SPEC_PROFILE` and
+`NAX_FINISH_QUALITY_PROFILE`, which the flow module reads at load time. You can
+set them yourself when running the flow by hand (§6).
+
+---
+
+## 5. Escalation
+
+On anything needing human judgment the flow pushes what it fixed and sends a
+"needs judgment" summary naming the reason and the findings.
+
+**Telegram (preferred when configured).** Credentials come from the telegram
+interaction plugin, or from env:
+
+```json
+{
+  "interaction": {
+    "plugin": "telegram",
+    "config": { "botToken": "…", "chatId": "…" }
+  }
+}
+```
+
+```bash
+export NAX_TELEGRAM_TOKEN=…      # or TELEGRAM_BOT_TOKEN
+export NAX_TELEGRAM_CHAT_ID=…
+```
+
+When Telegram is enabled **and** credentialed, the flow posts no PR comment and
+opens no draft to hold one.
+
+**PR/MR comment (fallback).** With `escalate.telegram: false`, or no credentials,
+the flow comments on the branch's existing PR/MR — opening a *draft* to hold the
+comment only if none exists. It never opens a ready PR while escalating.
+
+---
+
+## 6. Running the flow by hand
+
+Useful for debugging without a full `nax run`. It performs real work — it edits
+files, pushes, and can open a PR.
+
+First locate the flow that ships with your nax install:
+
+```bash
+NAX_ROOT="$(dirname "$(dirname "$(readlink -f "$(command -v nax)")")")"
+FLOW="$NAX_ROOT/flows/nax-finish/nax-finish.flow.ts"
+ls "$FLOW"    # if this is missing, your nax predates the shipped flows/ directory
+```
+
+Then:
+
+```bash
+acpx --approve-all flow run "$FLOW" \
+  --input-json '{
+    "feature": "auth-hardening",
+    "workdir": "'"$PWD"'",
+    "branch": "'"$(git branch --show-current)"'",
+    "prdPath": ".nax/features/auth-hardening/prd.json",
+    "escalateTelegram": false,
+    "timeouts": { "acceptanceMs": 600000, "gateMs": 900000 }
+  }' \
+  --default-agent claude
+```
+
+Flag placement matters: `--approve-all` (and `--timeout`) are top-level flags and
+must precede `flow`; `--default-agent` belongs to `flow run` and must follow the
+flow file. The flow declares `requireExplicitGrant`, so `--approve-all` must be
+an explicit CLI flag — `defaultPermissions` in acpx config does not satisfy it.
+
+Run state is kept under `~/.acpx/flows/runs/`.
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Cause / fix |
+|:---|:---|
+| `nax-finish: flow module "…" not found` | `flows/` missing from the nax install. Reinstall nax, or point `flowPath` at an absolute path. |
+| `unknown option '--default-agent'` | The flag was placed before `flow run`. Fixed in nax; if calling acpx by hand, move it after the flow file. |
+| `Flow "nax-finish" requires an explicit approve-all grant` | Pass `--approve-all` on the command line. |
+| Escalates with `No quality.commands configured` | Configure `quality.commands` (§2). The flow won't call an unverified branch green. |
+| Escalates with `still failing after 3 fix attempts` | The agent couldn't fix it — the cap is deliberate. Take it from here manually. |
+| Nothing happens after a run | Check `enabled`, that no story failed or paused, and that `HEAD` isn't `main`/`master`. |
+| A review step is cut off mid-way | Raise `timeouts.stepMs` (acpx's default step cap is 15 minutes). |
+| Flow killed at 90 minutes | Raise `timeouts.flowMs`. |
+| PR opened without the flow's fixes | Should not happen — both terminal nodes push first. Check for a failed push in the run output or the escalation comment. |
+| Duplicate PRs vs nax autoPR | Not possible by design: the flow promotes an existing draft rather than opening a second PR. |
+
+---
+
+## See also
+
+- [configuration.md](./configuration.md) — the `finish.autoFlow` key reference
+- [triggers.md](./triggers.md) — other post-run hooks
+- `flows/nax-finish/` — the flow module itself

--- a/flows/nax-finish/errors.ts
+++ b/flows/nax-finish/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Self-contained error type for the nax-finish flow.
+ *
+ * The flow module is loaded by `acpx flow run` from wherever `flows/` happens
+ * to be installed, in acpx's own process, with the *user's* repo as cwd. It
+ * therefore cannot import from nax's `src/` — neither via the `@/*` path alias
+ * (which only resolves through nax's own tsconfig) nor via a relative path
+ * (only `flows/` is published, not `src/`). `FinishError` mirrors `NaxError`'s
+ * shape (message + machine-readable code + structured context) so escalation
+ * output and logs stay consistent with the rest of nax.
+ */
+export class FinishError extends Error {
+  readonly code: string;
+  readonly context: Record<string, unknown>;
+
+  constructor(message: string, code: string, context: Record<string, unknown> = {}) {
+    const { cause, ...rest } = context;
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "FinishError";
+    this.code = code;
+    this.context = rest;
+  }
+}

--- a/flows/nax-finish/exec.ts
+++ b/flows/nax-finish/exec.ts
@@ -1,0 +1,70 @@
+/**
+ * Subprocess execution for the nax-finish flow.
+ *
+ * Two distinct entry points, deliberately:
+ *
+ * - `runArgv` — for commands *this flow* constructs (`git`, `gh`, `glab`). An
+ *   argv array is spawned directly: no shell, so no quoting or injection
+ *   surface for branch names and review text.
+ * - `runShell` — for command *strings the user configured* (`quality.commands`,
+ *   `acceptance.command`). These are run through `/bin/sh -c`, matching
+ *   `src/quality/runner.ts`, which is the only way to preserve `&&`, quoting,
+ *   globs and env prefixes. Splitting such a string on whitespace and spawning
+ *   argv (the previous behaviour) silently mis-ran every non-trivial command.
+ *
+ * Both cap wall-clock time: an unbounded gate would hang `acpx flow run`, and
+ * the post-run plugin awaits that subprocess.
+ */
+import type { RunResult } from "./types";
+
+/** Fallbacks used when the plugin passes no explicit budget in the flow input. */
+export const DEFAULT_ACCEPTANCE_TIMEOUT_MS = 600_000;
+export const DEFAULT_GATE_TIMEOUT_MS = 900_000;
+/** Short budget for the flow's own git/forge plumbing — these are never long-running. */
+export const DEFAULT_ARGV_TIMEOUT_MS = 120_000;
+
+export interface ExecOptions {
+  cwd: string;
+  timeoutMs?: number;
+}
+
+async function spawnCapture(cmd: string[], opts: ExecOptions): Promise<RunResult> {
+  const proc = Bun.spawn(cmd, { cwd: opts.cwd, stdout: "pipe", stderr: "pipe" });
+  let timedOut = false;
+  // setTimeout (not Bun.sleep) because the handle must be cancellable the moment
+  // the process exits — the documented exception in forbidden-patterns.md.
+  const timer =
+    opts.timeoutMs && opts.timeoutMs > 0
+      ? setTimeout(() => {
+          timedOut = true;
+          proc.kill();
+        }, opts.timeoutMs)
+      : undefined;
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    return timedOut
+      ? {
+          exitCode: exitCode === 0 ? 124 : exitCode,
+          stdout,
+          stderr: `${stderr}\n[nax-finish] killed after ${opts.timeoutMs}ms timeout`,
+          timedOut: true,
+        }
+      : { exitCode, stdout, stderr };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Spawn an argv array directly — no shell. For flow-constructed commands. */
+export function runArgv(cmd: string[], opts: ExecOptions): Promise<RunResult> {
+  return spawnCapture(cmd, { ...opts, timeoutMs: opts.timeoutMs ?? DEFAULT_ARGV_TIMEOUT_MS });
+}
+
+/** Run a configured command string through `/bin/sh -c`, preserving shell semantics. */
+export function runShell(command: string, opts: ExecOptions): Promise<RunResult> {
+  return spawnCapture(["/bin/sh", "-c", command], opts);
+}

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -9,39 +9,122 @@
  * `finish.autoFlow.reviewers.{spec,quality}` config before spawning, since
  * this flow module reloads fresh on every `acpx flow run` invocation.
  * Unset → both fall back to acpx's `--default-agent`.
+ *
+ * This module is loaded by acpx, from wherever `flows/` is installed, with the
+ * user's repo as cwd — so it never imports from nax's `src/` (see ./errors.ts).
+ *
+ * Graph shape (deviations from the design doc are deliberate and noted):
+ * - `load_ctx` is an `action`, not a `compute`: it shells git + `nax features
+ *   resolve` once, and its output feeds both the review prompts (specPath) and
+ *   the acceptance gate (groups), so nothing resolves the feature twice.
+ * - Review fixes loop: `review_* → route_* → fix_* → (re-run acceptance |
+ *   re-review) → review_*` until the reviewer comes back clean or the fix cap
+ *   trips. A single-shot fix left the fixed diff unverified.
+ * - `route_*` compute nodes hold the escalate/clean/fix decision so the cap is
+ *   enforced deterministically rather than trusting the model's own route.
  */
 import { defineFlow, extractJsonObject } from "acpx/flows";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
 import {
   _contextDeps,
   buildEscalationComment,
+  commitAndPush,
   detectBaseBranch,
   loadQualityCommands,
   openOrPromotePr,
-  parseAcceptanceGroups,
   postEscalation,
   preflight,
-  resolveSpec,
+  resolveFeature,
   runAcceptanceGate,
   runQualityGates,
   writeResult,
 } from "./steps";
-import type { FinishInput, ReviewVerdict } from "./types";
+import type { AcceptanceGroup, FinishInput, ReviewVerdict } from "./types";
 
 const inputOf = (ctx: { input: unknown }) => ctx.input as FinishInput;
 
 /**
- * Cap on acceptance/quality-gate fix-and-reverify iterations before
- * escalating instead of looping forever. acpx's flow engine has no built-in
- * cycle guard, so without this cap a stubborn failure (LLM can't fix it, or
- * fixes something else each time) hangs `acpx flow run` — and the post-run
- * plugin awaits that subprocess with no timeout, hanging the whole run's
- * completion phase indefinitely.
+ * Cap on fix-and-reverify iterations, per phase, before escalating instead of
+ * looping forever. acpx's flow engine has no built-in cycle guard, so without
+ * this cap a stubborn failure (LLM can't fix it, or fixes something else each
+ * time) hangs `acpx flow run` — and the post-run plugin awaits that subprocess.
  */
 const MAX_FIX_ATTEMPTS = 3;
 
+interface LoadCtxOutput {
+  base?: string;
+  specPath?: string;
+  groups?: AcceptanceGroup[];
+  route?: string;
+}
+
 function fixAttemptCount(ctx: { state: { steps: { nodeId: string }[] } }, fixNodeId: string): number {
-  return ctx.state.steps.filter((s) => s.nodeId === fixNodeId).length;
+  return (ctx.state.steps ?? []).filter((s) => s.nodeId === fixNodeId).length;
+}
+
+function loadCtxOf(ctx: { outputs: unknown }): LoadCtxOutput {
+  return ((ctx.outputs as Record<string, LoadCtxOutput | undefined>).load_ctx ?? {}) as LoadCtxOutput;
+}
+
+/** Re-run the acceptance gate, routing on the shared fix-cap rules. */
+async function acceptanceGateNode(ctx: {
+  input: unknown;
+  outputs: unknown;
+  state: { steps: { nodeId: string }[] };
+}): Promise<{ route: string; reason?: string; output: string }> {
+  const i = inputOf(ctx);
+  const groups = loadCtxOf(ctx).groups ?? [];
+  const r = await runAcceptanceGate(i.workdir, groups, { timeoutMs: i.timeouts?.acceptanceMs });
+  if (r.passed) return { route: "proceed", output: r.output };
+  const attempts = fixAttemptCount(ctx, "fix_acceptance");
+  if (attempts >= MAX_FIX_ATTEMPTS) {
+    return {
+      route: "escalate",
+      reason: `Acceptance tests still failing after ${attempts} fix attempts.`,
+      output: r.output,
+    };
+  }
+  return { route: "fix", output: r.output };
+}
+
+/**
+ * Turn a reviewer verdict into a deterministic route.
+ *
+ * `clean` (no findings) skips the fix node entirely — prompting an agent to
+ * "apply the recommended fixes" for an empty finding list burns a turn and
+ * invites unrequested edits.
+ */
+function routeReview(
+  ctx: { outputs: unknown; state: { steps: { nodeId: string }[] } },
+  phase: "spec" | "quality",
+): { route: string; escalationReason?: string; findings: ReviewVerdict["findings"] } {
+  const verdict = (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`];
+  const findings = verdict?.findings ?? [];
+  if (verdict?.route === "escalate") {
+    return {
+      route: "escalate",
+      escalationReason: verdict.escalationReason ?? `${phase} review raised a finding needing human judgment`,
+      findings,
+    };
+  }
+  if (findings.length === 0) return { route: "clean", findings };
+  const attempts = fixAttemptCount(ctx, `fix_${phase}`);
+  if (attempts >= MAX_FIX_ATTEMPTS) {
+    return {
+      route: "escalate",
+      escalationReason: `${phase} review still reporting ${findings.length} finding(s) after ${attempts} fix attempts.`,
+      findings,
+    };
+  }
+  return { route: "fix", findings };
+}
+
+/** Normalise a reviewer's JSON, rewriting a findings-free `proceed` to `clean`. */
+function parseVerdict(text: string): ReviewVerdict {
+  const raw = extractJsonObject(text) as Partial<ReviewVerdict>;
+  const findings = Array.isArray(raw.findings) ? raw.findings : [];
+  const route = raw.route === "escalate" ? "escalate" : findings.length === 0 ? "clean" : "proceed";
+  return { route, findings, escalationReason: raw.escalationReason };
 }
 
 export default defineFlow({
@@ -54,108 +137,117 @@ export default defineFlow({
   startAt: "load_ctx",
   nodes: {
     load_ctx: {
-      nodeType: "compute",
+      nodeType: "action",
       async run(ctx) {
         const i = inputOf(ctx);
         const base = await detectBaseBranch(i.workdir);
-        const { specPath } = await resolveSpec(i.feature, i.workdir);
+        const resolution = await resolveFeature(i.feature, i.workdir);
         const pf = await preflight(i.workdir, base);
-        return { base, specPath, route: pf.route };
+        return {
+          base,
+          specPath: resolution.specPath,
+          acceptanceStatus: resolution.acceptanceStatus,
+          groups: resolution.groups,
+          commitsAhead: pf.commitsAhead,
+          route: pf.route,
+        };
       },
     },
     acceptance: {
       nodeType: "action",
-      async run(ctx) {
-        const i = inputOf(ctx);
-        const res = await _contextDeps.run(["nax", "features", "resolve", i.feature, "--json"], { cwd: i.workdir });
-        const { groups } = parseAcceptanceGroups(res.stdout);
-        const r = await runAcceptanceGate(i.workdir, groups);
-        if (r.passed) return { route: "proceed", output: r.output };
-        const attempts = fixAttemptCount(ctx, "fix_acceptance");
-        if (attempts >= MAX_FIX_ATTEMPTS) {
-          return {
-            route: "escalate",
-            reason: `Acceptance tests still failing after ${attempts} fix attempts.`,
-            output: r.output,
-          };
-        }
-        return { route: "fix", output: r.output };
-      },
+      run: acceptanceGateNode,
     },
     fix_acceptance: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("acceptance", ctx),
-      parse: (t) => extractJsonObject(t) as ReviewVerdict,
+      parse: parseVerdict,
     },
     review_spec: {
       nodeType: "acp",
       session: { isolated: true },
       profile: process.env.NAX_FINISH_SPEC_PROFILE || undefined,
       prompt(ctx) {
-        const outs = ctx.outputs as Record<string, { base?: string; specPath?: string }>;
-        return buildReviewPrompt("spec", {
-          base: outs.load_ctx?.base ?? "origin/main",
-          specPath: outs.load_ctx?.specPath ?? "",
-        });
+        const outs = loadCtxOf(ctx);
+        return buildReviewPrompt("spec", { base: outs.base ?? "origin/main", specPath: outs.specPath ?? "" });
       },
-      parse: (text) => extractJsonObject(text) as ReviewVerdict,
+      parse: parseVerdict,
+    },
+    route_spec: {
+      nodeType: "compute",
+      run: (ctx) => routeReview(ctx, "spec"),
+    },
+    fix_spec: {
+      nodeType: "acp",
+      prompt: (ctx) => fixPrompt("spec", ctx),
+      parse: parseVerdict,
     },
     review_quality: {
       nodeType: "acp",
       session: { isolated: true },
       profile: process.env.NAX_FINISH_QUALITY_PROFILE || undefined,
       prompt(ctx) {
-        const outs = ctx.outputs as Record<string, { base?: string; specPath?: string }>;
-        return buildReviewPrompt("quality", {
-          base: outs.load_ctx?.base ?? "origin/main",
-          specPath: outs.load_ctx?.specPath ?? "",
-        });
+        const outs = loadCtxOf(ctx);
+        return buildReviewPrompt("quality", { base: outs.base ?? "origin/main", specPath: outs.specPath ?? "" });
       },
-      parse: (text) => extractJsonObject(text) as ReviewVerdict,
+      parse: parseVerdict,
     },
-    fix_spec: {
-      nodeType: "acp",
-      prompt: (ctx) => fixPrompt("spec", ctx),
-      parse: (t) => extractJsonObject(t) as ReviewVerdict,
+    route_quality: {
+      nodeType: "compute",
+      run: (ctx) => routeReview(ctx, "quality"),
     },
     fix_quality: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("quality", ctx),
-      parse: (t) => extractJsonObject(t) as ReviewVerdict,
+      parse: parseVerdict,
     },
     fix_gate: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("gate", ctx),
-      parse: (t) => extractJsonObject(t) as ReviewVerdict,
+      parse: parseVerdict,
     },
     quality_gates: {
       nodeType: "action",
       async run(ctx) {
         const i = inputOf(ctx);
         const cmds = await loadQualityCommands(i.workdir);
-        const r = await runQualityGates(i.workdir, cmds);
-        if (r.passed) return { route: "green", failing: r.failing, output: r.output };
+        const r = await runQualityGates(i.workdir, cmds, { timeoutMs: i.timeouts?.gateMs });
+        if (r.passed) return { route: "green", ran: r.ran, failing: r.failing, output: r.output };
+        // Nothing configured is not a pass — escalate immediately rather than
+        // open a "ready" PR having verified nothing. An LLM fix node cannot
+        // invent the repo's build/test commands.
+        if (r.ran.length === 0) {
+          return {
+            route: "escalate",
+            reason: "No quality.commands configured in .nax/config.json — nax-finish verified nothing.",
+            ran: r.ran,
+            failing: r.failing,
+            output: r.output,
+          };
+        }
         const attempts = fixAttemptCount(ctx, "fix_gate");
         if (attempts >= MAX_FIX_ATTEMPTS) {
           return {
             route: "escalate",
             reason: `Quality gates still failing after ${attempts} fix attempts (${r.failing.join(", ")}).`,
+            ran: r.ran,
             failing: r.failing,
             output: r.output,
           };
         }
-        return { route: "fix", failing: r.failing, output: r.output };
+        return { route: "fix", ran: r.ran, failing: r.failing, output: r.output };
       },
     },
     open_pr: {
       nodeType: "action",
       async run(ctx) {
         const i = inputOf(ctx);
-        const outs = ctx.outputs as Record<string, { route?: string } | undefined>;
-        if (outs.load_ctx?.route === "nothing-to-finish") {
+        if (loadCtxOf(ctx).route === "nothing-to-finish") {
           await writeResult(i.workdir, { feature: i.feature, status: "nothing-to-finish" });
           return { route: "done", status: "nothing-to-finish" };
         }
+        // Every fix node edited the working tree; without this the PR would be
+        // opened from a remote branch missing all of them.
+        const sync = await commitAndPush(i.workdir, i.branch, `fix(${i.feature}): nax-finish automated fixes`);
         const r = await openOrPromotePr(
           i.workdir,
           i.branch,
@@ -163,33 +255,46 @@ export default defineFlow({
           `Automated finish of \`${i.feature}\`.`,
         );
         await writeResult(i.workdir, { feature: i.feature, status: r.status, url: r.url });
-        return { route: "done", ...r };
+        return { route: "done", committed: sync.committed, ...r };
       },
     },
     escalate: {
       nodeType: "action",
       async run(ctx) {
         const i = inputOf(ctx);
-        const reviewOuts = ctx.outputs as Record<string, ReviewVerdict | undefined>;
-        const loopOuts = ctx.outputs as Record<string, { route?: string; reason?: string } | undefined>;
+        const outs = ctx.outputs as Record<string, { route?: string; reason?: string } | undefined>;
+        const routed = ctx.outputs as Record<string, ReviewVerdict | undefined>;
         const verdict =
-          reviewOuts.review_spec?.route === "escalate"
-            ? reviewOuts.review_spec
-            : reviewOuts.review_quality?.route === "escalate"
-              ? reviewOuts.review_quality
+          routed.route_spec?.route === "escalate"
+            ? routed.route_spec
+            : routed.route_quality?.route === "escalate"
+              ? routed.route_quality
               : undefined;
         const loopExhausted =
-          loopOuts.acceptance?.route === "escalate"
-            ? loopOuts.acceptance
-            : loopOuts.quality_gates?.route === "escalate"
-              ? loopOuts.quality_gates
+          outs.acceptance?.route === "escalate"
+            ? outs.acceptance
+            : outs.quality_gates?.route === "escalate"
+              ? outs.quality_gates
               : undefined;
         const reason =
           verdict?.escalationReason ?? loopExhausted?.reason ?? "nax-finish could not reach a green, shippable state";
-        const comment = buildEscalationComment(i.feature, reason, verdict?.findings ?? []);
-        const { url } = await postEscalation(i.workdir, i.branch, comment);
+
+        // Push what was fixed so the escalation describes state a human can see.
+        // A push failure must not swallow the escalation itself, so it is
+        // reported in the message rather than thrown.
+        let syncNote = "";
+        try {
+          await commitAndPush(i.workdir, i.branch, `wip(${i.feature}): nax-finish partial fixes before escalation`);
+        } catch (err) {
+          syncNote = `\n\n> Note: nax-finish could not push its partial fixes — ${String(err)}`;
+        }
+
+        const comment = buildEscalationComment(i.feature, reason, verdict?.findings ?? []) + syncNote;
+        const { url, channel } = await postEscalation(i.workdir, i.branch, comment, {
+          preferTelegram: i.escalateTelegram,
+        });
         await writeResult(i.workdir, { feature: i.feature, status: "escalated", url, escalationReason: reason });
-        return { route: "done", url, escalationReason: reason };
+        return { route: "done", url, channel, escalationReason: reason };
       },
     },
   },
@@ -200,10 +305,22 @@ export default defineFlow({
       switch: { on: "$.route", cases: { proceed: "review_spec", fix: "fix_acceptance", escalate: "escalate" } },
     },
     { from: "fix_acceptance", to: "acceptance" },
-    { from: "review_spec", switch: { on: "$.route", cases: { proceed: "fix_spec", escalate: "escalate" } } },
-    { from: "fix_spec", to: "review_quality" },
-    { from: "review_quality", switch: { on: "$.route", cases: { proceed: "fix_quality", escalate: "escalate" } } },
-    { from: "fix_quality", to: "quality_gates" },
+    { from: "review_spec", to: "route_spec" },
+    {
+      from: "route_spec",
+      switch: { on: "$.route", cases: { clean: "review_quality", fix: "fix_spec", escalate: "escalate" } },
+    },
+    // Spec fixes re-run the acceptance gate first (they can break it), and the
+    // acceptance node's `proceed` edge leads back into review_spec for re-review.
+    { from: "fix_spec", to: "acceptance" },
+    { from: "review_quality", to: "route_quality" },
+    {
+      from: "route_quality",
+      switch: { on: "$.route", cases: { clean: "quality_gates", fix: "fix_quality", escalate: "escalate" } },
+    },
+    // Quality fixes are re-reviewed by the same lens; the repo-root gates that
+    // follow catch anything the fix broke mechanically.
+    { from: "fix_quality", to: "review_quality" },
     {
       from: "quality_gates",
       switch: { on: "$.route", cases: { green: "open_pr", fix: "fix_gate", escalate: "escalate" } },

--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -335,7 +335,8 @@ export function fixPrompt(
         ? (outs.acceptance?.output ?? "")
         : JSON.stringify(outs[`review_${phase}`]?.findings ?? []);
   return [
-    `Apply the recommended fixes for the ${phase} phase, directly in the repo. Do not open PRs.`,
+    `Apply the recommended fixes for the ${phase} phase, directly in the repo.`,
+    "Do not commit, push, or open PRs — nax-finish commits and pushes your edits itself.",
     `Context:\n${detail}`,
     "After fixing, re-run the feature's acceptance tests and the relevant checks; only proceed when they pass.",
     'Return exactly {"route":"proceed"} when done and green.',

--- a/flows/nax-finish/steps/acceptance.ts
+++ b/flows/nax-finish/steps/acceptance.ts
@@ -1,48 +1,44 @@
-import type { RunFn } from "../types";
+import { DEFAULT_ACCEPTANCE_TIMEOUT_MS, runShell } from "../exec";
+import type { AcceptanceGroup, ShellRunFn } from "../types";
 
-export interface AcceptanceGroup {
-  packageDir: string;
-  testPath: string;
-  exists: boolean;
-  command?: string;
-  language: string;
+export const _acceptanceDeps: { runShell: ShellRunFn } = { runShell };
+
+/** Single-quote a path for `/bin/sh -c`, so spaces in a repo path can't split the command. */
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
-async function defaultRun(cmd: string[], opts: { cwd: string }) {
-  const proc = Bun.spawn(cmd, { cwd: opts.cwd, stdout: "pipe", stderr: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { exitCode, stdout, stderr };
-}
-export const _acceptanceDeps: { run: RunFn } = { run: defaultRun };
-
-export function parseAcceptanceGroups(resolveJson: string): { status: string; groups: AcceptanceGroup[] } {
-  const parsed = JSON.parse(resolveJson) as { acceptance?: { status?: string; groups?: AcceptanceGroup[] } };
-  return { status: parsed.acceptance?.status ?? "no-prd", groups: parsed.acceptance?.groups ?? [] };
+/**
+ * Build the acceptance command for one group, mirroring nax's own execution:
+ * the configured `command` template (any `{{FILE}}` / `{{file}}` / `{{files}}`
+ * placeholder replaced by the **absolute** test path) run from the group's
+ * package dir. The command is a string, run through `/bin/sh -c`, because
+ * configured commands legitimately contain `&&`, quotes and flags.
+ */
+export function buildAcceptanceCommand(repoRoot: string, group: AcceptanceGroup): string {
+  const absFile = shellQuote(`${repoRoot}/${group.testPath}`);
+  const template = group.command ?? `${languageRunner(group.language)} {{FILE}}`;
+  return template.replace(/\{\{FILE\}\}|\{\{file\}\}|\{\{files\}\}/g, absFile);
 }
 
 export async function runAcceptanceGate(
   repoRoot: string,
   groups: AcceptanceGroup[],
-): Promise<{ passed: boolean; output: string }> {
+  opts: { timeoutMs?: number } = {},
+): Promise<{ passed: boolean; ran: number; output: string }> {
   const chunks: string[] = [];
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_ACCEPTANCE_TIMEOUT_MS;
+  let ran = 0;
   for (const g of groups) {
     if (!g.exists) continue;
     const cwd = g.packageDir ? `${repoRoot}/${g.packageDir}` : repoRoot;
-    const absFile = `${repoRoot}/${g.testPath}`;
-    const template = g.command ?? `${languageRunner(g.language)} {{FILE}}`;
-    const cmd = template
-      .replace(/\{\{FILE\}\}|\{\{file\}\}|\{\{files\}\}/g, absFile)
-      .split(/\s+/)
-      .filter(Boolean);
-    const res = await _acceptanceDeps.run(cmd, { cwd });
+    ran += 1;
+    const res = await _acceptanceDeps.runShell(buildAcceptanceCommand(repoRoot, g), { cwd, timeoutMs });
     chunks.push(`[${g.packageDir || "root"}] exit=${res.exitCode}\n${res.stdout}\n${res.stderr}`);
-    if (res.exitCode !== 0) return { passed: false, output: chunks.join("\n\n") };
+    if (res.exitCode !== 0) return { passed: false, ran, output: chunks.join("\n\n") };
   }
-  return { passed: true, output: chunks.join("\n\n") };
+  if (ran === 0) chunks.push("[acceptance] no acceptance test files present — nothing to run");
+  return { passed: true, ran, output: chunks.join("\n\n") };
 }
 
 function languageRunner(language: string): string {

--- a/flows/nax-finish/steps/context.ts
+++ b/flows/nax-finish/steps/context.ts
@@ -1,17 +1,8 @@
-import { NaxError } from "@/errors";
-import type { RunFn } from "../types";
+import { FinishError } from "../errors";
+import { runArgv } from "../exec";
+import type { AcceptanceGroup, RunFn } from "../types";
 
-async function defaultRun(cmd: string[], opts: { cwd: string }) {
-  const proc = Bun.spawn(cmd, { cwd: opts.cwd, stdout: "pipe", stderr: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { exitCode, stdout, stderr };
-}
-
-export const _contextDeps: { run: RunFn } = { run: defaultRun };
+export const _contextDeps: { run: RunFn } = { run: runArgv };
 
 export async function detectBaseBranch(workdir: string): Promise<string> {
   const res = await _contextDeps.run(["git", "remote", "show", "origin"], { cwd: workdir });
@@ -21,19 +12,46 @@ export async function detectBaseBranch(workdir: string): Promise<string> {
   return main.exitCode === 0 ? "origin/main" : "origin/master";
 }
 
-export async function resolveSpec(
-  feature: string,
-  workdir: string,
-): Promise<{ specPath: string; specKind: "markdown" | "prd" }> {
+export interface FeatureResolution {
+  specPath: string;
+  specKind: "markdown" | "prd";
+  acceptanceStatus: string;
+  groups: AcceptanceGroup[];
+}
+
+/**
+ * One `nax features resolve` call for the whole flow — it yields both the spec
+ * source (for the review prompts) and the acceptance groups (for the gate), so
+ * `load_ctx` resolves once and the acceptance node reads the groups off
+ * `ctx.outputs.load_ctx` instead of shelling out a second time.
+ */
+export async function resolveFeature(feature: string, workdir: string): Promise<FeatureResolution> {
   const res = await _contextDeps.run(["nax", "features", "resolve", feature, "--json"], { cwd: workdir });
-  const parsed = JSON.parse(res.stdout) as { specSource?: { kind: "markdown" | "prd"; path: string } };
+  let parsed: {
+    specSource?: { kind: "markdown" | "prd"; path: string };
+    acceptance?: { status?: string; groups?: AcceptanceGroup[] };
+  };
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch (cause) {
+    throw new FinishError(
+      `nax features resolve returned unparseable JSON for "${feature}"`,
+      "FINISH_RESOLVE_UNPARSEABLE",
+      { stage: "finish-context", feature, exitCode: res.exitCode, cause },
+    );
+  }
   if (!parsed.specSource) {
-    throw new NaxError(`nax features resolve returned no specSource for "${feature}"`, "FINISH_SPEC_NOT_FOUND", {
+    throw new FinishError(`nax features resolve returned no specSource for "${feature}"`, "FINISH_SPEC_NOT_FOUND", {
       stage: "finish-context",
       feature,
     });
   }
-  return { specPath: parsed.specSource.path, specKind: parsed.specSource.kind };
+  return {
+    specPath: parsed.specSource.path,
+    specKind: parsed.specSource.kind,
+    acceptanceStatus: parsed.acceptance?.status ?? "no-prd",
+    groups: parsed.acceptance?.groups ?? [],
+  };
 }
 
 export async function preflight(

--- a/flows/nax-finish/steps/escalate.ts
+++ b/flows/nax-finish/steps/escalate.ts
@@ -1,20 +1,9 @@
-import { NaxError } from "@/errors";
+import { FinishError } from "../errors";
+import { runArgv } from "../exec";
 import type { Finding, RunFn } from "../types";
+import { detectForge, extractUrl, viewArgv } from "./forge";
 
-/** Matches the first http(s) URL on a line — `gh`/`glab` print the URL on stdout. */
-const URL_REGEX = /https?:\/\/\S+/;
-
-async function defaultRun(cmd: string[], opts: { cwd: string }) {
-  const proc = Bun.spawn(cmd, { cwd: opts.cwd, stdout: "pipe", stderr: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { exitCode, stdout, stderr };
-}
-
-export const _escalateDeps: { run: RunFn } = { run: defaultRun };
+export const _escalateDeps: { run: RunFn } = { run: runArgv };
 
 export function buildEscalationComment(feature: string, escalationReason: string, findings: Finding[]): string {
   const lines = [
@@ -30,25 +19,36 @@ export function buildEscalationComment(feature: string, escalationReason: string
   return lines.join("\n");
 }
 
-async function detectForge(repoRoot: string, stage: string): Promise<"github" | "gitlab"> {
-  const remote = await _escalateDeps.run(["git", "remote", "get-url", "origin"], { cwd: repoRoot });
-  const remoteUrl = remote.stdout.trim();
-  if (remoteUrl.includes("github.com")) return "github";
-  if (remoteUrl.includes("gitlab.com")) return "gitlab";
-  throw new NaxError(`Unable to determine forge from remote URL "${remoteUrl}"`, "FINISH_UNKNOWN_FORGE", {
-    stage,
-    remoteUrl,
-  });
+export interface EscalationOutcome {
+  url?: string;
+  /** Where the "needs judgment" message was delivered. */
+  channel: "telegram" | "pr-comment";
 }
 
-export async function postEscalation(repoRoot: string, branch: string, comment: string): Promise<{ url?: string }> {
-  const forge = await detectForge(repoRoot, "finish-escalate");
+/**
+ * Deliver an escalation.
+ *
+ * `preferTelegram` (set by the plugin only when Telegram is both enabled and
+ * credentialed) makes Telegram the sole channel: the flow posts no comment and
+ * — critically — opens no draft PR to hold one, matching the design's
+ * "prefer Telegram when configured, else fall back to a PR/MR comment". The
+ * plugin sends the message itself after reading the result file. It still reads
+ * any existing PR/MR so the notification can carry a link, which is a read-only
+ * lookup with no side effect.
+ */
+export async function postEscalation(
+  repoRoot: string,
+  branch: string,
+  comment: string,
+  opts: { preferTelegram?: boolean } = {},
+): Promise<EscalationOutcome> {
+  const forge = await detectForge(_escalateDeps.run, repoRoot, "finish-escalate");
+  const view = await _escalateDeps.run(viewArgv(forge, branch, "url"), { cwd: repoRoot });
+  const existingUrl = view.exitCode === 0 ? extractUrl(view.stdout) : undefined;
 
-  const viewCmd =
-    forge === "github"
-      ? ["gh", "pr", "view", branch, "--json", "url"]
-      : ["glab", "mr", "view", branch, "--output", "json"];
-  const view = await _escalateDeps.run(viewCmd, { cwd: repoRoot });
+  if (opts.preferTelegram) {
+    return { url: existingUrl, channel: "telegram" };
+  }
 
   if (view.exitCode === 0) {
     const commentCmd =
@@ -57,13 +57,13 @@ export async function postEscalation(repoRoot: string, branch: string, comment: 
         : ["glab", "mr", "note", branch, "--message", comment];
     const commented = await _escalateDeps.run(commentCmd, { cwd: repoRoot });
     if (commented.exitCode !== 0) {
-      throw new NaxError(
+      throw new FinishError(
         `Failed to post escalation comment on "${branch}": ${commented.stderr.trim() || `exit ${commented.exitCode}`}`,
         "FINISH_ESCALATION_COMMENT_FAILED",
         { stage: "finish-escalate", branch },
       );
     }
-    return { url: extractUrl(view.stdout) };
+    return { url: existingUrl, channel: "pr-comment" };
   }
 
   const createCmd =
@@ -83,23 +83,11 @@ export async function postEscalation(repoRoot: string, branch: string, comment: 
         ];
   const create = await _escalateDeps.run(createCmd, { cwd: repoRoot });
   if (create.exitCode !== 0) {
-    throw new NaxError(
+    throw new FinishError(
       `Failed to open a draft to hold the escalation for "${branch}": ${create.stderr.trim() || `exit ${create.exitCode}`}`,
       "FINISH_ESCALATION_DRAFT_FAILED",
       { stage: "finish-escalate", branch },
     );
   }
-  return { url: extractUrl(create.stdout) };
-}
-
-/** Best-effort URL extraction: try `{url}` JSON first, fall back to a raw URL regex on stdout. */
-function extractUrl(stdout: string): string | undefined {
-  try {
-    const parsed = JSON.parse(stdout) as { url?: string };
-    if (parsed.url) return parsed.url;
-  } catch {
-    // fall through to regex extraction
-  }
-  const match = stdout.match(URL_REGEX);
-  return match ? match[0] : undefined;
+  return { url: extractUrl(create.stdout), channel: "pr-comment" };
 }

--- a/flows/nax-finish/steps/forge.ts
+++ b/flows/nax-finish/steps/forge.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared forge (GitHub / GitLab) helpers for the nax-finish flow.
+ *
+ * `run` is passed in by the caller rather than held here so each step keeps a
+ * single injectable `_deps` object for tests.
+ */
+import { FinishError } from "../errors";
+import type { RunFn } from "../types";
+
+/** Matches the first http(s) URL on a line — `gh`/`glab` print the URL on stdout. */
+const URL_REGEX = /https?:\/\/\S+/;
+
+export type Forge = "github" | "gitlab";
+
+export async function detectForge(run: RunFn, repoRoot: string, stage: string): Promise<Forge> {
+  const remote = await run(["git", "remote", "get-url", "origin"], { cwd: repoRoot });
+  const remoteUrl = remote.stdout.trim();
+  if (remoteUrl.includes("github.com")) return "github";
+  if (remoteUrl.includes("gitlab.com")) return "gitlab";
+  throw new FinishError(`Unable to determine forge from remote URL "${remoteUrl}"`, "FINISH_UNKNOWN_FORGE", {
+    stage,
+    remoteUrl,
+  });
+}
+
+/** Best-effort URL extraction: try `{url}` JSON first, fall back to a raw URL regex. */
+export function extractUrl(stdout: string): string | undefined {
+  try {
+    const parsed = JSON.parse(stdout) as { url?: string; web_url?: string };
+    if (parsed.url) return parsed.url;
+    if (parsed.web_url) return parsed.web_url;
+  } catch {
+    // fall through to regex extraction
+  }
+  const match = stdout.match(URL_REGEX);
+  return match ? match[0] : undefined;
+}
+
+/** Argv for reading the branch's existing PR/MR as JSON. */
+export function viewArgv(forge: Forge, branch: string, githubFields: string): string[] {
+  return forge === "github"
+    ? ["gh", "pr", "view", branch, "--json", githubFields]
+    : ["glab", "mr", "view", branch, "--output", "json"];
+}

--- a/flows/nax-finish/steps/git.ts
+++ b/flows/nax-finish/steps/git.ts
@@ -1,0 +1,73 @@
+/**
+ * Branch synchronisation for the nax-finish flow.
+ *
+ * Every fix node edits the working tree in place. Without this step those edits
+ * stay local and uncommitted: `gh pr create --head <branch>` then opens a PR
+ * from the *remote* branch, which is missing every fix the flow just made (and
+ * an escalation comment would describe state nobody else can see). Both
+ * terminal nodes call `commitAndPush` before touching the forge.
+ */
+import { FinishError } from "../errors";
+import { runArgv } from "../exec";
+import type { RunFn } from "../types";
+
+export const _gitDeps: { run: RunFn } = { run: runArgv };
+
+export interface SyncOutcome {
+  /** True when the flow's fixes produced a new commit. */
+  committed: boolean;
+  /** True when the branch was pushed (always attempted, so the forge sees HEAD). */
+  pushed: boolean;
+}
+
+async function isDirty(repoRoot: string): Promise<boolean> {
+  const status = await _gitDeps.run(["git", "status", "--porcelain"], { cwd: repoRoot });
+  if (status.exitCode !== 0) {
+    throw new FinishError(
+      `git status failed in "${repoRoot}": ${status.stderr.trim() || `exit ${status.exitCode}`}`,
+      "FINISH_GIT_STATUS_FAILED",
+      { stage: "finish-git", repoRoot },
+    );
+  }
+  return status.stdout.trim().length > 0;
+}
+
+/**
+ * Commit any outstanding fixes and push the branch to `origin`.
+ *
+ * The push is unconditional — even with nothing new to commit the local branch
+ * may be ahead of its remote (nax's own run commits, or a previous partial
+ * finish), and the PR must reflect HEAD.
+ */
+export async function commitAndPush(repoRoot: string, branch: string, message: string): Promise<SyncOutcome> {
+  let committed = false;
+  if (await isDirty(repoRoot)) {
+    const add = await _gitDeps.run(["git", "add", "-A"], { cwd: repoRoot });
+    if (add.exitCode !== 0) {
+      throw new FinishError(
+        `git add failed in "${repoRoot}": ${add.stderr.trim() || `exit ${add.exitCode}`}`,
+        "FINISH_GIT_ADD_FAILED",
+        { stage: "finish-git", repoRoot },
+      );
+    }
+    const commit = await _gitDeps.run(["git", "commit", "-m", message], { cwd: repoRoot });
+    if (commit.exitCode !== 0) {
+      throw new FinishError(
+        `git commit failed in "${repoRoot}": ${commit.stderr.trim() || commit.stdout.trim() || `exit ${commit.exitCode}`}`,
+        "FINISH_GIT_COMMIT_FAILED",
+        { stage: "finish-git", repoRoot, branch },
+      );
+    }
+    committed = true;
+  }
+
+  const push = await _gitDeps.run(["git", "push", "--set-upstream", "origin", branch], { cwd: repoRoot });
+  if (push.exitCode !== 0) {
+    throw new FinishError(
+      `git push of "${branch}" failed: ${push.stderr.trim() || `exit ${push.exitCode}`}`,
+      "FINISH_GIT_PUSH_FAILED",
+      { stage: "finish-git", repoRoot, branch, committed },
+    );
+  }
+  return { committed, pushed: true };
+}

--- a/flows/nax-finish/steps/index.ts
+++ b/flows/nax-finish/steps/index.ts
@@ -2,5 +2,7 @@ export * from "./context";
 export * from "./acceptance";
 export * from "./quality";
 export * from "./escalate";
+export * from "./forge";
+export * from "./git";
 export * from "./pr";
 export * from "./result";

--- a/flows/nax-finish/steps/pr.ts
+++ b/flows/nax-finish/steps/pr.ts
@@ -1,31 +1,9 @@
-import { NaxError } from "@/errors";
+import { FinishError } from "../errors";
+import { runArgv } from "../exec";
 import type { RunFn } from "../types";
+import { type Forge, detectForge, extractUrl, viewArgv } from "./forge";
 
-/** Matches the first http(s) URL on a line — `gh`/`glab` print the URL on stdout. */
-const URL_REGEX = /https?:\/\/\S+/;
-
-async function defaultRun(cmd: string[], opts: { cwd: string }) {
-  const proc = Bun.spawn(cmd, { cwd: opts.cwd, stdout: "pipe", stderr: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { exitCode, stdout, stderr };
-}
-
-export const _prDeps: { run: RunFn } = { run: defaultRun };
-
-async function detectForge(repoRoot: string, stage: string): Promise<"github" | "gitlab"> {
-  const remote = await _prDeps.run(["git", "remote", "get-url", "origin"], { cwd: repoRoot });
-  const remoteUrl = remote.stdout.trim();
-  if (remoteUrl.includes("github.com")) return "github";
-  if (remoteUrl.includes("gitlab.com")) return "gitlab";
-  throw new NaxError(`Unable to determine forge from remote URL "${remoteUrl}"`, "FINISH_UNKNOWN_FORGE", {
-    stage,
-    remoteUrl,
-  });
-}
+export const _prDeps: { run: RunFn } = { run: runArgv };
 
 /**
  * Parse `gh pr view --json isDraft,url` / `glab mr view --output json` stdout.
@@ -37,24 +15,17 @@ async function detectForge(repoRoot: string, stage: string): Promise<"github" | 
  * found — per the task brief, "treat any successful view as already-ready unless you find
  * clear evidence otherwise."
  */
-function parseView(stdout: string, forge: "github" | "gitlab"): { isDraft: boolean; url?: string } {
+function parseView(stdout: string, forge: Forge): { isDraft: boolean; url?: string } {
   try {
     const parsed = JSON.parse(stdout) as Record<string, unknown>;
     if (forge === "github") {
       return { isDraft: parsed.isDraft === true, url: typeof parsed.url === "string" ? parsed.url : undefined };
     }
     const isDraft = parsed.isDraft === true || parsed.draft === true || parsed.work_in_progress === true;
-    const url =
-      typeof parsed.url === "string" ? parsed.url : typeof parsed.web_url === "string" ? parsed.web_url : undefined;
-    return { isDraft, url: url ?? extractUrl(stdout) };
+    return { isDraft, url: extractUrl(stdout) };
   } catch {
     return { isDraft: false, url: extractUrl(stdout) };
   }
-}
-
-function extractUrl(stdout: string): string | undefined {
-  const match = stdout.match(URL_REGEX);
-  return match ? match[0] : undefined;
 }
 
 export async function openOrPromotePr(
@@ -63,28 +34,20 @@ export async function openOrPromotePr(
   title: string,
   body: string,
 ): Promise<{ status: "opened" | "promoted" | "already-ready"; url?: string }> {
-  const forge = await detectForge(repoRoot, "finish-pr");
-
-  const viewCmd =
-    forge === "github"
-      ? ["gh", "pr", "view", branch, "--json", "isDraft,url"]
-      : ["glab", "mr", "view", branch, "--output", "json"];
-  const view = await _prDeps.run(viewCmd, { cwd: repoRoot });
+  const forge = await detectForge(_prDeps.run, repoRoot, "finish-pr");
+  const view = await _prDeps.run(viewArgv(forge, branch, "isDraft,url"), { cwd: repoRoot });
 
   if (view.exitCode !== 0) {
     const createCmd =
       forge === "github"
-        ? ["gh", "pr", "create", "--fill", "--head", branch]
+        ? ["gh", "pr", "create", "--title", title, "--body", body, "--head", branch]
         : ["glab", "mr", "create", "--title", title, "--description", body, "--source-branch", branch];
     const create = await _prDeps.run(createCmd, { cwd: repoRoot });
     if (create.exitCode !== 0) {
-      throw new NaxError(
+      throw new FinishError(
         `Failed to create PR/MR for "${branch}": ${create.stderr.trim() || `exit ${create.exitCode}`}`,
         "FINISH_PR_CREATE_FAILED",
-        {
-          stage: "finish-pr",
-          branch,
-        },
+        { stage: "finish-pr", branch },
       );
     }
     return { status: "opened", url: extractUrl(create.stdout) };
@@ -95,13 +58,10 @@ export async function openOrPromotePr(
     const readyCmd = forge === "github" ? ["gh", "pr", "ready", branch] : ["glab", "mr", "update", branch, "--ready"];
     const ready = await _prDeps.run(readyCmd, { cwd: repoRoot });
     if (ready.exitCode !== 0) {
-      throw new NaxError(
+      throw new FinishError(
         `Failed to promote PR/MR "${branch}" to ready: ${ready.stderr.trim() || `exit ${ready.exitCode}`}`,
         "FINISH_PR_PROMOTE_FAILED",
-        {
-          stage: "finish-pr",
-          branch,
-        },
+        { stage: "finish-pr", branch },
       );
     }
     return { status: "promoted", url };

--- a/flows/nax-finish/steps/quality.ts
+++ b/flows/nax-finish/steps/quality.ts
@@ -1,4 +1,6 @@
-import type { RunFn } from "../types";
+import { FinishError } from "../errors";
+import { DEFAULT_GATE_TIMEOUT_MS, runShell } from "../exec";
+import type { ShellRunFn } from "../types";
 
 export interface QualityCommands {
   build?: string;
@@ -8,17 +10,8 @@ export interface QualityCommands {
   format?: string;
 }
 
-async function defaultRun(cmd: string[], opts: { cwd: string }) {
-  const proc = Bun.spawn(cmd, { cwd: opts.cwd, stdout: "pipe", stderr: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { exitCode, stdout, stderr };
-}
-export const _qualityDeps: { run: RunFn; readText: (path: string) => Promise<string | null> } = {
-  run: defaultRun,
+export const _qualityDeps: { runShell: ShellRunFn; readText: (path: string) => Promise<string | null> } = {
+  runShell,
   readText: async (path) => {
     const file = Bun.file(path);
     return (await file.exists()) ? await file.text() : null;
@@ -27,25 +20,74 @@ export const _qualityDeps: { run: RunFn; readText: (path: string) => Promise<str
 
 const GATE_ORDER: (keyof QualityCommands)[] = ["build", "typecheck", "lint", "test", "format"];
 
+export interface QualityGateOutcome {
+  passed: boolean;
+  /** Gate names that actually ran — empty means nothing was configured. */
+  ran: string[];
+  failing: string[];
+  output: string;
+}
+
+/**
+ * Run the repo's configured quality commands in order, each through
+ * `/bin/sh -c` (matching `src/quality/runner.ts`) so `&&`, quoting and globs
+ * survive, and each under a wall-clock cap so a hung gate can't stall the flow.
+ *
+ * `passed` is only true when at least one gate ran. A repo with no configured
+ * commands must not report a green gate — that previously let the flow open a
+ * "ready" PR having verified nothing.
+ */
 export async function runQualityGates(
   repoRoot: string,
   commands: QualityCommands,
-): Promise<{ passed: boolean; failing: string[]; output: string }> {
+  opts: { timeoutMs?: number } = {},
+): Promise<QualityGateOutcome> {
   const failing: string[] = [];
+  const ran: string[] = [];
   const chunks: string[] = [];
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_GATE_TIMEOUT_MS;
   for (const gate of GATE_ORDER) {
     const command = commands[gate];
     if (!command) continue;
-    const res = await _qualityDeps.run(command.split(/\s+/).filter(Boolean), { cwd: repoRoot });
+    ran.push(gate);
+    const res = await _qualityDeps.runShell(command, { cwd: repoRoot, timeoutMs });
     chunks.push(`[${gate}] exit=${res.exitCode}\n${res.stdout}\n${res.stderr}`);
     if (res.exitCode !== 0) failing.push(gate);
   }
-  return { passed: failing.length === 0, failing, output: chunks.join("\n\n") };
+  if (ran.length === 0) {
+    return {
+      passed: false,
+      ran,
+      failing: [],
+      output: "[quality] no quality.commands configured in .nax/config.json — nothing was verified",
+    };
+  }
+  return { passed: failing.length === 0, ran, failing, output: chunks.join("\n\n") };
 }
 
+/**
+ * Read `quality.commands` from the repo-root `.nax/config.json` only.
+ *
+ * Deliberately root-scoped: per-package `.nax/mono/<pkg>/config.json` overrides
+ * are unreliable as a repo-root gate (a package's own `test` command does not
+ * verify the repo), and this gate runs once at the root by design.
+ */
 export async function loadQualityCommands(workdir: string): Promise<QualityCommands> {
   const text = await _qualityDeps.readText(`${workdir}/.nax/config.json`);
   if (!text) return {};
-  const cfg = JSON.parse(text) as { quality?: { commands?: QualityCommands } };
+  let cfg: { quality?: { commands?: QualityCommands } };
+  try {
+    cfg = JSON.parse(text);
+  } catch (cause) {
+    throw new FinishError(
+      "Failed to parse .nax/config.json while loading quality commands",
+      "FINISH_CONFIG_UNPARSEABLE",
+      {
+        stage: "finish-quality",
+        path: `${workdir}/.nax/config.json`,
+        cause,
+      },
+    );
+  }
   return cfg.quality?.commands ?? {};
 }

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -1,3 +1,12 @@
+/** One acceptance-test group as reported by `nax features resolve --json`. */
+export interface AcceptanceGroup {
+  packageDir: string;
+  testPath: string;
+  exists: boolean;
+  command?: string;
+  language: string;
+}
+
 export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
 export interface Finding {
   severity: Severity;
@@ -6,16 +15,33 @@ export interface Finding {
   fix: string;
 }
 export interface ReviewVerdict {
-  route: "proceed" | "escalate";
+  /**
+   * `clean` is not a model-produced route — the review nodes' `parse` rewrites
+   * `proceed` with zero findings to `clean` so the graph can skip the fix node
+   * entirely instead of prompting an agent to "apply fixes" for nothing.
+   */
+  route: "proceed" | "escalate" | "clean";
   findings: Finding[];
   escalationReason?: string;
+}
+/** Wall-clock budgets, forwarded from `finish.autoFlow.timeouts` by the plugin. */
+export interface FinishTimeouts {
+  acceptanceMs?: number;
+  gateMs?: number;
 }
 export interface FinishInput {
   feature: string;
   workdir: string;
   branch: string;
   prdPath: string;
+  /**
+   * True only when Telegram escalation is both enabled *and* credentialed, as
+   * determined by the plugin. When true the flow skips the PR/MR comment
+   * fallback (and does not open a draft to hold one) — the plugin sends the
+   * Telegram message from the result file instead.
+   */
   escalateTelegram: boolean;
+  timeouts?: FinishTimeouts;
 }
 export interface FinishResult {
   feature: string;
@@ -27,5 +53,7 @@ export interface RunResult {
   exitCode: number;
   stdout: string;
   stderr: string;
+  timedOut?: boolean;
 }
-export type RunFn = (cmd: string[], opts: { cwd: string }) => Promise<RunResult>;
+export type RunFn = (cmd: string[], opts: { cwd: string; timeoutMs?: number }) => Promise<RunResult>;
+export type ShellRunFn = (command: string, opts: { cwd: string; timeoutMs?: number }) => Promise<RunResult>;

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   ],
   "files": [
     "dist/",
+    "flows/",
     "README.md",
     "CHANGELOG.md"
   ],

--- a/scripts/baselines/file-sizes-baseline.json
+++ b/scripts/baselines/file-sizes-baseline.json
@@ -1,15 +1,14 @@
 {
-  "updatedAt": "2026-07-04T10:56:20.809Z",
+  "updatedAt": "2026-07-25T06:34:42.526Z",
   "byFile": {
     "src/agents/acp/adapter.ts": 636,
     "src/agents/acp/spawn-client.ts": 737,
     "src/agents/manager.ts": 820,
-    "src/config/runtime-types.ts": 615,
+    "src/config/runtime-types.ts": 612,
     "src/context/engine/providers/code-neighbor.ts": 613,
     "src/execution/unified-executor.ts": 689,
     "src/operations/call.ts": 631,
     "src/prompts/builders/rectifier-builder.ts": 902,
-    "src/review/adversarial.ts": 622,
     "src/session/manager.ts": 707,
     "test/unit/cli/plan.test.ts": 1087,
     "test/unit/debate/runner-plan.test.ts": 1048,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -95,6 +95,7 @@ export {
   llmRoutingConfigSelector,
   mutationCheckConfigSelector,
   executionGatesConfigSelector,
+  finishConfigSelector,
 } from "./selectors";
 export { createConfigLoader } from "./loader-runtime";
 export type { ConfigLoader } from "./loader-runtime";

--- a/src/config/runtime-types-finish.ts
+++ b/src/config/runtime-types-finish.ts
@@ -1,0 +1,30 @@
+/**
+ * `finish` config types — the autonomous post-run finish flow (nax-finish).
+ *
+ * Split out of `runtime-types.ts`, which is at its file-size limit.
+ */
+
+/** Wall-clock budgets for the nax-finish flow's subprocesses (ms) */
+export interface FinishTimeoutsConfig {
+  acceptanceMs: number;
+  gateMs: number;
+  flowMs: number;
+}
+
+/** `finish.autoFlow` — the autonomous post-run finish flow (opt-in, off by default) */
+export interface FinishAutoFlowConfig {
+  enabled: boolean;
+  /** Flow module path; relative paths resolve against the nax install, then the repo */
+  flowPath: string;
+  /** acpx `--default-agent` for nodes without a pinned profile */
+  defaultAgent: string | null;
+  /** Per-phase reviewer acpx profiles */
+  reviewers: { spec: string | null; quality: string | null };
+  escalate: { telegram: boolean };
+  timeouts: FinishTimeoutsConfig;
+}
+
+/** `finish` config block */
+export interface FinishConfig {
+  autoFlow: FinishAutoFlowConfig;
+}

--- a/src/config/runtime-types-finish.ts
+++ b/src/config/runtime-types-finish.ts
@@ -9,6 +9,8 @@ export interface FinishTimeoutsConfig {
   acceptanceMs: number;
   gateMs: number;
   flowMs: number;
+  /** Per flow step, forwarded to acpx as `--timeout`; null keeps acpx's own default */
+  stepMs: number | null;
 }
 
 /** `finish.autoFlow` — the autonomous post-run finish flow (opt-in, off by default) */

--- a/src/config/runtime-types-project.ts
+++ b/src/config/runtime-types-project.ts
@@ -1,0 +1,13 @@
+/**
+ * Project profile types.
+ *
+ * Split out of `runtime-types.ts`, which is over the file-size limit.
+ */
+
+/** Project profile — language and tooling metadata for language-aware features (US-001) */
+export interface ProjectProfile {
+  language?: "typescript" | "javascript" | "go" | "rust" | "python" | "ruby" | "java" | "kotlin" | "php";
+  type?: string;
+  testFramework?: string;
+  lintTool?: string;
+}

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -500,13 +500,7 @@ export interface TestingConfig {
   mockGuidance?: string;
 }
 
-/** Project profile — language and tooling metadata for language-aware features (US-001) */
-export interface ProjectProfile {
-  language?: "typescript" | "javascript" | "go" | "rust" | "python" | "ruby" | "java" | "kotlin" | "php";
-  type?: string;
-  testFramework?: string;
-  lintTool?: string;
-}
+export type { ProjectProfile } from "./runtime-types-project";
 
 // Re-exported from debate/types.ts to maintain single source of truth
 export type {
@@ -518,6 +512,8 @@ export type {
   ResolverType,
   SessionMode,
 } from "../debate/types";
+
+export type { FinishAutoFlowConfig, FinishConfig, FinishTimeoutsConfig } from "./runtime-types-finish";
 
 /** Full nax configuration */
 export interface NaxConfig {
@@ -558,6 +554,8 @@ export interface NaxConfig {
   disabledPlugins?: string[];
   /** Built-in reporter plugin settings (webhook / OTel) */
   reporters?: import("./schemas-reporters").ReportersConfig;
+  /** nax-finish autonomous finish flow settings */
+  finish?: import("./runtime-types-finish").FinishConfig;
   /** Hooks configuration (v0.10) */
   hooks?: RawHooksConfig;
   /** Interaction settings (v0.15.0) */
@@ -571,7 +569,7 @@ export interface NaxConfig {
   /** Generate settings */
   generate?: GenerateConfig;
   /** Project profile — language and tooling metadata (US-001) */
-  project?: ProjectProfile;
+  project?: import("./runtime-types-project").ProjectProfile;
   /** Multi-agent debate settings */
   debate?: import("../debate/types").DebateConfig;
   /** Curator configuration */

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -440,6 +440,19 @@ export const NaxConfigSchema = z
               })
               .default({ spec: null, quality: null }),
             escalate: z.object({ telegram: z.boolean().default(true) }).default({ telegram: true }),
+            // Wall-clock caps. Every one of these bounds a subprocess the flow
+            // awaits; without them a hung gate stalls the whole run's
+            // completion phase, which has no timeout of its own.
+            timeouts: z
+              .object({
+                /** Per acceptance-test group. */
+                acceptanceMs: z.number().int().positive().default(600_000),
+                /** Per quality gate (build / typecheck / lint / test / format). */
+                gateMs: z.number().int().positive().default(900_000),
+                /** Whole `acpx flow run` subprocess. */
+                flowMs: z.number().int().positive().default(5_400_000),
+              })
+              .default({ acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 }),
           })
           .default({
             enabled: false,
@@ -447,6 +460,7 @@ export const NaxConfigSchema = z
             defaultAgent: null,
             reviewers: { spec: null, quality: null },
             escalate: { telegram: true },
+            timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 },
           }),
       })
       .default({
@@ -456,6 +470,7 @@ export const NaxConfigSchema = z
           defaultAgent: null,
           reviewers: { spec: null, quality: null },
           escalate: { telegram: true },
+          timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 },
         },
       }),
     reporters: ReportersConfigSchema,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -451,8 +451,14 @@ export const NaxConfigSchema = z
                 gateMs: z.number().int().positive().default(900_000),
                 /** Whole `acpx flow run` subprocess. */
                 flowMs: z.number().int().positive().default(5_400_000),
+                /**
+                 * Per flow *step* (one review or fix agent turn), passed to acpx as
+                 * `--timeout`. null keeps acpx's own 15-minute default, which a
+                 * large-diff review can exceed.
+                 */
+                stepMs: z.number().int().positive().nullable().default(null),
               })
-              .default({ acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 }),
+              .default({ acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000, stepMs: null }),
           })
           .default({
             enabled: false,
@@ -460,7 +466,7 @@ export const NaxConfigSchema = z
             defaultAgent: null,
             reviewers: { spec: null, quality: null },
             escalate: { telegram: true },
-            timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 },
+            timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000, stepMs: null },
           }),
       })
       .default({
@@ -470,7 +476,7 @@ export const NaxConfigSchema = z
           defaultAgent: null,
           reviewers: { spec: null, quality: null },
           escalate: { telegram: true },
-          timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 },
+          timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000, stepMs: null },
         },
       }),
     reporters: ReportersConfigSchema,

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -122,6 +122,11 @@ export const llmRoutingConfigSelector = pickSelector(
   "precheck",
 );
 
+// nax-finish autonomous flow — needs its own `finish` block plus `interaction`
+// (Telegram escalation credentials) and `quality` (the gate commands the flow
+// re-runs at the repo root).
+export const finishConfigSelector = pickSelector("finish", "finish", "interaction", "quality");
+
 // Derived config-slice types — co-located with each selector so consumers
 // import the type instead of re-deriving `ReturnType<typeof xSelector.select>`
 // in every operation file.
@@ -151,3 +156,4 @@ export type MutationCheckConfig = ReturnType<typeof mutationCheckConfigSelector.
 export type AutofixConfig = ReturnType<typeof autofixConfigSelector.select>;
 export type ExecutionGatesConfig = ReturnType<typeof executionGatesConfigSelector.select>;
 export type NonBlockingFixConfig = NonNullable<z.infer<typeof AdversarialReviewConfigSchema>["nonBlockingFix"]>;
+export type FinishConfig = ReturnType<typeof finishConfigSelector.select>;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -55,6 +55,8 @@ export type {
   EscalationEntry,
   ExecutionConfig,
   FeatureContextEngineConfig,
+  FinishAutoFlowConfig,
+  FinishTimeoutsConfig,
   RawHooksConfig,
   InteractionConfig,
   LlmRoutingConfig,

--- a/src/plugins/builtin/nax-finish/config.ts
+++ b/src/plugins/builtin/nax-finish/config.ts
@@ -1,42 +1,66 @@
 /**
  * nax-finish Plugin — Config Readers
  *
- * Loose readers over `ctx.config.finish.autoFlow` (schema: `src/config/schemas.ts`)
- * and `ctx.config.interaction` (schema: `src/config/schemas-infra.ts`), mirroring
- * the `getAutoPrConfig` pattern in `src/plugins/builtin/auto-pr/index.ts`.
+ * `PostRunContext.config` is typed `unknown` (plugins receive whatever the
+ * runner loaded), so the `finish` / `interaction` slices are taken through
+ * `finishConfigSelector` when the value looks like a parsed NaxConfig, and fall
+ * back to schema defaults otherwise. Reading through the named selector keeps
+ * this plugin's config dependency declared in `src/config/selectors.ts` rather
+ * than as an ad-hoc key list here.
  */
 
-interface FinishAutoFlowConfig {
+import { finishConfigSelector } from "@/config";
+import type { NaxConfig } from "@/config/types";
+
+export interface FinishAutoFlowSettings {
   enabled: boolean;
   flowPath: string;
   defaultAgent: string | null;
   reviewers: { spec: string | null; quality: string | null };
   escalate: { telegram: boolean };
+  timeouts: { acceptanceMs: number; gateMs: number; flowMs: number };
 }
 
-const DEFAULT_FINISH_AUTO_FLOW_CONFIG: FinishAutoFlowConfig = {
+/**
+ * Defaults mirroring `finish.autoFlow` in `src/config/schemas.ts`. They apply
+ * only when the plugin is handed a config carrying no `finish` block at all
+ * (older configs, and tests that pass a partial object).
+ */
+const DEFAULT_FINISH_AUTO_FLOW_CONFIG: FinishAutoFlowSettings = {
   enabled: false,
   flowPath: "flows/nax-finish/nax-finish.flow.ts",
   defaultAgent: null,
   reviewers: { spec: null, quality: null },
   escalate: { telegram: true },
+  timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 },
 };
 
-/** Read the loose `finish.autoFlow` block from `ctx.config`, applying schema defaults when absent. */
-export function getFinishAutoFlowConfig(ctx: { config?: unknown }): FinishAutoFlowConfig {
-  const cfg = ctx.config as Record<string, unknown> | undefined;
-  const finish = cfg?.finish as { autoFlow?: Partial<FinishAutoFlowConfig> } | undefined;
-  const autoFlow = finish?.autoFlow;
+function selectFinish(config: unknown): { autoFlow?: Partial<FinishAutoFlowSettings> } | undefined {
+  if (!config || typeof config !== "object") return undefined;
+  return finishConfigSelector.select(config as NaxConfig)?.finish as
+    | { autoFlow?: Partial<FinishAutoFlowSettings> }
+    | undefined;
+}
+
+/** Read the `finish.autoFlow` slice from `ctx.config`, applying schema defaults when absent. */
+export function getFinishAutoFlowConfig(ctx: { config?: unknown }): FinishAutoFlowSettings {
+  const autoFlow = selectFinish(ctx.config)?.autoFlow;
   if (!autoFlow) return DEFAULT_FINISH_AUTO_FLOW_CONFIG;
+  const defaults = DEFAULT_FINISH_AUTO_FLOW_CONFIG;
   return {
     enabled: autoFlow.enabled === true,
-    flowPath: autoFlow.flowPath ?? DEFAULT_FINISH_AUTO_FLOW_CONFIG.flowPath,
+    flowPath: autoFlow.flowPath ?? defaults.flowPath,
     defaultAgent: autoFlow.defaultAgent ?? null,
     reviewers: {
       spec: autoFlow.reviewers?.spec ?? null,
       quality: autoFlow.reviewers?.quality ?? null,
     },
     escalate: { telegram: autoFlow.escalate?.telegram !== false },
+    timeouts: {
+      acceptanceMs: autoFlow.timeouts?.acceptanceMs ?? defaults.timeouts.acceptanceMs,
+      gateMs: autoFlow.timeouts?.gateMs ?? defaults.timeouts.gateMs,
+      flowMs: autoFlow.timeouts?.flowMs ?? defaults.timeouts.flowMs,
+    },
   };
 }
 

--- a/src/plugins/builtin/nax-finish/config.ts
+++ b/src/plugins/builtin/nax-finish/config.ts
@@ -18,7 +18,7 @@ export interface FinishAutoFlowSettings {
   defaultAgent: string | null;
   reviewers: { spec: string | null; quality: string | null };
   escalate: { telegram: boolean };
-  timeouts: { acceptanceMs: number; gateMs: number; flowMs: number };
+  timeouts: { acceptanceMs: number; gateMs: number; flowMs: number; stepMs: number | null };
 }
 
 /**
@@ -32,7 +32,7 @@ const DEFAULT_FINISH_AUTO_FLOW_CONFIG: FinishAutoFlowSettings = {
   defaultAgent: null,
   reviewers: { spec: null, quality: null },
   escalate: { telegram: true },
-  timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000 },
+  timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000, stepMs: null },
 };
 
 function selectFinish(config: unknown): { autoFlow?: Partial<FinishAutoFlowSettings> } | undefined {
@@ -60,6 +60,7 @@ export function getFinishAutoFlowConfig(ctx: { config?: unknown }): FinishAutoFl
       acceptanceMs: autoFlow.timeouts?.acceptanceMs ?? defaults.timeouts.acceptanceMs,
       gateMs: autoFlow.timeouts?.gateMs ?? defaults.timeouts.gateMs,
       flowMs: autoFlow.timeouts?.flowMs ?? defaults.timeouts.flowMs,
+      stepMs: autoFlow.timeouts?.stepMs ?? defaults.timeouts.stepMs,
     },
   };
 }

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -20,7 +20,7 @@
 
 import * as path from "node:path";
 import type { IPostRunAction, NaxPlugin, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
-import { getFinishAutoFlowConfig, telegramCreds } from "./config";
+import { type FinishAutoFlowSettings, getFinishAutoFlowConfig, telegramCreds } from "./config";
 import { sendTelegramNotify } from "./telegram";
 
 interface FinishResult {
@@ -32,27 +32,52 @@ interface FinishResult {
 
 type RunFn = (
   cmd: string[],
-  opts: { cwd: string; env?: Record<string, string> },
+  opts: { cwd: string; env?: Record<string, string>; timeoutMs?: number },
 ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
 
 const PLUGIN_NAME = "nax-finish";
 const PLUGIN_VERSION = "0.1.0";
 
+/** How far up from this module to look for the nax package root (`src/…` in dev, `dist/` when built). */
+const PACKAGE_ROOT_SEARCH_DEPTH = 6;
+
 /**
  * Default subprocess runner — wraps Bun.spawn with concurrent stdout/stderr
- * reads so non-trivial output does not deadlock. Tests override `_naxFinishDeps.run`.
+ * reads so non-trivial output does not deadlock, under a wall-clock cap so a
+ * wedged flow cannot hang the run's completion phase forever.
+ * Tests override `_naxFinishDeps.run`.
  */
 async function defaultRun(
   cmd: string[],
-  opts: { cwd: string; env?: Record<string, string> },
+  opts: { cwd: string; env?: Record<string, string>; timeoutMs?: number },
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const proc = Bun.spawn(cmd, { cwd: opts.cwd, env: opts.env, stdout: "pipe", stderr: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { exitCode, stdout, stderr };
+  let timedOut = false;
+  // setTimeout (not Bun.sleep) because the handle must be cancelled the moment
+  // the process exits — the documented exception in forbidden-patterns.md.
+  const timer =
+    opts.timeoutMs && opts.timeoutMs > 0
+      ? setTimeout(() => {
+          timedOut = true;
+          proc.kill();
+        }, opts.timeoutMs)
+      : undefined;
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    return timedOut
+      ? {
+          exitCode: exitCode === 0 ? 124 : exitCode,
+          stdout,
+          stderr: `${stderr}\n[nax-finish] flow killed after ${opts.timeoutMs}ms timeout`,
+        }
+      : { exitCode, stdout, stderr };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /** Default result reader — reads the flow's terminal result off disk. */
@@ -71,6 +96,10 @@ async function defaultReadResult(workdir: string): Promise<FinishResult | null> 
 export const _naxFinishDeps: {
   run: RunFn;
   readResult: (workdir: string) => Promise<FinishResult | null>;
+  /** Path-existence probe — used to resolve the flow module and the nax package root. */
+  exists: (p: string) => Promise<boolean>;
+  /** Directory this module was loaded from; overridable so package-root walking is testable. */
+  moduleDir: string;
   /**
    * Escalation notifier. Routed through `_deps` (rather than called as a direct
    * import) because `telegramCreds` falls back to ambient `TELEGRAM_BOT_TOKEN` /
@@ -82,11 +111,71 @@ export const _naxFinishDeps: {
 } = {
   run: defaultRun,
   readResult: defaultReadResult,
+  exists: (p) => Bun.file(p).exists(),
+  moduleDir: import.meta.dir,
   notify: sendTelegramNotify,
 };
 
 function isFeatureBranch(b: string): boolean {
   return b !== "main" && b !== "master" && b.length > 0;
+}
+
+/**
+ * Resolve the flow module.
+ *
+ * `flows/` ships with nax, not with the user's repo, so a relative `flowPath`
+ * resolves against the **nax package root** first (walking up from this module:
+ * `src/plugins/builtin/nax-finish` in dev, `dist/` when bundled) and only then
+ * against the repo, which lets a repo vendor its own variant. Absolute paths
+ * are taken as-is. Returns null when nothing exists — the caller reports that
+ * rather than handing acpx a path it will fail to open.
+ */
+export async function resolveFlowPath(
+  workdir: string,
+  flowPath: string,
+  deps: Pick<typeof _naxFinishDeps, "exists" | "moduleDir"> = _naxFinishDeps,
+): Promise<string | null> {
+  if (path.isAbsolute(flowPath)) {
+    return (await deps.exists(flowPath)) ? flowPath : null;
+  }
+  const candidates: string[] = [];
+  let dir = deps.moduleDir;
+  for (let i = 0; i < PACKAGE_ROOT_SEARCH_DEPTH; i += 1) {
+    dir = path.dirname(dir);
+    if (await deps.exists(path.join(dir, "package.json"))) candidates.push(path.resolve(dir, flowPath));
+  }
+  candidates.push(path.resolve(workdir, flowPath));
+  for (const candidate of candidates) {
+    if (await deps.exists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Build the `acpx flow run` argv.
+ *
+ * `--default-agent` is an option of the `flow run` subcommand, so it must come
+ * *after* the flow file; placing it before `flow` makes acpx exit with
+ * "unknown option '--default-agent'". `--approve-all` is a top-level flag.
+ */
+export function buildFlowArgv(flowPath: string, inputJson: string, defaultAgent: string | null): string[] {
+  return [
+    "acpx",
+    "--approve-all",
+    "flow",
+    "run",
+    flowPath,
+    "--input-json",
+    inputJson,
+    ...(defaultAgent ? ["--default-agent", defaultAgent] : []),
+  ];
+}
+
+function buildFlowEnv(cfg: FinishAutoFlowSettings): Record<string, string> {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  if (cfg.reviewers.spec) env.NAX_FINISH_SPEC_PROFILE = cfg.reviewers.spec;
+  if (cfg.reviewers.quality) env.NAX_FINISH_QUALITY_PROFILE = cfg.reviewers.quality;
+  return env;
 }
 
 const naxFinishAction: IPostRunAction = {
@@ -107,41 +196,43 @@ const naxFinishAction: IPostRunAction = {
   async execute(ctx: PostRunContext): Promise<PostRunActionResult> {
     try {
       const cfg = getFinishAutoFlowConfig(ctx);
-      const flowPath = path.resolve(ctx.workdir, cfg.flowPath);
+      const flowPath = await resolveFlowPath(ctx.workdir, cfg.flowPath);
+      if (!flowPath) {
+        return {
+          success: false,
+          message: `nax-finish: flow module "${cfg.flowPath}" not found in the nax install or ${ctx.workdir}`,
+        };
+      }
 
-      // No `reviewers` field on the flow input — it was removed; profiles flow
-      // to the flow module via env vars instead (see module header comment).
+      const creds = telegramCreds(ctx.config);
+      // Telegram is the escalation channel only when it is both enabled AND
+      // credentialed; otherwise the flow falls back to a PR/MR comment. It has
+      // to know which, so it doesn't do both (or open a draft it won't need).
+      const escalateTelegram = cfg.escalate.telegram && creds !== null;
+
+      // No `reviewers` field on the flow input — profiles flow to the flow
+      // module via env vars instead (see module header comment).
       const input = {
         feature: ctx.feature,
         workdir: ctx.workdir,
         branch: ctx.branch,
         prdPath: ctx.prdPath,
-        escalateTelegram: cfg.escalate.telegram,
+        escalateTelegram,
+        timeouts: { acceptanceMs: cfg.timeouts.acceptanceMs, gateMs: cfg.timeouts.gateMs },
       };
 
-      const env: Record<string, string> = { ...process.env } as Record<string, string>;
-      if (cfg.reviewers.spec) env.NAX_FINISH_SPEC_PROFILE = cfg.reviewers.spec;
-      if (cfg.reviewers.quality) env.NAX_FINISH_QUALITY_PROFILE = cfg.reviewers.quality;
-
-      const cmd = [
-        "acpx",
-        "--approve-all",
-        ...(cfg.defaultAgent ? ["--default-agent", cfg.defaultAgent] : []),
-        "flow",
-        "run",
-        flowPath,
-        "--input-json",
-        JSON.stringify(input),
-      ];
-
-      const res = await _naxFinishDeps.run(cmd, { cwd: ctx.workdir, env });
+      const cmd = buildFlowArgv(flowPath, JSON.stringify(input), cfg.defaultAgent);
+      const res = await _naxFinishDeps.run(cmd, {
+        cwd: ctx.workdir,
+        env: buildFlowEnv(cfg),
+        timeoutMs: cfg.timeouts.flowMs,
+      });
       const result = await _naxFinishDeps.readResult(ctx.workdir);
       if (!result) {
         return { success: res.exitCode === 0, message: `nax-finish flow exited ${res.exitCode} (no result file)` };
       }
 
-      const creds = telegramCreds(ctx.config);
-      if (result.status === "escalated" && cfg.escalate.telegram && creds) {
+      if (result.status === "escalated" && escalateTelegram && creds) {
         await _naxFinishDeps.notify(
           creds,
           `nax-finish escalated *${result.feature}*: ${result.escalationReason ?? ""}`,

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -154,14 +154,25 @@ export async function resolveFlowPath(
 /**
  * Build the `acpx flow run` argv.
  *
- * `--default-agent` is an option of the `flow run` subcommand, so it must come
- * *after* the flow file; placing it before `flow` makes acpx exit with
- * "unknown option '--default-agent'". `--approve-all` is a top-level flag.
+ * Flag placement is not interchangeable:
+ * - `--approve-all` and `--timeout` are **top-level** flags and must precede
+ *   `flow`. The flow declares `requireExplicitGrant`, so acpx rejects the run
+ *   unless the grant is an explicit CLI flag (config alone does not satisfy it).
+ * - `--default-agent` is an option of the `flow run` **subcommand**, so it must
+ *   come after the flow file; placing it before `flow` makes acpx exit with
+ *   "unknown option '--default-agent'".
  */
-export function buildFlowArgv(flowPath: string, inputJson: string, defaultAgent: string | null): string[] {
+export function buildFlowArgv(
+  flowPath: string,
+  inputJson: string,
+  defaultAgent: string | null,
+  stepMs?: number | null,
+): string[] {
+  const stepTimeout = stepMs && stepMs > 0 ? ["--timeout", String(Math.ceil(stepMs / 1000))] : [];
   return [
     "acpx",
     "--approve-all",
+    ...stepTimeout,
     "flow",
     "run",
     flowPath,
@@ -221,7 +232,7 @@ const naxFinishAction: IPostRunAction = {
         timeouts: { acceptanceMs: cfg.timeouts.acceptanceMs, gateMs: cfg.timeouts.gateMs },
       };
 
-      const cmd = buildFlowArgv(flowPath, JSON.stringify(input), cfg.defaultAgent);
+      const cmd = buildFlowArgv(flowPath, JSON.stringify(input), cfg.defaultAgent, cfg.timeouts.stepMs);
       const res = await _naxFinishDeps.run(cmd, {
         cwd: ctx.workdir,
         env: buildFlowEnv(cfg),

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -50,5 +50,5 @@ export { createWebhookReporterPlugin } from "./builtin/webhook-reporter";
 export { createOtelReporterPlugin } from "./builtin/otel-reporter";
 
 // Built-in nax-finish post-run action (Task 8) — exposed for test injection (`_naxFinishDeps`)
-export { naxFinishPlugin, _naxFinishDeps } from "./builtin/nax-finish";
+export { naxFinishPlugin, _naxFinishDeps, buildFlowArgv, resolveFlowPath } from "./builtin/nax-finish";
 export { getFinishAutoFlowConfig, isTelegramConfigured, telegramCreds } from "./builtin/nax-finish/config";

--- a/test/unit/config/finish-autoflow-schema.test.ts
+++ b/test/unit/config/finish-autoflow-schema.test.ts
@@ -18,9 +18,16 @@ describe("finish.autoFlow schema", () => {
   test("accepts timeout overrides and rejects non-positive budgets", () => {
     const c = NaxConfigSchema.parse({
       version: 1,
-      finish: { autoFlow: { timeouts: { acceptanceMs: 1000, gateMs: 2000, flowMs: 3000 } } },
+      finish: { autoFlow: { timeouts: { acceptanceMs: 1000, gateMs: 2000, flowMs: 3000, stepMs: 4000 } } },
     });
-    expect(c.finish.autoFlow.timeouts).toEqual({ acceptanceMs: 1000, gateMs: 2000, flowMs: 3000 });
+    expect(c.finish.autoFlow.timeouts).toEqual({
+      acceptanceMs: 1000,
+      gateMs: 2000,
+      flowMs: 3000,
+      stepMs: 4000,
+    });
+    // stepMs is nullable — null means "leave acpx's own step default alone"
+    expect(NaxConfigSchema.parse({ version: 1 }).finish.autoFlow.timeouts.stepMs).toBeNull();
     expect(NaxConfigSchema.safeParse({ version: 1, finish: { autoFlow: { timeouts: { gateMs: 0 } } } }).success).toBe(
       false,
     );

--- a/test/unit/config/finish-autoflow-schema.test.ts
+++ b/test/unit/config/finish-autoflow-schema.test.ts
@@ -9,6 +9,21 @@ describe("finish.autoFlow schema", () => {
     expect(c.finish.autoFlow.defaultAgent).toBeNull();
     expect(c.finish.autoFlow.reviewers).toEqual({ spec: null, quality: null });
     expect(c.finish.autoFlow.escalate.telegram).toBe(true);
+    // Every subprocess the flow awaits is capped — nothing defaults to unbounded.
+    expect(c.finish.autoFlow.timeouts.acceptanceMs).toBeGreaterThan(0);
+    expect(c.finish.autoFlow.timeouts.gateMs).toBeGreaterThan(0);
+    expect(c.finish.autoFlow.timeouts.flowMs).toBeGreaterThan(0);
+  });
+
+  test("accepts timeout overrides and rejects non-positive budgets", () => {
+    const c = NaxConfigSchema.parse({
+      version: 1,
+      finish: { autoFlow: { timeouts: { acceptanceMs: 1000, gateMs: 2000, flowMs: 3000 } } },
+    });
+    expect(c.finish.autoFlow.timeouts).toEqual({ acceptanceMs: 1000, gateMs: 2000, flowMs: 3000 });
+    expect(NaxConfigSchema.safeParse({ version: 1, finish: { autoFlow: { timeouts: { gateMs: 0 } } } }).success).toBe(
+      false,
+    );
   });
 
   test("accepts overrides", () => {

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -2,19 +2,49 @@ import { afterEach, describe, expect, test } from "bun:test";
 import flow from "@flows/nax-finish/nax-finish.flow";
 import { _acceptanceDeps } from "@flows/nax-finish/steps/acceptance";
 import { _contextDeps } from "@flows/nax-finish/steps/context";
+import { _escalateDeps } from "@flows/nax-finish/steps/escalate";
+import { _gitDeps } from "@flows/nax-finish/steps/git";
 import { _prDeps } from "@flows/nax-finish/steps/pr";
 import { _qualityDeps } from "@flows/nax-finish/steps/quality";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
 import type { FlowNodeContext } from "acpx/flows";
 
-const stepsCtx = (input: Record<string, unknown>, steps: { nodeId: string }[]): FlowNodeContext =>
+const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
+
+const ctxOf = (over: {
+  input?: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  steps?: { nodeId: string }[];
+}): FlowNodeContext =>
   ({
-    input,
-    outputs: {},
+    input: over.input ?? INPUT,
+    outputs: over.outputs ?? {},
     results: {},
-    state: { steps } as never,
+    state: { steps: over.steps ?? [] } as never,
     services: {},
   }) as FlowNodeContext;
+
+type NodeRun<T> = { run: (ctx: FlowNodeContext) => Promise<T> | T };
+const nodeRun = <T>(id: string) => flow.nodes[id] as unknown as NodeRun<T>;
+const switchOf = (from: string) => {
+  const edge = flow.edges.find((e) => e.from === from && "switch" in e);
+  if (!edge || !("switch" in edge)) throw new Error(`no switch edge from ${from}`);
+  return edge.switch;
+};
+const toOf = (from: string) => {
+  const edge = flow.edges.find((e) => e.from === from && "to" in e);
+  return edge && "to" in edge ? edge.to : undefined;
+};
+
+const GROUPS = [
+  {
+    packageDir: "",
+    testPath: ".nax/features/x/a.test.ts",
+    exists: true,
+    command: "bun test {{FILE}}",
+    language: "typescript",
+  },
+];
 
 describe("nax-finish flow graph", () => {
   test("declares approve-all + starts at load_ctx", () => {
@@ -23,162 +53,384 @@ describe("nax-finish flow graph", () => {
     expect(flow.startAt).toBe("load_ctx");
   });
 
-  test("has the review + escalate + pr nodes and routes review_spec on $.route", () => {
+  test("has every node the pipeline needs", () => {
     for (const n of [
-      "review_spec",
-      "review_quality",
+      "load_ctx",
       "acceptance",
       "fix_acceptance",
+      "review_spec",
+      "route_spec",
+      "fix_spec",
+      "review_quality",
+      "route_quality",
+      "fix_quality",
       "quality_gates",
+      "fix_gate",
       "open_pr",
       "escalate",
     ]) {
       expect(flow.nodes[n]).toBeDefined();
     }
     expect(flow.nodes.review_spec.nodeType).toBe("acp");
-    const specEdge = flow.edges.find((e) => e.from === "review_spec" && "switch" in e);
-    expect(specEdge && "switch" in specEdge && specEdge.switch.on).toBe("$.route");
+    // load_ctx shells git + `nax features resolve`, so it is an action, not a compute.
+    expect(flow.nodes.load_ctx.nodeType).toBe("action");
   });
 
-  test("review nodes are isolated and their profile is resolved from NAX_FINISH_*_PROFILE env vars at module load, not flow input", () => {
-    const specNode = flow.nodes.review_spec as { session?: { isolated?: boolean } };
-    expect(specNode.session?.isolated).toBe(true);
+  test("review nodes are isolated and their profile comes from NAX_FINISH_*_PROFILE at module load", () => {
+    for (const id of ["review_spec", "review_quality"]) {
+      expect((flow.nodes[id] as { session?: { isolated?: boolean } }).session?.isolated).toBe(true);
+    }
   });
 
-  test("acceptance failures route to fix_acceptance, which loops back to acceptance", () => {
-    const acceptanceEdge = flow.edges.find((e) => e.from === "acceptance" && "switch" in e);
-    expect(acceptanceEdge && "switch" in acceptanceEdge && acceptanceEdge.switch.cases.fix).toBe("fix_acceptance");
-    const loopEdge = flow.edges.find((e) => e.from === "fix_acceptance");
-    expect(loopEdge && "to" in loopEdge && loopEdge.to).toBe("acceptance");
+  test("every fix loop has an escalate exit, so no loop can run forever", () => {
+    expect(switchOf("acceptance").cases.escalate).toBe("escalate");
+    expect(switchOf("quality_gates").cases.escalate).toBe("escalate");
+    expect(switchOf("route_spec").cases.escalate).toBe("escalate");
+    expect(switchOf("route_quality").cases.escalate).toBe("escalate");
   });
 
-  test("acceptance and quality_gates fix loops have an escalate case, so a runaway loop can exit", () => {
-    const acceptanceEdge = flow.edges.find((e) => e.from === "acceptance" && "switch" in e);
-    expect(acceptanceEdge && "switch" in acceptanceEdge && acceptanceEdge.switch.cases.escalate).toBe("escalate");
-    const qualityEdge = flow.edges.find((e) => e.from === "quality_gates" && "switch" in e);
-    expect(qualityEdge && "switch" in qualityEdge && qualityEdge.switch.cases.escalate).toBe("escalate");
+  test("a clean review skips its fix node entirely", () => {
+    expect(switchOf("route_spec").cases.clean).toBe("review_quality");
+    expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
   });
 
-  describe("acceptance node — fix-loop escalation cap", () => {
-    const originalContextRun = _contextDeps.run;
-    const originalAcceptanceRun = _acceptanceDeps.run;
-    afterEach(() => {
-      _contextDeps.run = originalContextRun;
-      _acceptanceDeps.run = originalAcceptanceRun;
-    });
+  test("review fixes are re-verified, not applied once and trusted", () => {
+    // spec fixes re-run the acceptance gate, which routes back into review_spec
+    expect(toOf("fix_spec")).toBe("acceptance");
+    expect(switchOf("acceptance").cases.proceed).toBe("review_spec");
+    // quality fixes are re-reviewed by the same lens
+    expect(toOf("fix_quality")).toBe("review_quality");
+    expect(toOf("fix_acceptance")).toBe("acceptance");
+    expect(toOf("fix_gate")).toBe("quality_gates");
+  });
+});
 
-    const groups = [
-      {
-        packageDir: "",
-        testPath: ".nax/features/x/a.test.ts",
-        exists: true,
-        command: "bun test {{FILE}}",
-        language: "typescript",
-      },
-    ];
-
-    test("still under the cap routes to fix, not escalate", async () => {
-      _contextDeps.run = async () => ({
-        exitCode: 0,
-        stdout: JSON.stringify({ acceptance: { status: "ok", groups } }),
-        stderr: "",
-      });
-      _acceptanceDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "still failing" });
-
-      const acceptanceNode = flow.nodes.acceptance as { run: (ctx: FlowNodeContext) => Promise<{ route: string }> };
-      const out = await acceptanceNode.run(
-        stepsCtx({ feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false }, [
-          { nodeId: "fix_acceptance" },
-          { nodeId: "fix_acceptance" },
-        ]),
-      );
-
-      expect(out.route).toBe("fix");
-    });
-
-    test("at the cap routes to escalate with a reason", async () => {
-      _contextDeps.run = async () => ({
-        exitCode: 0,
-        stdout: JSON.stringify({ acceptance: { status: "ok", groups } }),
-        stderr: "",
-      });
-      _acceptanceDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "still failing" });
-
-      const acceptanceNode = flow.nodes.acceptance as {
-        run: (ctx: FlowNodeContext) => Promise<{ route: string; reason?: string }>;
-      };
-      const out = await acceptanceNode.run(
-        stepsCtx({ feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false }, [
-          { nodeId: "fix_acceptance" },
-          { nodeId: "fix_acceptance" },
-          { nodeId: "fix_acceptance" },
-        ]),
-      );
-
-      expect(out.route).toBe("escalate");
-      expect(out.reason).toContain("3 fix attempts");
-    });
+describe("load_ctx node", () => {
+  const originalRun = _contextDeps.run;
+  afterEach(() => {
+    _contextDeps.run = originalRun;
   });
 
-  describe("quality_gates node — fix-loop escalation cap", () => {
-    const originalQualityRun = _qualityDeps.run;
-    const originalQualityReadText = _qualityDeps.readText;
-    afterEach(() => {
-      _qualityDeps.run = originalQualityRun;
-      _qualityDeps.readText = originalQualityReadText;
-    });
+  test("resolves the feature once and carries base, specPath and groups forward", async () => {
+    const cmds: string[][] = [];
+    _contextDeps.run = async (cmd) => {
+      cmds.push(cmd);
+      const joined = cmd.join(" ");
+      if (joined.includes("remote show")) return { exitCode: 0, stdout: "HEAD branch: main\n", stderr: "" };
+      if (joined.includes("features resolve"))
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            specSource: { kind: "markdown", path: ".nax/features/x/spec.md" },
+            acceptance: { status: "ok", groups: GROUPS },
+          }),
+          stderr: "",
+        };
+      return { exitCode: 0, stdout: "2\n", stderr: "" };
+    };
 
-    test("at the cap routes to escalate with a reason naming the failing gates", async () => {
-      _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
-      _qualityDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "lint bad" });
+    const out = await nodeRun<{ base: string; specPath: string; groups: unknown[]; route: string }>("load_ctx").run(
+      ctxOf({}),
+    );
 
-      const qualityGatesNode = flow.nodes.quality_gates as {
-        run: (ctx: FlowNodeContext) => Promise<{ route: string; reason?: string }>;
-      };
-      const out = await qualityGatesNode.run(
-        stepsCtx({ feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false }, [
-          { nodeId: "fix_gate" },
-          { nodeId: "fix_gate" },
-          { nodeId: "fix_gate" },
-        ]),
-      );
+    expect(out).toMatchObject({ base: "origin/main", specPath: ".nax/features/x/spec.md", route: "proceed" });
+    expect(out.groups).toEqual(GROUPS);
+    expect(cmds.filter((c) => c.join(" ").includes("features resolve")).length).toBe(1);
+  });
+});
 
-      expect(out.route).toBe("escalate");
-      expect(out.reason).toContain("lint");
-    });
+describe("acceptance node", () => {
+  const originalRun = _acceptanceDeps.runShell;
+  afterEach(() => {
+    _acceptanceDeps.runShell = originalRun;
   });
 
-  describe("open_pr node", () => {
-    const originalPrRun = _prDeps.run;
-    const originalWriteText = _resultDeps.writeText;
-    afterEach(() => {
-      _prDeps.run = originalPrRun;
-      _resultDeps.writeText = originalWriteText;
-    });
+  test("reads groups from load_ctx instead of resolving the feature again", async () => {
+    let ran = 0;
+    _acceptanceDeps.runShell = async () => {
+      ran += 1;
+      return { exitCode: 0, stdout: "ok", stderr: "" };
+    };
+    const out = await nodeRun<{ route: string }>("acceptance").run(
+      ctxOf({ outputs: { load_ctx: { groups: GROUPS, base: "origin/main", specPath: "s" } } }),
+    );
+    expect(out.route).toBe("proceed");
+    expect(ran).toBe(1);
+  });
 
-    test("writes nothing-to-finish and skips openOrPromotePr when load_ctx routed nothing-to-finish", async () => {
-      const prCalls: string[][] = [];
-      _prDeps.run = async (cmd) => {
-        prCalls.push(cmd);
-        return { exitCode: 0, stdout: "", stderr: "" };
-      };
-      let wroteResult: string | null = null;
-      _resultDeps.writeText = async (_p, s) => {
-        wroteResult = s;
-      };
+  test("still under the cap routes to fix, not escalate", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "still failing" });
+    const out = await nodeRun<{ route: string }>("acceptance").run(
+      ctxOf({
+        outputs: { load_ctx: { groups: GROUPS } },
+        steps: [{ nodeId: "fix_acceptance" }, { nodeId: "fix_acceptance" }],
+      }),
+    );
+    expect(out.route).toBe("fix");
+  });
 
-      const openPrNode = flow.nodes.open_pr as { run: (ctx: FlowNodeContext) => Promise<unknown> };
-      const out = await openPrNode.run({
-        input: { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false },
-        outputs: { load_ctx: { route: "nothing-to-finish" } },
-        results: {},
-        state: {} as never,
-        services: {},
-      });
+  test("at the cap routes to escalate with a reason", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "still failing" });
+    const out = await nodeRun<{ route: string; reason?: string }>("acceptance").run(
+      ctxOf({
+        outputs: { load_ctx: { groups: GROUPS } },
+        steps: [{ nodeId: "fix_acceptance" }, { nodeId: "fix_acceptance" }, { nodeId: "fix_acceptance" }],
+      }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("3 fix attempts");
+  });
+});
 
-      expect(prCalls).toEqual([]);
-      expect(out).toMatchObject({ status: "nothing-to-finish" });
-      expect(JSON.parse(wroteResult as unknown as string)).toMatchObject({ status: "nothing-to-finish" });
-    });
+describe("review parse + route_* nodes", () => {
+  const parseSpec = (flow.nodes.review_spec as { parse: (t: string) => { route: string; findings: unknown[] } }).parse;
+
+  test("parse rewrites a findings-free proceed to clean", () => {
+    expect(parseSpec(JSON.stringify({ route: "proceed", findings: [] })).route).toBe("clean");
+  });
+
+  test("parse keeps proceed when there are findings, and escalate always", () => {
+    const finding = { severity: "HIGH", title: "t", problem: "p", fix: "f" };
+    expect(parseSpec(JSON.stringify({ route: "proceed", findings: [finding] })).route).toBe("proceed");
+    expect(parseSpec(JSON.stringify({ route: "escalate", findings: [] })).route).toBe("escalate");
+  });
+
+  test("parse tolerates a missing findings array", () => {
+    expect(parseSpec(JSON.stringify({ route: "proceed" })).findings).toEqual([]);
+  });
+
+  const finding = { severity: "HIGH" as const, title: "t", problem: "p", fix: "f" };
+
+  test("route_spec sends findings to the fix node while under the cap", () => {
+    const out = nodeRun<{ route: string }>("route_spec").run(
+      ctxOf({ outputs: { review_spec: { route: "proceed", findings: [finding] } } }),
+    ) as { route: string };
+    expect(out.route).toBe("fix");
+  });
+
+  test("route_spec escalates once the fix cap is reached", () => {
+    const out = nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
+      ctxOf({
+        outputs: { review_spec: { route: "proceed", findings: [finding] } },
+        steps: [{ nodeId: "fix_spec" }, { nodeId: "fix_spec" }, { nodeId: "fix_spec" }],
+      }),
+    ) as { route: string; escalationReason?: string };
+    expect(out.route).toBe("escalate");
+    expect(out.escalationReason).toContain("after 3 fix attempts");
+  });
+
+  test("route_spec passes the reviewer's own escalate verdict straight through", () => {
+    const out = nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
+      ctxOf({
+        outputs: {
+          review_spec: { route: "escalate", findings: [finding], escalationReason: "AC-3 contradicts the schema" },
+        },
+      }),
+    ) as { route: string; escalationReason?: string };
+    expect(out.route).toBe("escalate");
+    expect(out.escalationReason).toBe("AC-3 contradicts the schema");
+  });
+
+  test("route_quality reads the quality verdict, not the spec one", () => {
+    const out = nodeRun<{ route: string }>("route_quality").run(
+      ctxOf({
+        outputs: {
+          review_spec: { route: "proceed", findings: [finding] },
+          review_quality: { route: "clean", findings: [] },
+        },
+      }),
+    ) as { route: string };
+    expect(out.route).toBe("clean");
+  });
+});
+
+describe("quality_gates node", () => {
+  const originalRun = _qualityDeps.runShell;
+  const originalReadText = _qualityDeps.readText;
+  afterEach(() => {
+    _qualityDeps.runShell = originalRun;
+    _qualityDeps.readText = originalReadText;
+  });
+
+  test("escalates instead of reporting green when the repo configured no commands", async () => {
+    _qualityDeps.readText = async () => JSON.stringify({ quality: {} });
+    _qualityDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const out = await nodeRun<{ route: string; reason?: string }>("quality_gates").run(ctxOf({}));
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("No quality.commands configured");
+  });
+
+  test("at the cap routes to escalate with a reason naming the failing gates", async () => {
+    _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
+    _qualityDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "lint bad" });
+    const out = await nodeRun<{ route: string; reason?: string }>("quality_gates").run(
+      ctxOf({ steps: [{ nodeId: "fix_gate" }, { nodeId: "fix_gate" }, { nodeId: "fix_gate" }] }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("lint");
+  });
+
+  test("green when the configured gates pass", async () => {
+    _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
+    _qualityDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const out = await nodeRun<{ route: string }>("quality_gates").run(ctxOf({}));
+    expect(out.route).toBe("green");
+  });
+});
+
+describe("open_pr node", () => {
+  const originalPrRun = _prDeps.run;
+  const originalGitRun = _gitDeps.run;
+  const originalWriteText = _resultDeps.writeText;
+  afterEach(() => {
+    _prDeps.run = originalPrRun;
+    _gitDeps.run = originalGitRun;
+    _resultDeps.writeText = originalWriteText;
+  });
+
+  test("commits and pushes the flow's fixes before opening the PR", async () => {
+    const gitCalls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      gitCalls.push(cmd);
+      return cmd.includes("--porcelain")
+        ? { exitCode: 0, stdout: " M src/a.ts\n", stderr: "" }
+        : { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const prCalls: string[][] = [];
+    _prDeps.run = async (cmd) => {
+      prCalls.push(cmd);
+      if (cmd.join(" ").includes("remote get-url")) return { exitCode: 0, stdout: "git@github.com:o/r", stderr: "" };
+      if (cmd.includes("view"))
+        return { exitCode: 0, stdout: JSON.stringify({ isDraft: true, url: "https://gh/pr/1" }), stderr: "" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    let wrote = "";
+    _resultDeps.writeText = async (_p, s) => {
+      wrote = s;
+    };
+
+    const out = await nodeRun<{ status: string; committed: boolean }>("open_pr").run(
+      ctxOf({ outputs: { load_ctx: { route: "proceed" } } }),
+    );
+
+    expect(gitCalls.map((c) => c.join(" "))).toContain("git push --set-upstream origin feat/x");
+    expect(out.committed).toBe(true);
+    expect(out.status).toBe("promoted");
+    expect(JSON.parse(wrote)).toMatchObject({ status: "promoted", url: "https://gh/pr/1" });
+  });
+
+  test("writes nothing-to-finish and touches neither git nor the forge", async () => {
+    const calls: string[][] = [];
+    _prDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    let wrote = "";
+    _resultDeps.writeText = async (_p, s) => {
+      wrote = s;
+    };
+
+    const out = await nodeRun<{ status: string }>("open_pr").run(
+      ctxOf({ outputs: { load_ctx: { route: "nothing-to-finish" } } }),
+    );
+
+    expect(calls).toEqual([]);
+    expect(out).toMatchObject({ status: "nothing-to-finish" });
+    expect(JSON.parse(wrote)).toMatchObject({ status: "nothing-to-finish" });
+  });
+});
+
+describe("escalate node", () => {
+  const originalEscalateRun = _escalateDeps.run;
+  const originalGitRun = _gitDeps.run;
+  const originalWriteText = _resultDeps.writeText;
+  afterEach(() => {
+    _escalateDeps.run = originalEscalateRun;
+    _gitDeps.run = originalGitRun;
+    _resultDeps.writeText = originalWriteText;
+  });
+
+  const stubForge = (calls: string[][]) => {
+    _escalateDeps.run = async (cmd) => {
+      calls.push(cmd);
+      if (cmd.join(" ").includes("remote get-url")) return { exitCode: 0, stdout: "git@github.com:o/r", stderr: "" };
+      if (cmd.includes("view"))
+        return { exitCode: 0, stdout: JSON.stringify({ url: "https://gh/pr/9" }), stderr: "" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+  };
+
+  test("uses the routed review reason and pushes partial fixes", async () => {
+    const forgeCalls: string[][] = [];
+    stubForge(forgeCalls);
+    const gitCalls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      gitCalls.push(cmd);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    let wrote = "";
+    _resultDeps.writeText = async (_p, s) => {
+      wrote = s;
+    };
+
+    const out = await nodeRun<{ escalationReason: string; channel: string }>("escalate").run(
+      ctxOf({
+        outputs: {
+          route_spec: { route: "escalate", findings: [], escalationReason: "spec contradiction" },
+        },
+      }),
+    );
+
+    expect(out.escalationReason).toBe("spec contradiction");
+    expect(out.channel).toBe("pr-comment");
+    expect(gitCalls.map((c) => c.join(" "))).toContain("git push --set-upstream origin feat/x");
+    expect(JSON.parse(wrote)).toMatchObject({ status: "escalated", escalationReason: "spec contradiction" });
+  });
+
+  test("falls back to a loop-exhaustion reason from acceptance / quality_gates", async () => {
+    stubForge([]);
+    _gitDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    _resultDeps.writeText = async () => {};
+
+    const out = await nodeRun<{ escalationReason: string }>("escalate").run(
+      ctxOf({ outputs: { quality_gates: { route: "escalate", reason: "gates still failing (lint)" } } }),
+    );
+    expect(out.escalationReason).toBe("gates still failing (lint)");
+  });
+
+  test("a push failure is reported in the comment rather than losing the escalation", async () => {
+    const forgeCalls: string[][] = [];
+    stubForge(forgeCalls);
+    _gitDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "remote rejected" });
+    _resultDeps.writeText = async () => {};
+
+    const out = await nodeRun<{ escalationReason: string }>("escalate").run(
+      ctxOf({ outputs: { route_quality: { route: "escalate", findings: [], escalationReason: "needs judgment" } } }),
+    );
+
+    expect(out.escalationReason).toBe("needs judgment");
+    const comment = forgeCalls.find((c) => c.join(" ").includes("pr comment"))?.join(" ") ?? "";
+    expect(comment).toContain("could not push its partial fixes");
+  });
+
+  test("prefers Telegram when the input says it is configured", async () => {
+    const forgeCalls: string[][] = [];
+    stubForge(forgeCalls);
+    _gitDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    _resultDeps.writeText = async () => {};
+
+    const out = await nodeRun<{ channel: string }>("escalate").run(
+      ctxOf({
+        input: { ...INPUT, escalateTelegram: true },
+        outputs: { route_spec: { route: "escalate", findings: [], escalationReason: "r" } },
+      }),
+    );
+
+    expect(out.channel).toBe("telegram");
+    expect(forgeCalls.some((c) => c.join(" ").includes("pr comment"))).toBe(false);
   });
 });

--- a/test/unit/flows/nax-finish/steps/acceptance.test.ts
+++ b/test/unit/flows/nax-finish/steps/acceptance.test.ts
@@ -1,66 +1,81 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { _acceptanceDeps, parseAcceptanceGroups, runAcceptanceGate } from "@flows/nax-finish/steps/acceptance";
+import { _acceptanceDeps, buildAcceptanceCommand, runAcceptanceGate } from "@flows/nax-finish/steps/acceptance";
 
-const originalRun = _acceptanceDeps.run;
+const originalRunShell = _acceptanceDeps.runShell;
 afterEach(() => {
-  _acceptanceDeps.run = originalRun;
+  _acceptanceDeps.runShell = originalRunShell;
 });
 
-describe("acceptance steps", () => {
-  test("parseAcceptanceGroups pulls the acceptance block", () => {
-    const json = JSON.stringify({
-      acceptance: {
-        status: "ok",
-        groups: [
-          {
-            packageDir: "apps/web",
-            testPath: "apps/web/.nax/features/x/.nax-acceptance.test.tsx",
-            exists: true,
-            command: "bun vitest run {{FILE}}",
-            language: "typescript",
-          },
-        ],
-      },
-    });
-    const r = parseAcceptanceGroups(json);
-    expect(r.status).toBe("ok");
-    expect(r.groups[0].packageDir).toBe("apps/web");
+const group = (over: Record<string, unknown> = {}) => ({
+  packageDir: "apps/web",
+  testPath: "apps/web/.nax/features/x/a.test.tsx",
+  exists: true,
+  command: "bun vitest run {{FILE}}",
+  language: "typescript",
+  ...over,
+});
+
+describe("buildAcceptanceCommand", () => {
+  test("substitutes an absolute, shell-quoted FILE into the configured template", () => {
+    expect(buildAcceptanceCommand("/repo", group())).toBe(
+      "bun vitest run '/repo/apps/web/.nax/features/x/a.test.tsx'",
+    );
   });
 
-  test("runAcceptanceGate runs each existing group at cwd=repoRoot/packageDir with absolute FILE", async () => {
-    const calls: { cmd: string[]; cwd: string }[] = [];
-    _acceptanceDeps.run = async (cmd, opts) => {
-      calls.push({ cmd, cwd: opts.cwd });
+  test("quoting survives a repo path containing spaces", () => {
+    expect(buildAcceptanceCommand("/my repo", group())).toContain("'/my repo/apps/web/.nax/features/x/a.test.tsx'");
+  });
+
+  test("falls back to a per-language runner when no command is configured", () => {
+    expect(buildAcceptanceCommand("/repo", group({ command: undefined, language: "python" }))).toContain(
+      "uv run pytest",
+    );
+    expect(buildAcceptanceCommand("/repo", group({ command: undefined, language: "go" }))).toContain("go test");
+  });
+});
+
+describe("runAcceptanceGate", () => {
+  test("runs each existing group at cwd=repoRoot/packageDir, preserving shell semantics", async () => {
+    const calls: { command: string; cwd: string; timeoutMs?: number }[] = [];
+    _acceptanceDeps.runShell = async (command, opts) => {
+      calls.push({ command, cwd: opts.cwd, timeoutMs: opts.timeoutMs });
       return { exitCode: 0, stdout: "ok", stderr: "" };
     };
-    const groups = [
-      {
-        packageDir: "apps/web",
-        testPath: "apps/web/.nax/features/x/a.test.tsx",
-        exists: true,
-        command: "bun vitest run {{FILE}}",
-        language: "typescript",
-      },
-    ];
-    const r = await runAcceptanceGate("/repo", groups);
+    const r = await runAcceptanceGate("/repo", [group({ command: "cd .. && bun vitest run {{FILE}}" })]);
     expect(r.passed).toBe(true);
+    expect(r.ran).toBe(1);
     expect(calls[0].cwd).toBe("/repo/apps/web");
-    expect(calls[0].cmd.join(" ")).toContain("/repo/apps/web/.nax/features/x/a.test.tsx"); // absolute FILE
+    // The `&&` reaches the shell intact rather than being split into argv.
+    expect(calls[0].command).toContain("cd .. &&");
+    expect(calls[0].timeoutMs).toBeGreaterThan(0);
   });
 
-  test("runAcceptanceGate fails when a group exits non-zero", async () => {
-    _acceptanceDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "boom" });
-    const groups = [
-      {
-        packageDir: "",
-        testPath: ".nax/features/x/a.test.ts",
-        exists: true,
-        command: "bun test {{FILE}}",
-        language: "typescript",
-      },
-    ];
-    const r = await runAcceptanceGate("/repo", groups);
+  test("honours the acceptance timeout from the flow input", async () => {
+    const seen: number[] = [];
+    _acceptanceDeps.runShell = async (_c, opts) => {
+      seen.push(opts.timeoutMs ?? 0);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    await runAcceptanceGate("/repo", [group()], { timeoutMs: 1234 });
+    expect(seen).toEqual([1234]);
+  });
+
+  test("fails when a group exits non-zero", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "boom" });
+    const r = await runAcceptanceGate("/repo", [group({ packageDir: "", testPath: ".nax/features/x/a.test.ts" })]);
     expect(r.passed).toBe(false);
     expect(r.output).toContain("boom");
+  });
+
+  test("reports ran=0 (and says so) when no acceptance files exist", async () => {
+    let called = false;
+    _acceptanceDeps.runShell = async () => {
+      called = true;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const r = await runAcceptanceGate("/repo", [group({ exists: false })]);
+    expect(called).toBe(false);
+    expect(r.ran).toBe(0);
+    expect(r.output).toContain("no acceptance test files present");
   });
 });

--- a/test/unit/flows/nax-finish/steps/context.test.ts
+++ b/test/unit/flows/nax-finish/steps/context.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { _contextDeps, detectBaseBranch, preflight, resolveSpec } from "@flows/nax-finish/steps/context";
+import { _contextDeps, detectBaseBranch, preflight, resolveFeature } from "@flows/nax-finish/steps/context";
 import type { RunResult } from "@flows/nax-finish/types";
 
 const ok = (stdout: string): RunResult => ({ exitCode: 0, stdout, stderr: "" });
@@ -26,21 +26,53 @@ describe("context steps", () => {
     expect(await detectBaseBranch("/w")).toBe("origin/master");
   });
 
-  test("resolveSpec reads specSource from nax features resolve --json", async () => {
-    _contextDeps.run = async () =>
-      ok(
+  test("resolveFeature returns the spec source and the acceptance groups from one resolve call", async () => {
+    let calls = 0;
+    _contextDeps.run = async () => {
+      calls += 1;
+      return ok(
         JSON.stringify({
           status: "ok",
           featureName: "x",
           specSource: { kind: "prd", path: ".nax/features/x/prd.json" },
+          acceptance: {
+            status: "ok",
+            groups: [
+              {
+                packageDir: "apps/web",
+                testPath: "apps/web/.nax/features/x/a.test.tsx",
+                exists: true,
+                language: "typescript",
+              },
+            ],
+          },
         }),
       );
-    expect(await resolveSpec("x", "/w")).toEqual({ specPath: ".nax/features/x/prd.json", specKind: "prd" });
+    };
+    const r = await resolveFeature("x", "/w");
+    expect(calls).toBe(1);
+    expect(r.specPath).toBe(".nax/features/x/prd.json");
+    expect(r.specKind).toBe("prd");
+    expect(r.acceptanceStatus).toBe("ok");
+    expect(r.groups[0].packageDir).toBe("apps/web");
   });
 
-  test("resolveSpec throws NaxError when specSource is missing", async () => {
+  test("resolveFeature defaults acceptance to no-prd with no groups when absent", async () => {
+    _contextDeps.run = async () =>
+      ok(JSON.stringify({ status: "ok", specSource: { kind: "markdown", path: ".nax/features/x/spec.md" } }));
+    const r = await resolveFeature("x", "/w");
+    expect(r.acceptanceStatus).toBe("no-prd");
+    expect(r.groups).toEqual([]);
+  });
+
+  test("resolveFeature throws when specSource is missing", async () => {
     _contextDeps.run = async () => ok(JSON.stringify({ status: "no-prd", featureName: "x" }));
-    await expect(resolveSpec("x", "/w")).rejects.toThrow('no specSource for "x"');
+    await expect(resolveFeature("x", "/w")).rejects.toThrow('no specSource for "x"');
+  });
+
+  test("resolveFeature throws a coded error on unparseable stdout instead of a raw SyntaxError", async () => {
+    _contextDeps.run = async () => ({ exitCode: 1, stdout: "command not found", stderr: "" });
+    await expect(resolveFeature("x", "/w")).rejects.toThrow(/unparseable JSON/);
   });
 
   test("preflight routes nothing-to-finish at 0 commits ahead", async () => {

--- a/test/unit/flows/nax-finish/steps/escalate.test.ts
+++ b/test/unit/flows/nax-finish/steps/escalate.test.ts
@@ -54,7 +54,42 @@ describe("postEscalation", () => {
     expect(calls.some((c) => c.join(" ").includes("pr comment"))).toBe(false);
   });
 
-  test("throws NaxError when the remote is neither github nor gitlab", async () => {
+  test("prefers Telegram: no comment, and no draft PR opened to hold one", async () => {
+    const calls: string[][] = [];
+    _escalateDeps.run = async (cmd) => {
+      calls.push(cmd);
+      if (cmd.join(" ").includes("remote get-url")) return ok("git@github.com:o/r.git");
+      if (cmd.includes("view")) return { exitCode: 1, stdout: "", stderr: "no pr found" };
+      return ok("");
+    };
+    const r = await postEscalation("/repo", "feat/x", "comment", { preferTelegram: true });
+    expect(r.channel).toBe("telegram");
+    expect(r.url).toBeUndefined();
+    expect(calls.some((c) => c.join(" ").includes("pr create"))).toBe(false);
+    expect(calls.some((c) => c.join(" ").includes("pr comment"))).toBe(false);
+  });
+
+  test("prefers Telegram but still reports an existing PR URL for the notification", async () => {
+    _escalateDeps.run = async (cmd) => {
+      if (cmd.join(" ").includes("remote get-url")) return ok("git@github.com:o/r.git");
+      if (cmd.includes("view")) return ok(JSON.stringify({ url: "https://github.com/o/r/pull/7" }));
+      return ok("");
+    };
+    const r = await postEscalation("/repo", "feat/x", "comment", { preferTelegram: true });
+    expect(r).toEqual({ channel: "telegram", url: "https://github.com/o/r/pull/7" });
+  });
+
+  test("falls back to the PR comment channel when Telegram is not preferred", async () => {
+    _escalateDeps.run = async (cmd) => {
+      if (cmd.join(" ").includes("remote get-url")) return ok("git@github.com:o/r.git");
+      if (cmd.includes("view")) return ok(JSON.stringify({ url: "https://github.com/o/r/pull/1" }));
+      return ok("");
+    };
+    const r = await postEscalation("/repo", "feat/x", "comment", { preferTelegram: false });
+    expect(r.channel).toBe("pr-comment");
+  });
+
+  test("throws when the remote is neither github nor gitlab", async () => {
     _escalateDeps.run = async () => ok("git@bitbucket.org:o/r.git");
     await expect(postEscalation("/repo", "feat/x", "comment")).rejects.toThrow();
   });

--- a/test/unit/flows/nax-finish/steps/git.test.ts
+++ b/test/unit/flows/nax-finish/steps/git.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { _gitDeps, commitAndPush } from "@flows/nax-finish/steps/git";
+import type { RunResult } from "@flows/nax-finish/types";
+
+const ok = (stdout = ""): RunResult => ({ exitCode: 0, stdout, stderr: "" });
+const originalRun = _gitDeps.run;
+afterEach(() => {
+  _gitDeps.run = originalRun;
+});
+
+const argvOf = (calls: string[][]) => calls.map((c) => c.join(" "));
+
+describe("commitAndPush", () => {
+  test("commits the fix nodes' working-tree edits, then pushes the branch", async () => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--porcelain") ? ok(" M src/foo.ts\n?? src/bar.ts\n") : ok();
+    };
+    const r = await commitAndPush("/repo", "feat/x", "fix(x): nax-finish automated fixes");
+    expect(r).toEqual({ committed: true, pushed: true });
+    const argv = argvOf(calls);
+    expect(argv).toContain("git add -A");
+    expect(argv).toContain("git commit -m fix(x): nax-finish automated fixes");
+    expect(argv).toContain("git push --set-upstream origin feat/x");
+    // add/commit must precede the push
+    expect(argv.indexOf("git add -A")).toBeLessThan(argv.indexOf("git push --set-upstream origin feat/x"));
+  });
+
+  test("pushes even with a clean tree, so the remote reflects HEAD", async () => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return ok("");
+    };
+    const r = await commitAndPush("/repo", "feat/x", "msg");
+    expect(r).toEqual({ committed: false, pushed: true });
+    const argv = argvOf(calls);
+    expect(argv.some((c) => c.startsWith("git commit"))).toBe(false);
+    expect(argv).toContain("git push --set-upstream origin feat/x");
+  });
+
+  test("throws a coded error when the push is rejected", async () => {
+    _gitDeps.run = async (cmd) =>
+      cmd.includes("push") ? { exitCode: 1, stdout: "", stderr: "non-fast-forward" } : ok("");
+    await expect(commitAndPush("/repo", "feat/x", "msg")).rejects.toThrow(/non-fast-forward/);
+  });
+
+  test("throws when the commit fails", async () => {
+    _gitDeps.run = async (cmd) => {
+      if (cmd.includes("--porcelain")) return ok(" M a.ts\n");
+      if (cmd.includes("commit")) return { exitCode: 1, stdout: "", stderr: "pre-commit hook failed" };
+      return ok("");
+    };
+    await expect(commitAndPush("/repo", "feat/x", "msg")).rejects.toThrow(/pre-commit hook failed/);
+  });
+
+  test("throws when git status itself fails", async () => {
+    _gitDeps.run = async () => ({ exitCode: 128, stdout: "", stderr: "not a git repository" });
+    await expect(commitAndPush("/repo", "feat/x", "msg")).rejects.toThrow(/not a git repository/);
+  });
+});

--- a/test/unit/flows/nax-finish/steps/quality.test.ts
+++ b/test/unit/flows/nax-finish/steps/quality.test.ts
@@ -1,24 +1,25 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { _qualityDeps, loadQualityCommands, runQualityGates } from "@flows/nax-finish/steps/quality";
 
-const originalRun = _qualityDeps.run;
+const originalRunShell = _qualityDeps.runShell;
 const originalReadText = _qualityDeps.readText;
 afterEach(() => {
-  _qualityDeps.run = originalRun;
+  _qualityDeps.runShell = originalRunShell;
   _qualityDeps.readText = originalReadText;
 });
 
 describe("quality gates", () => {
   test("passes when all set commands exit 0; skips unset", async () => {
-    _qualityDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    _qualityDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
     const r = await runQualityGates("/repo", { typecheck: "bun run typecheck", test: "bun run test" });
     expect(r.passed).toBe(true);
+    expect(r.ran).toEqual(["typecheck", "test"]);
     expect(r.failing).toEqual([]);
   });
 
   test("collects failing gates by name", async () => {
-    _qualityDeps.run = async (cmd) => ({
-      exitCode: cmd.join(" ").includes("lint") ? 1 : 0,
+    _qualityDeps.runShell = async (command) => ({
+      exitCode: command.includes("lint") ? 1 : 0,
       stdout: "",
       stderr: "lint bad",
     });
@@ -26,19 +27,52 @@ describe("quality gates", () => {
     expect(r.passed).toBe(false);
     expect(r.failing).toEqual(["lint"]);
   });
+
+  test("runs each command through a shell, so composed commands survive intact", async () => {
+    const seen: { command: string; cwd: string; timeoutMs?: number }[] = [];
+    _qualityDeps.runShell = async (command, opts) => {
+      seen.push({ command, cwd: opts.cwd, timeoutMs: opts.timeoutMs });
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    await runQualityGates("/repo", { lint: 'bun run lint && echo "done"' }, { timeoutMs: 4321 });
+    expect(seen[0].command).toBe('bun run lint && echo "done"');
+    expect(seen[0].cwd).toBe("/repo");
+    expect(seen[0].timeoutMs).toBe(4321);
+  });
+
+  test("no configured commands is NOT a pass — nothing was verified", async () => {
+    let called = false;
+    _qualityDeps.runShell = async () => {
+      called = true;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const r = await runQualityGates("/repo", {});
+    expect(called).toBe(false);
+    expect(r.passed).toBe(false);
+    expect(r.ran).toEqual([]);
+    expect(r.output).toContain("no quality.commands configured");
+  });
 });
 
 describe("loadQualityCommands", () => {
-  test("returns commands parsed from .nax/config.json", async () => {
-    _qualityDeps.readText = async () =>
-      JSON.stringify({ quality: { commands: { typecheck: "bun run typecheck", lint: "bun run lint" } } });
+  test("returns commands parsed from the repo-root .nax/config.json", async () => {
+    const paths: string[] = [];
+    _qualityDeps.readText = async (p) => {
+      paths.push(p);
+      return JSON.stringify({ quality: { commands: { typecheck: "bun run typecheck", lint: "bun run lint" } } });
+    };
     const r = await loadQualityCommands("/repo");
+    expect(paths).toEqual(["/repo/.nax/config.json"]);
     expect(r).toEqual({ typecheck: "bun run typecheck", lint: "bun run lint" });
   });
 
   test("returns {} when config file is missing", async () => {
     _qualityDeps.readText = async () => null;
-    const r = await loadQualityCommands("/repo");
-    expect(r).toEqual({});
+    expect(await loadQualityCommands("/repo")).toEqual({});
+  });
+
+  test("throws a coded error when the config file is corrupt", async () => {
+    _qualityDeps.readText = async () => "{ not json";
+    await expect(loadQualityCommands("/repo")).rejects.toThrow(/Failed to parse .nax\/config.json/);
   });
 });

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -258,6 +258,17 @@ describe("buildFlowArgv", () => {
   test("omits --default-agent entirely when unset", () => {
     expect(buildFlowArgv("/f.ts", "{}", null)).not.toContain("--default-agent");
   });
+
+  test("puts --timeout (seconds) BEFORE `flow` — it is a top-level flag", () => {
+    const argv = buildFlowArgv("/f.ts", "{}", null, 1_800_000);
+    expect(argv.slice(0, 4)).toEqual(["acpx", "--approve-all", "--timeout", "1800"]);
+    expect(argv.indexOf("--timeout")).toBeLessThan(argv.indexOf("flow"));
+  });
+
+  test("omits --timeout when stepMs is unset, leaving acpx's own default", () => {
+    expect(buildFlowArgv("/f.ts", "{}", null, null)).not.toContain("--timeout");
+    expect(buildFlowArgv("/f.ts", "{}", null)).not.toContain("--timeout");
+  });
 });
 
 describe("resolveFlowPath", () => {

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { _naxFinishDeps, isTelegramConfigured, naxFinishPlugin, telegramCreds } from "@/plugins";
+import {
+  _naxFinishDeps,
+  buildFlowArgv,
+  isTelegramConfigured,
+  naxFinishPlugin,
+  resolveFlowPath,
+  telegramCreds,
+} from "@/plugins";
 import type { PostRunContext } from "@/plugins/types";
 
 const action = naxFinishPlugin.extensions.postRunAction!;
@@ -151,6 +158,69 @@ describe("nax-finish post-run action", () => {
     expect(capturedEnv?.NAX_FINISH_QUALITY_PROFILE).toBe("quality-profile");
   });
 
+  test("execute forwards the acceptance/gate budgets in the flow input and caps the flow itself", async () => {
+    let capturedCmd: string[] = [];
+    let capturedTimeout: number | undefined;
+    _naxFinishDeps.run = async (cmd, opts) => {
+      capturedCmd = cmd;
+      capturedTimeout = opts.timeoutMs;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
+
+    await action.execute(
+      baseCtx({
+        config: {
+          finish: {
+            autoFlow: { enabled: true, timeouts: { acceptanceMs: 111, gateMs: 222, flowMs: 333 } },
+          },
+        },
+      } as never),
+    );
+
+    expect(capturedTimeout).toBe(333);
+    const input = JSON.parse(capturedCmd[capturedCmd.indexOf("--input-json") + 1]);
+    expect(input.timeouts).toEqual({ acceptanceMs: 111, gateMs: 222 });
+  });
+
+  test("execute tells the flow to prefer Telegram only when it is enabled AND credentialed", async () => {
+    const inputsFor = async (config: Record<string, unknown>) => {
+      let cmd: string[] = [];
+      _naxFinishDeps.run = async (c) => {
+        cmd = c;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      };
+      _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
+      await action.execute(baseCtx({ config } as never));
+      return JSON.parse(cmd[cmd.indexOf("--input-json") + 1]);
+    };
+
+    const credentialed = await inputsFor({
+      finish: { autoFlow: { enabled: true } },
+      interaction: { plugin: "telegram", config: { botToken: "t", chatId: "c" } },
+    });
+    expect(credentialed.escalateTelegram).toBe(true);
+
+    // Enabled but with no credentials → the flow must fall back to a PR comment.
+    const uncredentialed = await inputsFor({ finish: { autoFlow: { enabled: true } }, interaction: { plugin: "cli" } });
+    expect(uncredentialed.escalateTelegram).toBe(false);
+  });
+
+  test("execute reports a clear failure when the flow module cannot be found", async () => {
+    let ran = false;
+    _naxFinishDeps.exists = async () => false;
+    _naxFinishDeps.run = async () => {
+      ran = true;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+
+    const r = await action.execute(baseCtx());
+
+    expect(ran).toBe(false);
+    expect(r.success).toBe(false);
+    expect(r.message).toContain("not found");
+  });
+
   test("execute omits reviewer profile env vars when reviewers are null", async () => {
     let capturedEnv: Record<string, string> | undefined;
     _naxFinishDeps.run = async (_cmd, opts) => {
@@ -163,6 +233,80 @@ describe("nax-finish post-run action", () => {
 
     expect(capturedEnv?.NAX_FINISH_SPEC_PROFILE).toBeUndefined();
     expect(capturedEnv?.NAX_FINISH_QUALITY_PROFILE).toBeUndefined();
+  });
+});
+
+describe("buildFlowArgv", () => {
+  test("puts --default-agent AFTER the flow file — acpx defines it on `flow run`, not the root", () => {
+    const argv = buildFlowArgv("/pkg/flows/nax-finish/nax-finish.flow.ts", "{}", "claude");
+    expect(argv).toEqual([
+      "acpx",
+      "--approve-all",
+      "flow",
+      "run",
+      "/pkg/flows/nax-finish/nax-finish.flow.ts",
+      "--input-json",
+      "{}",
+      "--default-agent",
+      "claude",
+    ]);
+    // Regression guard: `acpx --approve-all --default-agent x flow run …` exits
+    // with "unknown option '--default-agent'".
+    expect(argv.indexOf("--default-agent")).toBeGreaterThan(argv.indexOf("run"));
+  });
+
+  test("omits --default-agent entirely when unset", () => {
+    expect(buildFlowArgv("/f.ts", "{}", null)).not.toContain("--default-agent");
+  });
+});
+
+describe("resolveFlowPath", () => {
+  const deps = (existing: string[], moduleDir: string) => ({
+    moduleDir,
+    exists: async (p: string) => existing.includes(p),
+  });
+
+  test("resolves a relative path against the nax install, not the user's repo", async () => {
+    const resolved = await resolveFlowPath(
+      "/user/repo",
+      "flows/nax-finish/nax-finish.flow.ts",
+      deps(
+        ["/nax/package.json", "/nax/flows/nax-finish/nax-finish.flow.ts"],
+        "/nax/src/plugins/builtin/nax-finish",
+      ),
+    );
+    expect(resolved).toBe("/nax/flows/nax-finish/nax-finish.flow.ts");
+  });
+
+  test("works from a bundled dist/ layout", async () => {
+    const resolved = await resolveFlowPath(
+      "/user/repo",
+      "flows/nax-finish/nax-finish.flow.ts",
+      deps(["/nax/package.json", "/nax/flows/nax-finish/nax-finish.flow.ts"], "/nax/dist"),
+    );
+    expect(resolved).toBe("/nax/flows/nax-finish/nax-finish.flow.ts");
+  });
+
+  test("falls back to a repo-vendored flow when the install has none", async () => {
+    const resolved = await resolveFlowPath(
+      "/user/repo",
+      "flows/nax-finish/nax-finish.flow.ts",
+      deps(["/nax/package.json", "/user/repo/flows/nax-finish/nax-finish.flow.ts"], "/nax/dist"),
+    );
+    expect(resolved).toBe("/user/repo/flows/nax-finish/nax-finish.flow.ts");
+  });
+
+  test("honours an absolute override, and reports null when it is missing", async () => {
+    expect(await resolveFlowPath("/user/repo", "/custom/my.flow.ts", deps(["/custom/my.flow.ts"], "/nax/dist"))).toBe(
+      "/custom/my.flow.ts",
+    );
+    expect(await resolveFlowPath("/user/repo", "/custom/my.flow.ts", deps([], "/nax/dist"))).toBeNull();
+  });
+
+  test("returns null when the flow exists nowhere", async () => {
+    expect(
+      await resolveFlowPath("/user/repo", "flows/nax-finish/nax-finish.flow.ts", deps(["/nax/package.json"], "/nax/dist")),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
Follow-up to #1358. The flow and plugin landed, but the flow could not run outside a nax source checkout and several design decisions were declared rather than wired. This makes it functional and documents how to use it.

Each claim below was verified against the real toolchain (acpx 0.12.1, `npm pack`, standalone module load), not only against tests.

## Blockers

1. **`flows/` was never published.** `package.json` `files` was `dist/` only, and the plugin resolved `flowPath` against the *user's* repo — so every installed nax hit ENOENT and fail-open no-op'd. `flows/` now ships (`npm pack --dry-run` shows 14 flow files), and a relative `flowPath` resolves against the nax install first (dev `src/` and bundled `dist/` layouts), then the repo (vendor a variant), then absolute as-is. Confirmed the currently-installed 0.73.x has no `flows/` directory.
2. **`flows/` imported nax `src/` via the `@/` alias**, which only resolves through nax's own tsconfig — the module could not load in acpx's process. Replaced with a self-contained `FinishError`; the flow module now imports cleanly from an unrelated cwd (`loaded: nax-finish | nodes: 13 | edges: 11`).
3. **`--default-agent` was placed before `flow run`**, but acpx defines it on the subcommand, so setting `finish.autoFlow.defaultAgent` made acpx exit `unknown option '--default-agent'`. Verified both argv shapes against the binary.
4. **Nothing committed or pushed the fixes.** Every fix node edits the working tree, then `gh pr create --head <branch>` opened a PR from a remote branch missing all of them. New `steps/git.ts`; both terminal nodes sync the branch first, and an escalation reports a push failure in the comment instead of losing the escalation.

## Design fidelity

- Quality gates and acceptance commands run through `/bin/sh -c` (as `src/quality/runner.ts` does) instead of being split on whitespace, so `&&`, quoting and globs survive; acceptance paths are shell-quoted.
- Every awaited subprocess is capped — new `finish.autoFlow.timeouts` (`acceptanceMs`, `gateMs`, `flowMs`, `stepMs`). The plugin previously awaited `acpx flow run` unbounded, and acpx's 15-minute per-step default was unreachable from config, so a large-diff review could be truncated with no way to raise it.
- **No configured `quality.commands` is no longer a green gate** — it escalates rather than opening a "ready" PR having verified nothing.
- Escalation honours Telegram-first: when Telegram is enabled *and* credentialed, the flow posts no comment and opens no draft to hold one.
- A findings-free review routes `clean` and skips its fix node entirely (no agent turn prompted to "apply fixes" for an empty list).
- Review fixes are re-verified: `fix_spec` re-runs acceptance then re-reviews, `fix_quality` re-reviews, each capped by new `route_spec` / `route_quality` compute nodes rather than trusting the model's own route.
- `finish` is read through a named `finishConfigSelector` and typed on `NaxConfig`.
- `load_ctx` resolves the feature once (it shells, so it is an `action`, not a `compute`) and passes the acceptance groups forward.

Per-package config layering was deliberately **not** added for the gate: a package's own commands don't verify the repo root, and this gate runs once at the root by design. Documented at the call site.

## Docs

New `docs/guides/nax-finish-autoflow.md` — graph, outcome matrix, result-file shape, prerequisites, full config table, escalation setup, manual invocation, and a troubleshooting table keyed to the actual error strings.

The acpx section was written from acpx's resolution path rather than inferred: a node's `profile` is an acpx *agent name* resolved through the `agents` map (or a built-in); the model is encoded in that entry's `command`/`args` (acpx has no model field); entries are `{ command, args[] }` flattened to a command string; names are normalised; resolution is profile -> `--default-agent` -> config `defaultAgent`. Also documents that flag placement is not interchangeable and that the flow's `requireExplicitGrant` needs `--approve-all` as a CLI flag, not config.

Cross-linked from `docs/README.md` and the `configuration.md` key table.

## Notes

- `src/config/runtime-types.ts` was already grandfathered over the 600-line limit and the ratchet blocks growth, so `ProjectProfile` and the new finish types moved to leaf files; baseline lowered 15 -> 14.
- New coverage targets each fix specifically: argv ordering (both flags), the four path-resolution cases, shell-semantics preservation, `ran: []` non-pass, Telegram-first, `clean` routing, per-phase caps, commit-then-push ordering.

## Test plan

- [x] `bun run test` — 10115 unit + 1090 integration + 21 ui pass, 0 fail
- [x] `bun run typecheck`, `bun run lint` (incl. all ratchets), pre-commit gates
- [x] `acpx --approve-all [--timeout N] flow run <file> --input-json {} --default-agent claude` accepted by acpx 0.12.1 (reaches ENOENT); old ordering reproduces `unknown option`
- [x] flow module imports standalone from an unrelated cwd
- [x] `npm pack --dry-run` includes `flows/`
- [ ] Live end-to-end `acpx flow run` against a real branch and forge — not covered here; it needs real `git push` / `gh` against a live repo, and the original design put it outside the unit floor