### PR TITLE
fix(review): honour blockingThreshold in adversarial verdict (#1378)

### DIFF
--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -552,12 +552,24 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
       });
     }
 
-    // Pass when nothing blocks AND either the model passed, or the classifier
-    // reclassified a blocking-severity finding to non-blocking (recurrence-demoted
-    // OR oscillation-suppressed to advisory). Preserves fail-closed when the model
-    // fails with no blocking-severity findings at all.
-    const hadBlockingSeverity = accepted.some((f) => isBlockingSeverity(f.severity, threshold));
-    const passed = blocking.length === 0 && (parsed.passed || hadBlockingSeverity);
+    // Honour blockingThreshold: the verdict fails only when a blocking finding
+    // survives. The model's raw `passed:false` must NOT fail the review when every
+    // surviving finding is sub-threshold — that was nax#1347 for semantic, and
+    // nax#1378 here. This clause was previously `accepted.some(isBlockingSeverity)`,
+    // which can only be true when `blocking` is non-empty *unless* classifyRecurrence
+    // moved a blocking-severity finding out (demotion / oscillation-suppression);
+    // for ordinary sub-threshold findings it collapsed to `parsed.passed` alone.
+    //
+    // That collapse deadlocks the story rather than merely pausing it: `normalizedFindings`
+    // carries `blocking` only, so a sub-threshold-only failure hands the rectification
+    // cycle nothing routable — it exits "resolved" without dispatching a fix strategy,
+    // and the story terminates with no derivable failure category.
+    //
+    // `accepted.length > 0` preserves the fail-closed guard for the distinct case where
+    // the model claims failure but every finding was dropped as ungrounded (accepted
+    // empty): there we still respect the model's `passed` flag. `accepted` is a superset
+    // of what the old clause tested, so demotion/oscillation pass-through is unchanged.
+    const passed = blocking.length === 0 && (parsed.passed || accepted.length > 0);
 
     return {
       ...parsed,

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -103,6 +103,15 @@ function extractRepromptInfo(raw: Record<string, unknown> | null | undefined): R
 
 export interface AdversarialReviewOutput {
   passed: boolean;
+  /**
+   * The model's raw `passed` flag, before `verify()` applies blockingThreshold (#1378).
+   * `passed` answers "does this block the story?"; `modelPassed` answers "did the model
+   * claim failure?". The wrapper's ungrounded-drop branches key off the latter — they
+   * must fail closed when the model raised concerns it could not ground, regardless of
+   * whether an unrelated sub-threshold finding happened to survive filtering.
+   * Undefined on the fail-open / looksLikeFail short-circuits, which set no drops.
+   */
+  modelPassed?: boolean;
   /** Raw AdversarialLLMFinding[]. Consumed by `src/review/adversarial.ts`. */
   findings: unknown[];
   /**
@@ -574,6 +583,7 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
     return {
       ...parsed,
       passed,
+      modelPassed: parsed.passed,
       findings: accepted,
       // #1368 — `testFileMatch` also decides the fix lane: a finding located in a
       // test file goes to the test-writer whatever its category says, because the

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -473,56 +473,56 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     };
   }
 
-  // #1378 — NOT gated on `!opResult.passed`: the verdict now honours blockingThreshold,
-  // so a surviving advisory finding makes the op pass and these drops would vanish.
-  if (acDropped.length > 0 && acDropped.every((d) => d.code === "ac_quote_not_substring")) {
-    // Case A: every blocking finding cited a quote that does not exist in any AC.
-    // The model fabricated its grounding. Treat as pass — demote each dropped finding
-    // to "warning" and surface as advisory so it remains auditable.
-    const demotedFindings = toAdversarialReviewFindings(
-      acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
-      { isTestFile: testFileMatch },
-    );
-    // advisoryFindingsAsFindings is already [] when advisoryFindings is empty.
-    const allAdvisory = [...advisoryFindingsAsFindings, ...demotedFindings];
+  // #1378 — MODEL verdict, not `opResult.passed`: the latter now honours blockingThreshold,
+  // so a surviving sub-threshold finding would skip both branches — waving through blocking
+  // concerns the model could not ground (Case B) and losing the demoted drops (Case A).
+  if (!opResult.modelPassed && acDropped.length > 0) {
+    if (acDropped.every((d) => d.code === "ac_quote_not_substring")) {
+      // Case A: every blocking finding cited a quote that does not exist in any AC.
+      // The model fabricated its grounding. Treat as pass — demote each dropped finding
+      // to "warning" and surface as advisory so it remains auditable.
+      const demotedFindings = toAdversarialReviewFindings(
+        acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
+        { isTestFile: testFileMatch },
+      );
+      const allAdvisory = [...advisoryFindingsAsFindings, ...demotedFindings];
 
-    logger?.warn("review", "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes", {
-      storyId: story.id,
-      durationMs,
-      droppedCount: acDropped.length,
-      drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
-    });
-    recordAdversarialAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: true,
-      failOpen: false,
-      passed: true,
-      passReason: "ac_quote_not_substring_demoted",
-      blockingThreshold: threshold,
-      result: { passed: true, findings: [] },
-      advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
-      diffAvailable,
-      adversarialDropAnalysis,
-      adversarialAcceptAnalysis: [],
-    });
-    return {
-      check: "adversarial",
-      success: true,
-      passReason: "ac_quote_not_substring_demoted",
-      command: "",
-      exitCode: 0,
-      output: `Adversarial review passed: ${acDropped.length} blocking finding(s) demoted to advisory — all cited AC quotes were fabricated and could not be validated.`,
-      durationMs,
-      advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
-      cost: llmCost,
-    };
-  }
+      logger?.warn("review", "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes", {
+        storyId: story.id,
+        durationMs,
+        droppedCount: acDropped.length,
+        drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
+      });
+      recordAdversarialAudit({
+        runtime,
+        workdir,
+        projectDir,
+        storyId: story.id,
+        featureName,
+        parsed: true,
+        failOpen: false,
+        passed: true,
+        passReason: "ac_quote_not_substring_demoted",
+        blockingThreshold: threshold,
+        result: { passed: true, findings: [] },
+        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+        diffAvailable,
+        adversarialDropAnalysis,
+        adversarialAcceptAnalysis: [],
+      });
+      return {
+        check: "adversarial",
+        success: true,
+        passReason: "ac_quote_not_substring_demoted",
+        command: "",
+        exitCode: 0,
+        output: `Adversarial review passed: ${acDropped.length} blocking finding(s) demoted to advisory — all cited AC quotes were fabricated and could not be validated.`,
+        durationMs,
+        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+        cost: llmCost,
+      };
+    }
 
-  if (!opResult.passed && acDropped.length > 0) {
     // Case B: mix includes missing_ac_quote or ac_quote_does_not_constrain_locus —
     // fail-closed (existing behavior unchanged).
     logger?.warn("review", "Adversarial review fail-closed: blocking findings dropped as ungrounded", {

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -473,56 +473,56 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     };
   }
 
+  // #1378 — NOT gated on `!opResult.passed`: the verdict now honours blockingThreshold,
+  // so a surviving advisory finding makes the op pass and these drops would vanish.
+  if (acDropped.length > 0 && acDropped.every((d) => d.code === "ac_quote_not_substring")) {
+    // Case A: every blocking finding cited a quote that does not exist in any AC.
+    // The model fabricated its grounding. Treat as pass — demote each dropped finding
+    // to "warning" and surface as advisory so it remains auditable.
+    const demotedFindings = toAdversarialReviewFindings(
+      acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
+      { isTestFile: testFileMatch },
+    );
+    // advisoryFindingsAsFindings is already [] when advisoryFindings is empty.
+    const allAdvisory = [...advisoryFindingsAsFindings, ...demotedFindings];
+
+    logger?.warn("review", "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes", {
+      storyId: story.id,
+      durationMs,
+      droppedCount: acDropped.length,
+      drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
+    });
+    recordAdversarialAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      failOpen: false,
+      passed: true,
+      passReason: "ac_quote_not_substring_demoted",
+      blockingThreshold: threshold,
+      result: { passed: true, findings: [] },
+      advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+      diffAvailable,
+      adversarialDropAnalysis,
+      adversarialAcceptAnalysis: [],
+    });
+    return {
+      check: "adversarial",
+      success: true,
+      passReason: "ac_quote_not_substring_demoted",
+      command: "",
+      exitCode: 0,
+      output: `Adversarial review passed: ${acDropped.length} blocking finding(s) demoted to advisory — all cited AC quotes were fabricated and could not be validated.`,
+      durationMs,
+      advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+      cost: llmCost,
+    };
+  }
+
   if (!opResult.passed && acDropped.length > 0) {
-    const allHallucinated = acDropped.every((d) => d.code === "ac_quote_not_substring");
-
-    if (allHallucinated) {
-      // Case A: every blocking finding cited a quote that does not exist in any AC.
-      // The model fabricated its grounding. Treat as pass — demote each dropped finding
-      // to "warning" and surface as advisory so it remains auditable.
-      const demotedFindings = toAdversarialReviewFindings(
-        acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
-        { isTestFile: testFileMatch },
-      );
-      const existingAdvisory = advisoryFindings.length > 0 ? advisoryFindingsAsFindings : [];
-      const allAdvisory = [...existingAdvisory, ...demotedFindings];
-
-      logger?.warn("review", "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes", {
-        storyId: story.id,
-        durationMs,
-        droppedCount: acDropped.length,
-        drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
-      });
-      recordAdversarialAudit({
-        runtime,
-        workdir,
-        projectDir,
-        storyId: story.id,
-        featureName,
-        parsed: true,
-        failOpen: false,
-        passed: true,
-        passReason: "ac_quote_not_substring_demoted",
-        blockingThreshold: threshold,
-        result: { passed: true, findings: [] },
-        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
-        diffAvailable,
-        adversarialDropAnalysis,
-        adversarialAcceptAnalysis: [],
-      });
-      return {
-        check: "adversarial",
-        success: true,
-        passReason: "ac_quote_not_substring_demoted",
-        command: "",
-        exitCode: 0,
-        output: `Adversarial review passed: ${acDropped.length} blocking finding(s) demoted to advisory — all cited AC quotes were fabricated and could not be validated.`,
-        durationMs,
-        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
-        cost: llmCost,
-      };
-    }
-
     // Case B: mix includes missing_ac_quote or ac_quote_does_not_constrain_locus —
     // fail-closed (existing behavior unchanged).
     logger?.warn("review", "Adversarial review fail-closed: blocking findings dropped as ungrounded", {

--- a/test/unit/operations/adversarial-review-verify.test.ts
+++ b/test/unit/operations/adversarial-review-verify.test.ts
@@ -182,7 +182,10 @@ describe("adversarialReviewOp.verify() — filter pipeline (AC2 adversarial)", (
     });
   });
 
-  test("blocking/advisory split preserves passed:false when only advisory findings remain", async () => {
+  // Previously asserted `passed:false` here, encoding nax#1378 as intended behaviour.
+  // The verdict must honour blockingThreshold: an advisory-only result passes while the
+  // finding is still surfaced in `findings` and kept out of `normalizedFindings`.
+  test("blocking/advisory split keeps advisory findings out of normalizedFindings", async () => {
     return withTempDir(async (workdir) => {
       const ctx = makeVerifyCtx();
       const input: AdversarialReviewInput = {
@@ -207,7 +210,8 @@ describe("adversarialReviewOp.verify() — filter pipeline (AC2 adversarial)", (
       });
       const result = await adversarialReviewOp.verify!(parsed, input, ctx);
       expect(result).not.toBeNull();
-      expect(result!.passed).toBe(false);
+      expect(result!.passed).toBe(true);
+      expect(result!.findings).toHaveLength(1);
       expect(result!.normalizedFindings).toHaveLength(0);
     });
   });
@@ -485,5 +489,120 @@ describe("adversarialReviewOp.verify() — scope grounding", () => {
     expect(result?.findings).toHaveLength(1);
     expect((result?.findings[0] as AdversarialLLMFinding).scopeQuote).toBeUndefined();
     expect((result?.findings[0] as AdversarialLLMFinding).issue).toBe("Story added an Ink TUI");
+  });
+});
+
+describe("adversarialReviewOp.verify() — sub-threshold verdict (#1378)", () => {
+  test("#1378: advisory-only findings pass the verdict even when the model reports passed:false", async () => {
+    // Regression for nax#1378 — the adversarial half of nax#1347. When the model
+    // emits only sub-threshold findings but sets passed:false, the verdict must
+    // honour blockingThreshold. Failing here deadlocks the story: normalizedFindings
+    // carries blocking findings only, so the rectification cycle receives nothing
+    // routable, exits "resolved", and the story pauses on findings no fix strategy
+    // was ever handed.
+    return withTempDir(async (workdir) => {
+      const ctx = makeVerifyCtx();
+      const input: AdversarialReviewInput = { ...BASE_INPUT, workdir, mode: "ref" };
+      const parsed = makeOutput({
+        passed: false,
+        findings: [
+          {
+            severity: "warning",
+            category: "quality",
+            file: "src/auth.ts",
+            line: 1,
+            issue: "Logging missing",
+            suggestion: "Add logging",
+          },
+          {
+            severity: "info",
+            category: "quality",
+            file: "src/auth.ts",
+            line: 2,
+            issue: "Naming could be clearer",
+            suggestion: "Rename",
+          },
+        ],
+        normalizedFindings: [],
+      });
+
+      const result = await adversarialReviewOp.verify!(parsed, input, ctx);
+
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(true); // no blocking findings -> pass
+      expect(result!.findings).toHaveLength(2); // advisory findings still surfaced
+      expect(result!.normalizedFindings).toHaveLength(0); // but not blocking
+    });
+  });
+
+  test("#1378: fail-closed guard preserved — model passed:false with all findings dropped stays failing", async () => {
+    // The advisory-pass fix must NOT weaken the fail-closed guard: when the model
+    // claims failure but every finding is dropped as ungrounded (accepted empty),
+    // the verdict stays false so an ungrounded-but-real blocker cannot slip through.
+    return withTempDir(async (workdir) => {
+      const FILE_CONTENT = "function login(u, p) { return db.rawQuery(u + p); }\n";
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src", "auth.ts"), FILE_CONTENT);
+
+      const ctx = makeVerifyCtx();
+      const input: AdversarialReviewInput = { ...BASE_INPUT, workdir, mode: "ref" };
+      const parsed = makeOutput({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            category: "security",
+            file: "src/auth.ts",
+            line: 1,
+            issue: "Ungrounded blocker",
+            suggestion: "Fix it",
+            acIndex: 1,
+            // substantiation passes, but no acQuote -> filterByAcQuote drops it
+            verifiedBy: { file: "src/auth.ts", line: 1, observed: "db.rawQuery" },
+          },
+        ],
+        normalizedFindings: [],
+      });
+
+      const result = await adversarialReviewOp.verify!(parsed, input, ctx);
+
+      expect(result).not.toBeNull();
+      expect(result!.findings).toHaveLength(0); // dropped as ungrounded
+      expect(result!.passed).toBe(false); // fail closed
+    });
+  });
+
+  test("#1378: a blocking finding still fails the verdict", async () => {
+    return withTempDir(async (workdir) => {
+      const FILE_CONTENT = "function login(u, p) { return db.rawQuery(u + p); }\n";
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src", "auth.ts"), FILE_CONTENT);
+
+      const ctx = makeVerifyCtx();
+      const input: AdversarialReviewInput = { ...BASE_INPUT, workdir, mode: "ref" };
+      const parsed = makeOutput({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            category: "security",
+            file: "src/auth.ts",
+            line: 1,
+            issue: "SQL injection",
+            suggestion: "Use parameterized queries",
+            acIndex: 1,
+            acQuote: "auth login security must not allow SQL injection",
+            verifiedBy: { file: "src/auth.ts", line: 1, observed: "db.rawQuery" },
+          },
+        ],
+        normalizedFindings: [],
+      });
+
+      const result = await adversarialReviewOp.verify!(parsed, input, ctx);
+
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(false);
+      expect(result!.normalizedFindings.length).toBeGreaterThan(0); // routable for rectification
+    });
   });
 });

--- a/test/unit/operations/adversarial-review-verify.test.ts
+++ b/test/unit/operations/adversarial-review-verify.test.ts
@@ -605,4 +605,36 @@ describe("adversarialReviewOp.verify() — sub-threshold verdict (#1378)", () =>
       expect(result!.normalizedFindings.length).toBeGreaterThan(0); // routable for rectification
     });
   });
+
+  test("#1378: modelPassed preserves the raw model verdict independently of blockingThreshold", async () => {
+    // The wrapper's ungrounded-drop branches (src/review/adversarial.ts Case A / Case B)
+    // key off the model's claim, not the threshold-adjusted verdict. Without this field
+    // they would read `passed`, which now flips to true whenever any sub-threshold finding
+    // survives — skipping the Case B fail-closed path and waving through blocking concerns
+    // the model raised but could not ground.
+    return withTempDir(async (workdir) => {
+      const ctx = makeVerifyCtx();
+      const input: AdversarialReviewInput = { ...BASE_INPUT, workdir, mode: "ref" };
+      const parsed = makeOutput({
+        passed: false,
+        findings: [
+          {
+            severity: "warning",
+            category: "quality",
+            file: "src/auth.ts",
+            line: 1,
+            issue: "Advisory only",
+            suggestion: "Consider X",
+          },
+        ],
+        normalizedFindings: [],
+      });
+
+      const result = await adversarialReviewOp.verify!(parsed, input, ctx);
+
+      expect(result).not.toBeNull();
+      expect(result!.passed).toBe(true); // threshold-adjusted: nothing blocks
+      expect(result!.modelPassed).toBe(false); // raw model claim preserved
+    });
+  });
 });

--- a/test/unit/review/adversarial-pass-fail.test.ts
+++ b/test/unit/review/adversarial-pass-fail.test.ts
@@ -225,6 +225,10 @@ const ALL_MISSING_AC_QUOTE_RESPONSE = JSON.stringify({
       // no acQuote → missing_ac_quote drop
       verifiedBy: { file: "src/log.ts", observed: "login handler stub" },
     },
+    // #1378 — a surviving sub-threshold finding must NOT rescue the run. The verdict
+    // honours blockingThreshold so the op now passes; the wrapper must still fail closed
+    // off the model's own claim, or an ungroundable blocker rides in on an advisory nit.
+    { severity: "info", category: "quality", file: "src/log.ts", line: 2, issue: "Nit", suggestion: "Tidy" },
   ],
 });
 

--- a/test/unit/review/orchestrator-wrapper-parity.test.ts
+++ b/test/unit/review/orchestrator-wrapper-parity.test.ts
@@ -291,7 +291,7 @@ describe("Adversarial op verify() parity with wrapper consumer (AC10, AC11 adver
     });
   });
 
-  test("advisory-only run: verify() preserves passed:false for wrapper fail-closed handling", async () => {
+  test("advisory-only run: verdict passes (nax#1378) with empty normalizedFindings", async () => {
     return withTempDir(async (workdir) => {
       const ctx = makeAdversarialVerifyCtx();
       const input: AdversarialReviewInput = {
@@ -329,8 +329,11 @@ describe("Adversarial op verify() parity with wrapper consumer (AC10, AC11 adver
       const result = await adversarialReviewOp.verify!(parsed, input, ctx);
       expect(result).not.toBeNull();
 
-      // verify() preserves the LLM's failure signal even when only advisory findings remain.
-      expect(result!.passed).toBe(false);
+      // nax#1378 — parity with semantic (nax#1347): the verdict honours blockingThreshold,
+      // so an advisory-only result passes. Preserving the LLM's raw failure signal here
+      // deadlocked the story: the wrapper saw passed:false with nothing routable, so the
+      // rectification cycle had no finding to hand a fix strategy.
+      expect(result!.passed).toBe(true);
       expect(result!.normalizedFindings).toHaveLength(0);
     });
   });


### PR DESCRIPTION
Fixes #1378.

## The bug

nax#1347 was fixed for the **semantic** reviewer only. That commit (`bffeb116`) asserted "Adversarial review already uses an equivalent severity-driven formula" — it does not, and no test pinned the claim.

`adversarialReviewOp.verify()` computed the verdict as:

```ts
const hadBlockingSeverity = accepted.some((f) => isBlockingSeverity(f.severity, threshold));
const passed = blocking.length === 0 && (parsed.passed || hadBlockingSeverity);
```

`hadBlockingSeverity` can only be true when `classifyRecurrence` moved a blocking-severity finding *out* of `blocking` (demotion / oscillation-suppression). For ordinary sub-threshold findings it is false, so the expression collapses to `blocking.length === 0 && parsed.passed` — the exact pre-#1347 formula.

## Why this one deadlocks rather than pauses

`normalizedFindings` carries `blocking` only. A sub-threshold-only failure therefore returns `passed: false` with **zero routable findings**:

1. `extractPhaseFindings` returns `[]`.
2. The rectification cycle exits `"resolved"` — logging `"Rectification resolved all findings"` in the same breath as `"Adversarial review failed: N findings"`. No fix strategy is ever dispatched.
3. The post-rectification resume re-runs the review to the identical verdict, and with `secondRectifyUsed` goes terminal.
4. `deriveTddFailureCategory` gets no findings, derives no category, and the story pauses via `"TDD plan failed but no failure category derived — defaulting to pause"`.

Nothing an agent does can clear it. Retrying reproduces it exactly.

Observed on `nax` / `otel-telemetry-expansion` / US-003, run `run-2026-07-29T13-27-10-259Z`: 5 findings at `unverifiable`/`warning`/`info` against the default `"error"` threshold — paused after $6.82 and 45 minutes with nothing routable.

## The fix

**`src/operations/adversarial-review.ts`** — align with semantic:

```ts
const passed = blocking.length === 0 && (parsed.passed || accepted.length > 0);
```

`accepted` is a superset of what the old clause tested, so demotion / oscillation pass-through is unchanged. `accepted.length > 0` keeps the fail-closed guard for the distinct case where the model claims failure but every finding was dropped as ungrounded.

**`src/review/adversarial.ts`** — self-review of the above caught a regression it introduced, fixed in the second commit. The wrapper's ungrounded-drop branches were gated on `!opResult.passed`. Once `passed` honours blockingThreshold it flips to true whenever any sub-threshold finding survives, which skipped both branches:

- **Case B (fail-closed) was bypassed** — a blocking concern the model raised but could not ground got waved through whenever an unrelated advisory nit happened to survive. A real weakening of the guard.
- **Case A lost its demoted drops** from `advisoryFindings`.

Those branches ask "did the model claim failure?", not "does this block the story?". The raw flag is now exposed as `AdversarialReviewOutput.modelPassed` and the branches gate on it, restoring pre-fix branch semantics exactly while the verdict change stays isolated to the op. This also keeps `passReason: "ac_quote_not_substring_demoted"` meaning "passed *because of* demotion" rather than firing on runs that would have passed anyway.

## Tests

- `#1378` regression: advisory-only + model `passed:false` now passes.
- Fail-closed guard: model `passed:false` with all findings dropped as ungrounded still fails.
- Blocking guard: a blocking finding still fails **and** yields routable `normalizedFindings`.
- `modelPassed` is preserved independently of the threshold-adjusted verdict.
- Case 3's fixture gains a surviving sub-threshold finding so the fail-closed path is pinned against this exact distinction. Previously no fixture paired an ungrounded drop with an advisory survivor, which is why the bypass was invisible — both halves of the gate were verified to fail when reverted to `!opResult.passed`.

Three existing tests asserted the old behaviour as intended and were updated. Same situation #1347 hit on the semantic side, and one of them (`orchestrator-wrapper-parity.test.ts`) sat directly beside a semantic counterpart already asserting the corrected form — the parity drift was live in that file.

## Reviewer notes

- **The divergence looks deliberate.** The old comment stated the fail-closed intent explicitly ("Preserves fail-closed when the model fails with no blocking-severity findings at all"). If that intent was load-bearing for a reason not captured in #1378, this reverses it. My read is that it predates the #1347 analysis and the deadlock consequence was not seen.
- **`src/review/adversarial.ts` is at exactly 600 lines**, the hard limit. Staying there required tightening a comment and collapsing a redundant `advisoryFindings.length > 0 ? advisoryFindingsAsFindings : []` ternary (that array is already `[]` in that case). The file has no headroom; the next change to it needs a split.
- **Worth considering separately:** `passed: false` with zero routable findings should be unreachable for *any* reviewer op — a verdict that fails a story must hand the rectification cycle something actionable. A shared invariant test across `semanticReviewOp.verify` and `adversarialReviewOp.verify` would stop the two drifting apart again, which is what happened here.

## Verification

```
unit         10264 pass   0 fail
integration   1092 pass   0 fail
ui              21 pass   0 fail
typecheck    clean
lint         clean (all pre-commit gates green)
```

## Not fixed here

US-003 has a genuine AC8 bug of its own — `run-phase.ts` reads `adv?.blockingThreshold`, which `AdversarialReviewOutput` never carried — and its Scope/Interface declare 5 `PhaseDetails` arms while only 3 have ACs. This PR only stops nax deadlocking on the sub-threshold findings that reported them.
