### PR TITLE
fix: route test-file findings to the test lane; stop one UNRESOLVED from abandoning a co-run group

### DIFF
--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -351,6 +351,10 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           excludePatterns: prepared.excludePatterns,
           featureCtxBlock: buildFeatureCtxBlock(ctx, "reviewer-semantic"),
           priorSemanticIterations: ctx.priorSemanticIterations,
+          // Also set at the top level (not only inside `_refresh`) so the fix-lane
+          // override (#1368) still applies when the dispatch-time refresh fails and
+          // run-phase falls back to this stale input.
+          resolvedTestPatterns,
           // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
           blockingThreshold: ctx.config.review!.blockingThreshold,
           _refresh: {
@@ -400,6 +404,8 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           refExcludePatterns: prepared.refExcludePatterns,
           featureCtxBlock: buildFeatureCtxBlock(ctx, "reviewer-adversarial"),
           priorAdversarialIterations: ctx.priorAdversarialIterations,
+          // See the semantic input above — survives a failed dispatch-time refresh.
+          resolvedTestPatterns,
           // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
           blockingThreshold: ctx.config.review!.blockingThreshold,
           _refresh: {

--- a/src/execution/story-orchestrator/run-phase.ts
+++ b/src/execution/story-orchestrator/run-phase.ts
@@ -98,6 +98,9 @@ export async function refreshReviewInputForDispatch(opName: string, input: unkno
         diff: fresh.diff,
         excludePatterns: fresh.excludePatterns,
         storyGitRef: fresh.effectiveRef ?? semInput.storyGitRef,
+        // Mirrors the adversarial branch below — the op needs the patterns to keep
+        // findings about test files in the test lane (#1368).
+        resolvedTestPatterns: _refresh.resolvedTestPatterns,
       };
     }
     const { _refresh: __, ...advInput } = input as AdversarialReviewInput;

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -168,10 +168,15 @@ export async function runFixCycle<F extends Finding>(
   let unresolvedDetail: string | undefined;
 
   /**
-   * Attach the UNRESOLVED reason to whatever exit the cycle reaches. Once a
-   * strategy has given up, that text is the most useful diagnostic available no
-   * matter which exit fires afterwards — without this the detail is lost as soon
-   * as the cycle exits via `no-strategy` or a cap instead of `agent-gave-up`.
+   * Attach the UNRESOLVED reason to whatever failing exit the cycle reaches.
+   * Once a strategy has given up, that text is the most useful diagnostic
+   * available no matter which exit fires afterwards — without this the detail is
+   * lost as soon as the cycle exits via `no-strategy` or a cap instead of
+   * `agent-gave-up`.
+   *
+   * Deliberately NOT applied to the two `resolved` exits: a sibling cleared the
+   * findings, so reporting "the agent could not fix this" alongside a success
+   * would misread as a partial failure.
    */
   const finish = (result: FixCycleResult<F>): FixCycleResult<F> =>
     unresolvedDetail !== undefined && result.unresolvedDetail === undefined ? { ...result, unresolvedDetail } : result;
@@ -186,10 +191,13 @@ export async function runFixCycle<F extends Finding>(
     const selectable = cycle.strategies.filter((s) => !spentStrategies.has(s.name));
     const active = selectActiveStrategies(selectable, cycle.findings, cycle.verdict);
     if (active.length === 0) {
-      // Orphaned findings: at least one finding remains but no strategy's
-      // `appliesTo` claims it (e.g. an unhandled `source`). Surface the sources
-      // at warn level — without this the orphaned source is invisible, turning
-      // a routing gap into an un-diagnosable "story failed for no reason".
+      // Orphaned findings: at least one finding remains but no selectable
+      // strategy's `appliesTo` claims it. Two distinct causes, and the log must
+      // separate them or a reader chases the wrong one: either the `source` is
+      // genuinely unhandled (a routing gap), or the only strategy that claimed
+      // it was retired after answering UNRESOLVED (#1369). Surface both at warn
+      // level — without this the cause is invisible, turning either into an
+      // un-diagnosable "story failed for no reason".
       const orphanSources = [...new Set(cycle.findings.map((f) => f.source))];
       logger?.warn("findings.cycle", "cycle exited — no matching strategy (orphaned findings)", {
         storyId,
@@ -198,6 +206,7 @@ export async function runFixCycle<F extends Finding>(
         reason: "no-strategy",
         findingsCount: cycle.findings.length,
         orphanSources,
+        ...(spentStrategies.size > 0 ? { retiredStrategies: [...spentStrategies] } : {}),
       });
       return finish({
         iterations: cycle.iterations,
@@ -366,6 +375,11 @@ export async function runFixCycle<F extends Finding>(
       return prior + current >= s.maxAttempts;
     });
     if (allExhausted) {
+      // Accumulate once, up front, so every exit below reports this iteration's
+      // spend. Previously only the `continue` path did, so the four terminal
+      // exits in this branch under-reported cost the same way the agent-gave-up
+      // exit did (#1369).
+      totalCostUsd += fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
       let liteFindingsAfter: F[];
       let liteShortCircuited = false;
       try {
@@ -434,8 +448,7 @@ export async function runFixCycle<F extends Finding>(
         // mechanical-lintfix) may still be able to resolve the findings.
         const companions = uncappedActive.filter((s) => !group.includes(s));
         if (companions.length > 0) {
-          const iterCostUsd = fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
-          totalCostUsd += iterCostUsd;
+          // Cost already accumulated at the top of this branch.
           logger?.info("findings.cycle", "exclusive strategy exhausted — continuing to companion strategies", {
             storyId,
             packageDir,

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -159,13 +159,32 @@ export async function runFixCycle<F extends Finding>(
   const packageDir = ctx.packageDir;
   let totalCostUsd = 0;
 
+  // Strategies that answered UNRESOLVED. The signal is per-strategy — the agent
+  // said "I cannot fix this", not "nobody can" — so the strategy is retired for
+  // the rest of the cycle instead of being re-dispatched to reach the same
+  // answer. Retiring it can only shrink the selectable set, so the cycle still
+  // terminates. (#1369)
+  const spentStrategies = new Set<string>();
+  let unresolvedDetail: string | undefined;
+
+  /**
+   * Attach the UNRESOLVED reason to whatever exit the cycle reaches. Once a
+   * strategy has given up, that text is the most useful diagnostic available no
+   * matter which exit fires afterwards — without this the detail is lost as soon
+   * as the cycle exits via `no-strategy` or a cap instead of `agent-gave-up`.
+   */
+  const finish = (result: FixCycleResult<F>): FixCycleResult<F> =>
+    unresolvedDetail !== undefined && result.unresolvedDetail === undefined ? { ...result, unresolvedDetail } : result;
+
   for (;;) {
     if (cycle.findings.length === 0 && cycle.verdict === undefined) {
       return { iterations: cycle.iterations, finalFindings: [], exitReason: "resolved", costUsd: totalCostUsd };
     }
 
     // ── Select active strategies ──────────────────────────────────────────────
-    const active = selectActiveStrategies(cycle.strategies, cycle.findings, cycle.verdict);
+    // Strategies retired by an UNRESOLVED verdict are excluded (#1369).
+    const selectable = cycle.strategies.filter((s) => !spentStrategies.has(s.name));
+    const active = selectActiveStrategies(selectable, cycle.findings, cycle.verdict);
     if (active.length === 0) {
       // Orphaned findings: at least one finding remains but no strategy's
       // `appliesTo` claims it (e.g. an unhandled `source`). Surface the sources
@@ -180,12 +199,12 @@ export async function runFixCycle<F extends Finding>(
         findingsCount: cycle.findings.length,
         orphanSources,
       });
-      return {
+      return finish({
         iterations: cycle.iterations,
         finalFindings: cycle.findings,
         exitReason: "no-strategy",
         costUsd: totalCostUsd,
-      };
+      });
     }
 
     // ── Filter exhausted strategies ───────────────────────────────────────────
@@ -202,13 +221,13 @@ export async function runFixCycle<F extends Finding>(
         reason: "max-attempts-per-strategy",
         exhaustedStrategy: exhaustedStrategy?.name,
       });
-      return {
+      return finish({
         iterations: cycle.iterations,
         finalFindings: cycle.findings,
         exitReason: "max-attempts-per-strategy",
         exhaustedStrategy: exhaustedStrategy?.name,
         costUsd: totalCostUsd,
-      };
+      });
     }
 
     // ── Total attempt cap ─────────────────────────────────────────────────────
@@ -222,12 +241,12 @@ export async function runFixCycle<F extends Finding>(
         totalAttempts,
         maxAttemptsTotal: cycle.config.maxAttemptsTotal,
       });
-      return {
+      return finish({
         iterations: cycle.iterations,
         finalFindings: cycle.findings,
         exitReason: "max-attempts-total",
         costUsd: totalCostUsd,
-      };
+      });
     }
 
     // ── bailWhen predicates ───────────────────────────────────────────────────
@@ -242,13 +261,13 @@ export async function runFixCycle<F extends Finding>(
           strategyName: strategy.name,
           bailDetail: bailReason,
         });
-        return {
+        return finish({
           iterations: cycle.iterations,
           finalFindings: cycle.findings,
           exitReason: "bail-when",
           bailDetail: bailReason,
           costUsd: totalCostUsd,
-        };
+        });
       }
     }
 
@@ -273,37 +292,69 @@ export async function runFixCycle<F extends Finding>(
       });
     }
 
-    // ── Bail on agent-gave-up ─────────────────────────────────────────────────
+    // ── Handle agent-gave-up ──────────────────────────────────────────────────
     // Must run before the cap-exhausted skip-validate check: if the agent signals
     // UNRESOLVED on its final attempt, agent-gave-up takes priority so the
     // unresolvedDetail is surfaced rather than silently folded into a cap-exit.
-    const unresolvedFa = fixesApplied.find((fa) => fa.unresolved);
-    if (unresolvedFa) {
-      const finishedAt = now();
-      cycle.iterations.push({
-        iterationNum: cycle.iterations.length + 1,
-        findingsBefore,
-        fixesApplied,
-        findingsAfter: cycle.findings,
-        outcome: "unchanged",
-        startedAt,
-        finishedAt,
-      });
-      logger?.info("findings.cycle", "cycle exited — agent gave up", {
+    //
+    // UNRESOLVED is per-strategy, so the response depends on whether anyone else
+    // in the group still ran (#1369):
+    //
+    //   - EVERY strategy that ran gave up  -> nothing was attempted that could
+    //     have changed the tree, so revalidating would burn a full suite run to
+    //     learn nothing. Exit immediately, as before.
+    //   - SOME strategy ran without giving up -> its work may have resolved the
+    //     findings. Retire only the strategies that gave up and fall through to
+    //     validate, so the sibling's progress is measured instead of discarded.
+    //     Previously the whole group was abandoned here with `finalFindings` still
+    //     equal to `findingsBefore`, which reported the sibling's fix as no
+    //     progress and (via rectificationExhausted) rolled the working tree back.
+    const unresolvedFas = fixesApplied.filter((fa) => fa.unresolved);
+    if (unresolvedFas.length > 0) {
+      const firstUnresolved = unresolvedFas[0] as FixApplied;
+      unresolvedDetail = firstUnresolved.unresolved;
+      for (const fa of unresolvedFas) spentStrategies.add(fa.strategyName);
+
+      const allGaveUp = unresolvedFas.length === fixesApplied.length;
+      if (allGaveUp) {
+        const finishedAt = now();
+        cycle.iterations.push({
+          iterationNum: cycle.iterations.length + 1,
+          findingsBefore,
+          fixesApplied,
+          findingsAfter: cycle.findings,
+          outcome: "unchanged",
+          startedAt,
+          finishedAt,
+        });
+        // Every other exit accumulates the iteration's spend; this one used to
+        // return before doing so, reporting costUsd: 0 for real spend (#1369).
+        totalCostUsd += fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
+        logger?.info("findings.cycle", "cycle exited — agent gave up", {
+          storyId,
+          packageDir,
+          cycleName,
+          reason: "agent-gave-up",
+          strategyName: firstUnresolved.strategyName,
+          unresolvedDetail: firstUnresolved.unresolved,
+        });
+        return finish({
+          iterations: cycle.iterations,
+          finalFindings: cycle.findings,
+          exitReason: "agent-gave-up",
+          unresolvedDetail: firstUnresolved.unresolved,
+          costUsd: totalCostUsd,
+        });
+      }
+
+      logger?.info("findings.cycle", "strategy gave up — retired, continuing with co-run siblings", {
         storyId,
         packageDir,
         cycleName,
-        reason: "agent-gave-up",
-        strategyName: unresolvedFa.strategyName,
-        unresolvedDetail: unresolvedFa.unresolved,
+        strategyName: firstUnresolved.strategyName,
+        unresolvedDetail: firstUnresolved.unresolved,
+        ranWithoutGivingUp: fixesApplied.filter((fa) => !fa.unresolved).map((fa) => fa.strategyName),
       });
-      return {
-        iterations: cycle.iterations,
-        finalFindings: cycle.findings,
-        exitReason: "agent-gave-up",
-        unresolvedDetail: unresolvedFa.unresolved,
-        costUsd: totalCostUsd,
-      };
     }
 
     // ── Lite-validate on terminal exhausted iteration ─────────────────────────
@@ -339,13 +390,13 @@ export async function runFixCycle<F extends Finding>(
           cycleName,
           error: errorMessage(err),
         });
-        return {
+        return finish({
           iterations: cycle.iterations,
           finalFindings: cycle.findings,
           exitReason: "max-attempts-per-strategy",
           exhaustedStrategy: group[0]?.name,
           costUsd: totalCostUsd,
-        };
+        });
       }
 
       const outcome = classifyOutcome(findingsBefore, liteFindingsAfter);
@@ -368,12 +419,12 @@ export async function runFixCycle<F extends Finding>(
           cycleName,
           reason: "resolved",
         });
-        return {
+        return finish({
           iterations: cycle.iterations,
           finalFindings: [],
           exitReason: "resolved",
           costUsd: totalCostUsd,
-        };
+        });
       }
 
       if (liteShortCircuited) {
@@ -401,12 +452,12 @@ export async function runFixCycle<F extends Finding>(
           reason: "validate-short-circuit",
           liteFindingsAfterCount: liteFindingsAfter.length,
         });
-        return {
+        return finish({
           iterations: cycle.iterations,
           finalFindings: liteFindingsAfter,
           exitReason: "validate-short-circuit",
           costUsd: totalCostUsd,
-        };
+        });
       }
 
       logger?.info("findings.cycle", "cycle exited — strategy attempt cap reached (lite validate)", {
@@ -417,13 +468,13 @@ export async function runFixCycle<F extends Finding>(
         exhaustedStrategy: group[0]?.name,
         liteFindingsAfterCount: liteFindingsAfter.length,
       });
-      return {
+      return finish({
         iterations: cycle.iterations,
         finalFindings: liteFindingsAfter,
         exitReason: "max-attempts-per-strategy",
         exhaustedStrategy: group[0]?.name,
         costUsd: totalCostUsd,
-      };
+      });
     }
 
     // ── Validate ──────────────────────────────────────────────────────────────
@@ -443,12 +494,12 @@ export async function runFixCycle<F extends Finding>(
             reason: "validator-error",
             error: errorMessage(err),
           });
-          return {
+          return finish({
             iterations: cycle.iterations,
             finalFindings: cycle.findings,
             exitReason: "validator-error",
             costUsd: totalCostUsd,
-          };
+          });
         }
         logger?.warn("findings.cycle", "validator retry", {
           storyId,

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -563,10 +563,13 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
       ...parsed,
       passed,
       findings: accepted,
-      normalizedFindings: toAdversarialReviewFindings(blocking),
+      // #1368 — `testFileMatch` also decides the fix lane: a finding located in a
+      // test file goes to the test-writer whatever its category says, because the
+      // implementer may not edit test files and would answer UNRESOLVED.
+      normalizedFindings: toAdversarialReviewFindings(blocking, { isTestFile: testFileMatch }),
       advisoryFindings: [
-        ...toAdversarialReviewFindings(advisory),
-        ...tagCoverageGap(toAdversarialReviewFindings(demoted)),
+        ...toAdversarialReviewFindings(advisory, { isTestFile: testFileMatch }),
+        ...tagCoverageGap(toAdversarialReviewFindings(demoted, { isTestFile: testFileMatch })),
       ],
       acDropped: dropped,
     };

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -40,6 +40,13 @@ export interface SemanticReviewInput {
   featureCtxBlock?: string;
   blockingThreshold?: "error" | "warning" | "info";
   /**
+   * Resolved test-file patterns (ADR-009 SSOT). Used to keep a finding about a
+   * test file in the test lane (#1368) — semantic findings otherwise default to
+   * `fixTarget: "source"`, which hands them to an implementer that may not edit
+   * test files. Populated by the orchestrator's dispatch-time refresh.
+   */
+  resolvedTestPatterns?: import("../test-runners").ResolvedTestPatterns;
+  /**
    * Optional refresh payload — when present, the orchestrator re-runs
    * `prepareSemanticReviewInput` at dispatch time and overlays the fresh
    * `stat`/`diff`/`excludePatterns`/`effectiveRef` onto this input.
@@ -69,6 +76,16 @@ function withRepromptMarker(output: string, info: RepromptInfo): string {
   const parsed = tryParseLLMJson<Record<string, unknown>>(output);
   if (!parsed || typeof parsed !== "object") return output;
   return JSON.stringify({ ...parsed, _repromptInfo: info });
+}
+
+/**
+ * Test-file classifier for the fix-lane override (#1368). Mirrors the adversarial
+ * op's `testFileMatch`. Matches nothing when patterns are absent, so the lane
+ * falls back to the semantic default of `"source"`.
+ */
+function semanticTestFileMatch(input: SemanticReviewInput): (file: string) => boolean {
+  const patterns = input.resolvedTestPatterns?.regex ?? [];
+  return (file: string): boolean => patterns.some((re) => re.test(file));
 }
 
 function extractRepromptInfo(raw: Record<string, unknown> | null | undefined): RepromptInfo | undefined {
@@ -373,7 +390,7 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
       ...parsed,
       passed,
       findings: accepted,
-      normalizedFindings: toReviewFindings(blocking),
+      normalizedFindings: toReviewFindings(blocking, { isTestFile: semanticTestFileMatch(input) }),
       acDropped: dropped,
     };
   },

--- a/src/review/adversarial-helpers.ts
+++ b/src/review/adversarial-helpers.ts
@@ -7,7 +7,7 @@
 
 import type { Finding, FindingSeverity } from "../findings";
 import { tryParseLLMJson } from "../utils/llm-json";
-import { categoryToFixTarget } from "./category-fix-target";
+import { categoryToFixTarget, resolveFixTarget } from "./category-fix-target";
 import { isBlockingSeverity } from "./severity";
 export { isBlockingSeverity };
 
@@ -105,7 +105,10 @@ export function normalizeSeverity(sev: string): FindingSeverity {
 }
 
 /** Convert AdversarialLLMFinding[] to Finding[] with adversarial-review source. */
-export function toAdversarialReviewFindings(findings: AdversarialLLMFinding[]): Finding[] {
+export function toAdversarialReviewFindings(
+  findings: AdversarialLLMFinding[],
+  opts: { isTestFile?: (path: string) => boolean } = {},
+): Finding[] {
   return findings.map((f) => {
     const metaExtras: Record<string, unknown> = {};
     if (f.acQuote) metaExtras.acQuote = f.acQuote;
@@ -124,7 +127,7 @@ export function toAdversarialReviewFindings(findings: AdversarialLLMFinding[]): 
       line: f.line,
       message: f.issue,
       suggestion: f.suggestion,
-      fixTarget: categoryToFixTarget(f.category),
+      fixTarget: resolveFixTarget({ base: categoryToFixTarget(f.category), file: f.file, isTestFile: opts.isTestFile }),
       meta: Object.keys(metaExtras).length > 0 ? metaExtras : undefined,
     };
   });

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -331,13 +331,18 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   // (ReviewFinding for review-audit persistence, Finding for the pipeline
   // result) tags the recurrence-demoted subset with `meta.coverageGap: true`
   // (Fix design §7) without re-deriving the split at each call site.
+  // #1368 — `testFileMatch` also decides the fix lane: a finding located in a test
+  // file goes to the test-writer whatever its category says, because the implementer
+  // may not edit test files and would answer UNRESOLVED.
   const advisoryReviewFindings = [
-    ...llmFindingsToReviewFindings(advisoryOnly, { source: "adversarial-review" }),
-    ...tagCoverageGap(llmFindingsToReviewFindings(demoted, { source: "adversarial-review" })),
+    ...llmFindingsToReviewFindings(advisoryOnly, { source: "adversarial-review", isTestFile: testFileMatch }),
+    ...tagCoverageGap(
+      llmFindingsToReviewFindings(demoted, { source: "adversarial-review", isTestFile: testFileMatch }),
+    ),
   ];
   const advisoryFindingsAsFindings = [
-    ...toAdversarialReviewFindings(advisoryOnly),
-    ...tagCoverageGap(toAdversarialReviewFindings(demoted)),
+    ...toAdversarialReviewFindings(advisoryOnly, { isTestFile: testFileMatch }),
+    ...tagCoverageGap(toAdversarialReviewFindings(demoted, { isTestFile: testFileMatch })),
   ];
   const acDropped = opResult.acDropped ?? [];
 
@@ -441,7 +446,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       blockingThreshold: threshold,
       result: {
         passed: false,
-        findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review" }),
+        findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review", isTestFile: testFileMatch }),
       },
       advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
       diffAvailable,
@@ -459,7 +464,10 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       exitCode: 1,
       output,
       durationMs,
-      findings: blockingFindings.length > 0 ? toAdversarialReviewFindings(blockingFindings) : undefined,
+      findings:
+        blockingFindings.length > 0
+          ? toAdversarialReviewFindings(blockingFindings, { isTestFile: testFileMatch })
+          : undefined,
       advisoryFindings: advisoryFindings.length > 0 ? advisoryFindingsAsFindings : undefined,
       cost: llmCost,
     };
@@ -474,6 +482,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       // to "warning" and surface as advisory so it remains auditable.
       const demotedFindings = toAdversarialReviewFindings(
         acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
+        { isTestFile: testFileMatch },
       );
       const existingAdvisory = advisoryFindings.length > 0 ? advisoryFindingsAsFindings : [];
       const allAdvisory = [...existingAdvisory, ...demotedFindings];
@@ -568,7 +577,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     blockingThreshold: threshold,
     result: {
       passed: true,
-      findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review" }),
+      findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review", isTestFile: testFileMatch }),
     },
     advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
     diffAvailable,

--- a/src/review/category-fix-target.ts
+++ b/src/review/category-fix-target.ts
@@ -16,3 +16,38 @@ export function categoryToFixTarget(category: string | undefined): FixTarget {
   if (category === "out-of-scope") return "source";
   return category != null && BLOCKING_CATEGORIES.has(category) ? "source" : "test";
 }
+
+export interface ResolveFixTargetArgs {
+  /**
+   * The lane the producing subsystem would pick on its own — `categoryToFixTarget`
+   * for adversarial findings, the constant `"source"` for semantic ones.
+   */
+  base: FixTarget;
+  /** The finding's file, as reported by the reviewer (package-relative). */
+  file?: string;
+  /**
+   * Test-file classifier built from `resolveTestFilePatterns` (ADR-009 SSOT).
+   * Omit when patterns are unavailable — the base lane is then kept as-is.
+   */
+  isTestFile?: (path: string) => boolean;
+}
+
+/**
+ * Path beats category (#1368).
+ *
+ * A finding located in a test file belongs to the test lane no matter what its
+ * category says. Category is a weak proxy for "which lane owns this fix": a
+ * resource-leak finding is `abandonment` whether it lives in `src/` or `test/`,
+ * but only the test-writer can act on the second. Routing such a finding to
+ * `autofix-implementer` — which is forbidden from editing test files — deadlocks
+ * the fix cycle: the implementer emits `UNRESOLVED:` and the cycle exits
+ * `agent-gave-up` with the finding untouched.
+ *
+ * The override is one-way. It can only move a finding toward the test lane,
+ * never toward the implementer, so a missing or empty classifier degrades to
+ * exactly today's behaviour rather than misrouting in the opposite direction.
+ */
+export function resolveFixTarget({ base, file, isTestFile }: ResolveFixTargetArgs): FixTarget {
+  if (file && isTestFile?.(file)) return "test";
+  return base;
+}

--- a/src/review/finding-projection.ts
+++ b/src/review/finding-projection.ts
@@ -13,10 +13,10 @@
  * dashboards) only deal with the canonical shape.
  */
 
-import type { Finding } from "../findings";
+import type { Finding, FixTarget } from "../findings";
 import type { ReviewFinding } from "../plugins/extensions";
 import type { AdversarialLLMFinding } from "./adversarial-helpers";
-import { categoryToFixTarget } from "./category-fix-target";
+import { categoryToFixTarget, resolveFixTarget } from "./category-fix-target";
 import type { LLMFinding } from "./semantic-helpers";
 
 type AnyLLMFinding = LLMFinding | AdversarialLLMFinding;
@@ -24,6 +24,13 @@ type AnyLLMFinding = LLMFinding | AdversarialLLMFinding;
 export interface ProjectionOptions {
   /** Producer label for `ReviewFinding.source` (e.g. "semantic-review"). */
   source?: string;
+  /**
+   * Test-file classifier from `resolveTestFilePatterns` (ADR-009 SSOT). Supplied
+   * so the persisted audit records the SAME `fixTarget` the cycle routed on
+   * (#1368) — without it the audit would claim `source` for a finding that
+   * actually went to the test-writer.
+   */
+  isTestFile?: (path: string) => boolean;
 }
 
 const SEVERITY_MAP: Record<string, ReviewFinding["severity"]> = {
@@ -102,11 +109,15 @@ function findingCategory(f: AnyLLMFinding): string | undefined {
   return "category" in f && f.category ? f.category : undefined;
 }
 
-function deriveFixTargetForReviewFinding(category: string | undefined, source: string | undefined) {
-  if (source === "semantic-review" || source === "semantic-debate-review") {
-    return "source";
-  }
-  return categoryToFixTarget(category);
+function deriveFixTargetForReviewFinding(
+  category: string | undefined,
+  source: string | undefined,
+  file: string | undefined,
+  isTestFile: ((path: string) => boolean) | undefined,
+): FixTarget {
+  const base: FixTarget =
+    source === "semantic-review" || source === "semantic-debate-review" ? "source" : categoryToFixTarget(category);
+  return resolveFixTarget({ base, file, isTestFile });
 }
 
 export function llmFindingToReviewFinding(f: AnyLLMFinding, opts: ProjectionOptions = {}): ReviewFinding {
@@ -122,7 +133,7 @@ export function llmFindingToReviewFinding(f: AnyLLMFinding, opts: ProjectionOpti
   };
   if (category) result.category = category;
   if (source) result.source = source;
-  result.fixTarget = deriveFixTargetForReviewFinding(category, source);
+  result.fixTarget = deriveFixTargetForReviewFinding(category, source, f.file, opts.isTestFile);
   const meta = buildMeta(f, f.severity !== narrowed ? f.severity : undefined);
   if (meta) result.meta = meta;
   return result;

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -19,6 +19,7 @@ export * from "./runner";
 export * from "./requote-response";
 export * from "./severity";
 export { validateLLMShape } from "./semantic-helpers";
-export { categoryToFixTarget } from "./category-fix-target";
+export { categoryToFixTarget, resolveFixTarget } from "./category-fix-target";
+export type { ResolveFixTargetArgs } from "./category-fix-target";
 // Promoted from finding-filters: not re-exported by adversarial.ts (verify if that changes)
 export { hasInspectionTrail, substantiateAdversarialFindings } from "./finding-filters";

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -68,6 +68,12 @@ export interface SemanticDebateOptions {
   productionExcludePatterns: readonly string[];
   blockingThreshold: "error" | "warning" | "info" | undefined;
   createDebateRunner: (opts: DebateRunnerOptions) => DebateRunner;
+  /**
+   * Test-file classifier from the caller's resolved patterns. Keeps a debate
+   * finding about a test file in the test lane (#1368) — debate findings, like
+   * plain semantic ones, otherwise default to `fixTarget: "source"`.
+   */
+  isTestFile?: (path: string) => boolean;
 }
 
 export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<ReviewCheckResult> {
@@ -88,6 +94,7 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     productionExcludePatterns,
     blockingThreshold,
     createDebateRunner,
+    isTestFile,
   } = opts;
   const logger = getSafeLogger();
   // Safe: reviewDebateEnabled guard (in caller) confirms naxConfig.debate.stages.review is defined
@@ -181,11 +188,11 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
         blockingThreshold: debateThreshold,
         result: {
           passed: false,
-          findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review" }),
+          findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review", isTestFile }),
         },
         advisoryFindings:
           debateAdvisory.length > 0
-            ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review" })
+            ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review", isTestFile })
             : undefined,
       });
       return {
@@ -195,8 +202,8 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
         exitCode: 1,
         output: `Semantic review failed:\n\n${formatFindings(debateBlocking)}`,
         durationMs,
-        findings: toReviewFindings(debateBlocking),
-        advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
+        findings: toReviewFindings(debateBlocking, { isTestFile }),
+        advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory, { isTestFile }) : undefined,
         cost: debateCost,
       };
     }
@@ -215,11 +222,11 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
       blockingThreshold: debateThreshold,
       result: {
         passed: true,
-        findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review" }),
+        findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review", isTestFile }),
       },
       advisoryFindings:
         debateAdvisory.length > 0
-          ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review" })
+          ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review", isTestFile })
           : undefined,
     });
     return {
@@ -229,7 +236,7 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
       exitCode: 0,
       output: "Semantic review passed (debate, all findings were advisory — below blocking threshold)",
       durationMs,
-      advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
+      advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory, { isTestFile }) : undefined,
       cost: debateCost,
     };
   }
@@ -244,11 +251,11 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     blockingThreshold: debateThreshold,
     result: {
       passed: true,
-      findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review" }),
+      findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review", isTestFile }),
     },
     advisoryFindings:
       debateAdvisory.length > 0
-        ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review" })
+        ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review", isTestFile })
         : undefined,
   });
   return {
@@ -258,7 +265,7 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     exitCode: 0,
     output: "Semantic review passed",
     durationMs,
-    advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
+    advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory, { isTestFile }) : undefined,
     cost: debateCost,
   };
 }

--- a/src/review/semantic-helpers.ts
+++ b/src/review/semantic-helpers.ts
@@ -5,6 +5,7 @@
 
 import type { Finding, FindingSeverity } from "../findings";
 import { tryParseLLMJson } from "../utils/llm-json";
+import { resolveFixTarget } from "./category-fix-target";
 import { SEVERITY_RANK, isBlockingSeverity } from "./severity";
 export { isBlockingSeverity };
 import type { SemanticReviewConfig } from "./types";
@@ -121,8 +122,19 @@ function downgradeToUnverifiable(finding: LLMFinding): LLMFinding {
   };
 }
 
+/** Options shared by the semantic Finding converters. */
+export interface SemanticFindingOptions {
+  /**
+   * Test-file classifier from `resolveTestFilePatterns` (ADR-009 SSOT). Semantic
+   * findings default to the source lane, but a finding *about a test file* can
+   * only be fixed by the test-writer — routing it to the implementer, which may
+   * not edit tests, deadlocks the fix cycle (#1368).
+   */
+  isTestFile?: (path: string) => boolean;
+}
+
 /** Convert a single LLMFinding to the unified Finding wire format. */
-export function llmFindingToFinding(f: LLMFinding): Finding {
+export function llmFindingToFinding(f: LLMFinding, opts: SemanticFindingOptions = {}): Finding {
   const metaExtras: Record<string, unknown> = {};
   if (f.verifiedBy) metaExtras.verifiedBy = f.verifiedBy;
   if (f.acQuote) metaExtras.acQuote = f.acQuote;
@@ -135,12 +147,12 @@ export function llmFindingToFinding(f: LLMFinding): Finding {
     line: f.line,
     message: f.issue,
     suggestion: f.suggestion ?? undefined,
-    fixTarget: "source",
+    fixTarget: resolveFixTarget({ base: "source", file: f.file, isTestFile: opts.isTestFile }),
     meta: Object.keys(metaExtras).length > 0 ? metaExtras : undefined,
   };
 }
 
 /** Convert LLMFinding[] to Finding[] with semantic-review source. */
-export function toReviewFindings(findings: LLMFinding[]): Finding[] {
-  return findings.map(llmFindingToFinding);
+export function toReviewFindings(findings: LLMFinding[], opts: SemanticFindingOptions = {}): Finding[] {
+  return findings.map((f) => llmFindingToFinding(f, opts));
 }

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -272,6 +272,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       prompt,
       productionExcludePatterns: excludePatterns,
       blockingThreshold,
+      isTestFile: testFileMatch,
       createDebateRunner: _semanticDeps.createDebateRunner,
     });
   }

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -83,6 +83,11 @@ export interface RunSemanticReviewOptions {
   projectDir?: string;
   naxIgnoreIndex?: NaxIgnoreIndex;
   runtime?: import("../runtime").NaxRuntime;
+  /**
+   * Resolved test-file patterns (ADR-009 SSOT) — keeps a finding about a test
+   * file in the test lane (#1368). Mirrors `runAdversarialReview`.
+   */
+  resolvedTestPatterns?: import("../test-runners").ResolvedTestPatterns;
 }
 
 /**
@@ -104,9 +109,16 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     projectDir,
     naxIgnoreIndex,
     runtime,
+    resolvedTestPatterns,
   } = opts;
   const startTime = Date.now();
   const logger = getSafeLogger();
+  // #1368 — a semantic finding about a test file stays in the test lane. Semantic
+  // findings otherwise default to `fixTarget: "source"`, which hands them to an
+  // implementer that may not edit test files. Matches nothing when patterns are
+  // absent, preserving the pre-#1368 lane.
+  const testFilePatterns = resolvedTestPatterns?.regex ?? [];
+  const testFileMatch = (file: string): boolean => testFilePatterns.some((re) => re.test(file));
 
   if (featureName === undefined) {
     logger?.debug("semantic", "featureName missing — semantic session name will not include feature", {
@@ -444,11 +456,11 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       blockingThreshold: threshold,
       result: {
         passed: false,
-        findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review" }),
+        findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review", isTestFile: testFileMatch }),
       },
       advisoryFindings:
         advisoryFindings.length > 0
-          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review" })
+          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
           : undefined,
     });
     return {
@@ -458,8 +470,9 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       exitCode: 1,
       output,
       durationMs,
-      findings: toReviewFindings(blockingFindings),
-      advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
+      findings: toReviewFindings(blockingFindings, { isTestFile: testFileMatch }),
+      advisoryFindings:
+        advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
       cost: llmCost,
     };
   }
@@ -482,7 +495,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       result: { passed: false, findings: [] },
       advisoryFindings:
         advisoryFindings.length > 0
-          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review" })
+          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
           : undefined,
     });
     return {
@@ -493,7 +506,8 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       output:
         'Semantic review failed: blocking finding(s) were dropped — acIndex was missing or out of range. The model emitted "passed: false" without valid AC attribution.',
       durationMs,
-      advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
+      advisoryFindings:
+        advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
       cost: llmCost,
     };
   }
@@ -512,11 +526,11 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     blockingThreshold: threshold,
     result: {
       passed: true,
-      findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review" }),
+      findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review", isTestFile: testFileMatch }),
     },
     advisoryFindings:
       advisoryFindings.length > 0
-        ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review" })
+        ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
         : undefined,
   });
   return {
@@ -529,7 +543,8 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
         ? "Semantic review passed"
         : "Semantic review passed (all findings were advisory — below blocking threshold)",
     durationMs,
-    advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
+    advisoryFindings:
+      advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
     cost: llmCost,
   };
 }

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -271,6 +271,47 @@ callOp: makeCallOpMock() as unknown as CallOpFn});
     expect(validateCalls2[0]).toMatchObject({ mode: "lite", strategiesRun: ["fix-a", "fix-b"] });
     expect(r2.exitReason).toBe("max-attempts-per-strategy");
   });
+
+  test("reports the terminal iteration's cost on the lite-validate exits (#1369)", async () => {
+    // Only the `continue`-to-companions path used to accumulate, so every
+    // terminal exit in this branch under-reported spend as 0.
+    const s = makeStrategy({
+      name: "lint-fix",
+      maxAttempts: 1,
+      extractApplied: () => ({ summary: "", costUsd: 0.25 }),
+    });
+    const r = await runFixCycle(makeCycle([lintA], [s], async () => [lintA]), makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(r.exitReason).toBe("max-attempts-per-strategy");
+    expect(r.costUsd).toBeCloseTo(0.25, 5);
+  });
+
+  test("does not double-count cost when continuing to companion strategies (#1369)", async () => {
+    // The exclusive strategy exhausts and short-circuits, handing off to an
+    // uncapped companion. Its cost must be counted exactly once.
+    const exclusive = makeStrategy({
+      name: "mechanical-lintfix",
+      maxAttempts: 1,
+      coRun: "exclusive",
+      appliesTo: (f) => f.source === "lint",
+      extractApplied: () => ({ summary: "", costUsd: 1 }),
+    });
+    const companion = makeStrategy({
+      name: "implementer",
+      maxAttempts: 1,
+      coRun: "co-run-sequential",
+      appliesTo: (f) => f.source === "lint",
+      extractApplied: () => ({ summary: "", costUsd: 1 }),
+    });
+    const cycle = makeCycle([lintA], [exclusive, companion], async () => ({ findings: [lintA], shortCircuited: true }));
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    // One attempt each, $1 apiece — never 3 (which is what double-counting the
+    // first iteration would produce).
+    expect(r.costUsd).toBeCloseTo(2, 5);
+  });
 });
 
 // ─── runFixCycle — bail: agent-gave-up (#897) ────────────────────────────────

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -296,6 +296,110 @@ callOp: makeCallOpMock() as unknown as CallOpFn});
     expect(r2.unresolvedDetail).toBe("conflicting spec");
     expect(validateCalled2).toBe(false);
   });
+
+  test("accumulates the iteration's cost when every strategy gives up (#1369)", async () => {
+    const s1 = makeStrategy({
+      name: "source-fix",
+      extractApplied: () => ({ summary: "", unresolved: "cannot fix", costUsd: 0.42 }),
+    });
+    const r = await runFixCycle(makeCycle([lintA], [s1], async () => []), makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(r.exitReason).toBe("agent-gave-up");
+    expect(r.costUsd).toBeCloseTo(0.42, 5);
+  });
+});
+
+// ─── runFixCycle — partial give-up in a co-run group (#1369) ─────────────────
+
+describe("runFixCycle — one strategy gives up, a co-run sibling does not", () => {
+  /** Strategy that reports UNRESOLVED; stands in for autofix-implementer. */
+  const givesUp = (name: string) =>
+    makeStrategy({
+      name,
+      coRun: "co-run-sequential",
+      maxAttempts: 3,
+      extractApplied: () => ({ summary: "", unresolved: "cannot edit test files" }),
+    });
+  /** Strategy that completes normally; stands in for autofix-test-writer. */
+  const succeeds = (name: string) => makeStrategy({ name, coRun: "co-run-sequential", maxAttempts: 3 });
+
+  test("validates instead of abandoning the group, so the sibling's fix is measured", async () => {
+    let validateCalled = false;
+    const cycle = makeCycle([lintA], [givesUp("implementer"), succeeds("test-writer")], async () => {
+      validateCalled = true;
+      return []; // the sibling's fix resolved the finding
+    });
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(validateCalled).toBe(true);
+    expect(r.exitReason).toBe("resolved");
+    expect(r.finalFindings).toEqual([]);
+  });
+
+  test("carries the UNRESOLVED reason onto the later exit the cycle actually reaches", async () => {
+    // Each strategy owns a different finding. The implementer gives up on its
+    // one; the test-writer clears its own. Validation leaves only the abandoned
+    // finding, and its sole claimer is now retired — so the cycle exits
+    // `no-strategy` rather than `agent-gave-up`, and the diagnostic text has to
+    // survive that switch or the give-up becomes invisible.
+    const implementer = makeStrategy({
+      name: "implementer",
+      coRun: "co-run-sequential",
+      appliesTo: (f) => f.source === "lint",
+      extractApplied: () => ({ summary: "", unresolved: "cannot edit test files" }),
+    });
+    const testWriter = makeStrategy({
+      name: "test-writer",
+      coRun: "co-run-sequential",
+      appliesTo: (f) => f.source === "typecheck",
+    });
+    const cycle = makeCycle([lintA, typecheckC], [implementer, testWriter], async () => [lintA]);
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(r.exitReason).toBe("no-strategy");
+    expect(r.unresolvedDetail).toBe("cannot edit test files");
+    expect(r.finalFindings).toEqual([lintA]);
+  });
+
+  test("does not re-dispatch a strategy that already gave up while a sibling keeps working", async () => {
+    const dispatched: string[] = [];
+    const track = (name: string, unresolved?: string) =>
+      makeStrategy({
+        name,
+        coRun: "co-run-sequential",
+        maxAttempts: 3,
+        extractApplied: () => {
+          dispatched.push(name);
+          return { summary: "", ...(unresolved ? { unresolved } : {}) };
+        },
+      });
+    // Findings never clear, so the cycle keeps iterating until the caps bind.
+    // The sibling must be retried; the strategy that gave up must not be.
+    const cycle = makeCycle(
+      [lintA],
+      [track("implementer", "cannot edit test files"), track("test-writer")],
+      async () => [lintA],
+    );
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpMock() as unknown as CallOpFn });
+    expect(dispatched.filter((n) => n === "implementer")).toHaveLength(1);
+    expect(dispatched.filter((n) => n === "test-writer").length).toBeGreaterThan(1);
+  });
+
+  test("exits agent-gave-up without validating when every strategy in the group gives up", async () => {
+    let validateCalled = false;
+    const cycle = makeCycle([lintA], [givesUp("implementer"), givesUp("test-writer")], async () => {
+      validateCalled = true;
+      return [];
+    });
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(validateCalled).toBe(false);
+    expect(r.exitReason).toBe("agent-gave-up");
+  });
 });
 
 // ─── runFixCycle — bail: validator-error ─────────────────────────────────────

--- a/test/unit/review/adversarial-fixtarget.test.ts
+++ b/test/unit/review/adversarial-fixtarget.test.ts
@@ -14,6 +14,9 @@ import type { ReviewAuditEntry } from "@/runtime";
 
 const { writeReviewAudit } = _adversarialDeps;
 
+/** Stand-in for a `resolveTestFilePatterns`-derived classifier (ADR-009 SSOT). */
+const isTestFile = (path: string) => /\.(test|spec)\.tsx?$/.test(path);
+
 function makeAdversarialFinding(overrides: Partial<AdversarialLLMFinding> = {}): AdversarialLLMFinding {
   return {
     severity: "error",
@@ -67,6 +70,42 @@ describe("converter parity for fixTarget", () => {
     const audit = llmFindingsToReviewFindings([finding], { source: "adversarial-review" });
     expect(cycle[0].fixTarget).toBe(audit[0].fixTarget);
     expect(cycle[0].fixTarget).toBe("source");
+  });
+
+  test("both converters apply the test-path override identically (#1368)", () => {
+    const finding = makeAdversarialFinding({ category: "abandonment", file: "test/app.module.spec.ts" });
+    const cycle = toAdversarialReviewFindings([finding], { isTestFile });
+    const audit = llmFindingsToReviewFindings([finding], { source: "adversarial-review", isTestFile });
+    expect(cycle[0].fixTarget).toBe(audit[0].fixTarget);
+    expect(cycle[0].fixTarget).toBe("test");
+  });
+});
+
+describe("test-path override — a blocking category in a test file goes to the test lane (#1368)", () => {
+  test("toAdversarialReviewFindings routes a test-file abandonment finding to the test lane", () => {
+    // The redis-seams US-002 regression: a TestingModule-leak finding in a spec
+    // file was tagged `source` and handed to the implementer, which cannot edit
+    // tests and answered UNRESOLVED.
+    const result = toAdversarialReviewFindings(
+      [makeAdversarialFinding({ category: "abandonment", file: "test/app.module.redis-seams.spec.ts" })],
+      { isTestFile },
+    );
+    expect(result[0].fixTarget).toBe("test");
+  });
+
+  test("a source-file abandonment finding still routes to the implementer", () => {
+    const result = toAdversarialReviewFindings(
+      [makeAdversarialFinding({ category: "abandonment", file: "src/app.module.ts" })],
+      { isTestFile },
+    );
+    expect(result[0].fixTarget).toBe("source");
+  });
+
+  test("without a classifier the pre-#1368 category-only behaviour is preserved", () => {
+    const result = toAdversarialReviewFindings([
+      makeAdversarialFinding({ category: "abandonment", file: "test/app.module.spec.ts" }),
+    ]);
+    expect(result[0].fixTarget).toBe("source");
   });
 });
 

--- a/test/unit/review/category-fix-target.test.ts
+++ b/test/unit/review/category-fix-target.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { BLOCKING_CATEGORIES } from "@/review";
-import { categoryToFixTarget } from "@/review";
+import { categoryToFixTarget, resolveFixTarget } from "@/review";
 
 describe("categoryToFixTarget", () => {
   describe("BLOCKING_CATEGORIES members return source", () => {
@@ -33,5 +33,49 @@ describe("categoryToFixTarget", () => {
     test("categoryToFixTarget(null) returns test", () => {
       expect(categoryToFixTarget(null as unknown as undefined)).toBe("test");
     });
+  });
+});
+
+describe("resolveFixTarget — path beats category (#1368)", () => {
+  const isTestFile = (path: string) => /\.spec\.ts$/.test(path);
+
+  test("a source-lane base on a test file is overridden to test", () => {
+    expect(resolveFixTarget({ base: "source", file: "test/app.module.spec.ts", isTestFile })).toBe("test");
+  });
+
+  test("a source-lane base on a source file keeps source", () => {
+    expect(resolveFixTarget({ base: "source", file: "src/app.module.ts", isTestFile })).toBe("source");
+  });
+
+  test("a test-lane base on a source file is never promoted to source", () => {
+    expect(resolveFixTarget({ base: "test", file: "src/app.module.ts", isTestFile })).toBe("test");
+  });
+
+  describe("degrades to the base lane when it cannot classify", () => {
+    test("no classifier supplied", () => {
+      expect(resolveFixTarget({ base: "source", file: "test/app.module.spec.ts" })).toBe("source");
+    });
+
+    test("classifier matches nothing (empty configured patterns)", () => {
+      expect(resolveFixTarget({ base: "source", file: "test/app.module.spec.ts", isTestFile: () => false })).toBe(
+        "source",
+      );
+    });
+
+    test("finding carries no file", () => {
+      expect(resolveFixTarget({ base: "source", isTestFile })).toBe("source");
+    });
+
+    test("finding carries an empty file", () => {
+      expect(resolveFixTarget({ base: "source", file: "", isTestFile })).toBe("source");
+    });
+  });
+
+  test("composes with categoryToFixTarget: a blocking category in a test file routes to the test lane", () => {
+    // The redis-seams US-002 case: an `abandonment` finding (TestingModule leak)
+    // located in a test file must not reach the implementer.
+    const base = categoryToFixTarget("abandonment");
+    expect(base).toBe("source");
+    expect(resolveFixTarget({ base, file: "test/app.module.redis-seams.spec.ts", isTestFile })).toBe("test");
   });
 });


### PR DESCRIPTION
Fixes two defects on the rectification / non-blocking-fix path, found by diagnosing a real run.

Closes #1368
Closes #1369

## Evidence

Project `nathapp-nestjs-starter`, feature `redis-seams`, story US-002, nax `0.74.0` (`91bb7306`).
Run log: `~/.nax/nathapp-nestjs-starter/features/redis-seams/runs/2026-07-27T03-35-05.jsonl`

Adversarial review **passed**. Three advisory findings seeded the ADR-024 best-effort pass. One was a NestJS `TestingModule` leak in `test/app.module.redis-seams.spec.ts` — a **test file**, but with a category in `BLOCKING_CATEGORIES`, so it was tagged `fixTarget: "source"` and handed to `autofix-implementer`, which may not edit test files. The implementer verified the finding, fixed the two genuine source findings, then answered:

> `UNRESOLVED: Finding 1 (Nest TestingModule leak in test/app.module.redis-seams.spec.ts …) … I cannot author it under the four narrow test-edit exceptions.`

The cycle exited `agent-gave-up` → `rectificationExhausted` → `Rolling back git changes ref 0c723858` → *"best-effort fix exhausted — restored to adversarial-passed"*. The implementer's two valid, tested, lint-clean source fixes and the co-running test-writer's successful mock cleanup were both discarded. ~$0.81 and 3.5 min for zero net change, logged as `costUsd: 0`.

## #1368 — `fixTarget` ignored the file path

`categoryToFixTarget` derived the fix lane from category alone. Category is a weak proxy for lane ownership: a resource-leak finding is `abandonment` whether it lives in `src/` or `test/`, but only one lane can act on it. `semantic-helpers.ts` was worse — it hardcoded `fixTarget: "source"` for every semantic finding regardless of file.

New `resolveFixTarget` applies **path beats category**: a finding whose `file` classifies as a test file under `resolveTestFilePatterns` (ADR-009 SSOT) goes to the test lane. The override is one-way — it can only move a finding toward the test-writer, never toward the implementer — so a missing or empty classifier degrades to exactly the previous behaviour.

Applied at both producers and both audit projections, so the persisted `review-audit/*.json` records the same `fixTarget` the cycle routed on. The adversarial op already built a `testFileMatch` classifier for recurrence demotion; the semantic side needed `resolvedTestPatterns` threaded through `run-phase`'s refresh. Both review inputs now also carry the patterns at the top level so the override survives a failed dispatch-time refresh.

Covers the blocking three-session cycle too, where the same misrouting is more expensive — there an implementer `UNRESOLVED` fails the story and triggers a tier escalation.

## #1369 — one strategy's UNRESOLVED abandoned the whole co-run group

`runFixCycle` returned as soon as any strategy in the group reported `unresolved`, before `validate()` and before accumulating the iteration's cost. A sibling's completed work was discarded unmeasured (`finalFindings` was still `findingsBefore`), and reported spend was always `0`.

UNRESOLVED is per-strategy — "I cannot fix this", not "nobody can":

- **Every** strategy that ran gave up → exit immediately, as before. Nothing was attempted that could have changed the tree, so revalidating would burn a full suite run to learn nothing.
- **Some** strategy ran without giving up → retire only those that gave up, fall through to validate so the sibling's progress is measured. Retiring can only shrink the selectable set, so the cycle still terminates.

`unresolvedDetail` now rides onto whatever exit the cycle reaches, not only `agent-gave-up` — after a retirement the cycle typically lands on `no-strategy`, and the give-up reason would otherwise vanish. Both are in `EXHAUSTED_EXIT_REASONS`, so a genuinely unfixed finding still reports exhausted exactly as before.

## Scope note

**#1368 is the necessary and sufficient fix for the observed run.** #1369 alone would not have saved it: the leak finding was genuinely still unfixed, and in `triage` scope nothing claims a `fixTarget: "source"` finding once the implementer is retired, so the cycle would exit `no-strategy` with 1 finding and roll back anyway. #1369 covers the separate class of loss — when a sibling's work *does* clear the remaining findings, that progress was thrown away without ever being checked.

## Test plan

- [x] `resolveFixTarget` unit tests: override fires, one-way guarantee, and every degradation path (no classifier / empty patterns / no file / empty file)
- [x] Both adversarial converters apply the override identically, so cycle routing and persisted audit agree
- [x] Pre-#1368 category-only behaviour preserved when no classifier is supplied
- [x] Cycle: partial give-up reaches `validate()` and exits `resolved` when the sibling clears the findings
- [x] Cycle: `unresolvedDetail` survives onto a later `no-strategy` exit
- [x] Cycle: a retired strategy is not re-dispatched while its sibling keeps being retried
- [x] Cycle: all-gave-up still exits `agent-gave-up` without validating (regression guard for preserved behaviour)
- [x] Cycle: iteration cost is accumulated on the all-gave-up exit
- [x] All four behaviour-change tests verified RED against the unfixed source, GREEN with the fix
- [x] `bun run test` — 10111 unit + 1090 integration + 21 ui, 0 fail
- [x] `bun run typecheck`, `bun run lint` clean
