### PR TITLE
fix(interaction): stop Telegram backlog from being misread as a live answer

### DIFF
--- a/src/interaction/plugins/telegram.ts
+++ b/src/interaction/plugins/telegram.ts
@@ -45,10 +45,14 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   private readonly logger = getSafeLogger();
   private botToken: string | null = null;
   private chatId: string | null = null;
-  private pendingMessages = new Map<string, number[]>(); // requestId -> messageId[]
+  // requestId -> { type of the request (gates which update kinds count as an answer), sent message ids }
+  private pendingMessages = new Map<string, { type: InteractionRequest["type"]; ids: number[] }>();
   private lastUpdateId = 0;
   private backoffMs = 1000; // Exponential backoff for getUpdates (starts at 1s)
   private readonly maxBackoffMs = 30000; // Max 30 seconds between retries
+
+  /** Bound on how many getUpdates() pages drainBacklog() will consume before giving up. */
+  private static readonly MAX_DRAIN_PAGES = 10;
 
   private static readonly INTERACTIVE_REQUEST_TYPES = new Set<InteractionRequest["type"]>([
     "confirm",
@@ -67,6 +71,32 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
         "Telegram plugin requires botToken and chatId (env: NAX_TELEGRAM_TOKEN or TELEGRAM_BOT_TOKEN, NAX_TELEGRAM_CHAT_ID)",
       );
     }
+    // No network call here — the backlog is drained immediately before each prompt is
+    // posted (see send()), not at startup. Interactions can fire minutes into a run,
+    // so draining once at init() would still leave a wide window for stale updates to
+    // accumulate; draining right before send() shrinks that window to one round-trip
+    // and avoids paying a Telegram round-trip on every run that never prompts at all.
+  }
+
+  /**
+   * Advance lastUpdateId past any updates already queued, without processing them.
+   * Pages through getUpdates() (bounded by MAX_DRAIN_PAGES) since a single call only
+   * returns one page (Telegram default limit: 100) and a larger backlog would
+   * otherwise leave older updates unconsumed. Prevents stale/unrelated updates from
+   * being misread as the response to the next interaction request.
+   */
+  private async drainBacklog(): Promise<void> {
+    for (let page = 0; page < TelegramInteractionPlugin.MAX_DRAIN_PAGES; page++) {
+      const result = await this.fetchUpdates();
+      if (!result.ok) {
+        this.logger?.warn("interaction", "Telegram backlog drain failed — stale updates may be misread as a response");
+        return;
+      }
+      if (result.updates.length === 0) return;
+    }
+    this.logger?.warn("interaction", "Telegram backlog drain hit page cap — stale updates may remain", {
+      pages: TelegramInteractionPlugin.MAX_DRAIN_PAGES,
+    });
   }
 
   async destroy(): Promise<void> {
@@ -77,6 +107,14 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   async send(request: InteractionRequest): Promise<void> {
     if (!this.botToken || !this.chatId) {
       throw new Error("Telegram plugin not initialized");
+    }
+
+    // Drain any backlog immediately before posting this prompt so an update that
+    // predates it (stray chat message, old button tap) can never be picked up by
+    // receive() as the answer. Only interactive types ever wait for a response, so
+    // fire-and-forget notify/webhook sends skip the round-trip.
+    if (TelegramInteractionPlugin.INTERACTIVE_REQUEST_TYPES.has(request.type)) {
+      await this.drainBacklog();
     }
 
     const header = this.buildHeader(request);
@@ -120,7 +158,7 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
 
       // Store sent message IDs only for interactive requests that can receive a reply/callback.
       if (TelegramInteractionPlugin.INTERACTIVE_REQUEST_TYPES.has(request.type)) {
-        this.pendingMessages.set(request.id, sentIds);
+        this.pendingMessages.set(request.id, { type: request.type, ids: sentIds });
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -359,10 +397,22 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   }
 
   /**
-   * Get updates from Telegram Bot API with exponential backoff on failure
+   * Get updates from Telegram Bot API with exponential backoff on failure.
+   * Failures are swallowed (returns []) so the receive() poll loop can retry —
+   * callers that need to distinguish "no updates" from "the fetch failed" use
+   * fetchUpdates() directly (e.g. drainBacklog(), to avoid silently no-op'ing).
    */
   private async getUpdates(): Promise<TelegramUpdate[]> {
-    if (!this.botToken) return [];
+    const result = await this.fetchUpdates();
+    return result.updates;
+  }
+
+  /**
+   * Core getUpdates() implementation reporting success/failure explicitly.
+   * Mutates lastUpdateId/backoffMs the same way regardless of caller.
+   */
+  private async fetchUpdates(): Promise<{ ok: boolean; updates: TelegramUpdate[] }> {
+    if (!this.botToken) return { ok: true, updates: [] };
 
     try {
       // Client-side timeout guards against network hangs (no OS TCP timeout = 75s+ stall)
@@ -378,6 +428,7 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
           body: JSON.stringify({
             offset: this.lastUpdateId + 1,
             timeout: 1, // Short polling — server holds connection up to 1s
+            limit: 100, // Explicit: matches Telegram's default page size, made visible at the call site
           }),
           signal: controller.signal,
         });
@@ -402,12 +453,12 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
 
       // Reset backoff on success
       this.backoffMs = 1000;
-      return updates;
+      return { ok: true, updates };
     } catch (err) {
       // Apply exponential backoff on network error
       this.backoffMs = Math.min(this.backoffMs * 2, this.maxBackoffMs);
-      // Return empty updates and retry with backoff (logged for debugging, not exposed to user)
-      return [];
+      // Swallow the error (logged for debugging, not exposed to user) — callers retry with backoff
+      return { ok: false, updates: [] };
     }
   }
 
@@ -435,15 +486,17 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
       };
     }
 
-    // Check text message (for input type) — match any of our sent message IDs
+    // Check text message — only "input" requests are ever answerable by free text.
+    // confirm/choose/review are button-only in the keyboard nax posts for them (see
+    // buildKeyboard()), so a plain-text message can never legitimately be their answer.
     if (update.message?.text) {
-      const messageIds = this.pendingMessages.get(requestId);
-      if (!messageIds) return null;
+      const pending = this.pendingMessages.get(requestId);
+      if (!pending || pending.type !== "input") return null;
 
       const replyToId = update.message.reply_to_message?.message_id;
       // Accept if user replied directly to one of our messages, OR if it's the first text response
       // (handles case where user sends a plain message without explicit reply)
-      if (replyToId !== undefined && !messageIds.includes(replyToId)) return null;
+      if (replyToId !== undefined && !pending.ids.includes(replyToId)) return null;
 
       return {
         requestId,
@@ -515,14 +568,14 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
    * Edit message to show timeout/expired
    */
   private async sendTimeoutMessage(requestId: string): Promise<void> {
-    const messageIds = this.pendingMessages.get(requestId);
-    if (!messageIds || !this.botToken || !this.chatId) {
+    const pending = this.pendingMessages.get(requestId);
+    if (!pending || !this.botToken || !this.chatId) {
       this.pendingMessages.delete(requestId);
       return;
     }
 
     // Edit only the last message to avoid redundant notifications
-    const lastId = messageIds[messageIds.length - 1];
+    const lastId = pending.ids[pending.ids.length - 1];
     try {
       await fetch(`https://api.telegram.org/bot${this.botToken}/editMessageText`, {
         method: "POST",

--- a/test/unit/interaction/interaction-plugins.test.ts
+++ b/test/unit/interaction/interaction-plugins.test.ts
@@ -218,8 +218,14 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
 
     globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = url.toString();
-      const body = JSON.parse((init?.body as string) ?? "{}");
-      calls.push({ url: urlStr, body });
+      // Only track sendMessage calls — init() also calls getUpdates() to drain any backlog.
+      if (urlStr.includes("sendMessage")) {
+        const body = JSON.parse((init?.body as string) ?? "{}");
+        calls.push({ url: urlStr, body });
+      }
+      if (urlStr.includes("getUpdates")) {
+        return new Response(JSON.stringify({ ok: true, result: [] }), { status: 200 });
+      }
       return new Response(
         JSON.stringify({ ok: true, result: { message_id: 42, chat: { id: 12345 } } }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -444,6 +450,148 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
     expect(response.action).toBe("approve");
     expect(answeredCallbackIds).toContain("cq-other");
     expect(answeredCallbackIds).toContain("cq-current");
+  });
+
+  test("send() drains stale backlog so receive() does not misattribute it as the answer", async () => {
+    // Regression: paused-story prompts reuse a deterministic requestId
+    // (`ix-<storyId>-paused-resume`) across runs. If a prior run posted the same
+    // prompt and crashed/exited before the human tapped a button, that stale
+    // callback_query sits in Telegram's queue. A fresh plugin instance starts at
+    // lastUpdateId=0, so without draining, the very first receive() poll for the
+    // *new* run's identically-named request would replay that old tap and resolve
+    // instantly — exactly the reported symptom (resolved before the human replied).
+    // Using a callback_query here (not text) means this test exercises the backlog
+    // drain specifically, independent of the type==="input" text-gating fix below.
+    const staleUpdate = {
+      update_id: 1,
+      callback_query: {
+        id: "cq-stale",
+        data: "ix-US-002-paused-resume:resume",
+        message: { message_id: 999, chat: { id: 99999 } },
+      },
+    };
+
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes("sendMessage")) {
+        return new Response(
+          JSON.stringify({ ok: true, result: { message_id: 20, chat: { id: 99999 } } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (urlStr.includes("getUpdates")) {
+        const body = JSON.parse((init?.body as string) ?? "{}") as { offset?: number };
+        const offset = body.offset ?? 0;
+        // Real Telegram semantics: only updates with update_id >= offset are returned.
+        const pending = staleUpdate.update_id >= offset ? [staleUpdate] : [];
+        return new Response(JSON.stringify({ ok: true, result: pending }), { status: 200 });
+      }
+
+      if (urlStr.includes("answerCallbackQuery") || urlStr.includes("editMessageReplyMarkup")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" }); // no network call — nothing drained here
+
+    const chooseRequest: InteractionRequest = {
+      id: "ix-US-002-paused-resume",
+      type: "choose",
+      featureName: "my-feature",
+      stage: "pre-flight",
+      summary: "Story is paused — how to proceed?",
+      fallback: "continue",
+      createdAt: Date.now(),
+      options: [
+        { key: "resume", label: "Resume" },
+        { key: "skip", label: "Skip" },
+        { key: "keep", label: "Keep paused" },
+      ],
+    };
+
+    // send() drains the backlog immediately before posting — the stale tap above
+    // is consumed and discarded here, before pendingMessages is even populated.
+    await plugin.send(chooseRequest);
+
+    // No new update arrives after send() — the stale tap must not be replayed as
+    // the answer. receive() should time out instead of resolving instantly.
+    const response = await plugin.receive("ix-US-002-paused-resume", 150);
+
+    expect(response.respondedBy).toBe("timeout");
+  });
+
+  test("receive() ignores a plain-text reply to a button-only (choose) prompt", async () => {
+    // Regression (C2): the proximate cause of the reported incident. A `choose`
+    // request is only ever answerable via the inline keyboard buttons nax posts
+    // for it (see buildKeyboard()) — a stray or misdirected plain-text message must
+    // never be treated as its answer, even when it *is* a direct reply to the
+    // prompt message. Only `type: "input"` requests accept free text.
+    //
+    // getUpdatesCallCount gates when the reply becomes visible: call #1 is send()'s
+    // own pre-post backlog drain (must see nothing — the reply doesn't exist yet),
+    // calls #2+ are receive()'s polls, simulating the human replying only after the
+    // prompt was actually posted.
+    let getUpdatesCallCount = 0;
+
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes("sendMessage")) {
+        return new Response(
+          JSON.stringify({ ok: true, result: { message_id: 30, chat: { id: 99999 } } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (urlStr.includes("getUpdates")) {
+        getUpdatesCallCount++;
+        if (getUpdatesCallCount === 1) {
+          return new Response(JSON.stringify({ ok: true, result: [] }), { status: 200 });
+        }
+        const textReply = {
+          update_id: 1,
+          message: {
+            message_id: 31,
+            chat: { id: 99999 },
+            text: "resume",
+            reply_to_message: { message_id: 30, chat: { id: 99999 } },
+          },
+        };
+        return new Response(JSON.stringify({ ok: true, result: [textReply] }), { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+
+    const chooseRequest: InteractionRequest = {
+      id: "tg-choose-text-reply-1",
+      type: "choose",
+      featureName: "my-feature",
+      stage: "pre-flight",
+      summary: "Story is paused — how to proceed?",
+      fallback: "continue",
+      createdAt: Date.now(),
+      options: [
+        { key: "resume", label: "Resume" },
+        { key: "skip", label: "Skip" },
+      ],
+    };
+
+    await plugin.send(chooseRequest);
+
+    // The text reply is a direct reply to the correct message and matches an
+    // option key, yet must still be rejected — buttons are the only valid answer.
+    const response = await plugin.receive("tg-choose-text-reply-1", 150);
+
+    expect(response.respondedBy).toBe("timeout");
   });
 
   test("receive() clears inline keyboard on successful callback response", async () => {


### PR DESCRIPTION
## Summary

A user reported that resuming a paused nax story via the Telegram interaction plugin (5-minute timeout, "Resume/Skip/Keep paused" choose prompt) resolved in under a second instead of waiting for the human's reply.

Root cause was two compounding bugs in `TelegramInteractionPlugin`:

1. Every `nax run` constructs a fresh plugin instance with `lastUpdateId = 0`. The first `getUpdates()` poll therefore replays any backlog Telegram is still holding (old button taps, unrelated chat messages) instead of only new activity. Paused-story requestIds are deterministic (`ix-<storyId>-paused-resume`), so a stale tap left over from a prior crashed/exited run for the *same story* could be replayed and misattributed to the new prompt.
2. `parseUpdate()` accepted **any** plain-text message as the answer to a button-only prompt (`confirm`/`choose`/`review`) — this is the actual proximate cause of the reported incident, independent of the backlog issue.

## Fix

- `send()` now drains any backlog **immediately before posting a prompt** (for interactive types only), replacing an earlier draft that drained once at `init()`. Interactions can fire minutes to hours into a run (execution-stage review gates, the ACP interaction bridge), so draining at `init()` left a wide window open — draining at `send()` shrinks it to one round-trip.
- `drainBacklog()` pages through `getUpdates()` (bounded, `MAX_DRAIN_PAGES = 10`) since Telegram caps a single page at 100 updates, and logs a warning instead of silently no-op'ing when the drain call itself fails.
- `parseUpdate()`'s text-message branch now only fires for `type: "input"` requests (tracked via a small type field on `pendingMessages`). `confirm`/`choose`/`review` prompts are button-only, matching the keyboards nax actually posts for them.

## Testing

- Two regression tests, each reproducing one bug independently with a stateful, offset-aware `fetch` mock:
  - `send() drains stale backlog so receive() does not misattribute it as the answer`
  - `receive() ignores a plain-text reply to a button-only (choose) prompt`
- Both were verified to **fail** without their respective fix (confirmed by temporarily reverting each change locally) before being confirmed green with it — not tautological passes.
- Full suite: `bun run test` — 10117 unit + 1090 integration + 21 UI, 0 failures.
- `bun run lint` and `tsc --noEmit` clean.

## Known follow-ups (out of scope here)

- `parseUpdate()` doesn't verify the inbound update's `chat_id` against the configured `chatId`, so any chat the bot is added to can currently answer a pending interaction. This is pre-existing and orthogonal to the backlog bug — will file as a separate security-hardening issue.
- `telegram.ts` calls global `fetch` directly rather than through an injectable `_deps` seam (the pattern `webhook.ts` already uses), which is why several tests stub `globalThis.fetch`. Worth a follow-up to add `_telegramPluginDeps`.

## Test plan

- [x] `bun run test` (full suite) passes
- [x] `bun run lint` passes
- [x] `tsc --noEmit` passes
- [x] New regression tests confirmed to fail without their fix, pass with it