### PR TITLE
fix(interaction): drain past foreign Telegram pages + normalize the configured chatId

### DIFF
--- a/scripts/baselines/deep-relatives-baseline.json
+++ b/scripts/baselines/deep-relatives-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 2847,
-  "updatedAt": "2026-07-18T08:28:39.440Z",
+  "count": 2846,
+  "updatedAt": "2026-07-28T05:07:08.700Z",
   "byFile": {
     "src/pipeline/stages/acceptance-setup.ts": 1,
     "src/pipeline/stages/prompt.ts": 5,
@@ -644,7 +644,7 @@
     "test/unit/interaction/triggers-narrowed.test.ts": 4,
     "test/unit/interaction/plugins/cli.test.ts": 1,
     "test/unit/interaction/chain.test.ts": 2,
-    "test/unit/interaction/interaction-plugins.test.ts": 6,
+    "test/unit/interaction/interaction-plugins.test.ts": 5,
     "test/unit/interaction/triggers.test.ts": 4,
     "test/unit/interaction/telegram-timeout.test.ts": 2,
     "test/unit/interaction/auto-plugin-adapter.test.ts": 3,
@@ -765,13 +765,13 @@
     "test/helpers/mock-session-manager.ts": 2,
     "test/helpers/mock-story.ts": 1,
     "test/helpers/review-audit.ts": 2,
+    "test/helpers/warn-spy.ts": 1,
     "test/helpers/pipeline-context.ts": 4,
     "test/helpers/fake-agent-manager.ts": 10,
     "test/helpers/mock-nax-config.ts": 2,
     "test/helpers/helpers.test.ts": 2,
     "test/helpers/index.ts": 1,
     "test/helpers/deps.ts": 1,
-    "test/helpers/verbatim-warn-spy.ts": 1,
     "test/helpers/mock-agent-adapter.ts": 1,
     "scripts/logging-formatter-demo.ts": 3
   }

--- a/src/interaction/index.ts
+++ b/src/interaction/index.ts
@@ -37,7 +37,7 @@ export type { RunState } from "./state";
 
 // Plugins
 export { CLIInteractionPlugin } from "./plugins/cli";
-export { TelegramInteractionPlugin } from "./plugins/telegram";
+export { TelegramInteractionPlugin, _telegramPluginDeps } from "./plugins/telegram";
 export {
   MAX_MESSAGE_CHARS,
   buildBody,

--- a/src/interaction/index.ts
+++ b/src/interaction/index.ts
@@ -37,7 +37,7 @@ export type { RunState } from "./state";
 
 // Plugins
 export { CLIInteractionPlugin } from "./plugins/cli";
-export { TelegramInteractionPlugin, _telegramPluginDeps } from "./plugins/telegram";
+export { TelegramInteractionPlugin, _telegramPluginDeps, normalizeChatId } from "./plugins/telegram";
 export {
   MAX_MESSAGE_CHARS,
   buildBody,

--- a/src/interaction/plugins/telegram.ts
+++ b/src/interaction/plugins/telegram.ts
@@ -21,6 +21,30 @@ export const _telegramPluginDeps = {
 
 const CALLBACK_API_TIMEOUT_MS = 4000;
 
+/** Telegram numeric chat ids; negative for groups and supergroups. */
+const NUMERIC_CHAT_ID = /^-?\d+$/;
+
+/**
+ * Normalize a configured chat id and report whether it can ever match an
+ * inbound update.
+ *
+ * The ingestion filter compares `String(update.chat.id)` against the configured
+ * value, and getUpdates only ever reports NUMERIC chat ids. An `@channelusername`
+ * is accepted by sendMessage — which is precisely why a mismatch here is silent:
+ * outbound posting keeps working, so nothing looks broken until an answer never
+ * arrives and every interactive prompt quietly falls through to its timeout
+ * fallback. Same for a chat id that picked up whitespace from a .env file.
+ *
+ * Whitespace is stripped (unambiguously a typo). A non-numeric id is reported
+ * as `unmatchable` rather than rejected, because send-only usage — `notify`
+ * requests, which never wait for a response — is legitimate against an
+ * `@channelusername`.
+ */
+export function normalizeChatId(raw: string): { chatId: string; unmatchable: boolean } {
+  const chatId = raw.trim();
+  return { chatId, unmatchable: !NUMERIC_CHAT_ID.test(chatId) };
+}
+
 /** Zod schema for validating telegram plugin config */
 const TelegramConfigSchema = z.object({
   botToken: z.string().optional(),
@@ -72,7 +96,11 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   async init(config: Record<string, unknown>): Promise<void> {
     const cfg = TelegramConfigSchema.parse(config);
     this.botToken = cfg.botToken ?? process.env.NAX_TELEGRAM_TOKEN ?? process.env.TELEGRAM_BOT_TOKEN ?? null;
-    this.chatId = cfg.chatId ?? process.env.NAX_TELEGRAM_CHAT_ID ?? null;
+    const rawChatId = cfg.chatId ?? process.env.NAX_TELEGRAM_CHAT_ID ?? null;
+    // Normalize before the emptiness check so an all-whitespace chatId is
+    // treated as absent rather than as a configured value that matches nothing.
+    const normalized = rawChatId === null ? null : normalizeChatId(rawChatId);
+    this.chatId = normalized?.chatId || null;
 
     if (!this.botToken || !this.chatId) {
       throw new Error(
@@ -80,6 +108,16 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
       );
     }
 
+    // Loud at startup beats silent at prompt time: with an unmatchable chatId the
+    // prompt still posts and simply never accepts an answer. Warn rather than
+    // throw — notify-only usage against an @channelusername never needs a reply.
+    if (normalized?.unmatchable) {
+      this.logger?.warn(
+        "interaction",
+        "Telegram chatId is not numeric — inbound updates cannot be matched, so interactive prompts will always fall back to their timeout. Use the numeric chat id (see getUpdates or @userinfobot).",
+        { chatId: this.chatId },
+      );
+    }
     // No network call here — the backlog is drained immediately before each prompt is
     // posted (see send()), not at startup. Interactions can fire minutes into a run,
     // so draining once at init() would still leave a wide window for stale updates to

--- a/src/interaction/plugins/telegram.ts
+++ b/src/interaction/plugins/telegram.ts
@@ -79,6 +79,7 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
         "Telegram plugin requires botToken and chatId (env: NAX_TELEGRAM_TOKEN or TELEGRAM_BOT_TOKEN, NAX_TELEGRAM_CHAT_ID)",
       );
     }
+
     // No network call here — the backlog is drained immediately before each prompt is
     // posted (see send()), not at startup. Interactions can fire minutes into a run,
     // so draining once at init() would still leave a wide window for stale updates to
@@ -100,7 +101,12 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
         this.logger?.warn("interaction", "Telegram backlog drain failed — stale updates may be misread as a response");
         return;
       }
-      if (result.updates.length === 0) return;
+      // Terminate on the RAW page size, not the authorized one. A page filled
+      // entirely with foreign traffic filters down to nothing while Telegram
+      // still has pages left; stopping there would leave genuine stale updates
+      // from the configured chat unconsumed, which is exactly what the drain
+      // exists to prevent.
+      if (result.rawCount === 0) return;
     }
     this.logger?.warn("interaction", "Telegram backlog drain hit page cap — stale updates may remain", {
       pages: TelegramInteractionPlugin.MAX_DRAIN_PAGES,
@@ -258,9 +264,12 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   /**
    * Core getUpdates() implementation reporting success/failure explicitly.
    * Mutates lastUpdateId/backoffMs the same way regardless of caller.
+   *
+   * `rawCount` is the page size BEFORE chat-id filtering. drainBacklog() needs it
+   * to tell "Telegram has nothing left" apart from "nothing on this page was ours".
    */
-  private async fetchUpdates(): Promise<{ ok: boolean; updates: TelegramUpdate[] }> {
-    if (!this.botToken) return { ok: true, updates: [] };
+  private async fetchUpdates(): Promise<{ ok: boolean; updates: TelegramUpdate[]; rawCount: number }> {
+    if (!this.botToken) return { ok: true, updates: [], rawCount: 0 };
 
     try {
       // Client-side timeout guards against network hangs (no OS TCP timeout = 75s+ stall)
@@ -310,12 +319,17 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
 
       // Reset backoff on success
       this.backoffMs = 1000;
-      return { ok: true, updates };
+      return { ok: true, updates, rawCount: raw.length };
     } catch (err) {
       // Apply exponential backoff on network error
       this.backoffMs = Math.min(this.backoffMs * 2, this.maxBackoffMs);
-      // Swallow the error (logged for debugging, not exposed to user) — callers retry with backoff
-      return { ok: false, updates: [] };
+      // Swallow the error — callers retry with backoff. Logged at debug so a
+      // persistently failing poll is diagnosable rather than silent.
+      this.logger?.debug("interaction", "Telegram getUpdates failed — retrying with backoff", {
+        error: err instanceof Error ? err.message : String(err),
+        backoffMs: this.backoffMs,
+      });
+      return { ok: false, updates: [], rawCount: 0 };
     }
   }
 

--- a/test/unit/interaction/plugins/cli.test.ts
+++ b/test/unit/interaction/plugins/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { CLIInteractionPlugin } from "../../../../src/interaction/plugins/cli";
 
 const makeRequest = (id = "req-1") => ({

--- a/test/unit/interaction/plugins/telegram-authorization.test.ts
+++ b/test/unit/interaction/plugins/telegram-authorization.test.ts
@@ -225,3 +225,111 @@ describe("TelegramInteractionPlugin - inbound chat authorization", () => {
     expect(response.value).toBe("ship it");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Backlog drain vs. the authorization filter
+//
+// drainBacklog() advances lastUpdateId past everything already queued so a stale
+// update can never be misread as the answer to the next prompt. Once ingestion
+// filtering landed, the drain's "this page was empty, we're done" signal had to
+// keep meaning "Telegram has nothing left" -- not "nothing on this page was
+// ours". A page filled entirely with foreign traffic is the case that separates
+// the two.
+// ---------------------------------------------------------------------------
+
+describe("TelegramInteractionPlugin - backlog drain with foreign traffic", () => {
+  const originalFetch = _telegramPluginDeps.fetch;
+
+  afterEach(() => {
+    mock.restore();
+    _telegramPluginDeps.fetch = originalFetch;
+  });
+
+  /**
+   * Stubs Telegram with a ONE-UPDATE-PER-PAGE getUpdates.
+   *
+   * The page size is the whole point. Telegram serves getUpdates in pages, and
+   * the bug only appears when a page contains foreign updates and nothing else
+   * -- with every update crammed into a single page the filter always leaves
+   * something behind and the drain keeps going for the wrong reason.
+   */
+  function stubPagedTelegram(updates: Array<Record<string, unknown>>) {
+    const getUpdatesCalls: number[] = [];
+
+    _telegramPluginDeps.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = url.toString();
+      const body = JSON.parse((init?.body as string) ?? "{}");
+
+      if (urlStr.includes("sendMessage")) {
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 10, chat: { id: 99999 } } }), {
+          status: 200,
+        });
+      }
+      if (urlStr.includes("getUpdates")) {
+        const offset = body.offset as number;
+        getUpdatesCalls.push(offset);
+        const next = updates.find((u) => (u.update_id as number) >= offset);
+        return new Response(JSON.stringify({ ok: true, result: next ? [next] : [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    return { getUpdatesCalls };
+  }
+
+  test("a page of purely foreign updates does not end the drain early", async () => {
+    // Update 1 is foreign and fills its whole page; update 2 is a stale message
+    // from the configured chat that predates the prompt. The drain must get past
+    // the foreign page and consume BOTH.
+    //
+    // Exactly one foreign update, deliberately: the stale update then sits on the
+    // very first page receive() would poll, so the bug shows up on the first poll
+    // and the test needs no backoff cycles to expose it.
+    stubPagedTelegram([
+      { update_id: 1, message: { message_id: 71, chat: { id: 424242 }, text: "noise" } },
+      { update_id: 2, message: { message_id: 74, chat: { id: 99999 }, text: "yes do it" } },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send({
+      id: "drain-1",
+      type: "input",
+      featureName: "my-feature",
+      stage: "review",
+      summary: "What should I do?",
+      fallback: "abort",
+      createdAt: Date.now(),
+    } as InteractionRequest);
+
+    const response = await plugin.receive("drain-1", 300);
+
+    // "yes do it" was sitting in the queue BEFORE the prompt was posted, so it
+    // cannot be the answer to it. If the drain stopped at update 1 -- the first
+    // page holding only foreign traffic -- this comes back as a real answer.
+    expect(response.respondedBy).toBe("timeout");
+    expect(response.value).toBeUndefined();
+  });
+
+  test("the drain still stops once Telegram reports an empty page", async () => {
+    const { getUpdatesCalls } = stubPagedTelegram([
+      { update_id: 1, message: { message_id: 71, chat: { id: 424242 }, text: "noise" } },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send({
+      id: "drain-2",
+      type: "confirm",
+      featureName: "my-feature",
+      stage: "review",
+      summary: "Proceed?",
+      fallback: "abort",
+      createdAt: Date.now(),
+    } as InteractionRequest);
+
+    // One page holding update 1, then one empty page. Anything more means the
+    // drain is burning its full MAX_DRAIN_PAGES budget on every single send().
+    expect(getUpdatesCalls).toEqual([1, 2]);
+  });
+});

--- a/test/unit/interaction/plugins/telegram-authorization.test.ts
+++ b/test/unit/interaction/plugins/telegram-authorization.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { InteractionRequest } from "@/interaction";
-import { TelegramInteractionPlugin, _telegramPluginDeps } from "@/interaction";
+import { TelegramInteractionPlugin, _telegramPluginDeps, normalizeChatId } from "@/interaction";
 
 // ---------------------------------------------------------------------------
 // Inbound chat authorization (closes #1365)
@@ -331,5 +331,91 @@ describe("TelegramInteractionPlugin - backlog drain with foreign traffic", () =>
     // One page holding update 1, then one empty page. Anything more means the
     // drain is burning its full MAX_DRAIN_PAGES budget on every single send().
     expect(getUpdatesCalls).toEqual([1, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Configured chat id normalization
+//
+// The filter compares the inbound chat.id against the configured one as a
+// string. An id that cannot match anything Telegram will ever send makes every
+// inbound update fail the filter -- send() still works, so the prompt appears
+// and simply never accepts an answer. That has to be loud, not silent.
+// ---------------------------------------------------------------------------
+
+describe("normalizeChatId", () => {
+  test("strips surrounding whitespace", () => {
+    expect(normalizeChatId("  99999  ").chatId).toBe("99999");
+  });
+
+  test("accepts negative ids used by groups and supergroups", () => {
+    const result = normalizeChatId("-1001234567890");
+    expect(result.chatId).toBe("-1001234567890");
+    expect(result.unmatchable).toBe(false);
+  });
+
+  test("accepts a plain numeric id", () => {
+    expect(normalizeChatId("99999").unmatchable).toBe(false);
+  });
+
+  test("flags an @username id as unmatchable against inbound updates", () => {
+    // Valid for sendMessage, which is exactly why this fails silently today:
+    // outbound works, so nothing looks broken until an answer never arrives.
+    expect(normalizeChatId("@mychannel").unmatchable).toBe(true);
+  });
+
+  test("flags a non-numeric id as unmatchable", () => {
+    expect(normalizeChatId("not-an-id").unmatchable).toBe(true);
+  });
+});
+
+describe("TelegramInteractionPlugin - configured chat id normalization", () => {
+  const originalFetch = _telegramPluginDeps.fetch;
+
+  afterEach(() => {
+    mock.restore();
+    _telegramPluginDeps.fetch = originalFetch;
+  });
+
+  test("a whitespace-padded chatId still accepts a callback from that chat", async () => {
+    let posted = false;
+    _telegramPluginDeps.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = url.toString();
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      if (urlStr.includes("sendMessage")) {
+        posted = true;
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 10, chat: { id: 99999 } } }), {
+          status: 200,
+        });
+      }
+      if (urlStr.includes("getUpdates")) {
+        const offset = body.offset as number;
+        const update = {
+          update_id: 1,
+          callback_query: { id: "cq-ok", data: "norm-1:approve", message: { message_id: 10, chat: { id: 99999 } } },
+        };
+        const visible = posted && offset <= 1 ? [update] : [];
+        return new Response(JSON.stringify({ ok: true, result: visible }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    const plugin = new TelegramInteractionPlugin();
+    // Trailing whitespace is easy to pick up from a .env file or a copy-paste.
+    await plugin.init({ botToken: "bot-abc123", chatId: " 99999\n" });
+    await plugin.send({
+      id: "norm-1",
+      type: "confirm",
+      featureName: "my-feature",
+      stage: "review",
+      summary: "Proceed?",
+      fallback: "abort",
+      createdAt: Date.now(),
+    } as InteractionRequest);
+
+    const response = await plugin.receive("norm-1", 5000);
+
+    expect(response.action).toBe("approve");
+    expect(response.respondedBy).toBe("telegram");
   });
 });

--- a/test/unit/interaction/plugins/telegram-authorization.test.ts
+++ b/test/unit/interaction/plugins/telegram-authorization.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Telegram Interaction Plugin — inbound chat authorization tests.
+ *
+ * Split out of telegram.test.ts, which was at the 800-line limit.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { InteractionRequest } from "@/interaction";
+import { TelegramInteractionPlugin, _telegramPluginDeps } from "@/interaction";
+
+// ---------------------------------------------------------------------------
+// Inbound chat authorization (closes #1365)
+//
+// getUpdates() returns updates from EVERY chat the bot participates in. Without
+// a chat-id filter at ingestion, any third party who can message the bot can
+// answer a pending input interaction -- injected straight into the coding
+// agent's turn by the ACP interaction bridge -- or forge a callback_query to
+// approve, reject, or abort a run. Request ids are deterministic and guessable
+// for some flows.
+// ---------------------------------------------------------------------------
+
+describe("TelegramInteractionPlugin - inbound chat authorization", () => {
+  const originalFetch = _telegramPluginDeps.fetch;
+
+  afterEach(() => {
+    mock.restore();
+    _telegramPluginDeps.fetch = originalFetch;
+  });
+
+  /**
+   * Stubs the Telegram API.
+   *
+   * Two behaviours here are load-bearing, and getting either wrong produces a
+   * test that passes for the wrong reason:
+   *
+   * 1. Updates stay INVISIBLE until sendMessage has been called. send() calls
+   *    drainBacklog() before posting the prompt, so an update that is visible
+   *    from the start is consumed by the drain and never reaches receive() at
+   *    all -- the assertion would then pass even with the security fix reverted.
+   *    Gating on `posted` models what actually happens: the attacker taps the
+   *    button after the prompt appears.
+   *
+   * 2. getUpdates honours the offset, so an update is served once and not
+   *    re-served. That is what makes the lastUpdateId test meaningful.
+   */
+  function stubTelegram(updates: Array<Record<string, unknown>>) {
+    const acked: string[] = [];
+    const offsets: number[] = [];
+    let posted = false;
+
+    _telegramPluginDeps.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = url.toString();
+      const body = JSON.parse((init?.body as string) ?? "{}");
+
+      if (urlStr.includes("sendMessage")) {
+        posted = true;
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 10, chat: { id: 99999 } } }), {
+          status: 200,
+        });
+      }
+      if (urlStr.includes("answerCallbackQuery")) {
+        acked.push(body.callback_query_id as string);
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (urlStr.includes("getUpdates")) {
+        const offset = body.offset as number;
+        offsets.push(offset);
+        const visible = posted ? updates.filter((u) => (u.update_id as number) >= offset) : [];
+        return new Response(JSON.stringify({ ok: true, result: visible }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    return { acked, offsets };
+  }
+
+  function makeConfirmRequest(id: string): InteractionRequest {
+    return {
+      id,
+      type: "confirm",
+      featureName: "my-feature",
+      stage: "review",
+      summary: "Proceed with merge?",
+      fallback: "abort",
+      createdAt: Date.now(),
+    } as InteractionRequest;
+  }
+
+  test("a correctly-formed callback_query from a foreign chat does not resolve the request", async () => {
+    stubTelegram([
+      {
+        update_id: 1,
+        callback_query: {
+          id: "cq-foreign",
+          // Payload is exactly what a legitimate approval looks like.
+          data: "auth-1:approve",
+          message: { message_id: 10, chat: { id: 424242 } },
+        },
+      },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send(makeConfirmRequest("auth-1"));
+
+    const response = await plugin.receive("auth-1", 300);
+
+    expect(response.respondedBy).toBe("timeout");
+    expect(response.action).not.toBe("approve");
+  });
+
+  test("a foreign callback_query is never acknowledged", async () => {
+    const { acked } = stubTelegram([
+      {
+        update_id: 1,
+        callback_query: {
+          id: "cq-foreign",
+          data: "auth-2:approve",
+          message: { message_id: 10, chat: { id: 424242 } },
+        },
+      },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send(makeConfirmRequest("auth-2"));
+    await plugin.receive("auth-2", 300);
+
+    expect(acked).not.toContain("cq-foreign");
+  });
+
+  test("a text message from a foreign chat does not answer a pending input request", async () => {
+    stubTelegram([
+      {
+        update_id: 1,
+        message: { message_id: 77, chat: { id: 424242 }, text: "rm -rf /" },
+      },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send({
+      id: "auth-3",
+      type: "input",
+      featureName: "my-feature",
+      stage: "review",
+      summary: "What should I do?",
+      fallback: "abort",
+      createdAt: Date.now(),
+    } as InteractionRequest);
+
+    const response = await plugin.receive("auth-3", 300);
+
+    expect(response.respondedBy).toBe("timeout");
+    expect(response.value).toBeUndefined();
+  });
+
+  test("lastUpdateId still advances past foreign updates so they are not re-served forever", async () => {
+    const { offsets } = stubTelegram([
+      {
+        update_id: 7,
+        message: { message_id: 77, chat: { id: 424242 }, text: "noise" },
+      },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send(makeConfirmRequest("auth-4"));
+    // 2500ms, not 300ms: the poll loop backs off 1000ms between attempts, so a
+    // short timeout yields a single poll and never demonstrates the offset moving.
+    await plugin.receive("auth-4", 2500);
+
+    // Reaching offset 8 is the discriminating assertion. If the filter ran
+    // before lastUpdateId advanced, the offset would stay parked at 1 forever
+    // and 8 would never appear.
+    expect(offsets).toContain(8);
+    expect(offsets.at(-1)).toBe(8);
+  });
+
+  test("a callback_query from the configured chat still resolves", async () => {
+    stubTelegram([
+      {
+        update_id: 1,
+        callback_query: {
+          id: "cq-ok",
+          data: "auth-5:approve",
+          message: { message_id: 10, chat: { id: 99999 } },
+        },
+      },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send(makeConfirmRequest("auth-5"));
+
+    const response = await plugin.receive("auth-5", 5000);
+
+    expect(response.action).toBe("approve");
+    expect(response.respondedBy).toBe("telegram");
+  });
+
+  test("a text reply from the configured chat still answers an input request", async () => {
+    stubTelegram([
+      {
+        update_id: 1,
+        message: { message_id: 78, chat: { id: 99999 }, text: "ship it" },
+      },
+    ]);
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+    await plugin.send({
+      id: "auth-6",
+      type: "input",
+      featureName: "my-feature",
+      stage: "review",
+      summary: "What should I do?",
+      fallback: "abort",
+      createdAt: Date.now(),
+    } as InteractionRequest);
+
+    const response = await plugin.receive("auth-6", 5000);
+
+    expect(response.action).toBe("input");
+    expect(response.value).toBe("ship it");
+  });
+});

--- a/test/unit/interaction/plugins/telegram.test.ts
+++ b/test/unit/interaction/plugins/telegram.test.ts
@@ -6,8 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { InteractionRequest } from "@/interaction";
-import { TelegramInteractionPlugin } from "@/interaction";
-import { _telegramPluginDeps } from "../../../../src/interaction/plugins/telegram";
+import { TelegramInteractionPlugin, _telegramPluginDeps } from "@/interaction";
 
 describe("TelegramInteractionPlugin", () => {
   let savedToken: string | undefined;
@@ -104,10 +103,10 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
       if (urlStr.includes("getUpdates")) {
         return new Response(JSON.stringify({ ok: true, result: [] }), { status: 200 });
       }
-      return new Response(
-        JSON.stringify({ ok: true, result: { message_id: 42, chat: { id: 12345 } } }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 42, chat: { id: 12345 } } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
     }) as typeof fetch;
 
     const plugin = new TelegramInteractionPlugin();
@@ -144,10 +143,10 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
       const urlStr = url.toString();
 
       if (urlStr.includes("sendMessage")) {
-        return new Response(
-          JSON.stringify({ ok: true, result: { message_id: 10, chat: { id: 99999 } } }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 10, chat: { id: 99999 } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if (urlStr.includes("getUpdates")) {
@@ -194,10 +193,10 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
       const urlStr = url.toString();
 
       if (urlStr.includes("sendMessage")) {
-        return new Response(
-          JSON.stringify({ ok: true, result: { message_id: 11, chat: { id: 99999 } } }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 11, chat: { id: 99999 } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if (urlStr.includes("getUpdates")) {
@@ -265,10 +264,10 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
       const urlStr = url.toString();
 
       if (urlStr.includes("sendMessage")) {
-        return new Response(
-          JSON.stringify({ ok: true, result: { message_id: 12, chat: { id: 99999 } } }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 12, chat: { id: 99999 } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if (urlStr.includes("getUpdates")) {
@@ -353,10 +352,10 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
       const urlStr = url.toString();
 
       if (urlStr.includes("sendMessage")) {
-        return new Response(
-          JSON.stringify({ ok: true, result: { message_id: 20, chat: { id: 99999 } } }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 20, chat: { id: 99999 } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if (urlStr.includes("getUpdates")) {
@@ -420,10 +419,10 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
       const urlStr = url.toString();
 
       if (urlStr.includes("sendMessage")) {
-        return new Response(
-          JSON.stringify({ ok: true, result: { message_id: 30, chat: { id: 99999 } } }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 30, chat: { id: 99999 } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if (urlStr.includes("getUpdates")) {
@@ -483,10 +482,10 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
       const urlStr = url.toString();
 
       if (urlStr.includes("sendMessage")) {
-        return new Response(
-          JSON.stringify({ ok: true, result: { message_id: 13, chat: { id: 99999 } } }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 13, chat: { id: 99999 } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if (urlStr.includes("getUpdates")) {
@@ -556,10 +555,9 @@ describe("TelegramInteractionPlugin - fetch deps seam", () => {
       if (urlStr.includes("getUpdates")) {
         return new Response(JSON.stringify({ ok: true, result: [] }), { status: 200 });
       }
-      return new Response(
-        JSON.stringify({ ok: true, result: { message_id: 1, chat: { id: 99999 } } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1, chat: { id: 99999 } } }), {
+        status: 200,
+      });
     }) as typeof fetch;
 
     const plugin = new TelegramInteractionPlugin();
@@ -575,223 +573,5 @@ describe("TelegramInteractionPlugin - fetch deps seam", () => {
     } as InteractionRequest);
 
     expect(urls.some((u) => u.includes("sendMessage"))).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Inbound chat authorization (closes #1365)
-//
-// getUpdates() returns updates from EVERY chat the bot participates in. Without
-// a chat-id filter at ingestion, any third party who can message the bot can
-// answer a pending input interaction -- injected straight into the coding
-// agent's turn by the ACP interaction bridge -- or forge a callback_query to
-// approve, reject, or abort a run. Request ids are deterministic and guessable
-// for some flows.
-// ---------------------------------------------------------------------------
-
-describe("TelegramInteractionPlugin - inbound chat authorization", () => {
-  const originalFetch = _telegramPluginDeps.fetch;
-
-  afterEach(() => {
-    mock.restore();
-    _telegramPluginDeps.fetch = originalFetch;
-  });
-
-  /**
-   * Stubs the Telegram API.
-   *
-   * Two behaviours here are load-bearing, and getting either wrong produces a
-   * test that passes for the wrong reason:
-   *
-   * 1. Updates stay INVISIBLE until sendMessage has been called. send() calls
-   *    drainBacklog() before posting the prompt, so an update that is visible
-   *    from the start is consumed by the drain and never reaches receive() at
-   *    all -- the assertion would then pass even with the security fix reverted.
-   *    Gating on `posted` models what actually happens: the attacker taps the
-   *    button after the prompt appears.
-   *
-   * 2. getUpdates honours the offset, so an update is served once and not
-   *    re-served. That is what makes the lastUpdateId test meaningful.
-   */
-  function stubTelegram(updates: Array<Record<string, unknown>>) {
-    const acked: string[] = [];
-    const offsets: number[] = [];
-    let posted = false;
-
-    _telegramPluginDeps.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlStr = url.toString();
-      const body = JSON.parse((init?.body as string) ?? "{}");
-
-      if (urlStr.includes("sendMessage")) {
-        posted = true;
-        return new Response(JSON.stringify({ ok: true, result: { message_id: 10, chat: { id: 99999 } } }), {
-          status: 200,
-        });
-      }
-      if (urlStr.includes("answerCallbackQuery")) {
-        acked.push(body.callback_query_id as string);
-        return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }
-      if (urlStr.includes("getUpdates")) {
-        const offset = body.offset as number;
-        offsets.push(offset);
-        const visible = posted ? updates.filter((u) => (u.update_id as number) >= offset) : [];
-        return new Response(JSON.stringify({ ok: true, result: visible }), { status: 200 });
-      }
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
-    }) as typeof fetch;
-
-    return { acked, offsets };
-  }
-
-  function makeConfirmRequest(id: string): InteractionRequest {
-    return {
-      id,
-      type: "confirm",
-      featureName: "my-feature",
-      stage: "review",
-      summary: "Proceed with merge?",
-      fallback: "abort",
-      createdAt: Date.now(),
-    } as InteractionRequest;
-  }
-
-  test("a correctly-formed callback_query from a foreign chat does not resolve the request", async () => {
-    stubTelegram([
-      {
-        update_id: 1,
-        callback_query: {
-          id: "cq-foreign",
-          // Payload is exactly what a legitimate approval looks like.
-          data: "auth-1:approve",
-          message: { message_id: 10, chat: { id: 424242 } },
-        },
-      },
-    ]);
-
-    const plugin = new TelegramInteractionPlugin();
-    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
-    await plugin.send(makeConfirmRequest("auth-1"));
-
-    const response = await plugin.receive("auth-1", 300);
-
-    expect(response.respondedBy).toBe("timeout");
-    expect(response.action).not.toBe("approve");
-  });
-
-  test("a foreign callback_query is never acknowledged", async () => {
-    const { acked } = stubTelegram([
-      {
-        update_id: 1,
-        callback_query: {
-          id: "cq-foreign",
-          data: "auth-2:approve",
-          message: { message_id: 10, chat: { id: 424242 } },
-        },
-      },
-    ]);
-
-    const plugin = new TelegramInteractionPlugin();
-    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
-    await plugin.send(makeConfirmRequest("auth-2"));
-    await plugin.receive("auth-2", 300);
-
-    expect(acked).not.toContain("cq-foreign");
-  });
-
-  test("a text message from a foreign chat does not answer a pending input request", async () => {
-    stubTelegram([
-      {
-        update_id: 1,
-        message: { message_id: 77, chat: { id: 424242 }, text: "rm -rf /" },
-      },
-    ]);
-
-    const plugin = new TelegramInteractionPlugin();
-    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
-    await plugin.send({
-      id: "auth-3",
-      type: "input",
-      featureName: "my-feature",
-      stage: "review",
-      summary: "What should I do?",
-      fallback: "abort",
-      createdAt: Date.now(),
-    } as InteractionRequest);
-
-    const response = await plugin.receive("auth-3", 300);
-
-    expect(response.respondedBy).toBe("timeout");
-    expect(response.value).toBeUndefined();
-  });
-
-  test("lastUpdateId still advances past foreign updates so they are not re-served forever", async () => {
-    const { offsets } = stubTelegram([
-      {
-        update_id: 7,
-        message: { message_id: 77, chat: { id: 424242 }, text: "noise" },
-      },
-    ]);
-
-    const plugin = new TelegramInteractionPlugin();
-    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
-    await plugin.send(makeConfirmRequest("auth-4"));
-    // 2500ms, not 300ms: the poll loop backs off 1000ms between attempts, so a
-    // short timeout yields a single poll and never demonstrates the offset moving.
-    await plugin.receive("auth-4", 2500);
-
-    // Reaching offset 8 is the discriminating assertion. If the filter ran
-    // before lastUpdateId advanced, the offset would stay parked at 1 forever
-    // and 8 would never appear.
-    expect(offsets).toContain(8);
-    expect(offsets.at(-1)).toBe(8);
-  });
-
-  test("a callback_query from the configured chat still resolves", async () => {
-    stubTelegram([
-      {
-        update_id: 1,
-        callback_query: {
-          id: "cq-ok",
-          data: "auth-5:approve",
-          message: { message_id: 10, chat: { id: 99999 } },
-        },
-      },
-    ]);
-
-    const plugin = new TelegramInteractionPlugin();
-    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
-    await plugin.send(makeConfirmRequest("auth-5"));
-
-    const response = await plugin.receive("auth-5", 5000);
-
-    expect(response.action).toBe("approve");
-    expect(response.respondedBy).toBe("telegram");
-  });
-
-  test("a text reply from the configured chat still answers an input request", async () => {
-    stubTelegram([
-      {
-        update_id: 1,
-        message: { message_id: 78, chat: { id: 99999 }, text: "ship it" },
-      },
-    ]);
-
-    const plugin = new TelegramInteractionPlugin();
-    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
-    await plugin.send({
-      id: "auth-6",
-      type: "input",
-      featureName: "my-feature",
-      stage: "review",
-      summary: "What should I do?",
-      fallback: "abort",
-      createdAt: Date.now(),
-    } as InteractionRequest);
-
-    const response = await plugin.receive("auth-6", 5000);
-
-    expect(response.action).toBe("input");
-    expect(response.value).toBe("ship it");
   });
 });


### PR DESCRIPTION
Follow-up to #1372, from a pre-release review of the pending v0.75.0. Two silent-failure modes in the Telegram ingestion path that #1372 touched, plus one stale comment.

Neither is exploitable — the chat authorization filter itself is sound. Both make interactions fail quietly, which is the worst way for an approval prompt to fail.

## M1 — the backlog drain stopped early on a page of foreign traffic

`drainBacklog()` terminated on the page size **after** chat-id filtering. `getUpdates` is paged, so a page holding only foreign updates filters down to nothing while Telegram still has pages queued. The drain returned there, leaving genuine stale updates from the configured chat unconsumed — reopening exactly the misattribution the drain exists to prevent (#1364): a stale plain-text message with no `reply_to` is accepted as the answer to an `input` request.

`fetchUpdates()` now reports `rawCount`, the page size before filtering, and the drain terminates on that. The filtered list is untouched, so foreign updates still never reach `receive()`.

## M2 — an unmatchable `chatId` failed silently

The filter compares the inbound `chat.id` against the configured value as a string, and `getUpdates` only ever reports **numeric** chat ids. A `chatId` that picked up whitespace from a `.env` file, or an `@channelusername`, matched nothing.

`sendMessage` accepts both forms — which is precisely why this was invisible. The prompt posted, looked fine, and simply never accepted an answer; every interactive request fell through to its timeout fallback with nothing in the logs to explain why.

`normalizeChatId()` trims the value and reports whether it can ever match. `init()` **warns** rather than throws on a non-numeric id: send-only usage (`notify` requests, which never wait for a response) is legitimate against an `@channelusername`, so throwing would break working setups. Trimming before the emptiness check also makes an all-whitespace `chatId` fail the existing `requires botToken and chatId` guard instead of being accepted as a value matching nothing.

## Also

- The swallowed `getUpdates` error now logs at debug. The comment claimed it was "logged for debugging" and nothing logged it, so a persistently failing poll was indistinguishable from an idle one.
- `telegram.test.ts` was at 797 of the 800-line limit, so the first commit splits the authorization suite into its own file — same headroom wall #1372 hit. Pure move, no body changes.
- Both suites now reach the fetch seam through the `@/interaction` barrel instead of a 4-level relative path, so `_telegramPluginDeps` is exported from the barrel. That retires the pre-existing deep relative too (baseline 2847 -> 2846).

## Test plan

- [x] `bun run lint` — all ratchets at baseline
- [x] `bun run typecheck`
- [x] `bun run test` — 10240 tests, 0 fail
- [x] `bun run test:coverage` — 82.52% lines / 84.78% functions (floor 80%)
- [x] **Each new regression test re-run with its fix reverted, and confirmed to fail.** This mattered: the drain test initially passed *without* the fix. It needs exactly one foreign update so the stale update lands on `receive()`'s first poll — with three, the 300ms timeout expired before the poll loop (1000ms backoff per iteration) ever walked to it, and the test went green for the wrong reason.
