### PR TITLE
fix(cycle): retire fix strategies per-finding, not per-cycle (#1384)

### DIFF
--- a/src/findings/cycle-retirement.ts
+++ b/src/findings/cycle-retirement.ts
@@ -1,0 +1,79 @@
+/**
+ * ADR-022 — per-finding strategy retirement for `runFixCycle`.
+ *
+ * Owns the answer to one question: given that a strategy has answered UNRESOLVED
+ * before, may it be dispatched again now?
+ *
+ * scope: repo-scoped (pure bookkeeping over findings; no I/O, no config)
+ */
+
+import type { FixStrategy } from "./cycle-types";
+import type { Finding } from "./types";
+import { findingKey } from "./types";
+
+/**
+ * Ledger of which findings each strategy has declined.
+ *
+ * UNRESOLVED means "I cannot fix THIS", not "I cannot fix anything" — so retirement
+ * is scoped to the findings the strategy was actually given. Retiring cycle-wide
+ * (#1369's original shape) meant a later, unrelated finding routed only to that
+ * strategy exited the cycle `no-strategy` and the caller discarded the whole pass;
+ * on otel-telemetry-expansion US-006 that orphaned a one-line barrel export because
+ * of a refusal about an unrelated scoping decision (#1384).
+ *
+ * The declined unit is the DISPATCHED BATCH: a strategy receives every finding it
+ * claims in one call and answers once, so one UNRESOLVED declines all of them. That
+ * over-retires within the batch, which is harmless — findings the agent did fix
+ * leave the cycle's finding list anyway — and errs in the conservative direction.
+ *
+ * Termination: a strategy can decline any given finding at most once and the
+ * declined set only grows, so the selectable set still shrinks monotonically over a
+ * fixed finding set. `findingKey` includes `message`, so a re-emitted finding with
+ * LLM-rephrased text mints a new key and becomes dispatchable again — accepted,
+ * because the drift is in the "try again" direction and the cycle's
+ * `maxAttempts` caps still bind.
+ */
+export interface DeclineLedger<F extends Finding> {
+  /**
+   * Record that `strategy` declined every finding it claims out of `dispatched` —
+   * i.e. the input batch it just answered UNRESOLVED for.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
+  recordDeclined(strategy: FixStrategy<F, any, any, any>, dispatched: readonly F[]): void;
+  /**
+   * Is `strategy` retired with respect to `findings`? True only once it has declined
+   * EVERY remaining finding it claims — declining one must not retire it for others.
+   * A strategy that claims none of `findings` is not "retired"; it is simply inactive,
+   * which `selectActiveStrategies` decides.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+  isRetiredFor(strategy: FixStrategy<F, any, any, any>, findings: readonly F[]): boolean;
+  /** Names of strategies retired with respect to `findings` — for the orphan-exit log. */
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+  retiredNames(strategies: readonly FixStrategy<F, any, any, any>[], findings: readonly F[]): string[];
+}
+
+/** Create an empty per-cycle decline ledger. */
+export function createDeclineLedger<F extends Finding>(): DeclineLedger<F> {
+  const declinedByStrategy = new Map<string, Set<string>>();
+
+  const hasDeclined = (strategyName: string, finding: F): boolean =>
+    declinedByStrategy.get(strategyName)?.has(findingKey(finding)) === true;
+
+  const isRetiredFor: DeclineLedger<F>["isRetiredFor"] = (strategy, findings) => {
+    const claimed = findings.filter((f) => strategy.appliesTo(f));
+    return claimed.length > 0 && claimed.every((f) => hasDeclined(strategy.name, f));
+  };
+
+  return {
+    recordDeclined(strategy, dispatched) {
+      const declined = declinedByStrategy.get(strategy.name) ?? new Set<string>();
+      for (const f of dispatched.filter((x) => strategy.appliesTo(x))) declined.add(findingKey(f));
+      declinedByStrategy.set(strategy.name, declined);
+    },
+    isRetiredFor,
+    retiredNames(strategies, findings) {
+      return strategies.filter((s) => isRetiredFor(s, findings)).map((s) => s.name);
+    },
+  };
+}

--- a/src/findings/cycle-retirement.ts
+++ b/src/findings/cycle-retirement.ts
@@ -32,6 +32,15 @@ import { findingKey } from "./types";
  * LLM-rephrased text mints a new key and becomes dispatchable again — accepted,
  * because the drift is in the "try again" direction and the cycle's
  * `maxAttempts` caps still bind.
+ *
+ * Verdict-driven dispatches (`appliesToVerdict`, selected when the cycle has no
+ * findings) record nothing, and need not: `classifyOutcome([], [])` is "resolved", so
+ * `runFixCycle` returns at the end of that iteration. A verdict-only dispatch cannot
+ * iterate, so a strategy that declined one can never be re-dispatched and there is
+ * nothing for a ledger entry to prevent. If that resolved-exit ever changes, the
+ * verdict path needs whole-strategy retirement here — the test
+ * "verdict-only dispatch cannot iterate" in cycle-retirement.test.ts guards the
+ * assumption.
  */
 export interface DeclineLedger<F extends Finding> {
   /**

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -13,6 +13,7 @@ import type { Logger } from "@/logger";
 import { callOp as _callOp } from "@/operations";
 import type { Operation } from "@/operations";
 import { errorMessage } from "@/utils/errors";
+import { createDeclineLedger } from "./cycle-retirement";
 import type {
   FixApplied,
   FixCycle,
@@ -159,12 +160,10 @@ export async function runFixCycle<F extends Finding>(
   const packageDir = ctx.packageDir;
   let totalCostUsd = 0;
 
-  // Strategies that answered UNRESOLVED. The signal is per-strategy — the agent
-  // said "I cannot fix this", not "nobody can" — so the strategy is retired for
-  // the rest of the cycle instead of being re-dispatched to reach the same
-  // answer. Retiring it can only shrink the selectable set, so the cycle still
-  // terminates. (#1369)
-  const spentStrategies = new Set<string>();
+  // Per-finding retirement ledger (#1369, #1384) — see `createDeclineLedger` for why
+  // UNRESOLVED retires a (strategy, finding) pair rather than the strategy itself, and
+  // for the termination argument.
+  const declines = createDeclineLedger<F>();
   let unresolvedDetail: string | undefined;
 
   /**
@@ -187,8 +186,9 @@ export async function runFixCycle<F extends Finding>(
     }
 
     // ── Select active strategies ──────────────────────────────────────────────
-    // Strategies retired by an UNRESOLVED verdict are excluded (#1369).
-    const selectable = cycle.strategies.filter((s) => !spentStrategies.has(s.name));
+    // A strategy is excluded only once it has declined every remaining finding it
+    // claims — declining one finding must not retire it for the others (#1384).
+    const selectable = cycle.strategies.filter((s) => !declines.isRetiredFor(s, cycle.findings));
     const active = selectActiveStrategies(selectable, cycle.findings, cycle.verdict);
     if (active.length === 0) {
       // Orphaned findings: at least one finding remains but no selectable
@@ -199,6 +199,7 @@ export async function runFixCycle<F extends Finding>(
       // level — without this the cause is invisible, turning either into an
       // un-diagnosable "story failed for no reason".
       const orphanSources = [...new Set(cycle.findings.map((f) => f.source))];
+      const retiredStrategies = declines.retiredNames(cycle.strategies, cycle.findings);
       logger?.warn("findings.cycle", "cycle exited — no matching strategy (orphaned findings)", {
         storyId,
         packageDir,
@@ -206,7 +207,7 @@ export async function runFixCycle<F extends Finding>(
         reason: "no-strategy",
         findingsCount: cycle.findings.length,
         orphanSources,
-        ...(spentStrategies.size > 0 ? { retiredStrategies: [...spentStrategies] } : {}),
+        ...(retiredStrategies.length > 0 ? { retiredStrategies } : {}),
       });
       return finish({
         iterations: cycle.iterations,
@@ -316,6 +317,14 @@ export async function runFixCycle<F extends Finding>(
     //   - EVERY strategy that ran gave up  -> nothing was attempted that could
     //     have changed the tree, so revalidating would burn a full suite run to
     //     learn nothing. Exit immediately, as before.
+    //
+    //     This exit SURVIVES #1384's per-finding retirement, which looks wrong at a
+    //     glance — surely a strategy that declined only finding A deserves another
+    //     dispatch? It does not, here: nothing in the group touched the tree, so
+    //     `validate` can only re-emit the findings that were already in the declined
+    //     batch. There is no finding it could be re-dispatched FOR. The per-finding
+    //     scope pays off on the other branch, where a sibling's work surfaces
+    //     something new (US-006's barrel export).
     //   - SOME strategy ran without giving up -> its work may have resolved the
     //     findings. Retire only the strategies that gave up and fall through to
     //     validate, so the sibling's progress is measured instead of discarded.
@@ -326,7 +335,12 @@ export async function runFixCycle<F extends Finding>(
     if (unresolvedFas.length > 0) {
       const firstUnresolved = unresolvedFas[0] as FixApplied;
       unresolvedDetail = firstUnresolved.unresolved;
-      for (const fa of unresolvedFas) spentStrategies.add(fa.strategyName);
+      // Decline the findings that were IN that dispatch's input, not the strategy
+      // as a whole (#1384).
+      for (const fa of unresolvedFas) {
+        const strategy = group.find((s) => s.name === fa.strategyName);
+        if (strategy) declines.recordDeclined(strategy, findingsBefore);
+      }
 
       const allGaveUp = unresolvedFas.length === fixesApplied.length;
       if (allGaveUp) {

--- a/test/unit/findings/_cycle-fixtures.ts
+++ b/test/unit/findings/_cycle-fixtures.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared fixtures for the runFixCycle test files (cycle.test.ts,
+ * cycle-retirement.test.ts). Extracted when the cycle tests were split under the
+ * 800-line cap — two copies of an 80-line context/strategy fixture would drift
+ * silently, and the drift would look like a behaviour difference between the files.
+ *
+ * Follows the `_tdd-test-helpers.ts` precedent: leading underscore, not a `.test.ts`,
+ * so the runner does not pick it up as a suite.
+ */
+
+import { mock } from "bun:test";
+import type { FixCycle, FixCycleContext, FixStrategy } from "@/findings";
+import type { Finding } from "@/findings";
+import { makeMockAgentManager, makeNaxConfig } from "@test/helpers";
+
+export function makeFinding(overrides: Partial<Finding> & Pick<Finding, "source" | "message">): Finding {
+  return { severity: "error", category: "test", ...overrides };
+}
+
+export const lintA = makeFinding({ source: "lint", message: "unused var", file: "src/a.ts", line: 1 });
+export const lintB = makeFinding({ source: "lint", message: "missing semicolon", file: "src/b.ts", line: 5 });
+export const typecheckC = makeFinding({ source: "typecheck", message: "TS2304: Cannot find name", file: "src/c.ts", line: 3 });
+
+export function makeCtx(): FixCycleContext {
+  const config = makeNaxConfig();
+  return {
+    runtime: {
+      configLoader: { current: () => config },
+      agentManager: makeMockAgentManager(),
+      sessionManager: {} as FixCycleContext["runtime"]["sessionManager"],
+      packages: { resolve: () => ({ select: () => config }) } as unknown as FixCycleContext["runtime"]["packages"],
+      projectDir: "/tmp/test",
+    } as unknown as FixCycleContext["runtime"],
+    packageView: { select: () => config } as unknown as FixCycleContext["packageView"],
+    packageDir: "/tmp/test",
+    storyId: "story-1",
+    agentName: "claude",
+  };
+}
+
+export const noopOp = {
+  name: "noop-op",
+  kind: "complete" as const,
+  stage: "verify" as const,
+  config: [],
+  build: () => "",
+  parse: () => null,
+  jsonMode: false,
+} as unknown as FixStrategy<Finding, unknown, unknown>["fixOp"];
+
+export function makeStrategy(
+  overrides: Partial<FixStrategy<Finding, unknown, unknown>> & Pick<FixStrategy<Finding, unknown, unknown>, "name">,
+): FixStrategy<Finding, unknown, unknown> {
+  return {
+    appliesTo: () => true,
+    fixOp: noopOp,
+    buildInput: () => ({}),
+    maxAttempts: 3,
+    coRun: "co-run-sequential",
+    ...overrides,
+  };
+}
+
+export function makeCycle(
+  findings: Finding[],
+  strategies: FixStrategy<Finding, unknown, unknown>[],
+  validateFn: FixCycle<Finding>["validate"],
+  overrides?: Partial<FixCycle<Finding>>,
+): FixCycle<Finding> {
+  return {
+    findings,
+    iterations: [],
+    strategies,
+    validate: validateFn,
+    config: { maxAttemptsTotal: 10, validatorRetries: 1 },
+    ...overrides,
+  };
+}
+
+export function makeCallOpMock(returnValue: unknown = {}): ReturnType<typeof mock> {
+  return mock(async () => returnValue);
+}

--- a/test/unit/findings/cycle-retirement.test.ts
+++ b/test/unit/findings/cycle-retirement.test.ts
@@ -233,3 +233,41 @@ describe("runFixCycle — per-finding retirement", () => {
     expect(r.exitReason).toBe("max-attempts-per-strategy");
   });
 });
+
+// ─── verdict-driven dispatch — why it needs no ledger entry (#1384) ──────────
+
+describe("runFixCycle — verdict-driven dispatch", () => {
+  const verdictStrategy = (name: string, dispatched: string[], unresolved?: string) =>
+    makeStrategy({
+      name,
+      coRun: "co-run-sequential",
+      maxAttempts: 3,
+      appliesTo: () => false, // findings-blind: selected purely by verdict
+      appliesToVerdict: (v) => v === "source_bug",
+      extractApplied: () => {
+        dispatched.push(name);
+        return { summary: "", ...(unresolved ? { unresolved } : {}) };
+      },
+    });
+
+  test("verdict-only dispatch cannot iterate, so a declined strategy is never re-dispatched", async () => {
+    // Per-finding retirement has nothing to key on when selection is verdict-driven:
+    // the dispatched batch carries no claimed finding. That is safe only because such a
+    // cycle cannot reach a second iteration — findings stay empty, and
+    // `classifyOutcome([], [])` is "resolved", so runFixCycle returns.
+    //
+    // This test exists to guard that assumption. If it starts failing because the cycle
+    // now iterates on the verdict path, `createDeclineLedger` needs whole-strategy
+    // retirement for verdict declines or #1369's guarantee is lost there.
+    const dispatched: string[] = [];
+    const gaveUp = verdictStrategy("acceptance-source-fix", dispatched, "cannot fix");
+    const sibling = verdictStrategy("acceptance-test-fix", dispatched);
+    const cycle = makeCycle([], [gaveUp, sibling], async () => [], { verdict: "source_bug" });
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(r.exitReason).toBe("resolved");
+    expect(cycle.iterations).toHaveLength(1);
+    expect(dispatched.filter((n) => n === "acceptance-source-fix")).toHaveLength(1);
+  });
+});

--- a/test/unit/findings/cycle-retirement.test.ts
+++ b/test/unit/findings/cycle-retirement.test.ts
@@ -1,0 +1,235 @@
+/**
+ * runFixCycle — UNRESOLVED handling and strategy retirement.
+ *
+ * Split out of cycle.test.ts under the 800-line test cap. Covers the two issues
+ * that shaped this behaviour:
+ *   - #1369 — one strategy gives up while a co-run sibling keeps working; the
+ *     sibling's progress must be measured, not discarded.
+ *   - #1384 — retirement is scoped to the findings a strategy actually declined, so
+ *     an unrelated finding routed only to that strategy is not orphaned.
+ *
+ * Exercises `createDeclineLedger` (src/findings/cycle-retirement.ts) through
+ * `runFixCycle`, which is the only thing that drives it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CallOpFn } from "@/findings/cycle";
+import { runFixCycle } from "@/findings";
+import type { Finding } from "@/findings";
+import { lintA, lintB, makeCallOpMock, makeCtx, makeCycle, makeFinding, makeStrategy, typecheckC } from "./_cycle-fixtures";
+
+// ─── runFixCycle — partial give-up in a co-run group (#1369) ─────────────────
+
+describe("runFixCycle — one strategy gives up, a co-run sibling does not", () => {
+  /** Strategy that reports UNRESOLVED; stands in for autofix-implementer. */
+  const givesUp = (name: string) =>
+    makeStrategy({
+      name,
+      coRun: "co-run-sequential",
+      maxAttempts: 3,
+      extractApplied: () => ({ summary: "", unresolved: "cannot edit test files" }),
+    });
+  /** Strategy that completes normally; stands in for autofix-test-writer. */
+  const succeeds = (name: string) => makeStrategy({ name, coRun: "co-run-sequential", maxAttempts: 3 });
+
+  test("validates instead of abandoning the group, so the sibling's fix is measured", async () => {
+    let validateCalled = false;
+    const cycle = makeCycle([lintA], [givesUp("implementer"), succeeds("test-writer")], async () => {
+      validateCalled = true;
+      return []; // the sibling's fix resolved the finding
+    });
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(validateCalled).toBe(true);
+    expect(r.exitReason).toBe("resolved");
+    expect(r.finalFindings).toEqual([]);
+  });
+
+  test("carries the UNRESOLVED reason onto the later exit the cycle actually reaches", async () => {
+    // Each strategy owns a different finding. The implementer gives up on its
+    // one; the test-writer clears its own. Validation leaves only the abandoned
+    // finding, and its sole claimer is now retired — so the cycle exits
+    // `no-strategy` rather than `agent-gave-up`, and the diagnostic text has to
+    // survive that switch or the give-up becomes invisible.
+    const implementer = makeStrategy({
+      name: "implementer",
+      coRun: "co-run-sequential",
+      appliesTo: (f) => f.source === "lint",
+      extractApplied: () => ({ summary: "", unresolved: "cannot edit test files" }),
+    });
+    const testWriter = makeStrategy({
+      name: "test-writer",
+      coRun: "co-run-sequential",
+      appliesTo: (f) => f.source === "typecheck",
+    });
+    const cycle = makeCycle([lintA, typecheckC], [implementer, testWriter], async () => [lintA]);
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(r.exitReason).toBe("no-strategy");
+    expect(r.unresolvedDetail).toBe("cannot edit test files");
+    expect(r.finalFindings).toEqual([lintA]);
+  });
+
+  test("does not re-dispatch a strategy that already gave up while a sibling keeps working", async () => {
+    const dispatched: string[] = [];
+    const track = (name: string, unresolved?: string) =>
+      makeStrategy({
+        name,
+        coRun: "co-run-sequential",
+        maxAttempts: 3,
+        extractApplied: () => {
+          dispatched.push(name);
+          return { summary: "", ...(unresolved ? { unresolved } : {}) };
+        },
+      });
+    // Findings never clear, so the cycle keeps iterating until the caps bind.
+    // The sibling must be retried; the strategy that gave up must not be.
+    const cycle = makeCycle(
+      [lintA],
+      [track("implementer", "cannot edit test files"), track("test-writer")],
+      async () => [lintA],
+    );
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpMock() as unknown as CallOpFn });
+    expect(dispatched.filter((n) => n === "implementer")).toHaveLength(1);
+    expect(dispatched.filter((n) => n === "test-writer").length).toBeGreaterThan(1);
+  });
+
+  test("exits agent-gave-up without validating when every strategy in the group gives up", async () => {
+    let validateCalled = false;
+    const cycle = makeCycle([lintA], [givesUp("implementer"), givesUp("test-writer")], async () => {
+      validateCalled = true;
+      return [];
+    });
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(validateCalled).toBe(false);
+    expect(r.exitReason).toBe("agent-gave-up");
+  });
+});
+
+// ─── runFixCycle — retirement is per-finding, not per-cycle (#1384) ───────────
+//
+// UNRESOLVED is a per-finding signal: the agent said "I cannot fix THIS", not "I
+// cannot fix anything in this story". Retiring the strategy for the whole cycle
+// meant a later, unrelated finding routed only to that strategy exited the cycle
+// `no-strategy`, and the caller discarded the whole pass — even when the
+// outstanding fix was trivial. Observed on otel-telemetry-expansion US-006, where
+// a one-line barrel export was orphaned by a refusal about a scoping decision.
+//
+// The dispatch hands a strategy EVERY finding it claims in one call and gets back
+// one verdict, so the declined unit is that input batch.
+
+describe("runFixCycle — per-finding retirement", () => {
+  /** Records each dispatch's strategy name; optionally answers UNRESOLVED. */
+  function tracked(
+    name: string,
+    dispatched: string[],
+    opts: { unresolved?: string; appliesTo?: (f: Finding) => boolean } = {},
+  ) {
+    return makeStrategy({
+      name,
+      coRun: "co-run-sequential",
+      maxAttempts: 3,
+      ...(opts.appliesTo ? { appliesTo: opts.appliesTo } : {}),
+      extractApplied: () => {
+        dispatched.push(name);
+        return { summary: "", ...(opts.unresolved ? { unresolved: opts.unresolved } : {}) };
+      },
+    });
+  }
+
+  test("a strategy that declined finding A is still dispatched for a NEW finding B it claims", async () => {
+    // The exact #1384 shape. A co-run sibling is required, and not incidentally: when
+    // EVERY strategy in the group gives up, the cycle exits before validating — nothing
+    // touched the tree, so re-validating would burn a full suite run to learn nothing.
+    // On US-006 the sibling (autofix-test-writer) did commit, which is what surfaced the
+    // later finding the retired implementer was the only claimer of.
+    const dispatched: string[] = [];
+    const implementer = tracked("implementer", dispatched, {
+      unresolved: "needs a scoping decision",
+      appliesTo: (f) => f.source === "lint",
+    });
+    const testWriter = tracked("test-writer", dispatched, { appliesTo: (f) => f.source === "typecheck" });
+    // Round 1 clears both seeded findings but surfaces lintB — unrelated to the refusal,
+    // and claimed only by the implementer.
+    const cycle = makeCycle([lintA, typecheckC], [implementer, testWriter], async () => [lintB]);
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    // Before #1384 this was 1: the implementer was retired cycle-wide and lintB orphaned,
+    // exiting `no-strategy` so the caller discarded the sibling's work too.
+    expect(dispatched.filter((n) => n === "implementer").length).toBeGreaterThan(1);
+    expect(r.exitReason).not.toBe("no-strategy");
+  });
+
+  test("a strategy is NOT re-dispatched while every finding it claims is already declined", async () => {
+    // Termination guard: the declined set only grows, so a strategy facing the same
+    // batch must not be re-asked (the #1369 behaviour this must preserve).
+    const dispatched: string[] = [];
+    const implementer = tracked("implementer", dispatched, { unresolved: "cannot fix" });
+    const cycle = makeCycle([lintA], [implementer], async () => [lintA]);
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(dispatched).toEqual(["implementer"]);
+    expect(r.exitReason).toBe("agent-gave-up");
+  });
+
+  test("declining one finding does not retire the strategy for a sibling's findings", async () => {
+    // Retirement is scoped to (strategy, finding). Another strategy claiming the
+    // same finding is unaffected — and vice versa.
+    const dispatched: string[] = [];
+    const implementer = tracked("implementer", dispatched, {
+      unresolved: "cannot fix lint",
+      appliesTo: (f) => f.source === "lint",
+    });
+    const testWriter = tracked("test-writer", dispatched, { appliesTo: (f) => f.source === "typecheck" });
+    const cycle = makeCycle([lintA, typecheckC], [implementer, testWriter], async () => [lintA, typecheckC]);
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpMock() as unknown as CallOpFn });
+    expect(dispatched.filter((n) => n === "implementer")).toHaveLength(1);
+    expect(dispatched.filter((n) => n === "test-writer").length).toBeGreaterThan(1);
+  });
+
+  test("no-strategy now means a genuine routing gap, not a retired strategy", async () => {
+    // Nothing claims the typecheck finding at all.
+    const dispatched: string[] = [];
+    const implementer = tracked("implementer", dispatched, { appliesTo: (f) => f.source === "lint" });
+    const cycle = makeCycle([lintA], [implementer], async () => [typecheckC]);
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    expect(r.exitReason).toBe("no-strategy");
+    expect(r.finalFindings).toEqual([typecheckC]);
+  });
+
+  test("re-emitted-with-rephrased-message counts as a new finding — accepted drift, bounded by maxAttempts", async () => {
+    // `findingKey` includes `message`, so an LLM rewording mints a new key and the
+    // strategy becomes dispatchable again for what is substantively the same finding.
+    // Documented as accepted: the drift is in the "try again" direction and the
+    // per-strategy cap still binds. Mechanical producers have stable messages.
+    const dispatched: string[] = [];
+    const implementer = tracked("implementer", dispatched, {
+      unresolved: "cannot fix",
+      appliesTo: (f) => f.source === "lint",
+    });
+    // Sibling keeps the cycle alive past the all-gave-up early exit, as above.
+    const testWriter = tracked("test-writer", dispatched, { appliesTo: (f) => f.source === "typecheck" });
+    let round = 0;
+    const cycle = makeCycle([lintA, typecheckC], [implementer, testWriter], async () => {
+      round++;
+      return [
+        makeFinding({ source: "lint", message: `unused var (attempt ${round})`, file: "src/a.ts", line: 1 }),
+        typecheckC,
+      ];
+    });
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+    });
+    // Re-dispatched because the key changed — but the per-strategy cap still binds.
+    expect(dispatched.filter((n) => n === "implementer")).toHaveLength(3);
+    expect(r.exitReason).toBe("max-attempts-per-strategy");
+  });
+});

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -1,84 +1,20 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { CallOpFn } from "@/findings/cycle";
 import { classifyOutcome, runFixCycle } from "@/findings";
-import type { FixCycle, FixCycleContext, FixStrategy, Iteration, ValidateResult } from "@/findings";
+import type { FixCycle, FixStrategy, Iteration, ValidateResult } from "@/findings";
 import type { Finding } from "@/findings";
-import { makeLogger, makeMockAgentManager, makeNaxConfig } from "@test/helpers";
-
-// ─── Fixtures ─────────────────────────────────────────────────────────────────
-
-function makeFinding(overrides: Partial<Finding> & Pick<Finding, "source" | "message">): Finding {
-  return {
-    severity: "error",
-    category: "test",
-    ...overrides,
-  };
-}
-
-const lintA = makeFinding({ source: "lint", message: "unused var", file: "src/a.ts", line: 1 });
-const lintB = makeFinding({ source: "lint", message: "missing semicolon", file: "src/b.ts", line: 5 });
-const typecheckC = makeFinding({ source: "typecheck", message: "TS2304: Cannot find name", file: "src/c.ts", line: 3 });
-
-function makeCtx(): FixCycleContext {
-  const config = makeNaxConfig();
-  return {
-    runtime: {
-      configLoader: { current: () => config },
-      agentManager: makeMockAgentManager(),
-      sessionManager: {} as FixCycleContext["runtime"]["sessionManager"],
-      packages: { resolve: () => ({ select: () => config }) } as unknown as FixCycleContext["runtime"]["packages"],
-      projectDir: "/tmp/test",
-    } as unknown as FixCycleContext["runtime"],
-    packageView: { select: () => config } as unknown as FixCycleContext["packageView"],
-    packageDir: "/tmp/test",
-    storyId: "story-1",
-    agentName: "claude",
-  };
-}
-
-const noopOp = {
-  name: "noop-op",
-  kind: "complete" as const,
-  stage: "verify" as const,
-  config: [],
-  build: () => "",
-  parse: () => null,
-  jsonMode: false,
-} as unknown as FixStrategy<Finding, unknown, unknown>["fixOp"];
-
-function makeStrategy(
-  overrides: Partial<FixStrategy<Finding, unknown, unknown>> & Pick<FixStrategy<Finding, unknown, unknown>, "name">,
-): FixStrategy<Finding, unknown, unknown> {
-  return {
-    appliesTo: () => true,
-    fixOp: noopOp,
-    buildInput: () => ({}),
-    maxAttempts: 3,
-    coRun: "co-run-sequential",
-    ...overrides,
-  };
-}
-
-function makeCycle(
-  findings: Finding[],
-  strategies: FixStrategy<Finding, unknown, unknown>[],
-  validateFn: FixCycle<Finding>["validate"],
-  overrides?: Partial<FixCycle<Finding>>,
-): FixCycle<Finding> {
-  return {
-    findings,
-    iterations: [],
-    strategies,
-    validate: validateFn,
-    config: { maxAttemptsTotal: 10, validatorRetries: 1 },
-    ...overrides,
-  };
-}
-
-// callOp mock that returns a fixed output without calling real ops
-function makeCallOpMock(returnValue: unknown = {}): ReturnType<typeof mock> {
-  return mock(async () => returnValue);
-}
+import { makeLogger } from "@test/helpers";
+import {
+  lintA,
+  lintB,
+  makeCallOpMock,
+  makeCtx,
+  makeCycle,
+  makeFinding,
+  makeStrategy,
+  noopOp,
+  typecheckC,
+} from "./_cycle-fixtures";
 
 beforeEach(() => {
   // reset per-test state; individual tests inject _deps inline
@@ -348,98 +284,6 @@ callOp: makeCallOpMock() as unknown as CallOpFn});
     });
     expect(r.exitReason).toBe("agent-gave-up");
     expect(r.costUsd).toBeCloseTo(0.42, 5);
-  });
-});
-
-// ─── runFixCycle — partial give-up in a co-run group (#1369) ─────────────────
-
-describe("runFixCycle — one strategy gives up, a co-run sibling does not", () => {
-  /** Strategy that reports UNRESOLVED; stands in for autofix-implementer. */
-  const givesUp = (name: string) =>
-    makeStrategy({
-      name,
-      coRun: "co-run-sequential",
-      maxAttempts: 3,
-      extractApplied: () => ({ summary: "", unresolved: "cannot edit test files" }),
-    });
-  /** Strategy that completes normally; stands in for autofix-test-writer. */
-  const succeeds = (name: string) => makeStrategy({ name, coRun: "co-run-sequential", maxAttempts: 3 });
-
-  test("validates instead of abandoning the group, so the sibling's fix is measured", async () => {
-    let validateCalled = false;
-    const cycle = makeCycle([lintA], [givesUp("implementer"), succeeds("test-writer")], async () => {
-      validateCalled = true;
-      return []; // the sibling's fix resolved the finding
-    });
-    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
-      callOp: makeCallOpMock() as unknown as CallOpFn,
-    });
-    expect(validateCalled).toBe(true);
-    expect(r.exitReason).toBe("resolved");
-    expect(r.finalFindings).toEqual([]);
-  });
-
-  test("carries the UNRESOLVED reason onto the later exit the cycle actually reaches", async () => {
-    // Each strategy owns a different finding. The implementer gives up on its
-    // one; the test-writer clears its own. Validation leaves only the abandoned
-    // finding, and its sole claimer is now retired — so the cycle exits
-    // `no-strategy` rather than `agent-gave-up`, and the diagnostic text has to
-    // survive that switch or the give-up becomes invisible.
-    const implementer = makeStrategy({
-      name: "implementer",
-      coRun: "co-run-sequential",
-      appliesTo: (f) => f.source === "lint",
-      extractApplied: () => ({ summary: "", unresolved: "cannot edit test files" }),
-    });
-    const testWriter = makeStrategy({
-      name: "test-writer",
-      coRun: "co-run-sequential",
-      appliesTo: (f) => f.source === "typecheck",
-    });
-    const cycle = makeCycle([lintA, typecheckC], [implementer, testWriter], async () => [lintA]);
-    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
-      callOp: makeCallOpMock() as unknown as CallOpFn,
-    });
-    expect(r.exitReason).toBe("no-strategy");
-    expect(r.unresolvedDetail).toBe("cannot edit test files");
-    expect(r.finalFindings).toEqual([lintA]);
-  });
-
-  test("does not re-dispatch a strategy that already gave up while a sibling keeps working", async () => {
-    const dispatched: string[] = [];
-    const track = (name: string, unresolved?: string) =>
-      makeStrategy({
-        name,
-        coRun: "co-run-sequential",
-        maxAttempts: 3,
-        extractApplied: () => {
-          dispatched.push(name);
-          return { summary: "", ...(unresolved ? { unresolved } : {}) };
-        },
-      });
-    // Findings never clear, so the cycle keeps iterating until the caps bind.
-    // The sibling must be retried; the strategy that gave up must not be.
-    const cycle = makeCycle(
-      [lintA],
-      [track("implementer", "cannot edit test files"), track("test-writer")],
-      async () => [lintA],
-    );
-    await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpMock() as unknown as CallOpFn });
-    expect(dispatched.filter((n) => n === "implementer")).toHaveLength(1);
-    expect(dispatched.filter((n) => n === "test-writer").length).toBeGreaterThan(1);
-  });
-
-  test("exits agent-gave-up without validating when every strategy in the group gives up", async () => {
-    let validateCalled = false;
-    const cycle = makeCycle([lintA], [givesUp("implementer"), givesUp("test-writer")], async () => {
-      validateCalled = true;
-      return [];
-    });
-    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", {
-      callOp: makeCallOpMock() as unknown as CallOpFn,
-    });
-    expect(validateCalled).toBe(false);
-    expect(r.exitReason).toBe("agent-gave-up");
   });
 });
 


### PR DESCRIPTION
## Problem

`runFixCycle` retired a strategy for the **whole cycle** when it answered UNRESOLVED
(#1369). But UNRESOLVED is a per-finding signal — the agent said "I cannot fix **this**",
not "I cannot fix anything in this story". When a later, unrelated finding routed only to
that retired strategy, the cycle exited `no-strategy` (orphaned findings) and the caller
discarded the whole pass, even when the outstanding fix was trivial.

Observed on `otel-telemetry-expansion` US-006: the implementer correctly refused finding A
(it needed a scoping decision it could not guess), and the **one-line barrel export its own
co-run sibling had just created** was then orphaned — rolling back the sibling's commit
`47920f3b` after ~9 minutes and 3 agent sessions. `createBatchQueue` shipped to main as dead
code because of it.

Fixes #1384.

## Change

Retirement is now scoped to `(strategy, finding)` through a decline ledger
(`src/findings/cycle-retirement.ts`). A strategy is unselectable only once it has declined
**every** remaining finding it claims.

Three things reviewers should check specifically:

**1. The declined unit is the dispatched batch, not one finding.** `cycle.ts` hands a
strategy every finding it claims in one call and gets back one verdict, so there is no
per-finding answer to record. One UNRESOLVED declines the whole input batch. That
over-retires within the batch — harmless, since findings the agent did fix leave
`cycle.findings` anyway — and errs conservative. It is also sufficient for the motivating
run: the orphaning finding did not exist at retirement time (created 03:48:18, retirement
03:46:08).

**2. The all-gave-up early exit deliberately stays.** It looks like it defeats the change —
surely a strategy that declined only finding A deserves another dispatch? Not there: nothing
in the group touched the tree, so `validate` can only re-emit findings already in the
declined batch. There is no finding to re-dispatch *for*. The comment now says so, because
the code reads as a contradiction otherwise.

**3. Termination.** A strategy declines any given finding at most once, the declined set
only grows, and `maxAttemptsPerStrategy` / `maxAttemptsTotal` are untouched. The one caveat:
`findingKey` includes `message`, so a re-emitted finding with LLM-rephrased text mints a new
key and the strategy becomes dispatchable again. Accepted rather than worked around — the
drift is in the "try again" direction, mechanical producers have stable messages, and the
caps still bind. There is a test asserting exactly 3 dispatches and a
`max-attempts-per-strategy` exit for that case, so the bound is pinned rather than assumed.

Also: `retiredStrategies` in the orphan-exit log now means "retired with respect to the
remaining findings", which is what that exit's diagnostic actually needs — a strategy that
declined something irrelevant to the orphan is no longer named as its cause.

## Tests

5 new tests, all mutation-verified: reverting the ledger to cycle-wide retirement fails
exactly the two that encode new behaviour, and no others.

- a strategy that declined A **is** re-dispatched for a new, unrelated B it claims (the
  #1384 shape, sibling included as the real run had)
- a strategy is **not** re-dispatched while every finding it claims is already declined
  (the #1369 property this must preserve)
- declining one finding does not retire the strategy for a sibling's findings
- `no-strategy` now means a genuine routing gap
- rephrased re-emission → re-dispatchable, bounded at `maxAttempts`

All 4 pre-existing #1369 tests still pass unmodified.

## Splits (file-size caps)

`src/findings/cycle.ts` hit 610 lines (600 cap) and `cycle.test.ts` hit 914 (800 cap), so
this PR also:

- extracts the ledger to `src/findings/cycle-retirement.ts` (cycle.ts → 581)
- extracts the retirement suites to `test/unit/findings/cycle-retirement.test.ts` (624)
- extracts shared cycle fixtures to `_cycle-fixtures.ts` (following the
  `_tdd-test-helpers.ts` precedent) so the two test files cannot drift apart — I had
  duplicated ~80 lines of context/strategy fixtures across them, which would have looked
  like a behaviour difference once they diverged

## Verification

- `bun run typecheck` — clean
- `bun run lint` — green, all ratchets and the file-size baseline unchanged
- `bun run test` — 10505 unit + 1092 integration + 24 ui, **0 fail**

## Sequencing

Phase 2 of the plan across #1382 / #1383 / #1384 / #1359 —
https://github.com/nathapp-io/nax/issues/1382#issuecomment-5128244598. Independent of #1388
and #1389 (both merged). Remaining: Phase 3 (#1359 actionability filter), then Phase 4
(re-read the scope telemetry).
