### PR TITLE
feat(review): stop the best-effort fix pass acting on compliance confirmations (#1359)

### DIFF
--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -103,6 +103,14 @@ const DEFAULT_DEPS: NonBlockingFixDeps = {
 export interface NonBlockingFixArgs {
   workdir: string;
   storyId: string;
+  /**
+   * Sub-threshold adversarial findings to seed the pass with.
+   *
+   * MUST already be filtered through `actionableAdvisoryFindings` — the caller owns
+   * that because it also builds the `runRectify` closure these seed, so filtering here
+   * would fix the gate while leaving the seed unfiltered. Passing the raw bucket
+   * re-opens #1359: a pass gets dispatched for a finding that asked for nothing.
+   */
   advisoryFindings: readonly Finding[];
   cfg: NonBlockingFixConfig;
   phaseOutputs: Record<string, unknown>;

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -31,6 +31,26 @@ const REVIEW_PHASE_KINDS = ["semantic-review", "adversarial-review"] as const sa
  */
 const MAX_LOGGED_REGRESSED_KEYS = 10;
 
+/**
+ * Advisory findings that actually ask for a change.
+ *
+ * NBF seeds from the adversarial advisory bucket and used to apply no filter at all, so
+ * a finding whose own suggestion read "No action needed; this is the intended behaviour"
+ * still opened a pass: on otel-telemetry-expansion US-004 that dispatched a paid
+ * implementer session against a compliance confirmation, broke a test, and was rolled
+ * back for zero net change (#1359).
+ *
+ * Absent `actionRequired` counts as actionable — every producer predating #1359 omits
+ * it, and defaulting the other way would silence the whole feature.
+ *
+ * Applied at the SEEDING site only, never in the reviewer's own output: the end-of-run
+ * advisory report reads the op's `advisoryFindings` (`review-audit.ts`), and filtering
+ * there would delete the very visibility that made this diagnosable.
+ */
+export function actionableAdvisoryFindings(findings: readonly Finding[]): readonly Finding[] {
+  return findings.filter((f) => f.actionRequired !== false);
+}
+
 /** Run the pass only when enabled and there is at least one advisory finding. */
 export function shouldRunNonBlockingFix(cfg: NonBlockingFixConfig | undefined, advisoryCount: number): boolean {
   return cfg?.enabled === true && advisoryCount > 0;

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -4,6 +4,7 @@ import type { CallContext } from "@/operations";
 import { errorMessage } from "@/utils/errors";
 import { hydrateFromResumePlan } from "../checkpoint/resume-hydrate";
 import {
+  actionableAdvisoryFindings,
   createMeasureSourceDiff,
   nonBlockingExcludePhases,
   nonBlockingExtraPhases,
@@ -309,7 +310,11 @@ export class ExecutionPlan {
       Object.entries(phaseOutputs).every(([name, output]) => phasePassed(name, output, this.ctx.storyId));
     const advCfg = this.state.adversarialReview ? this.state.nonBlockingFix : undefined;
     const advisoryOut = phaseOutputs["adversarial-review"] as { advisoryFindings?: Finding[] } | undefined;
-    const advisoryFindings = advisoryOut?.advisoryFindings ?? [];
+    // Seed only the findings that ask for a change: a reviewer's compliance
+    // confirmation must not buy an agent session (#1359). The unfiltered bucket stays
+    // in `phaseOutputs` and in the reviewer's own output, so the end-of-run advisory
+    // report still shows everything.
+    const advisoryFindings = actionableAdvisoryFindings(advisoryOut?.advisoryFindings ?? []);
     if (
       advCfg &&
       storyCurrentlyGreen &&

--- a/src/findings/types.ts
+++ b/src/findings/types.ts
@@ -160,6 +160,22 @@ export interface Finding {
   fixTarget?: FixTarget;
 
   /**
+   * Does this finding ask for a change? `false` means the producer is REPORTING
+   * rather than requesting — e.g. an adversarial reviewer confirming that the
+   * implementation correctly honoured a declared out-of-scope boundary.
+   *
+   * Absent means actionable. Every producer predating #1359 omits the field, so the
+   * default must not drop their findings.
+   *
+   * First-class rather than a `meta` entry deliberately: consumers branch on this to
+   * decide whether to dispatch a paid fix pass (ADR-024 nbf seeding), and `meta` is
+   * read-only-by-convention — see the note on `meta` below. Non-actionable findings
+   * are still surfaced in the end-of-run advisory report; the filter applies only
+   * where the decision is "spend an agent session on this".
+   */
+  actionRequired?: boolean;
+
+  /**
    * Producer-specific extras — semantic review's verifiedBy evidence,
    * raw tool output, AC text, TS span, etc.
    *

--- a/src/log-format/formatter.ts
+++ b/src/log-format/formatter.ts
@@ -460,6 +460,14 @@ export function formatAdvisorySummary(
       ),
     );
   }
+  const noActionCount = findings.filter((f) => f.actionRequired === false).length;
+  if (noActionCount > 0) {
+    lines.push(
+      c.gray(
+        `  ${noActionCount} of ${findings.length} asked for no change (compliance notes — the best-effort fix pass skipped them)`,
+      ),
+    );
+  }
   lines.push(c.yellow("─".repeat(60)));
 
   for (const f of sorted) {
@@ -470,6 +478,7 @@ export function formatAdvisorySummary(
       location,
       f.category,
       f.coverageGap ? "coverage-gap" : undefined,
+      f.actionRequired === false ? "no-action" : undefined,
     ].filter((v): v is string => typeof v === "string" && v.length > 0);
     lines.push(`  ${c.gray(parts.join(" · "))}`);
     lines.push(`    ${f.issue}`);

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -142,6 +142,7 @@ Respond with ONLY a JSON object — no preamble, no explanation outside the JSON
       "acIndex": 2,
       "scopeQuote": "<out-of-scope findings ONLY: verbatim substring of one Out of Scope entry>",
       "scopeIndex": 1,
+      "actionRequired": true,
       "verifiedBy": {
         "command": "command used to inspect the current codebase",
         "file": "relative/path/to/file.ts",
@@ -194,6 +195,11 @@ A finding about code that crossed one of these boundaries must NOT cite an AC �
 - When the boundary comes from the numbered **Out of Scope** list, set \`scopeQuote\` to a verbatim substring of that entry and \`scopeIndex\` to its 1-based number. A \`scopeQuote\` that is not a verbatim substring of the entry you indexed is discarded.
 - When the boundary is only a description "Out:" bullet, quote it in \`issue\` and leave \`scopeQuote\`/\`scopeIndex\` unset.
 - Emit scope-violation findings as \`"warning"\` — never \`"error"\`. Reporting the boundary is the goal; it does not block the story.
+
+**Do not report compliance as a finding:**
+A finding is a request for a change. If you inspected something and the code was CORRECT — it honoured an out-of-scope boundary, satisfied a convention, handled the edge case — that is not a finding. Say it in \`passed\`, not in \`findings\`. Emitting "this is correct per Out of Scope #10 / no action needed" as a finding causes an automated fix pass to be dispatched against code that needs no fix; one such report edited working code and broke a test.
+
+If you judge a no-change note genuinely worth recording, set \`actionRequired: false\` on it. Every finding that asks for a change must leave \`actionRequired\` unset or \`true\`. Never pair \`actionRequired: false\` with a \`suggestion\` that requests an edit — pick one.
 
 Never use \`acIndex: 0\`; \`acIndex\` is 1-based (first AC bullet = 1). The same applies to \`scopeIndex\`.
 

--- a/src/review/adversarial-helpers.ts
+++ b/src/review/adversarial-helpers.ts
@@ -40,6 +40,13 @@ export interface AdversarialLLMFinding {
   /** 1-based index into story.outOfScope corresponding to scopeQuote. */
   scopeIndex?: number;
   /**
+   * `false` when the finding reports compliance rather than requesting a change —
+   * the reviewer noting that the code correctly honoured a constraint. Omitted means
+   * actionable. Read by the ADR-024 nbf seeding filter so a "no action needed"
+   * finding cannot trigger a paid fix pass (#1359).
+   */
+  actionRequired?: boolean;
+  /**
    * Required for severity "error" / "critical" (Issue #987): evidence anchoring
    * the finding to real source. `observed` is a verbatim 1–3 line code excerpt
    * from `verifiedBy.file` (defaulting to `file`). Substring-checked against
@@ -128,6 +135,9 @@ export function toAdversarialReviewFindings(
       message: f.issue,
       suggestion: f.suggestion,
       fixTarget: resolveFixTarget({ base: categoryToFixTarget(f.category), file: f.file, isTestFile: opts.isTestFile }),
+      // Only forwarded when the reviewer said `false`; absent stays absent so the
+      // "absent means actionable" default is not silently materialised (#1359).
+      ...(f.actionRequired === false ? { actionRequired: false } : {}),
       meta: Object.keys(metaExtras).length > 0 ? metaExtras : undefined,
     };
   });

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -19,6 +19,10 @@ export * from "./runner";
 export * from "./requote-response";
 export * from "./severity";
 export { validateLLMShape } from "./semantic-helpers";
+// Projection of adversarial LLM findings to the ADR-021 wire format. Already consumed
+// outside src/review (src/operations/adversarial-review.ts); exported here so callers
+// and tests reach it through the barrel rather than the leaf path.
+export { toAdversarialReviewFindings } from "./adversarial-helpers";
 export { categoryToFixTarget, resolveFixTarget } from "./category-fix-target";
 export type { ResolveFixTargetArgs } from "./category-fix-target";
 // Promoted from finding-filters: not re-exported by adversarial.ts (verify if that changes)

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -107,6 +107,12 @@ export interface AdvisoryFindingSummaryEntry {
   issue: string;
   /** True when this advisory finding was recurrence-demoted (tagged `meta.coverageGap`). */
   coverageGap?: boolean;
+  /**
+   * `false` when the reviewer marked the finding as requiring no change (#1359). Such
+   * findings are excluded from the nbf fix pass but still reported here — the point is
+   * to surface them, labelled, not to hide them.
+   */
+  actionRequired?: boolean;
 }
 
 export interface IReviewAuditor {
@@ -210,6 +216,7 @@ function toAdvisorySummaryEntries(entry: ReviewAuditDecision): AdvisoryFindingSu
       file?: string;
       line?: number;
       issue?: string;
+      actionRequired?: boolean;
       meta?: { coverageGap?: boolean };
     };
     return {
@@ -222,6 +229,7 @@ function toAdvisorySummaryEntries(entry: ReviewAuditDecision): AdvisoryFindingSu
       line: f.line,
       issue: f.issue ?? "(no description)",
       coverageGap: f.meta?.coverageGap === true ? true : undefined,
+      actionRequired: f.actionRequired === false ? false : undefined,
     };
   });
 }

--- a/test/unit/execution/non-blocking-fix-wiring.test.ts
+++ b/test/unit/execution/non-blocking-fix-wiring.test.ts
@@ -131,6 +131,76 @@ describe("non-blocking-fix runtime wiring", () => {
     expect(typeof deps?.measureSourceDiff).toBe("function");
   });
 
+  test("non-blocking fix is SKIPPED when every advisory finding requires no action (#1359)", async () => {
+    // The observed US-004 case: adversarial passed with ONE advisory finding, and that
+    // finding was a compliance confirmation whose own suggestion read "No action needed".
+    // NBF opened anyway, dispatched a paid implementer pass, broke a test, and rolled
+    // back. With the actionability filter the gate never opens.
+    const runNonBlockingFix = mock(async () => ({ ran: true, kept: true, restored: false }));
+    (_storyOrchestratorDeps as { runNonBlockingFix?: typeof runNonBlockingFix }).runNonBlockingFix = runNonBlockingFix;
+
+    const callOp = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = mock(async (_ctx, op) => {
+      if (op.name === "adversarial-review") {
+        return {
+          success: true,
+          passed: true,
+          advisoryFindings: [
+            {
+              source: "adversarial-review",
+              severity: "warning",
+              category: "out-of-scope",
+              message: "Removed quarantined:0 — correct per Out of Scope #10",
+              suggestion: "No action needed; this is the intended behaviour.",
+              actionRequired: false,
+            },
+          ],
+        };
+      }
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const config = makeNaxConfig({
+      quality: { autofix: { enabled: true } },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+      review: {
+        adversarial: {
+          model: "balanced",
+          diffMode: "ref",
+          rules: [],
+          timeoutMs: 600_000,
+          parallel: false,
+          maxConcurrentSessions: 2,
+          nonBlockingFix: { enabled: true, scope: "triage", regressionAttempts: 1, verifierGuard: true },
+        },
+      },
+    });
+    const story = makeStory({ attempts: 1 });
+    runtime = makeTestRuntime({ config });
+    const ctx = makeMockCallContext({ runtime });
+    const inputs = makeMockPlanInputs({
+      story,
+      implementer: { story },
+      fullSuiteGate: { story, workdir: "/tmp/test" },
+      verifier: { story },
+      adversarialReview: {
+        story,
+        workdir: "/tmp/test",
+        adversarialConfig: config.review.adversarial!,
+        mode: config.review.adversarial!.diffMode,
+      },
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+
+    try {
+      const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+      await plan.run();
+      expect(runNonBlockingFix).not.toHaveBeenCalled();
+    } finally {
+      _storyOrchestratorDeps.callOp = callOp;
+    }
+  });
+
   test("non-blocking fix is SKIPPED when the story is not green (rectification exhausted with unfixed findings)", async () => {
     // Regression: log 2026-06-24 US-001. Adversarial review FAILED (blocking findings)
     // yet its output still carried advisoryFindings. The outer rectification fixed the

--- a/test/unit/execution/non-blocking-fix.test.ts
+++ b/test/unit/execution/non-blocking-fix.test.ts
@@ -1,10 +1,12 @@
 // test/unit/execution/non-blocking-fix.test.ts
 import { describe, expect, test } from "bun:test";
 import {
+  actionableAdvisoryFindings,
   nonBlockingExtraPhases,
   runNonBlockingFix,
   shouldRunNonBlockingFix,
 } from "../../../src/execution/non-blocking-fix";
+import type { Finding } from "@/findings";
 import { withInfoSpy } from "@test/helpers";
 
 describe("non-blocking-fix gating", () => {
@@ -535,5 +537,38 @@ describe("runNonBlockingFix sourceDiffCap", () => {
     );
     expect(res).toEqual({ ran: true, kept: true, restored: false });
     expect(rolled).toBe("");
+  });
+});
+
+// ─── actionability filter (#1359) ─────────────────────────────────────────────
+
+describe("actionableAdvisoryFindings", () => {
+  const advisory = (overrides: Partial<Finding> = {}): Finding => ({
+    source: "adversarial-review",
+    severity: "warning",
+    category: "input",
+    message: "m",
+    ...overrides,
+  });
+
+  test("drops findings the reviewer marked as requiring no action", () => {
+    const kept = actionableAdvisoryFindings([
+      advisory({ message: "real issue" }),
+      advisory({ message: "compliance confirmation", actionRequired: false }),
+    ]);
+    expect(kept.map((f) => f.message)).toEqual(["real issue"]);
+  });
+
+  test("keeps findings that omit actionRequired — absent means actionable", () => {
+    // Every producer predating #1359 omits the field; none of them may be dropped.
+    expect(actionableAdvisoryFindings([advisory(), advisory({ actionRequired: true })])).toHaveLength(2);
+  });
+
+  test("an all-compliance advisory bucket closes the NBF gate", () => {
+    // The observed US-004 case: one advisory finding, and it asked for nothing.
+    // NBF must not open a paid pass for it.
+    const cfg = { enabled: true, scope: "both", regressionAttempts: 1, verifierGuard: true } as const;
+    const actionable = actionableAdvisoryFindings([advisory({ actionRequired: false })]);
+    expect(shouldRunNonBlockingFix(cfg, actionable.length)).toBe(false);
   });
 });

--- a/test/unit/log-format/formatter.test.ts
+++ b/test/unit/log-format/formatter.test.ts
@@ -212,6 +212,23 @@ describe("formatAdvisorySummary", () => {
     expect(output).toContain("coverage-gap");
   });
 
+  test("surfaces the no-action count and tags compliance notes (#1359)", () => {
+    // These are reported but never fixed — the label is what tells an operator that
+    // nothing was skipped by mistake.
+    const findings = [
+      advisoryFinding({ storyId: "US-004", actionRequired: false, issue: "correct per Out of Scope #10" }),
+      advisoryFinding({ storyId: "US-005", issue: "ordinary advisory" }),
+    ];
+    const output = plain(formatAdvisorySummary(findings, { mode: "normal", useColor: false }));
+    expect(output).toContain("1 of 2 asked for no change");
+    expect(output).toContain("no-action");
+  });
+
+  test("omits the no-action line when every finding asks for a change (#1359)", () => {
+    const output = plain(formatAdvisorySummary([advisoryFinding()], { mode: "normal", useColor: false }));
+    expect(output).not.toContain("asked for no change");
+  });
+
   test("omits the coverage-gap line when no finding was demoted", () => {
     const output = plain(formatAdvisorySummary([advisoryFinding()], { mode: "normal", useColor: false }));
     expect(output).not.toContain("coverage-gap demotions");

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -169,6 +169,16 @@ describe("AdversarialReviewPromptBuilder — placeholder-test carve-out (#2) and
     expect(result).toContain("No rubber-stamping");
   });
 
+  test("forbids reporting compliance as a finding, and offers actionRequired instead (#1359)", () => {
+    // The reviewer emitted "correct per Out of Scope #10 … No action needed" AS a
+    // finding, and nbf then paid an implementer to fix it. The prompt is the primary
+    // guard; the actionability filter is the backstop.
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, { mode: "ref", storyGitRef: STORY_GIT_REF });
+    expect(result).toContain("Do not report compliance as a finding");
+    expect(result).toContain('"actionRequired"');
+    expect(result).toContain("actionRequired: false");
+  });
+
   test("demandInspection re-prompt names inspectedFiles and demands tool use", () => {
     const reprompt = AdversarialReviewPromptBuilder.demandInspection();
     expect(reprompt).toContain("inspectedFiles");

--- a/test/unit/review/adversarial-threshold.test.ts
+++ b/test/unit/review/adversarial-threshold.test.ts
@@ -74,6 +74,25 @@ const ERROR_ONLY_RESPONSE = JSON.stringify({
   ],
 });
 
+// #1359 — actionRequired must not become a "do not block me" escape hatch.
+const BLOCKING_WITH_NO_ACTION_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/findings-bar.ts",
+      line: 2,
+      issue: "An error the reviewer would rather not be held to",
+      suggestion: "Fix error",
+      acQuote: "findings",
+      acIndex: 1,
+      actionRequired: false,
+      verifiedBy: { file: "src/findings-bar.ts", observed: "error stub" },
+    },
+  ],
+});
+
 const MIXED_RESPONSE = JSON.stringify({
   passed: false,
   findings: [
@@ -169,6 +188,18 @@ describe("runAdversarialReview — blockingThreshold defaults to 'error'", () =>
     const result = await runAdversarialReview({ workdir: "/tmp/wd", storyGitRef: "abc123", story: STORY, adversarialConfig: BASE_CFG, agentManager, runtime });
 
     expect(result.advisoryFindings?.[0]?.actionRequired).toBe(false);
+  });
+
+  test("actionRequired: false does NOT let a blocking finding escape the gate (#1359)", async () => {
+    // The filter is scoped to the advisory bucket at nbf seeding. If it ever reached the
+    // blocking bucket, a reviewer could self-exempt any error finding by flagging it
+    // no-action — turning an advisory hint into a story-verdict override.
+    const agentManager = makeAgentManager(BLOCKING_WITH_NO_ACTION_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager });
+    const result = await runAdversarialReview({ workdir: "/tmp/wd", storyGitRef: "abc123", story: STORY, adversarialConfig: BASE_CFG, agentManager, runtime });
+
+    expect(result.success).toBe(false);
+    expect(result.findings?.length).toBeGreaterThan(0);
   });
 
   test("error finding blocks by default", async () => {

--- a/test/unit/review/adversarial-threshold.test.ts
+++ b/test/unit/review/adversarial-threshold.test.ts
@@ -50,6 +50,23 @@ const WARNING_ONLY_RESPONSE = JSON.stringify({
   ],
 });
 
+// #1359 — the observed US-004 shape: an advisory finding that asks for nothing.
+const COMPLIANCE_RESPONSE = JSON.stringify({
+  passed: true,
+  findings: [
+    {
+      severity: "warning",
+      category: "out-of-scope",
+      file: "src/foo.ts",
+      line: 1,
+      issue: "Removed quarantined:0 — correct per Out of Scope #10 which mandates omission",
+      suggestion: "No action needed; this is the intended behaviour.",
+      actionRequired: false,
+      verifiedBy: { file: "src/foo.ts", observed: "warning stub" },
+    },
+  ],
+});
+
 const ERROR_ONLY_RESPONSE = JSON.stringify({
   passed: false,
   findings: [
@@ -141,6 +158,17 @@ describe("runAdversarialReview — blockingThreshold defaults to 'error'", () =>
     expect(!result.findings || result.findings.length === 0).toBe(true);
     expect(result.advisoryFindings).toBeDefined();
     expect(result.advisoryFindings![0].message).toBe("A warning");
+  });
+
+  // #1359 — the actionability filter reads `actionRequired` off the wire Finding, so it
+  // has to survive the whole reviewer pipeline (parse → substantiate → recurrence split
+  // → projection), not just the projection helper the unit test covers.
+  test("actionRequired: false survives the reviewer pipeline onto the advisory finding", async () => {
+    const agentManager = makeAgentManager(COMPLIANCE_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager });
+    const result = await runAdversarialReview({ workdir: "/tmp/wd", storyGitRef: "abc123", story: STORY, adversarialConfig: BASE_CFG, agentManager, runtime });
+
+    expect(result.advisoryFindings?.[0]?.actionRequired).toBe(false);
   });
 
   test("error finding blocks by default", async () => {

--- a/test/unit/review/finding-projection.test.ts
+++ b/test/unit/review/finding-projection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { llmFindingToReviewFinding, llmFindingsToReviewFindings } from "../../../src/review";
+import { llmFindingToReviewFinding, llmFindingsToReviewFindings, toAdversarialReviewFindings } from "../../../src/review";
 // LLMFinding / AdversarialLLMFinding are import-type only (erased at compile
 // time) so leaf-path imports here do not cause singleton fragmentation.
 import type { LLMFinding } from "../../../src/review/semantic-helpers";
@@ -192,5 +192,43 @@ describe("llmFindingsToReviewFindings", () => {
 
   test("returns empty array for empty input", () => {
     expect(llmFindingsToReviewFindings([])).toEqual([]);
+  });
+});
+
+// ─── actionRequired projection (#1359) ────────────────────────────────────────
+//
+// The adversarial reviewer emitted a COMPLIANCE CONFIRMATION as an out-of-scope
+// finding ("correct per Out of Scope #10 … No action needed; this is the intended
+// behaviour"). NBF seeds from the advisory bucket and applied no actionability
+// filter, so it paid an implementer pass to "fix" a finding whose own suggestion
+// said no action was needed — and that pass broke a test and was rolled back.
+//
+// `actionRequired: false` is how the reviewer says so in a machine-readable way.
+// It has to survive projection to the wire Finding or the filter has nothing to read.
+
+describe("actionRequired projection", () => {
+  test("actionRequired: false survives projection to the wire Finding", () => {
+    const f: AdversarialLLMFinding = {
+      severity: "warning",
+      category: "out-of-scope",
+      file: "src/execution/lifecycle/run-completion.ts",
+      line: 187,
+      issue: "Removed quarantined:0 — correct per Out of Scope #10",
+      suggestion: "No action needed; this is the intended behaviour.",
+      actionRequired: false,
+    };
+    expect(toAdversarialReviewFindings([f])[0]?.actionRequired).toBe(false);
+  });
+
+  test("actionRequired defaults to absent (treated as true) when the reviewer omits it", () => {
+    const f: AdversarialLLMFinding = {
+      severity: "warning",
+      category: "input",
+      file: "src/a.ts",
+      line: 1,
+      issue: "unvalidated input",
+      suggestion: "guard it",
+    };
+    expect(toAdversarialReviewFindings([f])[0]?.actionRequired).toBeUndefined();
   });
 });

--- a/test/unit/review/review-audit.test.ts
+++ b/test/unit/review/review-audit.test.ts
@@ -352,6 +352,33 @@ describe("ReviewAuditor.getAdvisoryFindings", () => {
     expect(summary.find((s) => s.issue === "ordinary")?.coverageGap).toBeUndefined();
   });
 
+  test("preserves actionRequired:false on the summary entry (#1359)", async () => {
+    const { deps } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-ar", "/tmp/workdir");
+
+    auditor.recordDecision({
+      reviewer: "adversarial",
+      storyId: "US-004",
+      featureName: "f",
+      parsed: true,
+      passed: true,
+      blockingThreshold: "error",
+      result: { passed: true, findings: [] },
+      advisoryFindings: [
+        { severity: "warning", category: "out-of-scope", file: "lib/s.ts", issue: "compliance", actionRequired: false },
+        { severity: "warning", category: "correctness", file: "lib/s.ts", issue: "ordinary" },
+      ],
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    const summary = auditor.getAdvisoryFindings();
+    // Excluded from the fix pass, still present in the report.
+    expect(summary.find((s) => s.issue === "compliance")?.actionRequired).toBe(false);
+    expect(summary.find((s) => s.issue === "ordinary")?.actionRequired).toBeUndefined();
+  });
+
   test("decisions with no advisory findings contribute nothing", async () => {
     const { deps } = makeDeps();
     Object.assign(_reviewAuditDeps, deps);


### PR DESCRIPTION
## Problem

On `otel-telemetry-expansion` US-004 the adversarial reviewer emitted a **compliance
confirmation** as a finding. Verbatim from the review audit:

> **issue:** "Removed `quarantined: 0` from the regression completion details — **correct
> per Out of Scope #10** which mandates omission over a false 0."
> **suggestion:** "**No action needed; this is the intended behaviour.**"

ADR-024 NBF seeds from the advisory bucket and applied **no actionability filter** — it
counted findings and opened a pass. So it dispatched a paid implementer session to "fix" a
finding whose own suggestion said not to. That pass broke a test, tripped the §3 guard, and
was rolled back: ~4 minutes and part of the story's $6.49 for zero net change.

Fixes #1359 (the actionability half — see below on the gate).

## Change, primary first

**1. The prompt.** The reviewer is now told that a finding is a *request for a change*; that
code which turned out to be correct belongs in `passed`, not in `findings`; and that a
no-change note worth recording must carry `actionRequired: false` and must not also carry a
suggestion that requests an edit. This is the real fix — the filter below is the backstop.

**2. `actionRequired?: boolean` on the wire `Finding`.** Absent means actionable, so every
producer predating this change behaves identically. Deliberately **not** a `meta` entry:
consumers branch on it to decide whether to spend an agent session, and `findings/types.ts`
forbids branching on `meta` for load-bearing logic. The `coverageGap` precedent lives in
`meta` but is only *read* for reporting, so it does not license this.

**3. The filter runs at NBF seeding, not in the reviewer's output.** `ExecutionPlan` seeds
`actionableAdvisoryFindings(...)`. Filtering inside `adversarialReviewOp.parse` would have
been simpler and wrong: `review-audit.ts` builds the end-of-run advisory report from the
op's `advisoryFindings`, so filtering there deletes the very visibility that made this
diagnosable.

Non-actionable findings therefore still appear in the run-end report — now **labelled**
`no-action` with a counted header line ("1 of 2 asked for no change"), mirroring the
coverage-gap precedent. Surfaced without being paid for.

## What this does NOT do

No `review.adversarial.blockingCategories`. The scope-gate question in #1359 stays closed on
the evidence: N=3 firings across one feature, one distinct boundary, 25% ungrounded. That
issue can stay open on telemetry (Phase 4).

## Tests

10 new, spanning all four layers, each mutation-verified against the change it covers:

- **prompt** — forbids compliance-as-finding, documents `actionRequired`
- **projection** — `actionRequired: false` survives `toAdversarialReviewFindings`; absent
  stays absent (so "absent means actionable" is not silently materialised)
- **reviewer pipeline end-to-end** — `runAdversarialReview` with a raw LLM response carrying
  `actionRequired: false` lands it on `advisoryFindings`. This one matters: the transform
  chain (substantiate → recurrence split → projection) had to be checked for a field-by-file
  rebuild that would drop unknown keys. It spreads throughout, and this test pins that.
- **filter** — drops `false`, keeps absent/`true`, and an all-compliance bucket closes the gate
- **`ExecutionPlan` level** — NBF is not invoked at all when the only advisory finding is a
  compliance note (the exact US-004 shape)
- **report** — the audit entry keeps the flag, and the formatter counts and labels it

## Verification

- `bun run typecheck` — clean
- `bun run lint` — green, every ratchet and the file-size baseline unchanged
- `bun run test` — 10517 unit + 1092 integration + 24 ui, **0 fail**

## Sequencing

Phase 3 (last implementation phase) of the plan across #1382 / #1383 / #1384 / #1359 —
https://github.com/nathapp-io/nax/issues/1382#issuecomment-5128244598. #1388, #1389, #1390
are merged. Phase 4 is measurement only: re-read the scope counters across more features and
then close #1359 or open a scoped gate with evidence attached.

One incidental change: `toAdversarialReviewFindings` is now re-exported from the `src/review`
barrel. It was already consumed outside `src/review` via the leaf path, and the alias-internals
gate requires barrel imports.
