### PR TITLE
feat(logging): name the findings of a failing phase, not just count them (#1392)

### DIFF
--- a/src/execution/story-orchestrator-logging.ts
+++ b/src/execution/story-orchestrator-logging.ts
@@ -1,4 +1,16 @@
 import { getSafeLogger } from "../logger";
+// Leaf import, not the `./story-orchestrator` barrel: `run-phase.ts` inside that barrel
+// imports THIS module, so going through it would close an import cycle.
+import { extractPhaseFindings } from "./story-orchestrator/phase-eval";
+
+/**
+ * How many finding identities to sample into a failing phase's log line.
+ *
+ * This fires on every failing phase, so the bound is load-bearing: an all-red suite
+ * would otherwise emit a JSONL record that dwarfs every other line in the run log.
+ * `findingsCount` carries the true magnitude alongside the sample.
+ */
+const MAX_LOGGED_FINDING_IDENTITIES = 10;
 
 export function formatPhaseResultMessage(opName: string, success: boolean, stage?: string, status?: string): string {
   if (opName === "greenfield-gate") {
@@ -34,6 +46,19 @@ export function buildPhaseOutcomeLogData(
 
   const data: Record<string, unknown> = { storyId, phase: opName, durationMs };
   if (findingsCount !== undefined) data.findingsCount = findingsCount;
+  // WHICH findings failed, not just how many (#1392). `extractPhaseFindings` yields []
+  // for a passing phase, so a green phase's line stays exactly as terse as before; it
+  // also normalises both output shapes and drops entries without a `source`, so the
+  // sample can be narrower than `findingsCount` (which counts the raw array).
+  //
+  // Note this runs on every phase, not only the ones that log: `derivePhaseOutcome`
+  // (run-phase.ts) calls this function as a pass/fail predicate and discards `data`,
+  // and `logDeterministicPhaseOutcome` returns early for the LLM reviews. The work is a
+  // filter + a ≤10-element map, so it is not worth a second code path to avoid.
+  const identities = extractPhaseFindings(output)
+    .slice(0, MAX_LOGGED_FINDING_IDENTITIES)
+    .map((f) => `${f.file ?? ""}::${f.rule ?? ""}`);
+  if (identities.length > 0) data.findingIdentities = identities;
   if (status !== undefined) data.status = status;
   if (typeof r.failureCategory === "string") data.failureCategory = r.failureCategory;
   if (typeof r.reviewReason === "string") data.reviewReason = r.reviewReason;

--- a/test/unit/execution/story-orchestrator-logging.test.ts
+++ b/test/unit/execution/story-orchestrator-logging.test.ts
@@ -84,3 +84,65 @@ describe("buildPhaseOutcomeLogData — verdict detail surfacing", () => {
     expect(built?.data.status).toBe("skipped");
   });
 });
+
+// ─── finding identities on a failing phase (#1392) ───────────────────────────
+//
+// The log recorded how MANY findings a failing phase produced and never WHICH:
+// `{"message":"Phase failed: full-suite-gate","data":{"findingsCount":1,"status":"failed"}}`
+// is close to useless when the first thing you want is the failing test's name.
+// #1388 fixed this for the nbf rollback path, where the evidence was also
+// unrecoverable afterwards; this covers every other gate failure.
+
+describe("buildPhaseOutcomeLogData — finding identities (#1392)", () => {
+  const testFinding = (file: string, rule: string) => ({
+    source: "test-runner",
+    category: "failed-test",
+    severity: "error",
+    message: "boom",
+    file,
+    rule,
+  });
+
+  test("names the findings of a FAILING phase as file::rule identities", () => {
+    const output = { success: false, findings: [testFinding("test/unit/a.test.ts", "renders empty state")] };
+    const built = buildPhaseOutcomeLogData("US-001", "full-suite-gate", output, 42920);
+    expect(built?.data.findingIdentities).toEqual(["test/unit/a.test.ts::renders empty state"]);
+    expect(built?.data.findingsCount).toBe(1);
+  });
+
+  test("emits nothing extra for a PASSING phase", () => {
+    // extractPhaseFindings yields [] on success, so a green phase stays as terse as before.
+    const built = buildPhaseOutcomeLogData("US-001", "full-suite-gate", { success: true, findings: [] }, 200);
+    expect(built?.data).not.toHaveProperty("findingIdentities");
+  });
+
+  test("reads the verifier's normalizedFindings shape too", () => {
+    const output = { success: false, normalizedFindings: [testFinding("test/unit/b.test.ts", "t-b")] };
+    const built = buildPhaseOutcomeLogData("US-001", "verifier", output, 10);
+    expect(built?.data.findingIdentities).toEqual(["test/unit/b.test.ts::t-b"]);
+  });
+
+  test("caps the sample but leaves findingsCount carrying the true magnitude", () => {
+    // An all-red suite must not produce a JSONL line that dwarfs every other record.
+    const findings = Array.from({ length: 25 }, (_, i) => testFinding(`test/unit/f${i}.test.ts`, `t${i}`));
+    const built = buildPhaseOutcomeLogData("US-001", "full-suite-gate", { success: false, findings }, 10);
+    expect((built?.data.findingIdentities as string[]).length).toBe(10);
+    expect(built?.data.findingsCount).toBe(25);
+  });
+
+  test("tolerates findings with no file or rule", () => {
+    // Execution-failure synth findings carry neither; they must not crash or vanish.
+    const output = {
+      success: false,
+      findings: [{ source: "test-runner", category: "execution-failed", severity: "error", message: "exit 1" }],
+    };
+    const built = buildPhaseOutcomeLogData("US-001", "full-suite-gate", output, 10);
+    expect(built?.data.findingIdentities).toEqual(["::"]);
+  });
+
+  test("storyId stays the first key", () => {
+    const output = { success: false, findings: [testFinding("a.test.ts", "t")] };
+    const built = buildPhaseOutcomeLogData("US-001", "full-suite-gate", output, 10);
+    expect(Object.keys(built!.data)[0]).toBe("storyId");
+  });
+});


### PR DESCRIPTION
## Problem

A failing phase's run-log line recorded how *many* findings it produced and never *which*:

```jsonl
{"stage":"story-orchestrator","message":"Phase failed: full-suite-gate","data":{"storyId":"US-004","phase":"full-suite-gate","durationMs":42920,"findingsCount":1,"status":"failed"}}
```

`findingsCount: 1` on a full-suite gate is close to useless when the failing test's name is
the first thing you want. #1388 fixed this for the ADR-024 nbf rollback path, where the
evidence was *also* unrecoverable afterwards (phaseOutputs wiped, edit hard-reset away). This
covers every other gate failure, where it was merely undiagnosable without digging.

Closes #1392 (split out of #1382 item 2 — deferred there because it benefits every gate
failure, not just the NBF path, so it did not belong in an NBF-scoped fix).

## Change

`buildPhaseOutcomeLogData` emits `findingIdentities`: up to `MAX_LOGGED_FINDING_IDENTITIES`
(10) `file::rule` strings, matching the key shape #1388 established for `regressedKeys`.

Three things worth noting:

- **The bound is load-bearing.** This fires on *every* failing phase, so an all-red suite
  would otherwise emit a JSONL record that dwarfs every other line in the run log.
  `findingsCount` still carries the true magnitude, so nothing is hidden by the cap.
- **Reuses `extractPhaseFindings`** rather than re-deriving. It normalises both output shapes
  (`normalizedFindings` / `findings`), and it yields `[]` for a passing phase — so a green
  phase's line stays exactly as terse as it was, and the field is simply absent.
- **Leaf import, not the barrel.** `run-phase.ts` inside `./story-orchestrator` imports this
  module, so importing the barrel here would close an import cycle.

## One thing reviewers should know

`derivePhaseOutcome` (`run-phase.ts:394`) calls this same function as a pass/fail predicate and
discards `data`, and `logDeterministicPhaseOutcome` returns early for the LLM reviews. So the
identity computation runs on every phase completion including ones that never log it. It is a
filter plus a ≤10-element map, which is not worth a second code path to avoid — but it is
documented at the site so the next reader is not surprised.

## Tests

6 new, in the existing `story-orchestrator-logging.test.ts`:

- names findings of a failing phase as `file::rule`
- emits nothing extra for a passing phase (the terseness guarantee)
- reads the verifier's `normalizedFindings` shape too
- caps the sample at 10 while `findingsCount` stays at 25
- tolerates findings with neither file nor rule (execution-failure synth findings → `"::"`)
- `storyId` stays the first key (parallel-log correlation rule)

## Verification

- `bun run typecheck` — clean
- `bun run lint` — green, all ratchets and the file-size baseline unchanged, incl.
  `check:logger-storyid` (0 violations)
- `bun run test` — unit + integration + ui, **0 fail**
