### PR TITLE
fix(operations): resolve mock-structure handoff paths against repoRoot, contained to the package

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -176,8 +176,9 @@ export async function buildPlanForStrategy(
   // Path anchors shared by both the main-rectification postValidate and the nbf postValidate.
   // Computed once here; used in both closures below to avoid duplicate async FS reads.
   // ctx.packageDir = repo root (absolute); story.workdir = relative sub-path to package.
-  const packageDir = join(ctx.packageDir, story.workdir ?? "");
-  const resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.packageDir, story.workdir);
+  const repoRoot = ctx.packageDir;
+  const packageDir = join(repoRoot, story.workdir ?? "");
+  const resolvedTestPatterns = await resolveTestFilePatterns(config, repoRoot, story.workdir);
 
   // Rectification: requires both config gate and typed inputs.
   // Assemble strategies: mechanical fixes first, then full-suite (TDD), then autofix agents.
@@ -272,7 +273,11 @@ export async function buildPlanForStrategy(
         reasonDetail: h.reasonDetail,
       }));
 
-      const { valid, invalid } = await validateMockStructureFiles(pendingMock, resolvedTestPatterns, packageDir);
+      const { valid, invalid } = await validateMockStructureFiles(pendingMock, resolvedTestPatterns, packageDir, {
+        // The agent declares paths as it read them from the findings stream —
+        // repo-relative — so repoRoot must be offered as a second anchor (#1385).
+        repoRoot,
+      });
 
       // Replace sink.mockHandoffs with only valid entries for test-writer to consume.
       sink.mockHandoffs = valid.map((d) => ({ files: d.files ?? [], reasonDetail: d.reasonDetail ?? "" }));
@@ -395,7 +400,11 @@ export async function buildPlanForStrategy(
         reasonDetail: h.reasonDetail,
       }));
 
-      const { valid, invalid } = await validateMockStructureFiles(pendingMock, resolvedTestPatterns, packageDir);
+      const { valid, invalid } = await validateMockStructureFiles(pendingMock, resolvedTestPatterns, packageDir, {
+        // The agent declares paths as it read them from the findings stream —
+        // repo-relative — so repoRoot must be offered as a second anchor (#1385).
+        repoRoot,
+      });
 
       nbSink.mockHandoffs = valid.map((d) => ({ files: d.files ?? [], reasonDetail: d.reasonDetail ?? "" }));
 

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -102,7 +102,7 @@ export type {
 export { validateMockStructureFiles } from "./validate-mock-structure-files";
 export { setupGenerateOp, MAX_SETUP_LLM_ATTEMPTS } from "./setup-generate";
 export type { SetupPlan, MonoPackageConfig, RawSetupPlan } from "./setup-generate";
-export type { ValidateMockStructureDeps } from "./validate-mock-structure-files";
+export type { ValidateMockStructureOptions } from "./validate-mock-structure-files";
 export { makeDeclarationSink } from "./declaration-sink";
 export type { DeclarationSink } from "./declaration-sink";
 export { findingsToFailedChecks } from "./_finding-to-check";

--- a/src/operations/validate-mock-structure-files.ts
+++ b/src/operations/validate-mock-structure-files.ts
@@ -3,7 +3,8 @@
  *
  * A declaration is valid when ALL its declared files:
  *   (a) exist on disk under `packageDir` or (when supplied) `repoRoot`, AND
- *   (b) match at least one resolved test-file pattern regex, tested against the
+ *   (b) resolve to a path *inside* `packageDir`, AND
+ *   (c) match at least one resolved test-file pattern regex, tested against the
  *       path rebased to be package-relative.
  *
  * Two anchors are tried because the declaration's paths come from an LLM that
@@ -11,6 +12,12 @@
  * per-package config are package-relative. Anchoring on `packageDir` alone
  * double-prefixed repo-relative declarations in monorepos, rejecting real test
  * files as nonexistent and deadlocking the story (#1385).
+ *
+ * Containment (b) keeps the second anchor from widening scope: resolver regexes
+ * are typically unanchored, so without it a repo-relative path naming another
+ * package's tests would now match and be handed to a test-writer that may only
+ * edit inside its own package. Cross-package spillover routes through the
+ * sibling_scope declaration instead.
  *
  * Non-mock_structure declarations pass through unchanged to `valid`.
  *
@@ -35,12 +42,37 @@ const defaultFileExists = (p: string): Promise<boolean> => Bun.file(p).exists();
 /** Candidate absolute paths for a declared file, package-relative anchor first. */
 function resolutionCandidates(file: string, packageDir: string, repoRoot?: string): string[] {
   if (isAbsolute(file)) return [file];
-  const candidates = [join(packageDir, file)];
-  if (repoRoot !== undefined) {
-    const viaRepoRoot = join(repoRoot, file);
-    if (viaRepoRoot !== candidates[0]) candidates.push(viaRepoRoot);
+  const viaPackageDir = join(packageDir, file);
+  if (repoRoot === undefined) return [viaPackageDir];
+  const viaRepoRoot = join(repoRoot, file);
+  // Equal in a single-package repo — probe once rather than twice.
+  return viaRepoRoot === viaPackageDir ? [viaPackageDir] : [viaPackageDir, viaRepoRoot];
+}
+
+interface ResolveOptions {
+  packageDir: string;
+  repoRoot?: string;
+  fileExists: (path: string) => Promise<boolean>;
+}
+
+/**
+ * Resolve a declared file to its package-relative path.
+ *
+ * Returns null when the file exists under no anchor, or when the first anchor it
+ * does exist under places it outside `packageDir` — see containment in the module
+ * header. A path that escapes under one anchor escapes under both, so the first
+ * hit is decisive.
+ */
+async function resolvePackageRelative(file: string, opts: ResolveOptions): Promise<string | null> {
+  for (const candidate of resolutionCandidates(file, opts.packageDir, opts.repoRoot)) {
+    if (!(await opts.fileExists(candidate))) continue;
+    const rel = relative(opts.packageDir, candidate);
+    // "" means the path IS packageDir; ".." escapes it; absolute means a
+    // different root entirely.
+    if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return null;
+    return rel;
   }
-  return candidates;
+  return null;
 }
 
 /**
@@ -70,23 +102,20 @@ export async function validateMockStructureFiles(
 
     const files = d.files ?? [d.file];
 
-    // Check all files: must exist on disk AND match at least one test pattern regex
+    // Check all files: must resolve inside the package AND match a test pattern.
     let allValid = true;
     for (const file of files) {
-      let resolved: string | null = null;
-      for (const candidate of resolutionCandidates(file, packageDir, opts?.repoRoot)) {
-        if (await fileExists(candidate)) {
-          resolved = candidate;
-          break;
-        }
-      }
-      if (resolved === null) {
+      const packageRelative = await resolvePackageRelative(file, {
+        packageDir,
+        repoRoot: opts?.repoRoot,
+        fileExists,
+      });
+      if (packageRelative === null) {
         allValid = false;
         break;
       }
       // Patterns are package-relative, so test the resolved path rebased onto
       // packageDir — never the raw declared string, whose anchor is unknown.
-      const packageRelative = relative(packageDir, resolved);
       const matchesPattern = resolvedTestPatterns.regex.some((re) => re.test(packageRelative));
       if (!matchesPattern) {
         allValid = false;

--- a/src/operations/validate-mock-structure-files.ts
+++ b/src/operations/validate-mock-structure-files.ts
@@ -2,39 +2,63 @@
  * Partition mock_structure TestEditDeclarations into valid/invalid.
  *
  * A declaration is valid when ALL its declared files:
- *   (a) exist on disk, AND
- *   (b) match at least one resolved test-file pattern regex.
+ *   (a) exist on disk under `packageDir` or (when supplied) `repoRoot`, AND
+ *   (b) match at least one resolved test-file pattern regex, tested against the
+ *       path rebased to be package-relative.
+ *
+ * Two anchors are tried because the declaration's paths come from an LLM that
+ * reads findings rendered repo-relative, while `resolvedTestPatterns` and the
+ * per-package config are package-relative. Anchoring on `packageDir` alone
+ * double-prefixed repo-relative declarations in monorepos, rejecting real test
+ * files as nonexistent and deadlocking the story (#1385).
  *
  * Non-mock_structure declarations pass through unchanged to `valid`.
  *
  * Injectable _deps for testability (default: Bun.file(p).exists()).
  */
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import type { ResolvedTestPatterns } from "@/test-runners";
 import type { TestEditDeclaration } from "./test-edit-declaration";
 
-export interface ValidateMockStructureDeps {
+export interface ValidateMockStructureOptions {
   fileExists?: (path: string) => Promise<boolean>;
+  /**
+   * Absolute repo root, used as a secondary resolution anchor when the agent
+   * declares repo-relative paths. Omit for single-package repos, where it is
+   * equal to `packageDir` and adds no candidate.
+   */
+  repoRoot?: string;
 }
 
 const defaultFileExists = (p: string): Promise<boolean> => Bun.file(p).exists();
+
+/** Candidate absolute paths for a declared file, package-relative anchor first. */
+function resolutionCandidates(file: string, packageDir: string, repoRoot?: string): string[] {
+  if (isAbsolute(file)) return [file];
+  const candidates = [join(packageDir, file)];
+  if (repoRoot !== undefined) {
+    const viaRepoRoot = join(repoRoot, file);
+    if (viaRepoRoot !== candidates[0]) candidates.push(viaRepoRoot);
+  }
+  return candidates;
+}
 
 /**
  * Partition mock_structure declarations into valid/invalid.
  *
  * @param declarations - All declarations (any reason).
  * @param resolvedTestPatterns - Resolved test file patterns for the package.
- * @param packageDir - Absolute path to the package directory.
- * @param deps - Injectable deps for testing (fileExists override).
+ * @param packageDir - Absolute path to the story's package directory.
+ * @param opts - Injectable fileExists plus the optional `repoRoot` anchor.
  * @returns { valid, invalid } — non-mock_structure always go to valid.
  */
 export async function validateMockStructureFiles(
   declarations: TestEditDeclaration[],
   resolvedTestPatterns: ResolvedTestPatterns,
   packageDir: string,
-  deps?: ValidateMockStructureDeps,
+  opts?: ValidateMockStructureOptions,
 ): Promise<{ valid: TestEditDeclaration[]; invalid: TestEditDeclaration[] }> {
-  const fileExists = deps?.fileExists ?? defaultFileExists;
+  const fileExists = opts?.fileExists ?? defaultFileExists;
   const valid: TestEditDeclaration[] = [];
   const invalid: TestEditDeclaration[] = [];
 
@@ -49,14 +73,21 @@ export async function validateMockStructureFiles(
     // Check all files: must exist on disk AND match at least one test pattern regex
     let allValid = true;
     for (const file of files) {
-      const absolutePath = join(packageDir, file);
-      const exists = await fileExists(absolutePath);
-      if (!exists) {
+      let resolved: string | null = null;
+      for (const candidate of resolutionCandidates(file, packageDir, opts?.repoRoot)) {
+        if (await fileExists(candidate)) {
+          resolved = candidate;
+          break;
+        }
+      }
+      if (resolved === null) {
         allValid = false;
         break;
       }
-      // Test the relative file path (as stored in the declaration) against the regex
-      const matchesPattern = resolvedTestPatterns.regex.some((re) => re.test(file));
+      // Patterns are package-relative, so test the resolved path rebased onto
+      // packageDir — never the raw declared string, whose anchor is unknown.
+      const packageRelative = relative(packageDir, resolved);
+      const matchesPattern = resolvedTestPatterns.regex.some((re) => re.test(packageRelative));
       if (!matchesPattern) {
         allValid = false;
         break;

--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -95,7 +95,10 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.`;
+- FILES must list real test files. Each path must exist and be a test file.
+- Write each path exactly as it appears in the findings above (repository-relative).
+  Paths that resolve under neither the repository root nor the package directory are
+  rejected and the handoff is dropped — the findings then have no owner.`;
 
 // ─── Escape hatch builder ─────────────────────────────────────────────────────
 

--- a/test/unit/operations/validate-mock-structure-files.test.ts
+++ b/test/unit/operations/validate-mock-structure-files.test.ts
@@ -247,6 +247,158 @@ describe("validateMockStructureFiles", () => {
     });
   });
 
+  // Regression: #1385. In a monorepo the rectification agent declares paths in
+  // the form it reads them from findings — repo-relative — while `packageDir` is
+  // the story's package. Resolving against `packageDir` alone double-prefixed the
+  // path, so a real, existing test file was rejected as nonexistent, the
+  // mock-structure handoff was stripped, and the story deadlocked into a wasted
+  // tier escalation (rs-stock metrics-endpoint-protection US-002).
+  describe("monorepo path anchoring (packageDir !== repoRoot)", () => {
+    // A Python package at apps/api whose test patterns are package-relative.
+    const pyPatterns: ResolvedTestPatterns = {
+      regex: [/(?:^|\/)tests(?:.*\/)?[^/]*\.py$/],
+      globs: ["tests/**/*.py"],
+      pathspec: [],
+      testDirs: ["tests"],
+    };
+
+    test("accepts a repo-relative declaration when repoRoot is supplied", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "apps/api/tests/test_observability.py",
+        files: ["apps/api/tests/test_observability.py", "apps/api/tests/test__security_headers.py"],
+        reasonDetail: "existing tests assert the pre-protection /metrics contract",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists([
+          "/repo/apps/api/tests/test_observability.py",
+          "/repo/apps/api/tests/test__security_headers.py",
+        ]),
+      });
+
+      expect(invalid).toHaveLength(0);
+      expect(valid).toHaveLength(1);
+      expect(valid[0]).toBe(decl);
+    });
+
+    test("still accepts a package-relative declaration for the same package", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "tests/test_observability.py",
+        files: ["tests/test_observability.py"],
+        reasonDetail: "package-relative form",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/apps/api/tests/test_observability.py"]),
+      });
+
+      expect(invalid).toHaveLength(0);
+      expect(valid).toHaveLength(1);
+    });
+
+    test("pattern is tested against the package-relative form of the resolved path", async () => {
+      // Anchored package-relative pattern: only "tests/..." matches, so a
+      // repo-relative declaration must be rebased before the pattern test.
+      const anchored: ResolvedTestPatterns = {
+        regex: [/^tests\/.+\.py$/],
+        globs: ["tests/**/*.py"],
+        pathspec: [],
+        testDirs: ["tests"],
+      };
+
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "apps/api/tests/test_observability.py",
+        files: ["apps/api/tests/test_observability.py"],
+        reasonDetail: "anchored pattern",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], anchored, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/apps/api/tests/test_observability.py"]),
+      });
+
+      expect(invalid).toHaveLength(0);
+      expect(valid).toHaveLength(1);
+    });
+
+    test("a file that exists under neither anchor is still invalid", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "apps/api/tests/test_missing.py",
+        files: ["apps/api/tests/test_missing.py"],
+        reasonDetail: "hallucinated file",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists([]),
+      });
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+      expect(invalid[0]).toBe(decl);
+    });
+
+    test("a non-test file resolved via repoRoot is still invalid", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "apps/api/src/stock_api/app.py",
+        files: ["apps/api/src/stock_api/app.py"],
+        reasonDetail: "source file smuggled through the handoff",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/apps/api/src/stock_api/app.py"]),
+      });
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+    });
+
+    test("omitting repoRoot preserves package-relative-only resolution", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "apps/api/tests/test_observability.py",
+        files: ["apps/api/tests/test_observability.py"],
+        reasonDetail: "no repoRoot anchor available",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        fileExists: makeFileExists(["/repo/apps/api/tests/test_observability.py"]),
+      });
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+    });
+
+    test("single-package repo (repoRoot === packageDir) resolves once", async () => {
+      const seen: string[] = [];
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "tests/test_observability.py",
+        files: ["tests/test_observability.py"],
+        reasonDetail: "single package",
+      };
+
+      const { valid } = await validateMockStructureFiles([decl], pyPatterns, "/repo", {
+        repoRoot: "/repo",
+        fileExists: (p) => {
+          seen.push(p);
+          return Promise.resolve(p === "/repo/tests/test_observability.py");
+        },
+      });
+
+      expect(valid).toHaveLength(1);
+      expect(seen).toEqual(["/repo/tests/test_observability.py"]);
+    });
+  });
+
   describe("injectable deps", () => {
     test("uses injectable fileExists (no real disk I/O)", async () => {
       let callCount = 0;

--- a/test/unit/operations/validate-mock-structure-files.test.ts
+++ b/test/unit/operations/validate-mock-structure-files.test.ts
@@ -377,6 +377,129 @@ describe("validateMockStructureFiles", () => {
       expect(invalid).toHaveLength(1);
     });
 
+    test("package-relative anchor wins when the file exists under both", async () => {
+      // Anchored pattern matches only the package-relative rebase, so a pass
+      // proves the packageDir candidate was the one used — not just probed first.
+      const anchored: ResolvedTestPatterns = {
+        regex: [/^tests\/.+\.py$/],
+        globs: ["tests/**/*.py"],
+        pathspec: [],
+        testDirs: ["tests"],
+      };
+      const probed: string[] = [];
+
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "tests/test_observability.py",
+        files: ["tests/test_observability.py"],
+        reasonDetail: "ambiguous under both anchors",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], anchored, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: (p) => {
+          probed.push(p);
+          // Both a package-local and a repo-root tests/ tree exist.
+          return Promise.resolve(
+            p === "/repo/apps/api/tests/test_observability.py" || p === "/repo/tests/test_observability.py",
+          );
+        },
+      });
+
+      expect(invalid).toHaveLength(0);
+      expect(valid).toHaveLength(1);
+      expect(probed[0]).toBe("/repo/apps/api/tests/test_observability.py");
+    });
+
+    test("rejects a test file belonging to a different package", async () => {
+      // Resolver regexes are typically unanchored, so without containment this
+      // repo-relative path would match and be handed to a test-writer scoped to
+      // apps/api. Cross-package spillover belongs to sibling_scope.
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "packages/shared/tests/test_helpers.py",
+        files: ["packages/shared/tests/test_helpers.py"],
+        reasonDetail: "another package's tests",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/packages/shared/tests/test_helpers.py"]),
+      });
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+      expect(invalid[0]).toBe(decl);
+    });
+
+    test("rejects a path that escapes packageDir via ..", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "../shared/tests/test_helpers.py",
+        files: ["../shared/tests/test_helpers.py"],
+        reasonDetail: "traversal out of the package",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/apps/shared/tests/test_helpers.py"]),
+      });
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+    });
+
+    test("accepts an absolute declaration inside the package", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "/repo/apps/api/tests/test_observability.py",
+        files: ["/repo/apps/api/tests/test_observability.py"],
+        reasonDetail: "absolute form",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/apps/api/tests/test_observability.py"]),
+      });
+
+      expect(invalid).toHaveLength(0);
+      expect(valid).toHaveLength(1);
+    });
+
+    test("rejects an absolute declaration outside the package", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "/repo/packages/shared/tests/test_helpers.py",
+        files: ["/repo/packages/shared/tests/test_helpers.py"],
+        reasonDetail: "absolute, wrong package",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/packages/shared/tests/test_helpers.py"]),
+      });
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+    });
+
+    test("rejects a declaration naming packageDir itself", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: ".",
+        files: ["."],
+        reasonDetail: "directory, not a file",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles([decl], pyPatterns, "/repo/apps/api", {
+        repoRoot: "/repo",
+        fileExists: makeFileExists(["/repo/apps/api"]),
+      });
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+    });
+
     test("single-package repo (repoRoot === packageDir) resolves once", async () => {
       const seen: string[] = [];
       const decl: TestEditDeclaration = {

--- a/test/unit/prompts/builders/__snapshots__/rectifier-builder-helpers.test.ts.snap
+++ b/test/unit/prompts/builders/__snapshots__/rectifier-builder-helpers.test.ts.snap
@@ -93,7 +93,10 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file."
+- FILES must list real test files. Each path must exist and be a test file.
+- Write each path exactly as it appears in the findings above (repository-relative).
+  Paths that resolve under neither the repository root nor the package directory are
+  rejected and the handoff is dropped — the findings then have no owner."
 `;
 
 exports[`buildEscapeHatch non-TDD path (includeMockHandoff: false) snapshot: full non-TDD escape hatch 1`] = `


### PR DESCRIPTION
Fixes #1385.

## Problem

`validateMockStructureFiles` resolved every declared handoff file with `join(packageDir, file)` only. The rectification agent declares paths in the form it reads them from the findings stream — **repo-relative** — so in a monorepo (`packageDir !== repoRoot`) the join double-prefixed the package path:

```
packageDir: <repo>/apps/api
declared:   apps/api/tests/test_thing.py
resolved:   <repo>/apps/api/apps/api/tests/test_thing.py   <- never exists
```

`exists` returned false, the mock-structure handoff was stripped as invalid, and — because `enforceTestWriterIsolation` makes that handoff the implementer's only legal route to a test-owned finding — the findings lost their owner. The cycle exited `validate-short-circuit`, the staleness guard failed the story, and it burned a tier escalation:

```
[findings.cycle] test-edit declaration rejected - ignoring declaration
  reason: mock_structure_invalid_files
  detail: "...references file that does not exist or is not a test file: ..."
[story-orchestrator] Rectification exited: validate-short-circuit
[story-orchestrator] Gate regressed during rectification after verifier passed
[escalation]         Escalating story to next tier
```

The files were present on disk the whole time. Reproduced on a Python package in a monorepo, where every retry hit the same rejection and consumed another rung of the escalation ladder.

Two emitters reach the defect, not one: `makeFullSuiteRectifyStrategy` (failing-test findings) and `makeAutofixImplementerStrategy` (review findings) both register on the same declaration sink and are validated by the same `postValidate`, so failing-test rectification is blocked as well as review rectification.

The regex half of the check was never at fault — `globsToTestRegex(["tests/**/*.py"])` yields the unanchored `(?:^|\/)tests(?:.*\/)?[^/]*\.py$`, which matches the repo-relative path fine. The existence check was the sole failure point.

## Change

1. **Two anchors.** Each declared file is probed under `packageDir` first, then `repoRoot` when the two differ. A single-package repo probes once, not twice. Absolute declarations are taken as-is.
2. **Containment.** The resolved path must rebase to a location *inside* `packageDir`. This is what keeps the second anchor from widening scope — see below.
3. **Pattern test on the rebased path.** Patterns are package-relative, so they run against `relative(packageDir, resolved)`, never the raw declared string whose anchor is unknown. This also makes anchored per-package patterns (`^tests/`) work with repo-relative declarations.
4. **Prompt contract.** `EXCEPTION_4_MOCK_HANDOFF` asked for "test file paths" without ever saying relative to what, while every finding in the same prompt was repo-relative. It now states the anchor and warns that an unresolvable path drops the handoff.
5. `ValidateMockStructureDeps` → `ValidateMockStructureOptions`, since the bag now carries a resolution anchor and not only injected deps.

### On containment (found in self-review, commit 726d3fb)

The first pass added the `repoRoot` anchor with no containment check, which **widened what the handoff accepts**. Because resolver regexes are typically unanchored, a repo-relative declaration naming `packages/shared/tests/test_helpers.py` resolved via `repoRoot`, rebased to `../../packages/shared/tests/test_helpers.py`, matched the pattern, and was handed to a test-writer whose `testWriterAllowedPaths` is scoped to its own package. Before the anchor existed this failed closed. Cross-package spillover is what the `sibling_scope` declaration is for, so containment restores the closed door.

Verified load-bearing: disabling the guard fails three of the new tests, including the cross-package one.

## Rejection semantics preserved

Everything that should still be rejected still is: files absent under both anchors, non-test files resolved via `repoRoot`, `..` escapes, absolute paths outside the package, and a declaration naming `packageDir` itself.

## Test coverage

Both anchor configurations are pinned explicitly — monorepo (`packageDir !== repoRoot`) and single-package (`repoRoot === packageDir`):

| Case | Expected |
|:---|:---|
| repo-relative declaration, monorepo | valid (the bug) |
| package-relative declaration, monorepo | valid |
| anchored pattern vs repo-relative declaration | valid — proves the rebase |
| exists under both anchors | valid, `packageDir` candidate used |
| single-package, `repoRoot === packageDir` | valid, probes one candidate |
| `repoRoot` omitted | package-relative resolution only |
| absent under both anchors | invalid |
| non-test file via `repoRoot` | invalid |
| different package's tests | invalid (containment) |
| `..` escape | invalid (containment) |
| absolute inside package | valid |
| absolute outside package | invalid (containment) |
| `packageDir` itself | invalid |

TDD order held: the first run was RED on exactly the two bug-pinning cases with the guard-rail tests already green, so they pin the fix rather than the scaffolding.

## Verification

- `bun test test/unit/operations/validate-mock-structure-files.test.ts` -> 24 pass, 0 fail
- `bun test test/unit/execution/` -> 1258 pass, 0 fail
- `bun run test` (full suite) -> all phases passed, 10279 pass / 0 fail
- `bun run typecheck` -> clean
- `bun run lint` -> clean, every ratchet at baseline

Beyond the unit suite, the fix was exercised against a real rejected declaration captured from a run: `REJECTED` before, `VALID` after, and the cross-package variant still `REJECTED`.

One snapshot changed: `rectifier-builder-helpers.test.ts.snap`, 4 lines, the intentional Exception 4 prompt text.

## Not in scope

Whether a mock-structure handoff should *ever* name another package's tests is a policy question beyond this fix — this PR restores the pre-existing closed behavior rather than deciding it.
