### PR TITLE
fix(nax-finish): stop the flow passing, escalating, or shipping on unverified state

### DIFF
--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -20,25 +20,31 @@ load_ctx          detect base branch, resolve the feature spec + acceptance grou
                   check the branch is ahead of base (else: nothing-to-finish)
   ↓
 acceptance        run the feature's acceptance tests
-  ↳ fail → fix_acceptance (agent) → re-run          [max 3 attempts → escalate]
+  ↳ fail → fix_acceptance (agent) → commit → re-run [max 3 attempts → escalate]
   ↓
 review_spec       spec-relative review, isolated session, own agent profile
   ↳ clean            → skip to review_quality
-  ↳ recommended fix  → fix_spec (agent) → re-run acceptance → re-review
+  ↳ recommended fix  → fix_spec (agent) → commit → re-run acceptance → re-review
   ↳ needs judgment   → escalate
   ↓
 review_quality    code-quality review, isolated session, own agent profile
   ↳ clean            → skip to quality_gates
-  ↳ recommended fix  → fix_quality (agent) → re-review
+  ↳ recommended fix  → fix_quality (agent) → commit → re-review
   ↳ needs judgment   → escalate
   ↓
 quality_gates     run the repo's own quality.commands at the repo root
-  ↳ red → fix_gate (agent) → re-run                 [max 3 attempts → escalate]
+  ↳ red → fix_gate (agent) → commit → re-run        [max 3 attempts → escalate]
   ↳ none configured → escalate (a gate that verified nothing is not a pass)
   ↓
 open_pr           commit + push the fixes, then open a ready PR
                   (or promote the draft autoPR already opened)
 ```
+
+Every fix node is followed by a `commit_*` node that commits the agent's edits
+locally (no push). The reviewers read `git diff <base>...HEAD`, so a fix left
+uncommitted is invisible to the re-review — the loop would re-report findings it
+had already fixed and escalate at the cap ([#1397](https://github.com/nathapp-io/nax/issues/1397)).
+The fix agent itself is still told not to commit; the flow owns the history.
 
 Both terminal nodes (`open_pr`, `escalate`) commit and push first, so the PR — or
 the escalation — describes state a human can actually see.

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -45,10 +45,16 @@ open_pr           commit + push the fixes, then open a ready PR
 ```
 
 Every fix node is followed by a `commit_*` node that commits the agent's edits
-locally (no push). The reviewers read `git diff <base>...HEAD`, so a fix left
-uncommitted is invisible to the re-review — the loop would re-report findings it
-had already fixed and escalate at the cap ([#1397](https://github.com/nathapp-io/nax/issues/1397)).
+locally (no push, `--no-verify`). The reviewers read `git diff <base>...HEAD`, so
+a fix left uncommitted is invisible to the re-review — the loop would re-report
+findings it had already fixed and escalate at the cap ([#1397](https://github.com/nathapp-io/nax/issues/1397)).
 The fix agent itself is still told not to commit; the flow owns the history.
+
+These are internal checkpoints, so they skip your pre-commit hooks: a hook that
+runs lint or typecheck would otherwise reject an intermediate state the gate
+loop was about to fix, and take the whole flow down with it. Nothing is lost —
+`quality_gates` runs the repo's own build/typecheck/lint/test and no PR opens
+unless they pass. The terminal commit before pushing runs hooks normally.
 
 Both terminal nodes (`open_pr`, `escalate`) commit and push first, so the PR — or
 the escalation — describes state a human can actually see.

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -21,6 +21,9 @@ load_ctx          detect base branch, resolve the feature spec + acceptance grou
   ↓
 acceptance        run the feature's acceptance tests
   ↳ fail → fix_acceptance (agent) → commit → re-run [max 3 attempts → escalate]
+  ↳ acceptance disabled in config → skip cleanly
+  ↳ no PRD, or a package's test never generated → escalate
+                  (nothing verified is not a pass — same rule as quality_gates)
   ↓
 review_spec       spec-relative review, isolated session, own agent profile
   ↳ clean            → skip to review_quality
@@ -64,6 +67,19 @@ The terminal state is written to `.nax/nax-finish-result.json`:
 
 `status` is one of `opened`, `promoted`, `already-ready`, `escalated`,
 `nothing-to-finish`. Add it to `.gitignore`.
+
+On `escalated` the file also carries `escalationReason` and the `findings` that
+caused it:
+
+```json
+{
+  "feature": "auth-hardening",
+  "status": "escalated",
+  "url": "https://github.com/o/r/pull/42",
+  "escalationReason": "spec review still reporting 3 finding(s) after 3 fix attempts.",
+  "findings": [{ "severity": "HIGH", "title": "…", "problem": "…", "fix": "…" }]
+}
+```
 
 ---
 
@@ -294,7 +310,10 @@ export NAX_TELEGRAM_CHAT_ID=…
 ```
 
 When Telegram is enabled **and** credentialed, the flow posts no PR comment and
-opens no draft to hold one.
+opens no draft to hold one. The message names each finding by severity and
+title, not just the count, and is truncated to the Bot API's 4096-char limit
+(saying how many it dropped). It is sent as plain text — review titles carry
+backticks and underscores that Markdown parsing would reject outright.
 
 **PR/MR comment (fallback).** With `escalate.telegram: false`, or no credentials,
 the flow comments on the branch's existing PR/MR — opening a *draft* to hold the

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -319,6 +319,17 @@ backticks and underscores that Markdown parsing would reject outright.
 the flow comments on the branch's existing PR/MR — opening a *draft* to hold the
 comment only if none exists. It never opens a ready PR while escalating.
 
+**Delivery is never fatal.** The result file is written *before* delivery is
+attempted, so a rate limit, an expired token or an unrecognised remote cannot
+lose the escalation. A failed delivery is recorded as `deliveryError` in the
+result, logged, and reported by the plugin as `escalated but undelivered` —
+Telegram still fires, because the plugin sends from the result file.
+
+**Forge detection** matches the remote's *host*, so self-hosted instances
+(`gitlab.mycorp.com`, `github.mycorp.com`) work. For an enterprise host naming
+neither forge (`git.corp.com`), it falls back to whichever of `gh` / `glab` is
+installed, and only errors when that is ambiguous too.
+
 ---
 
 ## 6. Running the flow by hand

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -35,7 +35,8 @@ review_quality    code-quality review, isolated session, own agent profile
   ↳ recommended fix  → fix_quality (agent) → commit → re-review
   ↳ needs judgment   → escalate
   ↓
-quality_gates     run the repo's own quality.commands at the repo root
+quality_gates     re-run the feature's acceptance tests (gate zero), then the
+                  repo's own quality.commands at the repo root
   ↳ red → fix_gate (agent) → commit → re-run        [max 3 attempts → escalate]
   ↳ none configured → escalate (a gate that verified nothing is not a pass)
   ↓
@@ -51,6 +52,29 @@ The fix agent itself is still told not to commit; the flow owns the history.
 
 Both terminal nodes (`open_pr`, `escalate`) commit and push first, so the PR — or
 the escalation — describes state a human can actually see.
+
+### Why acceptance runs twice
+
+The `acceptance` node is the cheap fail-fast gate: it proves the feature meets
+its own contract before a full LLM review is spent on it. But two fix loops run
+*after* it — quality review and the gate loop — and both edit code. The repo-root
+`test` command does not cover the feature's acceptance tests: they are generated
+per-feature under `<packageDir>/.nax/features/<feature>/` and usually need their
+own runner config (a separate jest/vitest/pytest invocation), which is exactly
+why they are excluded from the normal suite. So a quality-phase fix could break
+the contract the first gate proved, and nothing downstream would notice.
+
+Re-running them as gate zero of `quality_gates` makes one property true on every
+path: **nothing reaches `open_pr` without the feature's own acceptance tests
+passing against the tree as it will ship.** A failure there routes to `fix_gate`
+with the failing output, so it is repaired rather than escalated.
+
+It runs unconditionally, even on the all-green path where nothing changed since
+the first run. Skipping it when no fix has landed is derivable from the step
+history, but a conditional correctness check that can be *wrong* is worse than a
+cheap one that cannot — a missed re-run is a silent false green, the failure
+mode this exists to prevent. Acceptance is the cheapest gate in the pipeline;
+the redundant run costs seconds against a flow that spends minutes in review.
 
 | Outcome | Result |
 |:---|:---|
@@ -169,7 +193,7 @@ post-run driver treats it as non-blocking and logs a warning).
 | `reviewers.spec` | `null` | acpx agent profile for the spec-review phase — see §4. |
 | `reviewers.quality` | `null` | acpx agent profile for the quality-review phase. |
 | `escalate.telegram` | `true` | Prefer Telegram for escalations when credentials resolve; else PR/MR comment. |
-| `timeouts.acceptanceMs` | 600000 (10 min) | Cap per acceptance-test group. |
+| `timeouts.acceptanceMs` | 600000 (10 min) | Cap per acceptance-test group, in both the `acceptance` node and gate zero of `quality_gates`. |
 | `timeouts.gateMs` | 900000 (15 min) | Cap per quality gate. |
 | `timeouts.flowMs` | 5400000 (90 min) | Cap on the whole `acpx flow run`. |
 | `timeouts.stepMs` | `null` | Cap per flow step (one agent turn), passed to acpx as `--timeout`. `null` keeps acpx's own 15-minute default — raise it if reviews of large diffs get cut off. |

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -26,6 +26,11 @@
  *   escalated at the cap (issue #1397).
  * - `route_*` compute nodes hold the escalate/clean/fix decision so the cap is
  *   enforced deterministically rather than trusting the model's own route.
+ * - `quality_gates` re-runs the feature's acceptance tests before the repo's
+ *   own commands. The quality-review and gate fix loops both edit code after
+ *   the `acceptance` node last passed, and the repo-root `test` command does
+ *   not cover per-feature acceptance tests — so without this a fix could break
+ *   the contract the first gate proved and still ship.
  */
 import { defineFlow, extractJsonObject } from "acpx/flows";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
@@ -269,6 +274,46 @@ export default defineFlow({
       nodeType: "action",
       async run(ctx) {
         const i = inputOf(ctx);
+
+        // Acceptance is gate zero here, not just at the `acceptance` node.
+        // Both fix loops that run after it — quality review and this gate —
+        // edit code, and the repo-root `test` command does not cover the
+        // feature's acceptance tests: they live under `<pkg>/.nax/features/<f>/`
+        // and usually need their own runner config. Re-running them here is what
+        // makes "nothing reaches open_pr without the feature's own contract
+        // passing against the tree as it will ship" true on every path (#1398).
+        //
+        // Unconditional, though the common green path re-runs a gate that
+        // already passed: acceptance is the cheapest gate in the pipeline, and a
+        // conditional skip derived from step history would be a check that can
+        // be *wrong* — a silent false green, the failure mode this exists to
+        // prevent.
+        //
+        // `missing` is deliberately ignored: groups are resolved once at
+        // load_ctx, so a coverage hole was already escalated by the acceptance
+        // node and cannot appear here.
+        const acc = await runAcceptanceGate(i.workdir, loadCtxOf(ctx).groups ?? [], {
+          timeoutMs: i.timeouts?.acceptanceMs,
+        });
+        if (!acc.passed) {
+          // Short-circuit: the repo gates are re-run next round anyway, and
+          // skipping them keeps this out of the "nothing configured" branch
+          // below, which would otherwise misreport configured-but-skipped
+          // commands as absent.
+          const accAttempts = fixAttemptCount(ctx, "fix_gate");
+          const failing = ["acceptance"];
+          if (accAttempts >= MAX_FIX_ATTEMPTS) {
+            return {
+              route: "escalate",
+              reason: `A later fix broke the feature's own contract: acceptance still failing after ${accAttempts} fix attempts.`,
+              ran: [],
+              failing,
+              output: acc.output,
+            };
+          }
+          return { route: "fix", ran: [], failing, output: acc.output };
+        }
+
         const cmds = await loadQualityCommands(i.workdir);
         const r = await runQualityGates(i.workdir, cmds, { timeoutMs: i.timeouts?.gateMs });
         if (r.passed) return { route: "green", ran: r.ran, failing: r.failing, output: r.output };

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -175,7 +175,10 @@ function commitFixNode(phase: "acceptance" | "spec" | "quality" | "gate") {
     nodeType: "action" as const,
     async run(ctx: { input: unknown }): Promise<{ committed: boolean }> {
       const i = inputOf(ctx);
-      return commitFixes(i.workdir, `fix(${i.feature}): nax-finish ${phase} fixes`);
+      // skipHooks: an intermediate checkpoint must not be rejected by a repo's
+      // pre-commit hook — quality_gates runs the repo's real gates before any
+      // PR opens, and a hook failure here would kill the flow mid-loop.
+      return commitFixes(i.workdir, `fix(${i.feature}): nax-finish ${phase} fixes`, { skipHooks: true });
     },
   };
 }

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -44,7 +44,7 @@ import {
   runQualityGates,
   writeResult,
 } from "./steps";
-import type { AcceptanceGroup, FinishInput, ReviewVerdict } from "./types";
+import type { AcceptanceGroup, FinishInput, FinishResult, ReviewVerdict } from "./types";
 
 const inputOf = (ctx: { input: unknown }) => ctx.input as FinishInput;
 
@@ -349,18 +349,36 @@ export default defineFlow({
           syncNote = `\n\n> Note: nax-finish could not push its partial fixes — ${String(err)}`;
         }
 
-        const comment = buildEscalationComment(i.feature, reason, verdict?.findings ?? []) + syncNote;
-        const { url, channel } = await postEscalation(i.workdir, i.branch, comment, {
-          preferTelegram: i.escalateTelegram,
-        });
-        await writeResult(i.workdir, {
+        // Write the result BEFORE attempting delivery. Delivery touches the
+        // network and the forge — a rate limit, an expired token, a locked PR
+        // or an unrecognised remote used to throw here, killing the node before
+        // any result existed. The plugin then had nothing to report and, on the
+        // Telegram channel, nothing to notify from: the one path whose job is
+        // to say "a human is needed" was the one path with no fallback (#1399).
+        const result: FinishResult = {
           feature: i.feature,
           status: "escalated",
-          url,
           escalationReason: reason,
           findings: verdict?.findings ?? [],
-        });
-        return { route: "done", url, channel, escalationReason: reason };
+        };
+        await writeResult(i.workdir, result);
+
+        const comment = buildEscalationComment(i.feature, reason, verdict?.findings ?? []) + syncNote;
+        let url: string | undefined;
+        let channel: string | undefined;
+        let deliveryError: string | undefined;
+        try {
+          const posted = await postEscalation(i.workdir, i.branch, comment, {
+            preferTelegram: i.escalateTelegram,
+          });
+          url = posted.url;
+          channel = posted.channel;
+        } catch (err) {
+          deliveryError = String(err);
+        }
+        await writeResult(i.workdir, { ...result, url, deliveryError });
+
+        return { route: "done", url, channel, deliveryError, escalationReason: reason };
       },
     },
   },

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -60,6 +60,8 @@ interface LoadCtxOutput {
   base?: string;
   specPath?: string;
   groups?: AcceptanceGroup[];
+  /** `nax features resolve`'s acceptance status: "ok" | "disabled" | "no-prd". */
+  acceptanceStatus?: string;
   route?: string;
 }
 
@@ -71,16 +73,48 @@ function loadCtxOf(ctx: { outputs: unknown }): LoadCtxOutput {
   return ((ctx.outputs as Record<string, LoadCtxOutput | undefined>).load_ctx ?? {}) as LoadCtxOutput;
 }
 
-/** Re-run the acceptance gate, routing on the shared fix-cap rules. */
+/**
+ * Re-run the acceptance gate, routing on the shared fix-cap rules.
+ *
+ * "Nothing ran" is not a pass — the same rule `quality_gates` applies to an
+ * unconfigured repo. `nax features resolve` reports `groups: []` for BOTH
+ * `no-prd` and `disabled`, and reports `exists: false` for a group whose test
+ * was expected at its canonical path but never generated. Treating all of those
+ * as green let the flow open a ready PR having verified nothing about the
+ * feature's own contract (#1398). Only `disabled` — the repo's explicit opt-out
+ * — skips cleanly.
+ */
 async function acceptanceGateNode(ctx: {
   input: unknown;
   outputs: unknown;
   state: { steps: { nodeId: string }[] };
 }): Promise<{ route: string; reason?: string; output: string }> {
   const i = inputOf(ctx);
-  const groups = loadCtxOf(ctx).groups ?? [];
+  const { groups = [], acceptanceStatus } = loadCtxOf(ctx);
+  if (acceptanceStatus === "disabled") {
+    return { route: "proceed", output: "[acceptance] disabled in .nax/config.json — skipping" };
+  }
+  if (acceptanceStatus === "no-prd") {
+    return {
+      route: "escalate",
+      reason: `Acceptance targets could not be computed (status: no-prd) — nothing was verified for "${i.feature}".`,
+      output: "[acceptance] no prd.json resolved — acceptance targets unknown",
+    };
+  }
+
   const r = await runAcceptanceGate(i.workdir, groups, { timeoutMs: i.timeouts?.acceptanceMs });
-  if (r.passed) return { route: "proceed", output: r.output };
+  if (r.passed) {
+    // A real failure below routes to the fix loop, which is more actionable;
+    // the coverage hole is only reported once the runnable groups are green.
+    if (r.missing.length > 0) {
+      return {
+        route: "escalate",
+        reason: `Acceptance test never generated for: ${r.missing.join(", ")} — that package's contract is unverified.`,
+        output: r.output,
+      };
+    }
+    return { route: "proceed", output: r.output };
+  }
   const attempts = fixAttemptCount(ctx, "fix_acceptance");
   if (attempts >= MAX_FIX_ATTEMPTS) {
     return {
@@ -319,7 +353,13 @@ export default defineFlow({
         const { url, channel } = await postEscalation(i.workdir, i.branch, comment, {
           preferTelegram: i.escalateTelegram,
         });
-        await writeResult(i.workdir, { feature: i.feature, status: "escalated", url, escalationReason: reason });
+        await writeResult(i.workdir, {
+          feature: i.feature,
+          status: "escalated",
+          url,
+          escalationReason: reason,
+          findings: verdict?.findings ?? [],
+        });
         return { route: "done", url, channel, escalationReason: reason };
       },
     },

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -17,9 +17,13 @@
  * - `load_ctx` is an `action`, not a `compute`: it shells git + `nax features
  *   resolve` once, and its output feeds both the review prompts (specPath) and
  *   the acceptance gate (groups), so nothing resolves the feature twice.
- * - Review fixes loop: `review_* → route_* → fix_* → (re-run acceptance |
- *   re-review) → review_*` until the reviewer comes back clean or the fix cap
- *   trips. A single-shot fix left the fixed diff unverified.
+ * - Review fixes loop: `review_* → route_* → fix_* → commit_* → (re-run
+ *   acceptance | re-review) → review_*` until the reviewer comes back clean or
+ *   the fix cap trips. A single-shot fix left the fixed diff unverified.
+ * - Every `fix_*` node is followed by a `commit_*` node. The reviewers read
+ *   `git diff <base>...HEAD`, so an uncommitted fix is invisible to the
+ *   re-review: the loop re-reported findings that were already fixed and always
+ *   escalated at the cap (issue #1397).
  * - `route_*` compute nodes hold the escalate/clean/fix decision so the cap is
  *   enforced deterministically rather than trusting the model's own route.
  */
@@ -29,6 +33,7 @@ import {
   _contextDeps,
   buildEscalationComment,
   commitAndPush,
+  commitFixes,
   detectBaseBranch,
   loadQualityCommands,
   openOrPromotePr,
@@ -119,6 +124,23 @@ function routeReview(
   return { route: "fix", findings };
 }
 
+/**
+ * Build the `commit_<phase>` node that follows `fix_<phase>`.
+ *
+ * One node per phase rather than a single shared one because each returns to a
+ * different successor, and acpx routes on the node id — a shared node would
+ * need a switch reconstructing which fix ran from the step history.
+ */
+function commitFixNode(phase: "acceptance" | "spec" | "quality" | "gate") {
+  return {
+    nodeType: "action" as const,
+    async run(ctx: { input: unknown }): Promise<{ committed: boolean }> {
+      const i = inputOf(ctx);
+      return commitFixes(i.workdir, `fix(${i.feature}): nax-finish ${phase} fixes`);
+    },
+  };
+}
+
 /** Normalise a reviewer's JSON, rewriting a findings-free `proceed` to `clean`. */
 function parseVerdict(text: string): ReviewVerdict {
   const raw = extractJsonObject(text) as Partial<ReviewVerdict>;
@@ -162,6 +184,7 @@ export default defineFlow({
       prompt: (ctx) => fixPrompt("acceptance", ctx),
       parse: parseVerdict,
     },
+    commit_acceptance: commitFixNode("acceptance"),
     review_spec: {
       nodeType: "acp",
       session: { isolated: true },
@@ -181,6 +204,7 @@ export default defineFlow({
       prompt: (ctx) => fixPrompt("spec", ctx),
       parse: parseVerdict,
     },
+    commit_spec: commitFixNode("spec"),
     review_quality: {
       nodeType: "acp",
       session: { isolated: true },
@@ -200,11 +224,13 @@ export default defineFlow({
       prompt: (ctx) => fixPrompt("quality", ctx),
       parse: parseVerdict,
     },
+    commit_quality: commitFixNode("quality"),
     fix_gate: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("gate", ctx),
       parse: parseVerdict,
     },
+    commit_gate: commitFixNode("gate"),
     quality_gates: {
       nodeType: "action",
       async run(ctx) {
@@ -304,7 +330,11 @@ export default defineFlow({
       from: "acceptance",
       switch: { on: "$.route", cases: { proceed: "review_spec", fix: "fix_acceptance", escalate: "escalate" } },
     },
-    { from: "fix_acceptance", to: "acceptance" },
+    // Each fix commits before anything re-reads the diff: the reviewers see
+    // `git diff <base>...HEAD` only, so an uncommitted fix would be re-reported
+    // verbatim until the cap escalated it (#1397).
+    { from: "fix_acceptance", to: "commit_acceptance" },
+    { from: "commit_acceptance", to: "acceptance" },
     { from: "review_spec", to: "route_spec" },
     {
       from: "route_spec",
@@ -312,7 +342,8 @@ export default defineFlow({
     },
     // Spec fixes re-run the acceptance gate first (they can break it), and the
     // acceptance node's `proceed` edge leads back into review_spec for re-review.
-    { from: "fix_spec", to: "acceptance" },
+    { from: "fix_spec", to: "commit_spec" },
+    { from: "commit_spec", to: "acceptance" },
     { from: "review_quality", to: "route_quality" },
     {
       from: "route_quality",
@@ -320,11 +351,13 @@ export default defineFlow({
     },
     // Quality fixes are re-reviewed by the same lens; the repo-root gates that
     // follow catch anything the fix broke mechanically.
-    { from: "fix_quality", to: "review_quality" },
+    { from: "fix_quality", to: "commit_quality" },
+    { from: "commit_quality", to: "review_quality" },
     {
       from: "quality_gates",
       switch: { on: "$.route", cases: { green: "open_pr", fix: "fix_gate", escalate: "escalate" } },
     },
-    { from: "fix_gate", to: "quality_gates" },
+    { from: "fix_gate", to: "commit_gate" },
+    { from: "commit_gate", to: "quality_gates" },
   ],
 });

--- a/flows/nax-finish/steps/acceptance.ts
+++ b/flows/nax-finish/steps/acceptance.ts
@@ -21,24 +21,47 @@ export function buildAcceptanceCommand(repoRoot: string, group: AcceptanceGroup)
   return template.replace(/\{\{FILE\}\}|\{\{file\}\}|\{\{files\}\}/g, absFile);
 }
 
+export interface AcceptanceGateOutcome {
+  /** Every group that ran exited 0. Says nothing about groups that could not run. */
+  passed: boolean;
+  ran: number;
+  /**
+   * Package names whose acceptance test the resolver expected at its canonical
+   * path but which is absent on disk — never generated, or generation failed.
+   * The caller must treat a non-empty list as a coverage hole rather than a
+   * pass: skipping these silently is how a feature reached a "ready" PR with
+   * nothing verified.
+   */
+  missing: string[];
+  output: string;
+}
+
 export async function runAcceptanceGate(
   repoRoot: string,
   groups: AcceptanceGroup[],
   opts: { timeoutMs?: number } = {},
-): Promise<{ passed: boolean; ran: number; output: string }> {
+): Promise<AcceptanceGateOutcome> {
   const chunks: string[] = [];
   const timeoutMs = opts.timeoutMs ?? DEFAULT_ACCEPTANCE_TIMEOUT_MS;
+  const missing: string[] = [];
   let ran = 0;
   for (const g of groups) {
-    if (!g.exists) continue;
+    const name = g.packageDir || "root";
+    if (!g.exists) {
+      missing.push(name);
+      continue;
+    }
     const cwd = g.packageDir ? `${repoRoot}/${g.packageDir}` : repoRoot;
     ran += 1;
     const res = await _acceptanceDeps.runShell(buildAcceptanceCommand(repoRoot, g), { cwd, timeoutMs });
-    chunks.push(`[${g.packageDir || "root"}] exit=${res.exitCode}\n${res.stdout}\n${res.stderr}`);
-    if (res.exitCode !== 0) return { passed: false, ran, output: chunks.join("\n\n") };
+    chunks.push(`[${name}] exit=${res.exitCode}\n${res.stdout}\n${res.stderr}`);
+    if (res.exitCode !== 0) return { passed: false, ran, missing, output: chunks.join("\n\n") };
+  }
+  if (missing.length > 0) {
+    chunks.push(`[acceptance] no acceptance test file on disk for: ${missing.join(", ")}`);
   }
   if (ran === 0) chunks.push("[acceptance] no acceptance test files present — nothing to run");
-  return { passed: true, ran, output: chunks.join("\n\n") };
+  return { passed: true, ran, missing, output: chunks.join("\n\n") };
 }
 
 function languageRunner(language: string): string {

--- a/flows/nax-finish/steps/forge.ts
+++ b/flows/nax-finish/steps/forge.ts
@@ -12,15 +12,64 @@ const URL_REGEX = /https?:\/\/\S+/;
 
 export type Forge = "github" | "gitlab";
 
+/**
+ * Host of a git remote, for both URL forms git accepts:
+ * `git@host:path` (scp-like) and `scheme://[user@]host[:port]/path`.
+ */
+export function remoteHost(remoteUrl: string): string {
+  const scp = remoteUrl.match(/^[^/]*@([^:/]+):/);
+  if (scp?.[1]) return scp[1].toLowerCase();
+  const url = remoteUrl.match(/^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]*@)?([^:/]+)/i);
+  return url?.[1]?.toLowerCase() ?? "";
+}
+
+/**
+ * Classify by host name.
+ *
+ * Matching the host (not a substring of the whole URL) is what makes
+ * self-hosted instances work: `"gitlab.mycorp.com".includes("gitlab.com")` is
+ * false, so the previous check rejected every self-hosted forge. GitHub is
+ * tested first purely for determinism on an absurd host naming both.
+ */
+function forgeFromHost(host: string): Forge | null {
+  if (host.includes("github")) return "github";
+  if (host.includes("gitlab")) return "gitlab";
+  return null;
+}
+
+/**
+ * Last resort for an enterprise host that names neither forge (`git.corp.com`):
+ * ask which CLI is installed. Only decisive when exactly one is — with both or
+ * neither present a guess would send `gh` at a GitLab remote.
+ */
+async function forgeFromCli(run: RunFn, repoRoot: string): Promise<Forge | null> {
+  const [gh, glab] = await Promise.all([
+    run(["gh", "--version"], { cwd: repoRoot }),
+    run(["glab", "--version"], { cwd: repoRoot }),
+  ]);
+  const hasGh = gh.exitCode === 0;
+  const hasGlab = glab.exitCode === 0;
+  if (hasGh && !hasGlab) return "github";
+  if (hasGlab && !hasGh) return "gitlab";
+  return null;
+}
+
 export async function detectForge(run: RunFn, repoRoot: string, stage: string): Promise<Forge> {
   const remote = await run(["git", "remote", "get-url", "origin"], { cwd: repoRoot });
   const remoteUrl = remote.stdout.trim();
-  if (remoteUrl.includes("github.com")) return "github";
-  if (remoteUrl.includes("gitlab.com")) return "gitlab";
-  throw new FinishError(`Unable to determine forge from remote URL "${remoteUrl}"`, "FINISH_UNKNOWN_FORGE", {
-    stage,
-    remoteUrl,
-  });
+  const host = remoteHost(remoteUrl);
+
+  const byHost = forgeFromHost(host);
+  if (byHost) return byHost;
+
+  const byCli = await forgeFromCli(run, repoRoot);
+  if (byCli) return byCli;
+
+  throw new FinishError(
+    `Unable to determine forge for remote host "${host || remoteUrl}" — its name matches neither github nor gitlab, and the gh/glab probe was inconclusive`,
+    "FINISH_UNKNOWN_FORGE",
+    { stage, remoteUrl, host },
+  );
 }
 
 /** Best-effort URL extraction: try `{url}` JSON first, fall back to a raw URL regex. */

--- a/flows/nax-finish/steps/git.ts
+++ b/flows/nax-finish/steps/git.ts
@@ -1,11 +1,17 @@
 /**
  * Branch synchronisation for the nax-finish flow.
  *
- * Every fix node edits the working tree in place. Without this step those edits
- * stay local and uncommitted: `gh pr create --head <branch>` then opens a PR
- * from the *remote* branch, which is missing every fix the flow just made (and
- * an escalation comment would describe state nobody else can see). Both
- * terminal nodes call `commitAndPush` before touching the forge.
+ * Every fix node edits the working tree in place, which two different consumers
+ * would otherwise miss:
+ *
+ * - The **reviewers** read `git diff <base>...HEAD` — committed history only.
+ *   With the fixes uncommitted, every re-review re-read the pre-fix code and
+ *   re-reported findings the fix node had already resolved, so the loop could
+ *   never converge and always escalated at the fix cap (issue #1397). Each
+ *   `commit_*` node calls `commitFixes` for this reason.
+ * - The **forge**: `gh pr create --head <branch>` opens a PR from the *remote*
+ *   branch, and an escalation comment would describe state nobody else can see.
+ *   Both terminal nodes call `commitAndPush` before touching the forge.
  */
 import { FinishError } from "../errors";
 import { runArgv } from "../exec";
@@ -33,33 +39,50 @@ async function isDirty(repoRoot: string): Promise<boolean> {
 }
 
 /**
+ * Commit the working tree, if it has anything in it, without pushing.
+ *
+ * Called by the `commit_*` nodes after every fix node so the next reviewer's
+ * `git diff <base>...HEAD` contains the fix. `git add -A` (not `-u`) because a
+ * fix routinely adds a *new* test file, and an untracked file is invisible to
+ * that diff — which is also why committing beats widening the reviewer's diff
+ * to include the working tree.
+ *
+ * A failing commit (a rejecting pre-commit hook, most likely) throws: the fix
+ * is then unreviewable, and continuing would silently reproduce the stale-diff
+ * bug this exists to fix. The flow fails loudly and the plugin reports the
+ * flow's stderr.
+ */
+export async function commitFixes(repoRoot: string, message: string): Promise<{ committed: boolean }> {
+  if (!(await isDirty(repoRoot))) return { committed: false };
+
+  const add = await _gitDeps.run(["git", "add", "-A"], { cwd: repoRoot });
+  if (add.exitCode !== 0) {
+    throw new FinishError(
+      `git add failed in "${repoRoot}": ${add.stderr.trim() || `exit ${add.exitCode}`}`,
+      "FINISH_GIT_ADD_FAILED",
+      { stage: "finish-git", repoRoot },
+    );
+  }
+  const commit = await _gitDeps.run(["git", "commit", "-m", message], { cwd: repoRoot });
+  if (commit.exitCode !== 0) {
+    throw new FinishError(
+      `git commit failed in "${repoRoot}": ${commit.stderr.trim() || commit.stdout.trim() || `exit ${commit.exitCode}`}`,
+      "FINISH_GIT_COMMIT_FAILED",
+      { stage: "finish-git", repoRoot },
+    );
+  }
+  return { committed: true };
+}
+
+/**
  * Commit any outstanding fixes and push the branch to `origin`.
  *
  * The push is unconditional — even with nothing new to commit the local branch
- * may be ahead of its remote (nax's own run commits, or a previous partial
- * finish), and the PR must reflect HEAD.
+ * may be ahead of its remote (nax's own run commits, or the `commit_*` nodes'
+ * per-round commits), and the PR must reflect HEAD.
  */
 export async function commitAndPush(repoRoot: string, branch: string, message: string): Promise<SyncOutcome> {
-  let committed = false;
-  if (await isDirty(repoRoot)) {
-    const add = await _gitDeps.run(["git", "add", "-A"], { cwd: repoRoot });
-    if (add.exitCode !== 0) {
-      throw new FinishError(
-        `git add failed in "${repoRoot}": ${add.stderr.trim() || `exit ${add.exitCode}`}`,
-        "FINISH_GIT_ADD_FAILED",
-        { stage: "finish-git", repoRoot },
-      );
-    }
-    const commit = await _gitDeps.run(["git", "commit", "-m", message], { cwd: repoRoot });
-    if (commit.exitCode !== 0) {
-      throw new FinishError(
-        `git commit failed in "${repoRoot}": ${commit.stderr.trim() || commit.stdout.trim() || `exit ${commit.exitCode}`}`,
-        "FINISH_GIT_COMMIT_FAILED",
-        { stage: "finish-git", repoRoot, branch },
-      );
-    }
-    committed = true;
-  }
+  const { committed } = await commitFixes(repoRoot, message);
 
   const push = await _gitDeps.run(["git", "push", "--set-upstream", "origin", branch], { cwd: repoRoot });
   if (push.exitCode !== 0) {

--- a/flows/nax-finish/steps/git.ts
+++ b/flows/nax-finish/steps/git.ts
@@ -47,12 +47,22 @@ async function isDirty(repoRoot: string): Promise<boolean> {
  * that diff — which is also why committing beats widening the reviewer's diff
  * to include the working tree.
  *
- * A failing commit (a rejecting pre-commit hook, most likely) throws: the fix
- * is then unreviewable, and continuing would silently reproduce the stale-diff
- * bug this exists to fix. The flow fails loudly and the plugin reports the
- * flow's stderr.
+ * `skipHooks` (used by every mid-loop `commit_*` node) adds `--no-verify`. Those
+ * commits are internal checkpoints, not shipped history: a repo whose
+ * pre-commit hook runs lint or typecheck would otherwise reject an intermediate
+ * state — a lint error the gate loop was about to fix — and take the whole flow
+ * down with it, with no result file. Nothing is lost by skipping them, because
+ * `quality_gates` runs the repo's own build/typecheck/lint/test and no PR opens
+ * unless they are green. The terminal `commitAndPush` leaves hooks enabled.
+ *
+ * A failing commit still throws: the fix is then unreviewable, and continuing
+ * would silently reproduce the stale-diff bug this exists to fix.
  */
-export async function commitFixes(repoRoot: string, message: string): Promise<{ committed: boolean }> {
+export async function commitFixes(
+  repoRoot: string,
+  message: string,
+  opts: { skipHooks?: boolean } = {},
+): Promise<{ committed: boolean }> {
   if (!(await isDirty(repoRoot))) return { committed: false };
 
   const add = await _gitDeps.run(["git", "add", "-A"], { cwd: repoRoot });
@@ -63,7 +73,8 @@ export async function commitFixes(repoRoot: string, message: string): Promise<{ 
       { stage: "finish-git", repoRoot },
     );
   }
-  const commit = await _gitDeps.run(["git", "commit", "-m", message], { cwd: repoRoot });
+  const commitArgv = ["git", "commit", "-m", message, ...(opts.skipHooks ? ["--no-verify"] : [])];
+  const commit = await _gitDeps.run(commitArgv, { cwd: repoRoot });
   if (commit.exitCode !== 0) {
     throw new FinishError(
       `git commit failed in "${repoRoot}": ${commit.stderr.trim() || commit.stdout.trim() || `exit ${commit.exitCode}`}`,

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -55,6 +55,13 @@ export interface FinishResult {
    * never posted. Without this the findings survived only in acpx's run bundle.
    */
   findings?: Finding[];
+  /**
+   * Set when the escalation could not be delivered to its channel (forge
+   * comment failed, remote unrecognised). The result file is written before
+   * delivery is attempted, so an undelivered escalation is still reported
+   * rather than lost.
+   */
+  deliveryError?: string;
 }
 export interface RunResult {
   exitCode: number;

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -48,6 +48,13 @@ export interface FinishResult {
   status: "opened" | "promoted" | "already-ready" | "escalated" | "nothing-to-finish";
   url?: string;
   escalationReason?: string;
+  /**
+   * The findings behind an escalation. Persisted because the reason alone is a
+   * bare count ("3 finding(s) after 3 fix attempts"), and on the Telegram
+   * channel the composed PR comment — the only other thing carrying them — is
+   * never posted. Without this the findings survived only in acpx's run bundle.
+   */
+  findings?: Finding[];
 }
 export interface RunResult {
   exitCode: number;

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -303,30 +303,38 @@ const naxFinishAction: IPostRunAction = {
       }
 
       // An escalation nobody receives is the same broken-state-wearing-an-
-      // unremarkable-label failure as a missing result file, so both a rejected
-      // send and a delivery the flow already gave up on are reported as such.
-      const undelivered: string[] = [];
+      // unremarkable-label failure as a missing result file.
+      //
+      // Which channel counts is not symmetric: the flow posts the PR/MR comment
+      // itself ONLY when Telegram is not the channel, so on the Telegram path
+      // its `deliveryError` means just that the URL lookup failed — the comment
+      // was never meant to be posted. Treating that as undelivered would raise
+      // a false alarm on the path that actually worked.
       if (result.status === "escalated") {
-        if (result.deliveryError) undelivered.push(`flow could not post it: ${result.deliveryError}`);
+        const problems: string[] = [];
+        let delivered = !escalateTelegram && !result.deliveryError;
         if (escalateTelegram && creds) {
           const sent = await _naxFinishDeps.notify(
             creds,
             buildEscalationMessage(result.feature, result.escalationReason ?? "", result.findings ?? []),
           );
-          if (!sent) undelivered.push("Telegram rejected the message");
+          if (sent) delivered = true;
+          else problems.push("Telegram rejected the message");
         }
-      }
-      if (undelivered.length > 0) {
-        ctx.logger.warn("nax-finish escalation was not delivered", {
-          feature: result.feature,
-          reasons: undelivered,
-          escalationReason: result.escalationReason,
-        });
-        return {
-          success: false,
-          message: `nax-finish: escalated but undelivered — ${undelivered.join("; ")}`,
-          url: result.url,
-        };
+        if (!delivered) {
+          if (result.deliveryError) problems.push(`the flow could not post it: ${result.deliveryError}`);
+          if (problems.length === 0) problems.push("no escalation channel was reachable");
+          ctx.logger.warn("nax-finish escalation was not delivered", {
+            feature: result.feature,
+            reasons: problems,
+            escalationReason: result.escalationReason,
+          });
+          return {
+            success: false,
+            message: `nax-finish: escalated but undelivered — ${problems.join("; ")}`,
+            url: result.url,
+          };
+        }
       }
 
       return { success: true, message: `nax-finish: ${result.status}`, url: result.url };

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -21,13 +21,15 @@
 import * as path from "node:path";
 import type { IPostRunAction, NaxPlugin, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
 import { type FinishAutoFlowSettings, getFinishAutoFlowConfig, telegramCreds } from "./config";
-import { sendTelegramNotify } from "./telegram";
+import { buildEscalationMessage, sendTelegramNotify } from "./telegram";
 
 interface FinishResult {
   feature: string;
   status: "opened" | "promoted" | "already-ready" | "escalated" | "nothing-to-finish";
   url?: string;
   escalationReason?: string;
+  /** Findings behind an escalation — named in the notification, not just counted. */
+  findings?: { severity: string; title: string }[];
 }
 
 type RunFn = (
@@ -301,7 +303,7 @@ const naxFinishAction: IPostRunAction = {
       if (result.status === "escalated" && escalateTelegram && creds) {
         await _naxFinishDeps.notify(
           creds,
-          `nax-finish escalated *${result.feature}*: ${result.escalationReason ?? ""}`,
+          buildEscalationMessage(result.feature, result.escalationReason ?? "", result.findings ?? []),
         );
       }
 

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -30,6 +30,8 @@ interface FinishResult {
   escalationReason?: string;
   /** Findings behind an escalation — named in the notification, not just counted. */
   findings?: { severity: string; title: string }[];
+  /** Set by the flow when it could not deliver the escalation to its channel. */
+  deliveryError?: string;
 }
 
 type RunFn = (
@@ -300,11 +302,31 @@ const naxFinishAction: IPostRunAction = {
         };
       }
 
-      if (result.status === "escalated" && escalateTelegram && creds) {
-        await _naxFinishDeps.notify(
-          creds,
-          buildEscalationMessage(result.feature, result.escalationReason ?? "", result.findings ?? []),
-        );
+      // An escalation nobody receives is the same broken-state-wearing-an-
+      // unremarkable-label failure as a missing result file, so both a rejected
+      // send and a delivery the flow already gave up on are reported as such.
+      const undelivered: string[] = [];
+      if (result.status === "escalated") {
+        if (result.deliveryError) undelivered.push(`flow could not post it: ${result.deliveryError}`);
+        if (escalateTelegram && creds) {
+          const sent = await _naxFinishDeps.notify(
+            creds,
+            buildEscalationMessage(result.feature, result.escalationReason ?? "", result.findings ?? []),
+          );
+          if (!sent) undelivered.push("Telegram rejected the message");
+        }
+      }
+      if (undelivered.length > 0) {
+        ctx.logger.warn("nax-finish escalation was not delivered", {
+          feature: result.feature,
+          reasons: undelivered,
+          escalationReason: result.escalationReason,
+        });
+        return {
+          success: false,
+          message: `nax-finish: escalated but undelivered — ${undelivered.join("; ")}`,
+          url: result.url,
+        };
       }
 
       return { success: true, message: `nax-finish: ${result.status}`, url: result.url };

--- a/src/plugins/builtin/nax-finish/telegram.ts
+++ b/src/plugins/builtin/nax-finish/telegram.ts
@@ -9,15 +9,64 @@
 
 type FetchFn = (input: string | Request | URL, init?: RequestInit) => Promise<Response>;
 
+/** Bot API hard limit for `sendMessage` — a longer body is rejected outright. */
+export const TELEGRAM_MAX_MESSAGE_CHARS = 4096;
+
+/** Per-finding title budget, so one verbose title can't crowd out every other finding. */
+const MAX_FINDING_TITLE_CHARS = 120;
+
+/**
+ * Compose the escalation message: the reason, then each finding by severity and
+ * title.
+ *
+ * The reason alone is a bare count ("3 finding(s) after 3 fix attempts"), which
+ * left the human no way to judge urgency without opening acpx's run bundle. The
+ * list is truncated to fit the Bot API limit and says how many it dropped.
+ */
+export function buildEscalationMessage(
+  feature: string,
+  reason: string,
+  findings: { severity: string; title: string }[],
+): string {
+  const head = `nax-finish escalated ${feature}: ${reason}`;
+  if (findings.length === 0) return head;
+
+  // Reserved up front for the worst case (every finding dropped), so adding a
+  // line can never push the finished message past the limit.
+  const footerReserve = `\n…and ${findings.length} more`.length;
+  const lines: string[] = [];
+  let used = head.length;
+  for (const f of findings) {
+    const title = f.title.length > MAX_FINDING_TITLE_CHARS ? `${f.title.slice(0, MAX_FINDING_TITLE_CHARS)}…` : f.title;
+    const line = `\n- [${f.severity}] ${title}`;
+    if (used + line.length + footerReserve > TELEGRAM_MAX_MESSAGE_CHARS) break;
+    lines.push(line);
+    used += line.length;
+  }
+  const omitted = findings.length - lines.length;
+  return `${head}${lines.join("")}${omitted > 0 ? `\n…and ${omitted} more` : ""}`;
+}
+
 /** Module-level deps for testability (`_deps` pattern). */
 export const _telegramDeps: { fetch: FetchFn } = { fetch: (...a) => fetch(...a) };
 
-/** POST a Markdown-formatted message to a Telegram chat via the Bot API. */
+/**
+ * POST a plain-text message to a Telegram chat via the Bot API.
+ *
+ * Deliberately no `parse_mode`. The body now carries model-authored review
+ * titles, which routinely contain backticks and underscores
+ * (`` `_calendar.py` ignores timezone ``); under `parse_mode: "Markdown"` an
+ * unbalanced one makes the API reject the whole message with a 400, so the
+ * escalation would be dropped silently. Escaping is not an option either —
+ * legacy Markdown has no reliable escape, and stripping the characters would
+ * rewrite `_calendar.py` to `calendar.py`, pointing the reader at a file that
+ * isn't the one under discussion. Plain text delivers the names intact.
+ */
 export async function sendTelegramNotify(cfg: { token: string; chatId: string }, text: string): Promise<boolean> {
   const res = await _telegramDeps.fetch(`https://api.telegram.org/bot${cfg.token}/sendMessage`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ chat_id: cfg.chatId, text, parse_mode: "Markdown" }),
+    body: JSON.stringify({ chat_id: cfg.chatId, text }),
   });
   return res.ok;
 }

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -576,4 +576,73 @@ describe("escalate node", () => {
 
     expect(JSON.parse(wrote).findings).toEqual(findings);
   });
+
+  // Regression: postEscalation ran before writeResult, so a failing comment (or
+  // an unknown forge) killed the node with no result file — the plugin then had
+  // nothing to notify from, and the escalation vanished entirely (#1399).
+  test("a failed delivery still leaves a result file the plugin can notify from", async () => {
+    _escalateDeps.run = async (cmd) => {
+      if (cmd.join(" ").includes("remote get-url")) return { exitCode: 0, stdout: "git@github.com:o/r", stderr: "" };
+      if (cmd.includes("view")) return { exitCode: 0, stdout: JSON.stringify({ url: "https://gh/pr/9" }), stderr: "" };
+      return { exitCode: 1, stdout: "", stderr: "rate limit exceeded" };
+    };
+    _gitDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const writes: string[] = [];
+    _resultDeps.writeText = async (_p, s) => {
+      writes.push(s);
+    };
+
+    const out = await nodeRun<{ escalationReason: string; deliveryError?: string }>("escalate").run(
+      ctxOf({ outputs: { route_spec: { route: "escalate", findings: [], escalationReason: "needs judgment" } } }),
+    );
+
+    expect(out.escalationReason).toBe("needs judgment");
+    expect(out.deliveryError).toContain("rate limit exceeded");
+    const final = JSON.parse(writes[writes.length - 1]);
+    expect(final).toMatchObject({ status: "escalated", escalationReason: "needs judgment" });
+    expect(final.deliveryError).toContain("rate limit exceeded");
+  });
+
+  test("writes the result before attempting delivery, not after", async () => {
+    const order: string[] = [];
+    _escalateDeps.run = async (cmd) => {
+      if (cmd.join(" ").includes("remote get-url")) return { exitCode: 0, stdout: "git@github.com:o/r", stderr: "" };
+      if (cmd.includes("view")) return { exitCode: 0, stdout: JSON.stringify({ url: "https://gh/pr/9" }), stderr: "" };
+      order.push("deliver");
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    _gitDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    _resultDeps.writeText = async () => {
+      order.push("write");
+    };
+
+    await nodeRun("escalate").run(
+      ctxOf({ outputs: { route_spec: { route: "escalate", findings: [], escalationReason: "r" } } }),
+    );
+
+    expect(order[0]).toBe("write");
+    expect(order).toContain("deliver");
+  });
+
+  test("an unknown forge does not sink the escalation", async () => {
+    _escalateDeps.run = async (cmd) => {
+      if (cmd.join(" ").includes("remote get-url")) return { exitCode: 0, stdout: "git@git.corp:o/r", stderr: "" };
+      return { exitCode: 127, stdout: "", stderr: "command not found" };
+    };
+    _gitDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    let wrote = "";
+    _resultDeps.writeText = async (_p, s) => {
+      wrote = s;
+    };
+
+    const out = await nodeRun<{ deliveryError?: string }>("escalate").run(
+      ctxOf({
+        input: { ...INPUT, escalateTelegram: true },
+        outputs: { route_spec: { route: "escalate", findings: [], escalationReason: "r" } },
+      }),
+    );
+
+    expect(out.deliveryError).toBeTruthy();
+    expect(JSON.parse(wrote)).toMatchObject({ status: "escalated", escalationReason: "r" });
+  });
 });

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -221,6 +221,73 @@ describe("acceptance node", () => {
     expect(out.route).toBe("fix");
   });
 
+  // Regression: an empty/ungenerated acceptance set used to report `passed`,
+  // so the flow could open a ready PR having verified nothing (issue #1398).
+  test("escalates instead of passing when the feature has no PRD to compute targets from", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const out = await nodeRun<{ route: string; reason?: string }>("acceptance").run(
+      ctxOf({ outputs: { load_ctx: { groups: [], acceptanceStatus: "no-prd" } } }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("no-prd");
+  });
+
+  test("skips cleanly when acceptance is disabled in config", async () => {
+    let ran = 0;
+    _acceptanceDeps.runShell = async () => {
+      ran += 1;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const out = await nodeRun<{ route: string; output: string }>("acceptance").run(
+      ctxOf({ outputs: { load_ctx: { groups: [], acceptanceStatus: "disabled" } } }),
+    );
+    expect(out.route).toBe("proceed");
+    expect(ran).toBe(0);
+    expect(out.output).toContain("disabled");
+  });
+
+  test("escalates when every group's acceptance test is missing — nothing was verified", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const out = await nodeRun<{ route: string; reason?: string }>("acceptance").run(
+      ctxOf({
+        outputs: { load_ctx: { groups: [{ ...GROUPS[0], exists: false }], acceptanceStatus: "ok" } },
+      }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("never generated");
+  });
+
+  test("escalates on a partial coverage hole even when the runnable groups pass", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const out = await nodeRun<{ route: string; reason?: string }>("acceptance").run(
+      ctxOf({
+        outputs: {
+          load_ctx: {
+            groups: [GROUPS[0], { ...GROUPS[0], packageDir: "apps/web", exists: false }],
+            acceptanceStatus: "ok",
+          },
+        },
+      }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("apps/web");
+  });
+
+  test("a real test failure still routes to the fix loop, not the coverage escalation", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "assert failed" });
+    const out = await nodeRun<{ route: string }>("acceptance").run(
+      ctxOf({
+        outputs: {
+          load_ctx: {
+            groups: [GROUPS[0], { ...GROUPS[0], packageDir: "apps/web", exists: false }],
+            acceptanceStatus: "ok",
+          },
+        },
+      }),
+    );
+    expect(out.route).toBe("fix");
+  });
+
   test("at the cap routes to escalate with a reason", async () => {
     _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "still failing" });
     const out = await nodeRun<{ route: string; reason?: string }>("acceptance").run(
@@ -484,5 +551,29 @@ describe("escalate node", () => {
 
     expect(out.channel).toBe("telegram");
     expect(forgeCalls.some((c) => c.join(" ").includes("pr comment"))).toBe(false);
+  });
+
+  // Regression: on the Telegram path the composed comment (the only thing
+  // carrying the findings) was discarded, and the result file recorded just a
+  // count — so no artifact anywhere named what needed judgment (issue #1398).
+  test("persists the findings in the result file, not only the reason", async () => {
+    stubForge([]);
+    _gitDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    let wrote = "";
+    _resultDeps.writeText = async (_p, s) => {
+      wrote = s;
+    };
+    const findings = [
+      { severity: "HIGH", title: "holidays ignores timezone", problem: "no query param", fix: "add it" },
+    ];
+
+    await nodeRun("escalate").run(
+      ctxOf({
+        input: { ...INPUT, escalateTelegram: true },
+        outputs: { route_spec: { route: "escalate", findings, escalationReason: "3 findings after 3 attempts" } },
+      }),
+    );
+
+    expect(JSON.parse(wrote).findings).toEqual(findings);
   });
 });

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -366,9 +366,102 @@ describe("review parse + route_* nodes", () => {
 describe("quality_gates node", () => {
   const originalRun = _qualityDeps.runShell;
   const originalReadText = _qualityDeps.readText;
+  const originalAcceptanceRun = _acceptanceDeps.runShell;
   afterEach(() => {
     _qualityDeps.runShell = originalRun;
     _qualityDeps.readText = originalReadText;
+    _acceptanceDeps.runShell = originalAcceptanceRun;
+  });
+
+  // The feature's acceptance tests are re-run here because the quality-review
+  // and gate fix loops edit code after the `acceptance` node last passed, and
+  // the repo-root `test` command does not cover them — they live under
+  // `<pkg>/.nax/features/<f>/` and usually need their own runner config. Without
+  // this, a quality fix could break the feature's own contract and still ship.
+  describe("acceptance as gate zero", () => {
+    const withGroups = () => ctxOf({ outputs: { load_ctx: { groups: GROUPS } } });
+
+    test("runs the feature's acceptance tests before the configured commands", async () => {
+      const order: string[] = [];
+      _acceptanceDeps.runShell = async () => {
+        order.push("acceptance");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      };
+      _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
+      _qualityDeps.runShell = async () => {
+        order.push("lint");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      };
+
+      const out = await nodeRun<{ route: string }>("quality_gates").run(withGroups());
+
+      expect(out.route).toBe("green");
+      expect(order).toEqual(["acceptance", "lint"]);
+    });
+
+    test("a fix that broke the contract routes to the gate fix loop, naming acceptance", async () => {
+      _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "AssertionError" });
+      _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
+      _qualityDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+
+      const out = await nodeRun<{ route: string; failing: string[]; output: string }>("quality_gates").run(
+        withGroups(),
+      );
+
+      expect(out.route).toBe("fix");
+      expect(out.failing).toContain("acceptance");
+      expect(out.output).toContain("AssertionError");
+    });
+
+    test("does not run the repo gates while acceptance is red", async () => {
+      _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "boom" });
+      _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
+      let gatesRan = 0;
+      _qualityDeps.runShell = async () => {
+        gatesRan += 1;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      };
+
+      const out = await nodeRun<{ route: string; reason?: string }>("quality_gates").run(withGroups());
+
+      expect(gatesRan).toBe(0);
+      // must not be mistaken for the "nothing configured" escalation — the
+      // commands are configured, they were skipped on purpose
+      expect(out.reason).toBeUndefined();
+    });
+
+    test("at the cap it escalates naming the broken contract, not the lint gate", async () => {
+      _acceptanceDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "boom" });
+      _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
+      _qualityDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+
+      const out = await nodeRun<{ route: string; reason?: string }>("quality_gates").run(
+        ctxOf({
+          outputs: { load_ctx: { groups: GROUPS } },
+          steps: [{ nodeId: "fix_gate" }, { nodeId: "fix_gate" }, { nodeId: "fix_gate" }],
+        }),
+      );
+
+      expect(out.route).toBe("escalate");
+      expect(out.reason).toContain("contract");
+    });
+
+    test("acceptance disabled (no groups) does not block a green gate", async () => {
+      let acceptanceRan = 0;
+      _acceptanceDeps.runShell = async () => {
+        acceptanceRan += 1;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      };
+      _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
+      _qualityDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+
+      const out = await nodeRun<{ route: string }>("quality_gates").run(
+        ctxOf({ outputs: { load_ctx: { groups: [] } } }),
+      );
+
+      expect(acceptanceRan).toBe(0);
+      expect(out.route).toBe("green");
+    });
   });
 
   test("escalates instead of reporting green when the repo configured no commands", async () => {

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -137,7 +137,9 @@ describe("commit_* nodes", () => {
   test("commits the fix with a conventional, phase-named message and no push", async () => {
     const { out, argv } = await runCommitNode("commit_spec", " M apps/api/_calendar.py\n");
     expect(out.committed).toBe(true);
-    expect(argv).toContain("git commit -m fix(x): nax-finish spec fixes");
+    // --no-verify: a pre-commit hook rejecting an intermediate state would
+    // otherwise kill the flow before the gate loop could fix it
+    expect(argv).toContain("git commit -m fix(x): nax-finish spec fixes --no-verify");
     // the push belongs to the terminal nodes; a mid-loop push would publish
     // half-fixed states to the forge on every round
     expect(argv.some((c) => c.startsWith("git push"))).toBe(false);
@@ -146,7 +148,7 @@ describe("commit_* nodes", () => {
   test("each phase commits under its own message", async () => {
     for (const phase of ["acceptance", "quality", "gate"]) {
       const { argv } = await runCommitNode(`commit_${phase}`, " M a.ts\n");
-      expect(argv).toContain(`git commit -m fix(x): nax-finish ${phase} fixes`);
+      expect(argv).toContain(`git commit -m fix(x): nax-finish ${phase} fixes --no-verify`);
     }
   });
 

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -96,12 +96,64 @@ describe("nax-finish flow graph", () => {
 
   test("review fixes are re-verified, not applied once and trusted", () => {
     // spec fixes re-run the acceptance gate, which routes back into review_spec
-    expect(toOf("fix_spec")).toBe("acceptance");
+    expect(toOf("commit_spec")).toBe("acceptance");
     expect(switchOf("acceptance").cases.proceed).toBe("review_spec");
     // quality fixes are re-reviewed by the same lens
-    expect(toOf("fix_quality")).toBe("review_quality");
-    expect(toOf("fix_acceptance")).toBe("acceptance");
-    expect(toOf("fix_gate")).toBe("quality_gates");
+    expect(toOf("commit_quality")).toBe("review_quality");
+    expect(toOf("commit_acceptance")).toBe("acceptance");
+    expect(toOf("commit_gate")).toBe("quality_gates");
+  });
+
+  // Regression: #1397 — reviewers read `git diff base...HEAD`, so an uncommitted
+  // fix is invisible to the re-review and the loop escalates at the cap having
+  // re-reported findings that were already fixed.
+  test("every fix node commits before anything re-reads the diff", () => {
+    for (const phase of ["acceptance", "spec", "quality", "gate"]) {
+      expect(flow.nodes[`commit_${phase}`]).toBeDefined();
+      expect(flow.nodes[`commit_${phase}`].nodeType).toBe("action");
+      expect(toOf(`fix_${phase}`)).toBe(`commit_${phase}`);
+    }
+  });
+});
+
+describe("commit_* nodes", () => {
+  const originalRun = _gitDeps.run;
+  afterEach(() => {
+    _gitDeps.run = originalRun;
+  });
+
+  const runCommitNode = async (id: string, porcelain: string) => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--porcelain")
+        ? { exitCode: 0, stdout: porcelain, stderr: "" }
+        : { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const out = await nodeRun<{ committed: boolean }>(id).run(ctxOf({}));
+    return { out, argv: calls.map((c) => c.join(" ")) };
+  };
+
+  test("commits the fix with a conventional, phase-named message and no push", async () => {
+    const { out, argv } = await runCommitNode("commit_spec", " M apps/api/_calendar.py\n");
+    expect(out.committed).toBe(true);
+    expect(argv).toContain("git commit -m fix(x): nax-finish spec fixes");
+    // the push belongs to the terminal nodes; a mid-loop push would publish
+    // half-fixed states to the forge on every round
+    expect(argv.some((c) => c.startsWith("git push"))).toBe(false);
+  });
+
+  test("each phase commits under its own message", async () => {
+    for (const phase of ["acceptance", "quality", "gate"]) {
+      const { argv } = await runCommitNode(`commit_${phase}`, " M a.ts\n");
+      expect(argv).toContain(`git commit -m fix(x): nax-finish ${phase} fixes`);
+    }
+  });
+
+  test("a fix node that changed nothing produces no commit", async () => {
+    const { out, argv } = await runCommitNode("commit_gate", "");
+    expect(out.committed).toBe(false);
+    expect(argv.some((c) => c.startsWith("git commit"))).toBe(false);
   });
 });
 

--- a/test/unit/flows/nax-finish/steps/acceptance.test.ts
+++ b/test/unit/flows/nax-finish/steps/acceptance.test.ts
@@ -78,4 +78,27 @@ describe("runAcceptanceGate", () => {
     expect(r.ran).toBe(0);
     expect(r.output).toContain("no acceptance test files present");
   });
+
+  test("names the packages whose acceptance test was expected but never generated", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await runAcceptanceGate("/repo", [
+      group({ packageDir: "apps/api", exists: true }),
+      group({ packageDir: "apps/web", exists: false }),
+    ]);
+    // the runnable group passed, but the gate must not hide the missing one
+    expect(r.ran).toBe(1);
+    expect(r.missing).toEqual(["apps/web"]);
+  });
+
+  test("reports the root package's missing test under a readable name", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await runAcceptanceGate("/repo", [group({ packageDir: "", exists: false })]);
+    expect(r.missing).toEqual(["root"]);
+  });
+
+  test("missing is empty when every group ran", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await runAcceptanceGate("/repo", [group()]);
+    expect(r.missing).toEqual([]);
+  });
 });

--- a/test/unit/flows/nax-finish/steps/forge.test.ts
+++ b/test/unit/flows/nax-finish/steps/forge.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { detectForge, extractUrl, viewArgv } from "@flows/nax-finish/steps/forge";
+import type { RunFn, RunResult } from "@flows/nax-finish/types";
+
+const ok = (stdout = ""): RunResult => ({ exitCode: 0, stdout, stderr: "" });
+const missing = (): RunResult => ({ exitCode: 127, stdout: "", stderr: "command not found" });
+
+/** A `run` that answers `git remote get-url` with `remote`, and CLI probes per `cli`. */
+const runner = (remote: string, cli: { gh?: boolean; glab?: boolean } = {}): RunFn => {
+  return async (cmd) => {
+    if (cmd.join(" ").includes("remote get-url")) return ok(remote);
+    if (cmd[0] === "gh") return cli.gh ? ok("gh version 2.0.0") : missing();
+    if (cmd[0] === "glab") return cli.glab ? ok("glab 1.0.0") : missing();
+    return ok();
+  };
+};
+
+describe("detectForge", () => {
+  test.each([
+    ["git@github.com:o/r.git", "github"],
+    ["https://github.com/o/r.git", "github"],
+    ["git@gitlab.com:g/p/r.git", "gitlab"],
+    ["https://gitlab.com/g/p/r.git", "gitlab"],
+  ])("recognises the hosted forge %s", async (remote, expected) => {
+    expect(await detectForge(runner(remote), "/repo", "test")).toBe(expected);
+  });
+
+  // Regression: substring matching on "gitlab.com" rejected every self-hosted
+  // instance — "gitlab.mycorp.com".includes("gitlab.com") is false (#1399).
+  test.each([
+    ["git@gitlab.mycorp.com:g/r.git", "gitlab"],
+    ["https://gitlab.internal.example.org/g/r.git", "gitlab"],
+    ["ssh://git@github.mycorp.com:2222/o/r.git", "github"],
+  ])("recognises the self-hosted forge %s by host", async (remote, expected) => {
+    expect(await detectForge(runner(remote), "/repo", "test")).toBe(expected);
+  });
+
+  test("falls back to the only installed CLI when the host names neither forge", async () => {
+    expect(await detectForge(runner("git@git.mycorp.com:o/r.git", { glab: true }), "/repo", "test")).toBe("gitlab");
+    expect(await detectForge(runner("git@git.mycorp.com:o/r.git", { gh: true }), "/repo", "test")).toBe("github");
+  });
+
+  test("throws when the host is unrecognised and the CLI probe is ambiguous", async () => {
+    await expect(detectForge(runner("git@git.mycorp.com:o/r.git", { gh: true, glab: true }), "/repo", "s")).rejects.toThrow(
+      /git\.mycorp\.com/,
+    );
+    await expect(detectForge(runner("git@git.mycorp.com:o/r.git"), "/repo", "s")).rejects.toThrow(/git\.mycorp\.com/);
+  });
+
+  test("throws when the repo has no origin remote at all", async () => {
+    const run: RunFn = async () => ({ exitCode: 128, stdout: "", stderr: "no such remote" });
+    await expect(detectForge(run, "/repo", "s")).rejects.toThrow(/FINISH_UNKNOWN_FORGE|remote/);
+  });
+});
+
+describe("extractUrl", () => {
+  test("prefers a JSON url field, then web_url, then a raw URL", () => {
+    expect(extractUrl(JSON.stringify({ url: "https://gh/pr/1" }))).toBe("https://gh/pr/1");
+    expect(extractUrl(JSON.stringify({ web_url: "https://gl/mr/2" }))).toBe("https://gl/mr/2");
+    expect(extractUrl("created: https://gh/pr/3\n")).toBe("https://gh/pr/3");
+  });
+
+  test("returns undefined when there is no URL", () => {
+    expect(extractUrl("nothing here")).toBeUndefined();
+  });
+});
+
+describe("viewArgv", () => {
+  test("asks each forge for its own JSON shape", () => {
+    expect(viewArgv("github", "feat/x", "isDraft,url")).toEqual(["gh", "pr", "view", "feat/x", "--json", "isDraft,url"]);
+    expect(viewArgv("gitlab", "feat/x", "isDraft,url")).toEqual(["glab", "mr", "view", "feat/x", "--output", "json"]);
+  });
+});

--- a/test/unit/flows/nax-finish/steps/git.test.ts
+++ b/test/unit/flows/nax-finish/steps/git.test.ts
@@ -106,4 +106,29 @@ describe("commitFixes", () => {
     };
     await expect(commitFixes("/repo", "msg")).rejects.toThrow(/pre-commit hook failed/);
   });
+
+  // A mid-loop commit is an internal checkpoint, not shipped history. Letting a
+  // repo's pre-commit hook run there means a hook that rejects an intermediate
+  // state (a lint error the gate loop would go on to fix) kills the whole flow
+  // with no result file — a failure mode that did not exist when the only
+  // commit was at a terminal node.
+  test("skipHooks passes --no-verify so an intermediate state cannot kill the flow", async () => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--porcelain") ? ok(" M a.ts\n") : ok("");
+    };
+    await commitFixes("/repo", "msg", { skipHooks: true });
+    expect(argvOf(calls)).toContain("git commit -m msg --no-verify");
+  });
+
+  test("hooks run by default — the terminal commit is real history", async () => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--porcelain") ? ok(" M a.ts\n") : ok("");
+    };
+    await commitAndPush("/repo", "feat/x", "msg");
+    expect(argvOf(calls).some((c) => c.includes("--no-verify"))).toBe(false);
+  });
 });

--- a/test/unit/flows/nax-finish/steps/git.test.ts
+++ b/test/unit/flows/nax-finish/steps/git.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { _gitDeps, commitAndPush } from "@flows/nax-finish/steps/git";
+import { _gitDeps, commitAndPush, commitFixes } from "@flows/nax-finish/steps/git";
 import type { RunResult } from "@flows/nax-finish/types";
 
 const ok = (stdout = ""): RunResult => ({ exitCode: 0, stdout, stderr: "" });
@@ -58,5 +58,52 @@ describe("commitAndPush", () => {
   test("throws when git status itself fails", async () => {
     _gitDeps.run = async () => ({ exitCode: 128, stdout: "", stderr: "not a git repository" });
     await expect(commitAndPush("/repo", "feat/x", "msg")).rejects.toThrow(/not a git repository/);
+  });
+});
+
+describe("commitFixes", () => {
+  test("commits the working tree so the next review's diff includes the fix", async () => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--porcelain") ? ok(" M apps/api/_calendar.py\n?? apps/api/tests/test_new.py\n") : ok();
+    };
+    const r = await commitFixes("/repo", "fix(x): nax-finish spec fixes");
+    expect(r).toEqual({ committed: true });
+    const argv = argvOf(calls);
+    // -A, not -u: a fix that adds a new test file must be committed too, or the
+    // reviewer's `git diff base...HEAD` still cannot see it.
+    expect(argv).toContain("git add -A");
+    expect(argv).toContain("git commit -m fix(x): nax-finish spec fixes");
+  });
+
+  test("never pushes — mid-loop commits stay local until a terminal node", async () => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--porcelain") ? ok(" M a.ts\n") : ok();
+    };
+    await commitFixes("/repo", "msg");
+    expect(argvOf(calls).some((c) => c.startsWith("git push"))).toBe(false);
+  });
+
+  test("is a no-op on a clean tree, so a fix node that changed nothing makes no commit", async () => {
+    const calls: string[][] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return ok("");
+    };
+    const r = await commitFixes("/repo", "msg");
+    expect(r).toEqual({ committed: false });
+    expect(argvOf(calls).some((c) => c.startsWith("git commit"))).toBe(false);
+  });
+
+  test("throws a coded error when the commit fails", async () => {
+    _gitDeps.run = async (cmd) => {
+      if (cmd.includes("--porcelain")) return ok(" M a.ts\n");
+      if (cmd.includes("commit")) return { exitCode: 1, stdout: "", stderr: "pre-commit hook failed" };
+      return ok("");
+    };
+    await expect(commitFixes("/repo", "msg")).rejects.toThrow(/pre-commit hook failed/);
   });
 });

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -258,6 +258,35 @@ describe("nax-finish post-run action", () => {
       expect(sent[0].text).toBe("nax-finish escalated x: gates still failing (lint)");
     });
 
+    test("reports a rejected Telegram send instead of claiming the escalation landed", async () => {
+      _naxFinishDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+      _naxFinishDeps.readResult = async () =>
+        ({ feature: "x", status: "escalated", escalationReason: "design call" }) as never;
+      _naxFinishDeps.notify = async () => false;
+
+      const r = await action.execute(baseCtx({ config: CONFIG_WITH_TELEGRAM } as never));
+
+      expect(r.success).toBe(false);
+      expect(r.message).toContain("Telegram");
+    });
+
+    test("reports an undelivered escalation the flow already flagged", async () => {
+      _naxFinishDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+      _naxFinishDeps.readResult = async () =>
+        ({
+          feature: "x",
+          status: "escalated",
+          escalationReason: "design call",
+          deliveryError: "rate limit exceeded",
+        }) as never;
+      _naxFinishDeps.notify = async () => true;
+
+      const r = await action.execute(baseCtx());
+
+      expect(r.success).toBe(false);
+      expect(r.message).toContain("rate limit exceeded");
+    });
+
     test("does not notify for a non-escalated status", async () => {
       const sent = stubRun({ feature: "x", status: "opened" });
 

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -168,7 +168,12 @@ describe("nax-finish post-run action", () => {
       interaction: { plugin: "telegram", config: { botToken: "t", chatId: "c" } },
     };
 
-    function stubRun(result: { feature: string; status: string; escalationReason?: string }) {
+    function stubRun(result: {
+      feature: string;
+      status: string;
+      escalationReason?: string;
+      findings?: { severity: string; title: string; problem: string; fix: string }[];
+    }) {
       const sent: Array<{ creds: { token: string; chatId: string }; text: string }> = [];
       _naxFinishDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
       _naxFinishDeps.readResult = async () => result as never;
@@ -185,8 +190,72 @@ describe("nax-finish post-run action", () => {
       await action.execute(baseCtx({ config: CONFIG_WITH_TELEGRAM } as never));
 
       expect(sent).toHaveLength(1);
-      expect(sent[0].text).toBe("nax-finish escalated *x*: design call");
+      expect(sent[0].text).toBe("nax-finish escalated x: design call");
       expect(sent[0].creds).toEqual({ token: "t", chatId: "c" });
+    });
+
+    // Regression: the message carried only the reason ("3 finding(s) after 3 fix
+    // attempts"), so the human had to dig through the acpx run bundle to learn
+    // what the findings actually were (issue #1398).
+    test("names each finding in the message, not just the count", async () => {
+      const sent = stubRun({
+        feature: "x",
+        status: "escalated",
+        escalationReason: "spec review still reporting 2 finding(s)",
+        findings: [
+          { severity: "HIGH", title: "holidays ignores timezone", problem: "no query param", fix: "add it" },
+          { severity: "MEDIUM", title: "routes untyped", problem: "dict[str, Any]", fix: "add response_model" },
+        ],
+      });
+
+      await action.execute(baseCtx({ config: CONFIG_WITH_TELEGRAM } as never));
+
+      expect(sent[0].text).toContain("spec review still reporting 2 finding(s)");
+      expect(sent[0].text).toContain("[HIGH] holidays ignores timezone");
+      expect(sent[0].text).toContain("[MEDIUM] routes untyped");
+    });
+
+    test("caps the message so a long finding list cannot exceed Telegram's limit", async () => {
+      const sent = stubRun({
+        feature: "x",
+        status: "escalated",
+        escalationReason: "many findings",
+        findings: Array.from({ length: 40 }, (_, n) => ({
+          severity: "HIGH",
+          title: `finding ${n} ${"x".repeat(300)}`,
+          problem: "p",
+          fix: "f",
+        })),
+      });
+
+      await action.execute(baseCtx({ config: CONFIG_WITH_TELEGRAM } as never));
+
+      expect(sent[0].text.length).toBeLessThanOrEqual(4096);
+      expect(sent[0].text).toContain("more");
+    });
+
+    // Sent as plain text: under parse_mode Markdown these characters either 400
+    // the whole message or, if stripped, rewrite `_calendar.py` to a filename
+    // that isn't the one under discussion.
+    test("delivers filenames and punctuation in a finding title verbatim", async () => {
+      const sent = stubRun({
+        feature: "x",
+        status: "escalated",
+        escalationReason: "r",
+        findings: [{ severity: "HIGH", title: "`_calendar.py` ignores *timezone*", problem: "p", fix: "f" }],
+      });
+
+      await action.execute(baseCtx({ config: CONFIG_WITH_TELEGRAM } as never));
+
+      expect(sent[0].text).toContain("`_calendar.py` ignores *timezone*");
+    });
+
+    test("still sends a reason-only message when the flow reported no findings", async () => {
+      const sent = stubRun({ feature: "x", status: "escalated", escalationReason: "gates still failing (lint)" });
+
+      await action.execute(baseCtx({ config: CONFIG_WITH_TELEGRAM } as never));
+
+      expect(sent[0].text).toBe("nax-finish escalated x: gates still failing (lint)");
     });
 
     test("does not notify for a non-escalated status", async () => {

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -270,6 +270,26 @@ describe("nax-finish post-run action", () => {
       expect(r.message).toContain("Telegram");
     });
 
+    // The flow's deliveryError on the Telegram path means only that its URL
+    // lookup failed — the comment is deliberately not posted there. Reporting
+    // that as undelivered false-alarms on the path that actually worked.
+    test("does not report undelivered when Telegram carried it despite a flow-side failure", async () => {
+      _naxFinishDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+      _naxFinishDeps.readResult = async () =>
+        ({
+          feature: "x",
+          status: "escalated",
+          escalationReason: "design call",
+          deliveryError: "Unable to determine forge",
+        }) as never;
+      _naxFinishDeps.notify = async () => true;
+
+      const r = await action.execute(baseCtx({ config: CONFIG_WITH_TELEGRAM } as never));
+
+      expect(r.success).toBe(true);
+      expect(r.message).toBe("nax-finish: escalated");
+    });
+
     test("reports an undelivered escalation the flow already flagged", async () => {
       _naxFinishDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
       _naxFinishDeps.readResult = async () =>


### PR DESCRIPTION
Five defects in the `nax-finish` flow, all of the same shape: **the flow could pass, escalate, or ship on something it never actually verified.** Found while diagnosing a real escalation on rs-stock `trading-calendar-core`, then reviewing `flows/nax-finish/` against its design doc and the skill it was ported from.

Closes #1397, closes #1398, closes #1399.

## 1. The review loop could never converge (#1397)

The reviewers read `git diff <base>...HEAD` — committed history only — while every fix node edits the working tree and is told *"Do not commit… nax-finish commits your edits itself."* `commitAndPush` ran only at a terminal node, so every re-review re-read the **pre-fix** code, re-reported findings the fix had already resolved, and the loop burned all three `MAX_FIX_ATTEMPTS` and escalated.

Evidence from the run that started this (acpx bundle `~/.acpx/flows/runs/2026-07-30T171813183Z-nax-finish-75f668fe/`): all 4 spec-review rounds reported the same 3 HIGH findings, all 3 already fixed in the working tree by round 2. Round 4 cited `_calendar.py:202-212`; in the fixed file that handler is at line 261. Fix attempt 2's own transcript reads *"The requested fixes are present"* — the fixer was reading the tree, the reviewer was reading HEAD.

**Fix:** a `commit_<phase>` node after every fix node. `git add -A` (not `-u`) because fixes routinely add new test files, which are untracked and invisible to that diff either way — which is also why this beats widening the reviewer's diff to the working tree.

## 2. The acceptance gate passed when nothing ran (#1398)

`runAcceptanceGate` skipped groups with `exists: false` and returned `passed: true` when zero groups ran. `nax features resolve` reports `groups: []` for **both** `no-prd` and `disabled`, so a missing PRD, a disabled gate and never-generated tests were indistinguishable — all three sailed through the fail-fast gate, and the flow could open a **ready** PR having verified nothing about the feature's own contract. `load_ctx` already resolved `acceptanceStatus` and nothing read it.

`quality_gates` had applied the opposite rule one node over since day one ("nothing configured is not a pass").

**Fix:** `disabled` skips cleanly, `no-prd` escalates, a package whose test file is absent escalates once the runnable groups are green (a real failure still routes to the fix loop first — it is more actionable and an agent can fix it).

## 3. Escalation findings were computed, then discarded (#1398)

`buildEscalationComment` composes the full findings list; `preferTelegram` returned early without posting it. The notification sent only the reason and `writeResult` persisted only `escalationReason` — so the findings existed nowhere on disk. The escalation that prompted this work read *"3 finding(s) after 3 fix attempts"* without naming one; recovering them meant reading acpx's run bundle.

**Fix:** `findings` persisted to `.nax/nax-finish-result.json`; the Telegram message lists each by severity and title, capped to the Bot API's 4096 chars with a dropped-count. The message also drops `parse_mode: "Markdown"` — review titles carry backticks and underscores (`` `_calendar.py` ignores timezone ``) that would 400 the whole message, and stripping them rewrites `_calendar.py` to `calendar.py`, pointing the reader at a different file.

## 4. A failed delivery lost the escalation entirely (#1399)

`postEscalation` ran before `writeResult` and was unwrapped. A rate limit, an expired token, a locked PR or an unrecognised remote killed the node before any result file existed — so the plugin had no status **and no file to send the Telegram message from**. A failed PR-comment attempt suppressed a perfectly healthy Telegram channel. `commitAndPush` in the same node was already non-fatal; the asymmetry was the bug.

Compounding it, `detectForge` matched the substring `gitlab.com` against the whole remote URL, so every self-hosted instance threw (`"gitlab.mycorp.com".includes("gitlab.com")` is `false`) — and took the escalation with it.

**Fix:** result written first, delivery second, failures recorded as `deliveryError`. `detectForge` parses the host from both URL forms git accepts, falling back to whichever of `gh`/`glab` is installed for an enterprise host naming neither. `sendTelegramNotify`'s return value — previously discarded, so a Bot API rejection was silent — is now checked.

## 5. Quality- and gate-phase fixes never re-verified acceptance (#1398)

Two fix loops run after the `acceptance` node last passed, and the repo-root `test` command does not cover the feature's acceptance tests: they are generated under `<pkg>/.nax/features/<feature>/` and usually need their own runner config, which is why they are excluded from the normal suite. The fix prompt does tell the agent to re-run them — but that is self-reported by a model, the same unverified claim that hid #1397.

**Fix:** acceptance runs as gate zero of `quality_gates`, short-circuiting the repo gates on red. Chosen over a dedicated re-check node, which needed six new nodes (the `acceptance` node's `proceed` edge goes to `review_spec`, so it cannot be reused, and each re-check needs its own fix loop and cap). Unconditional even on the green path: a conditional skip derived from step history is a check that can be *wrong*, and a missed re-run is a silent false green.

The property this buys: **nothing reaches `open_pr` without the feature's own acceptance tests passing against the tree as it will ship.**

## Two defects found reviewing this branch's own diff

- **Mid-loop commits inherited pre-commit hooks.** Before per-round commits that happened once, at a terminal node. A repo whose hook runs lint or typecheck (nax itself does) would reject an intermediate state — a lint error the gate loop was about to fix — and kill the flow with no result file. A regression introduced by this PR's own first commit. Mid-loop commits now pass `--no-verify`; `quality_gates` runs the repo's real gates before any PR opens, and the terminal commit still runs hooks.
- **The plugin false-alarmed on a delivered escalation.** On the Telegram path the flow posts no comment, so its `deliveryError` means only that the URL lookup failed. A successful Telegram send was still reported `escalated but undelivered` — a false alarm on the path that worked. Delivery is now judged per channel.

## Testing

- 168 tests across the two nax-finish suites (was 88); every new test confirmed RED before its fix
- New `test/unit/flows/nax-finish/steps/forge.test.ts` — `detectForge` previously had no direct test
- `bun run lint`, `bun run typecheck`, `bun run test` all green

## Note for reviewers

`flows/` is loaded from the **installed** nax package (`~/.bun/install/global/node_modules/@nathapp/nax/flows/…`), not from a consuming repo's working tree. None of this reaches a real run until a release ships.

## Not fixed here (recorded in #1398)

The stub PR body for newly created PRs; no collapsed-review path for tiny diffs; `quality.commands.format` is gated by the flow but absent from `QualityConfigSchema`. Separately, the `nax-toolkit-skills` copy of the skill still tells readers to honour `quality.require*`, which nax now **rejects at parse time**.
