### PR TITLE
fix(execution): let a gate regression reach the nbf fix cycle so regressionAttempts is spendable (#1401)

### DIFF
--- a/docs/adr/ADR-024-non-blocking-adversarial-fix.md
+++ b/docs/adr/ADR-024-non-blocking-adversarial-fix.md
@@ -78,6 +78,33 @@ Three deliberate limits:
   bounded by the memo only ever holding tests a probe showed to be non-deterministic on an
   earlier tree.
 
+#### Amendment (2026-07-31, #1401): the verifier-SSOT carve-out does not apply to nbf
+
+§4 promises "one best-effort fix plus `regressionAttempts` (default 1) ... to clear any
+regression the fix introduced". On any verifier-bearing (three-session) plan that budget was
+unreachable, so the code did not implement §4.
+
+`phasesToRevalidate` orders `full-suite-gate` before `verifier` in the sweep, so when the
+verifier-SSOT carve-out was evaluated `phaseOutputs[verifier]` still held the verifier's
+*pre-rectification* pass. On the nbf path that stale green made the carve-out skip the gate,
+which both discarded the regression the pass had just introduced — the cycle then exited
+"resolved" on iteration 1 and never requested the repair — and bypassed the halt-on-failure
+short-circuit, so lint, typecheck and a full verifier session ran against a red gate.
+`runNonBlockingFix` read the same gate output raw and restored anyway.
+
+The carve-out is therefore **off on the nbf path** (`shouldSkipPhaseForRectification`'s
+`nbfPath` input, derived from the same `overrides.initialFindings` branch that governs the
+triage skip above). Rationale: the carve-out exists so a story is not rolled back over
+regressions it did not cause, and nbf never fails a story — it only chooses keep-vs-discard
+of its own edits. Blast radius is bounded by the §5 entry condition: nbf runs only when every
+phase output passes, gate included, so a red gate inside the pass is always newly introduced.
+
+One accepted cost: a *keyless* gate failure (timeout / execution-failure) now also seeds a
+finding, so the pass spends one repair attempt before restoring where it previously restored
+immediately. Bounded by `regressionAttempts`, and the alternative — special-casing keyless
+here — would re-create the same split-brain between what the cycle sees and what
+`describeGateRegression` sees.
+
 ### 4. Bounded, transactional
 
 One best-effort fix plus `regressionAttempts` (default 1) source/test fix attempts to clear any regression the fix introduced. The whole pass is a single transaction.

--- a/docs/adr/ADR-024-non-blocking-adversarial-fix.md
+++ b/docs/adr/ADR-024-non-blocking-adversarial-fix.md
@@ -80,6 +80,8 @@ Three deliberate limits:
 
 #### Amendment (2026-07-31, #1401): the verifier-SSOT carve-out does not apply to nbf
 
+> Subject is §4's budget; placed here because it builds directly on the #1383 amendment above.
+
 §4 promises "one best-effort fix plus `regressionAttempts` (default 1) ... to clear any
 regression the fix introduced". On any verifier-bearing (three-session) plan that budget was
 unreachable, so the code did not implement §4.
@@ -99,11 +101,31 @@ regressions it did not cause, and nbf never fails a story — it only chooses ke
 of its own edits. Blast radius is bounded by the §5 entry condition: nbf runs only when every
 phase output passes, gate included, so a red gate inside the pass is always newly introduced.
 
-One accepted cost: a *keyless* gate failure (timeout / execution-failure) now also seeds a
-finding, so the pass spends one repair attempt before restoring where it previously restored
-immediately. Bounded by `regressionAttempts`, and the alternative — special-casing keyless
-here — would re-create the same split-brain between what the cycle sees and what
-`describeGateRegression` sees.
+The considered alternative — "apply the carve-out only if the verifier re-ran within this
+sweep" — was rejected because it silently changes the main path too: `autofix-implementer`
+and `autofix-test-writer` deliberately exclude `verifier` from
+`STRATEGY_TO_REVALIDATION_PHASES`, so the verifier structurally cannot have re-run in most
+main-path sweeps either, and the carve-out would switch off there as a side effect.
+
+Because the sweep and `describeGateRegression` now both see the same gate output, they must
+agree on what counts as blame. The sweep therefore applies the **same quarantine-memo
+exclusion** (`isQuarantinedFlake`, sharing `gateFindingKey` with `gateFailureKeys`): a failure
+this run already quarantined seeds no finding, so #1383's "a known flake keeps the pass"
+outcome is preserved rather than being turned into a paid repair attempt on a flake — which,
+via `full-suite-rectify`, would have edited test code and then discarded the pass.
+
+Two consequences beyond the budget itself:
+
+- **`execution-failure` costs one attempt.** A gate that dies without structured results
+  emits the synthetic `"::"` finding, which now seeds the cycle, so the pass spends one repair
+  attempt before restoring where it previously restored immediately. Bounded by
+  `regressionAttempts`. *Timeout does not* — `full-suite-gate` returns `findings: []` there,
+  so the sweep short-circuits with nothing to fix and the pass still exits at iteration 1.
+- **Pre-existing failures the pass re-breaks are now visible.** `describeGateRegression`
+  exempts keys in the verifier-time baseline (`preRectGateFailureKeys`), but the sweep has no
+  baseline. Such a failure previously stayed hidden and the pass was kept with a red gate;
+  it now earns a repair attempt and is restored if the repair fails. Strictly safer, but it
+  is an outcome change, recorded here rather than treated as a pure bug fix.
 
 ### 4. Bounded, transactional
 

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -256,23 +256,12 @@ export async function runNonBlockingFix(
       // `restoreToSnapshot` clears `phaseOutputs` (so the gate's rawOutput goes with it)
       // and `rollbackToRef` hard-resets the offending edit, leaving `git reflog` with
       // only the destination. Without this record the revert is unattributable (#1382).
-      logger?.info("non-blocking-fix", "kept tree regressed the full-suite gate — restoring (ADR-024 §3)", {
-        storyId: args.storyId,
-        regressedKeys: gateVerdict.regressedKeys.slice(0, MAX_LOGGED_REGRESSED_KEYS),
-        regressedKeyCount: gateVerdict.regressedKeys.length,
-        baselineKeySize: gateVerdict.baselineKeySize,
-        // True ⇒ timeout / execution-failure, so `regressedKeys` is empty because there
-        // was no identity to capture, NOT because nothing regressed.
-        keyless: gateVerdict.keyless,
-        // Failures excluded as already-quarantined flakes (#1383).
-        memoExcludedKeyCount: gateVerdict.memoExcludedKeys.length,
-        // Stated, not computed: this pass's revalidation gate is never flake-triaged —
-        // triage owns the main gate path only (`rectification.ts`, the non-override
-        // branch). So a FIRST-observation flake inside the revalidation window still
-        // reads as a regression here, and an operator must be able to see that was
-        // possible rather than infer a real break (#1383 option 3).
-        flakeTriageRan: false,
-      });
+      logGateRegression(
+        logger,
+        args.storyId,
+        "kept tree regressed the full-suite gate — restoring (ADR-024 §3)",
+        gateVerdict,
+      );
       return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
     }
     // Enforce sourceDiffCap over the post-pass snapshot. A pass whose source
@@ -311,21 +300,55 @@ export async function runNonBlockingFix(
   // diagnostic disappears in exactly the case an operator most needs it: a regression
   // real enough to survive a repair attempt. Read-only — `describeGateRegression` diffs
   // key sets already in `phaseOutputs` and re-runs nothing.
+  //
+  // Also reached when `runRectify` THREW (above), where `phaseOutputs` may hold a
+  // half-finished sweep. The verdict is log-only and the restore happens regardless, so a
+  // partial read is harmless — but the keys named on that path describe an aborted
+  // validation, not a completed one.
   const exhaustedGateVerdict = args.keptTreeRegressed?.();
   if (exhaustedGateVerdict?.regressed) {
-    logger?.info("non-blocking-fix", "best-effort fix exhausted with the full-suite gate red", {
-      storyId: args.storyId,
-      regressedKeys: exhaustedGateVerdict.regressedKeys.slice(0, MAX_LOGGED_REGRESSED_KEYS),
-      regressedKeyCount: exhaustedGateVerdict.regressedKeys.length,
-      baselineKeySize: exhaustedGateVerdict.baselineKeySize,
-      keyless: exhaustedGateVerdict.keyless,
-      memoExcludedKeyCount: exhaustedGateVerdict.memoExcludedKeys.length,
-      // Same gap as the sibling log above — triage owns the main gate path only (#1383).
-      flakeTriageRan: false,
-    });
+    logGateRegression(
+      logger,
+      args.storyId,
+      "best-effort fix exhausted with the full-suite gate red",
+      exhaustedGateVerdict,
+    );
   }
 
   return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
+}
+
+/**
+ * Emit the #1382 regression evidence: which test identities the pass is being blamed for.
+ *
+ * Shared by both restore paths — the gate-regressed keep-decision and the exhausted tail —
+ * because they must report the same fields. `flakeTriageRan` in particular is stated, not
+ * computed, and two hardcoded copies would drift the moment #1383's triage lands.
+ */
+function logGateRegression(
+  logger: ReturnType<typeof getSafeLogger>,
+  storyId: string,
+  message: string,
+  verdict: GateRegressionDetail,
+): void {
+  logger?.info("non-blocking-fix", message, {
+    storyId,
+    regressedKeys: verdict.regressedKeys.slice(0, MAX_LOGGED_REGRESSED_KEYS),
+    regressedKeyCount: verdict.regressedKeys.length,
+    baselineKeySize: verdict.baselineKeySize,
+    // True ⇒ execution-failure (or timeout, which yields no findings at all), so
+    // `regressedKeys` is empty because there was no identity to capture, NOT because
+    // nothing regressed.
+    keyless: verdict.keyless,
+    // Failures excluded as already-quarantined flakes (#1383).
+    memoExcludedKeyCount: verdict.memoExcludedKeys.length,
+    // Stated, not computed: this pass's revalidation gate is never flake-triaged — triage
+    // owns the main gate path only (`rectification.ts`, the non-override branch). So a
+    // FIRST-observation flake inside the revalidation window still reads as a regression,
+    // and an operator must be able to see that was possible rather than infer a real
+    // break (#1383 option 3).
+    flakeTriageRan: false,
+  });
 }
 
 async function restoreToSnapshot(

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -303,6 +303,28 @@ export async function runNonBlockingFix(
     return { ran: true, kept: true, restored: false };
   }
 
+  // #1382 parity on the exhausted path. Before #1401 the gate's regression was hidden
+  // from the cycle, so a gate-red pass always exited "resolved" and the identity log
+  // above was the only one that could fire. Now the cycle can see that regression and
+  // spend `regressionAttempts` on it — and when the repair fails, the restore arrives
+  // HERE instead, where the identities were never named. Without this the richer
+  // diagnostic disappears in exactly the case an operator most needs it: a regression
+  // real enough to survive a repair attempt. Read-only — `describeGateRegression` diffs
+  // key sets already in `phaseOutputs` and re-runs nothing.
+  const exhaustedGateVerdict = args.keptTreeRegressed?.();
+  if (exhaustedGateVerdict?.regressed) {
+    logger?.info("non-blocking-fix", "best-effort fix exhausted with the full-suite gate red", {
+      storyId: args.storyId,
+      regressedKeys: exhaustedGateVerdict.regressedKeys.slice(0, MAX_LOGGED_REGRESSED_KEYS),
+      regressedKeyCount: exhaustedGateVerdict.regressedKeys.length,
+      baselineKeySize: exhaustedGateVerdict.baselineKeySize,
+      keyless: exhaustedGateVerdict.keyless,
+      memoExcludedKeyCount: exhaustedGateVerdict.memoExcludedKeys.length,
+      // Same gap as the sibling log above — triage owns the main gate path only (#1383).
+      flakeTriageRan: false,
+    });
+  }
+
   return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
 }
 

--- a/src/execution/story-orchestrator/phase-eval.ts
+++ b/src/execution/story-orchestrator/phase-eval.ts
@@ -113,9 +113,34 @@ export function gateFailureKeys(gateOutput: unknown): Set<string> {
   for (const f of extractPhaseFindings(gateOutput)) {
     if (f.source !== "test-runner") continue;
     if (f.category === "flaky-test") continue;
-    keys.add(`${f.file ?? ""}::${f.rule ?? ""}`);
+    keys.add(gateFindingKey(f));
   }
   return keys;
+}
+
+/**
+ * Identity key for a single gate test-failure finding: `file::rule`.
+ *
+ * SSOT for every consumer that has to decide "is this the same failure?" — baseline
+ * diffing here, and quarantine-memo exclusion in both `describeGateRegression` and the
+ * rectification validate sweep. Extracted because those consumers must agree: when the
+ * sweep computed membership differently from the keep-decision that consumes its verdict,
+ * a known flake could seed a fix attempt that the keep-decision would have ignored (#1401).
+ */
+export function gateFindingKey(finding: Finding): string {
+  return `${finding.file ?? ""}::${finding.rule ?? ""}`;
+}
+
+/**
+ * True when this finding is a test failure the run has already quarantined as a flake.
+ *
+ * Mirrors the exclusion `describeGateRegression` applies before assigning blame, so a
+ * consumer that filters findings and a consumer that diffs keys reach the same verdict
+ * about the same gate output.
+ */
+export function isQuarantinedFlake(finding: Finding, quarantineMemo: QuarantineMemo | undefined): boolean {
+  if (finding.source !== "test-runner") return false;
+  return quarantineMemo?.has(gateFindingKey(finding)) === true;
 }
 
 /**

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -3,7 +3,7 @@ import { getSafeLogger } from "@/logger";
 import type { CallContext, Operation, RunOperation } from "@/operations";
 import { countOscillationOutcomes, recordOscillations } from "../oscillation-store";
 import { extractPhaseFindings, orderGateLast, phasesToRevalidate } from "./phase-eval";
-import { phaseExplicitlyPassed, phasePassed } from "./phase-eval";
+import { isQuarantinedFlake, phaseExplicitlyPassed, phasePassed } from "./phase-eval";
 import { _storyOrchestratorDeps, runPhase, withIncreasingFailuresBail } from "./run-phase";
 import type { AnySlot, InternalBuildState, InternalPhase, RectificationOverrides, RectificationResult } from "./types";
 import { EXHAUSTED_EXIT_REASONS } from "./types";
@@ -337,7 +337,23 @@ export async function runRectification(
         await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
         if (shouldSkipPhaseForRectification({ phase, state, phaseOutputs, nbfPath })) continue;
         const output = phaseOutputs[phase.slot.op.name];
-        findings.push(...extractPhaseFindings(output));
+        // #1383 parity. `describeGateRegression` — the predicate that actually decides
+        // keep-vs-discard for this pass — excludes failures the run already quarantined as
+        // flakes. Until #1401 the carve-out hid the whole gate output from the nbf sweep, so
+        // the cycle never had to agree with it; now it does. Without this filter a known
+        // flake firing inside the revalidation window would buy an agent session to "fix" it
+        // (via `full-suite-rectify`, which edits TEST code) and then discard a pass the
+        // keep-decision would have kept — silently walking back #1383.
+        //
+        // nbf-scoped: the main path reaches the same place differently (triage runs there and
+        // relabels quarantined failures to `flaky-test`, which `gatherRectificationFindings`
+        // already drops), so widening this would be an unrelated behaviour change.
+        const phaseFindings = extractPhaseFindings(output);
+        findings.push(
+          ...(nbfPath
+            ? phaseFindings.filter((f) => !isQuarantinedFlake(f, ctx.runtime.quarantineMemo))
+            : phaseFindings),
+        );
         // Mirror the main loop's halt-on-failure contract (spec §2C, PR #1127):
         // verifier and reviews must never judge broken-gate code, even inside the
         // rectification revalidation sweep. Findings collected so far feed the next

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -8,18 +8,40 @@ import { _storyOrchestratorDeps, runPhase, withIncreasingFailuresBail } from "./
 import type { AnySlot, InternalBuildState, InternalPhase, RectificationOverrides, RectificationResult } from "./types";
 import { EXHAUSTED_EXIT_REASONS } from "./types";
 
+/** Inputs to `shouldSkipPhaseForRectification`. Options object — the convention caps positional params at three. */
+export interface SkipPhaseForRectificationInput {
+  phase: InternalPhase;
+  state: InternalBuildState;
+  phaseOutputs: Record<string, unknown>;
+  /**
+   * True on the ADR-024 nbf revalidation sweep, where the carve-out must NOT apply (#1401).
+   *
+   * Two reasons. First, correctness: `phasesToRevalidate` orders the gate BEFORE the
+   * verifier, so at this point `phaseOutputs[verifier]` still holds the verifier's
+   * PRE-rectification pass. Reading it would exempt the gate on stale evidence — the
+   * verifier has not yet judged the tree the nbf pass just edited.
+   *
+   * Second, the policy has nothing to protect here. The carve-out exists so a story is
+   * not rolled back over regressions it did not cause; nbf never fails a story, it only
+   * chooses keep-vs-discard of its own edits, and `runNonBlockingFix` reads the same gate
+   * output RAW (`describeGateRegression`) to make that choice. Hiding the failure from the
+   * cycle therefore changed nothing about the outcome — it only forfeited the
+   * `regressionAttempts` repair budget and let the sweep spend a verifier session on a
+   * tree that was already condemned.
+   */
+  nbfPath?: boolean;
+}
+
 /**
  * Verifier-as-SSOT: when the verifier explicitly passed, full-suite-gate
  * failures represent unrelated regressions that this story did not cause.
  * Excluded from rectification (mirrors the carve-out in ExecutionPlan.run
  * success aggregation and post-run.ts:deriveFailureCategory).
  */
-export function shouldSkipPhaseForRectification(
-  phase: InternalPhase,
-  state: InternalBuildState,
-  phaseOutputs: Record<string, unknown>,
-): boolean {
+export function shouldSkipPhaseForRectification(input: SkipPhaseForRectificationInput): boolean {
+  const { phase, state, phaseOutputs, nbfPath } = input;
   if (phase.kind !== "full-suite-gate") return false;
+  if (nbfPath) return false;
   const verifierName = state.verifier?.slot.op.name;
   if (!verifierName) return false;
   return phaseExplicitlyPassed(phaseOutputs[verifierName]);
@@ -32,7 +54,9 @@ export function gatherRectificationFindings(
 ): Finding[] {
   const findings: Finding[] = [];
   for (const phase of phases) {
-    if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
+    // Seed-gathering runs only on the main path (the nbf path seeds from
+    // `overrides.initialFindings`), so the carve-out always applies here.
+    if (shouldSkipPhaseForRectification({ phase, state, phaseOutputs })) continue;
     for (const f of extractPhaseFindings(phaseOutputs[phase.slot.op.name])) {
       // Quarantined flakes (category === "flaky-test") are NOT actionable — the
       // story didn't cause them. Excluding them here keeps them out of the fix
@@ -195,7 +219,14 @@ export async function runRectification(
   }
 
   let initialFindings: Finding[];
+  // The ADR-024 nbf discriminator, assigned by the branch below rather than re-tested
+  // from `overrides` — the two must never be able to disagree about which path is
+  // running. Seeded findings are what distinguishes the best-effort pass from the main
+  // rectification loop, so this is also the SSOT for the behaviours that differ: no
+  // flake triage (#1383), and no verifier-SSOT carve-out in the validate sweep (#1401).
+  let nbfPath = false;
   if (overrides?.initialFindings) {
+    nbfPath = true;
     // ADR-024 nbf path — triage is a separate concern owned by the main gate path.
     //
     // This branch is what `runNonBlockingFix`'s restore log asserts as
@@ -281,14 +312,18 @@ export async function runRectification(
       // saving that motivated lite mode), and when everything cheaper is green
       // the gate is re-run to validate the fix.
       //
-      // Caveat — the verifier-SSOT carve-out still applies: when a verifier ran
-      // and passed, `shouldSkipPhaseForRectification` discards the gate's finding
-      // (unrelated-regression policy, lines ~430), so in that case the gate is
+      // Caveat — on the MAIN path the verifier-SSOT carve-out still applies: when a
+      // verifier ran and passed, `shouldSkipPhaseForRectification` discards the gate's
+      // finding (unrelated-regression policy, lines ~430), so in that case the gate is
       // dispatched (validating the just-applied fix per Q1) but does NOT block
       // "resolved". The gate is the decisive arbiter only when no passing
       // verifier overrides it (single-session, or a failed/absent verifier).
       // Session-agnostic — also covers a single-session per-story
       // full-suite-gate; verify-scoped was never skipped and is unaffected.
+      //
+      // On the nbf path the carve-out is OFF (#1401): the verifier output in scope is
+      // pre-rectification, and nbf discards its own tree on gate red regardless — see
+      // `SkipPhaseForRectificationInput.nbfPath`.
       const phases = lite ? orderGateLast(selectedWithExtra) : selectedWithExtra;
       getSafeLogger()?.debug("story-orchestrator", "rectification validate scope", {
         storyId: ctx.storyId,
@@ -300,7 +335,7 @@ export async function runRectification(
       let shortCircuited = false;
       for (const phase of phases) {
         await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
-        if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
+        if (shouldSkipPhaseForRectification({ phase, state, phaseOutputs, nbfPath })) continue;
         const output = phaseOutputs[phase.slot.op.name];
         findings.push(...extractPhaseFindings(output));
         // Mirror the main loop's halt-on-failure contract (spec §2C, PR #1127):

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -199,7 +199,16 @@ export const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[
  * blocking-cycle behavior exactly.
  */
 export interface RectificationOverrides {
-  /** Seed findings instead of gatherRectificationFindings(...). */
+  /**
+   * Seed findings instead of `gatherRectificationFindings(...)`.
+   *
+   * Load-bearing beyond seeding: setting this field IS the ADR-024 nbf discriminator, and
+   * `runRectification` derives two further behaviours from it — flake triage is skipped
+   * (#1383) and the verifier-SSOT carve-out is disabled in the validate sweep, with the
+   * quarantine-memo exclusion applied there instead (#1401). A caller that seeds findings
+   * for some other reason inherits all three. `ExecutionPlan.run`'s nbf branch is currently
+   * the only such caller; a second one should promote this to an explicit flag.
+   */
   initialFindings?: readonly Finding[];
   /** Strategy set instead of state.rectification.strategies (scope filtering). */
   strategies?: FixStrategy<Finding, unknown, unknown, unknown>[];

--- a/test/unit/execution/non-blocking-fix.test.ts
+++ b/test/unit/execution/non-blocking-fix.test.ts
@@ -169,6 +169,68 @@ describe("runNonBlockingFix keep vs restore", () => {
     expect(Object.keys(data)[0]).toBe("storyId");
   });
 
+  // #1401 — once the gate regression became visible to the cycle, a pass that spends
+  // `regressionAttempts` and still fails exits EXHAUSTED, so the restore arrives on the
+  // exhausted path instead of the keptTreeRegressed one above. Without a log there, the
+  // #1382 diagnostic silently vanishes in the case that most warrants it: a regression
+  // real enough to survive a repair attempt.
+  test("exhausted restore also names the regressing keys when the gate is red (#1401)", async () => {
+    const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: false } };
+    const record = await withInfoSpy(async (infoSpy) => {
+      await runNonBlockingFix(
+        {
+          ...baseArgs,
+          phaseOutputs,
+          // The repair attempt ran and failed — the cycle exhausted its budget.
+          runRectify: async () => ({ rectificationExhausted: true }),
+          keptTreeRegressed: () => ({
+            regressed: true,
+            regressedKeys: ["still-broke.test.ts::renders empty state"],
+            memoExcludedKeys: [],
+            baselineKeySize: 3,
+            keyless: false,
+          }),
+        },
+        fakeDeps,
+      );
+      return infoSpy.mock.calls.find((c) => String(c[1]).includes("exhausted with the full-suite gate red"));
+    });
+
+    expect(record).toBeDefined();
+    const data = record?.[2] as Record<string, unknown>;
+    expect(data.regressedKeys).toEqual(["still-broke.test.ts::renders empty state"]);
+    expect(data.regressedKeyCount).toBe(1);
+    expect(data.baselineKeySize).toBe(3);
+    expect(data.keyless).toBe(false);
+    expect(Object.keys(data)[0]).toBe("storyId");
+  });
+
+  test("exhausted restore stays quiet when the gate did NOT regress (ordinary exhaustion)", async () => {
+    // Guards the log above from degrading into noise on every exhausted pass — the
+    // common case is "the fix just didn't land", which has no gate regression to name.
+    const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
+    const record = await withInfoSpy(async (infoSpy) => {
+      await runNonBlockingFix(
+        {
+          ...baseArgs,
+          phaseOutputs,
+          runRectify: async () => ({ rectificationExhausted: true }),
+          keptTreeRegressed: () => ({
+            regressed: false,
+            regressedKeys: [],
+            memoExcludedKeys: [],
+            baselineKeySize: 0,
+            keyless: false,
+          }),
+        },
+        fakeDeps,
+      );
+      return infoSpy.mock.calls.find((c) => String(c[1]).includes("exhausted with the full-suite gate red"));
+    });
+
+    expect(record).toBeUndefined();
+  });
+
   test("keyless regression is logged as such, with an empty key list (#1382)", async () => {
     // A timeout / execution-failure yields no comparable identity. The log must say so
     // rather than showing an empty `regressedKeys` that reads as "nothing regressed".

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -15,7 +15,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { type DEFAULT_CONFIG, pickSelector } from "@/config";
-import { StoryOrchestratorBuilder, _storyOrchestratorDeps, orderGateLast } from "@/execution";
+import { StoryOrchestratorBuilder, _storyOrchestratorDeps, orderGateLast, runRectification } from "@/execution";
 import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
 import type { Finding } from "@/findings/types";
 import type { CallContext, RunOperation } from "@/operations";
@@ -553,5 +553,233 @@ describe("orderGateLast — pure ordering helper", () => {
   test("is a no-op when there is no full-suite-gate phase", () => {
     const input = [mk("lint-check"), mk("typecheck-check"), mk("semantic-review")];
     expect(orderGateLast(input).map((p) => p.kind)).toEqual(["lint-check", "typecheck-check", "semantic-review"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1401 — the nbf revalidation must not inherit a STALE verifier pass.
+//
+// `phasesToRevalidate` places full-suite-gate before the verifier in the sweep,
+// so when the carve-out is evaluated `phaseOutputs[verifier]` still holds the
+// PRE-rectification pass. On the nbf path that stale green made the carve-out
+// discard the very regression the pass had just introduced, which (a) let the
+// cycle exit "resolved" so `regressionAttempts` was never spent, and (b) skipped
+// the halt-on-failure short-circuit so the verifier session still ran against a
+// red gate. `runNonBlockingFix` then read the same gate output RAW and restored.
+//
+// The carve-out exists so a story is not rolled back over regressions it did not
+// cause. nbf never fails a story — it only chooses keep-vs-discard of its own
+// edits — so the policy has nothing to protect there and only forfeits the repair.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verifier-SSOT carve-out — nbf revalidation must not inherit a stale verifier pass (#1401)", () => {
+  const ADVISORY = {
+    source: "adversarial-review",
+    severity: "warning",
+    category: "style",
+    message: "advisory — seeds the nbf pass",
+  } as unknown as Finding;
+
+  const GATE_FAILURE = {
+    source: "test-runner",
+    severity: "error",
+    category: "",
+    message: "the regression the nbf pass introduced",
+    file: "test/integration/tdd/story-orchestrator-verdict.test.ts",
+    rule: "verifier session fails",
+  } as unknown as Finding;
+
+  /** Gate + verifier + the cheap checks: the minimum to reproduce the stale read. */
+  function makeRectifyState(strategies: unknown[] = []): Parameters<typeof runRectification>[1] {
+    return {
+      fullSuiteGate: { kind: "full-suite-gate", slot: { op: mockFullSuiteGateOp, input: { story: "US-1401" } } },
+      verifier: { kind: "verifier", slot: { op: mockVerifierOp, input: { story: "US-1401" } } },
+      lintCheck: { kind: "lint-check", slot: { op: mockLintCheckOp, input: { story: "US-1401" } } },
+      typecheckCheck: { kind: "typecheck-check", slot: { op: mockTypecheckCheckOp, input: { story: "US-1401" } } },
+      rectification: { maxAttempts: 3, strategies, abortOnIncreasingFailures: false },
+    } as unknown as Parameters<typeof runRectification>[1];
+  }
+
+  /** Mirrors ExecutionPlan's nbf wiring: seeded advisories + verifierGuard extra phase. */
+  function nbfOverrides(extra: Record<string, unknown> = {}) {
+    return {
+      initialFindings: [ADVISORY],
+      extraRevalidationKinds: ["verifier"],
+      // 1 + review.nonBlockingFix.regressionAttempts (default 1).
+      maxAttempts: 2,
+      ...extra,
+    } as unknown as Parameters<typeof runRectification>[4];
+  }
+
+  /** Pre-rectification state: the story was green, verifier included. */
+  const greenBefore = (): Record<string, unknown> => ({
+    verifier: { success: true, passed: true, findings: [] },
+    "full-suite-gate": { success: true, passed: true, findings: [] },
+  });
+
+  /** Re-runs during validate: only the gate is red. */
+  function failGateOnly(): void {
+    _storyOrchestratorDeps.callOp = mock(async (_c: unknown, op: { name: string }) => {
+      if (op.name === "full-suite-gate") return { success: false, passed: false, findings: [GATE_FAILURE] };
+      return { success: true, passed: true, findings: [] };
+    }) as typeof _storyOrchestratorDeps.callOp;
+  }
+
+  /** Capture the FixCycle runRectification builds, without running it. */
+  async function captureNbfCycle(
+    ctx: CallContext,
+    state: Parameters<typeof runRectification>[1],
+    phaseOutputs: Record<string, unknown>,
+    overrides: Parameters<typeof runRectification>[4],
+  ): Promise<{ cycle: FixCycle<Finding>; cycleCtx: FixCycleContext }> {
+    let cycle: FixCycle<Finding> | null = null;
+    let cycleCtx: FixCycleContext | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (c: FixCycle<Finding>, cc: FixCycleContext) => {
+      cycle = c;
+      cycleCtx = cc;
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as FixCycleExitReason, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    await runRectification(ctx, state, {}, phaseOutputs, overrides);
+    failGateOnly();
+    return { cycle: cycle as unknown as FixCycle<Finding>, cycleCtx: cycleCtx as unknown as FixCycleContext };
+  }
+
+  test("nbf path: a gate regression surfaces as a finding instead of being discarded by the stale verifier pass", async () => {
+    const ctx = makeCtx();
+    const phaseOutputs = greenBefore();
+    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
+
+    const result = await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    // The gate's failure must reach the cycle — this is what makes the next
+    // iteration happen at all, i.e. what makes `regressionAttempts` spendable.
+    expect(result.findings.some((f) => f.source === "test-runner")).toBe(true);
+    // And the halt-on-failure contract must hold: nothing downstream of a red
+    // gate may run, so the expensive verifier session is never dispatched.
+    expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(true);
+  });
+
+  test("nbf path: the verifier is NOT dispatched after the gate goes red (no session spent on a doomed pass)", async () => {
+    const ctx = makeCtx();
+    const phaseOutputs = greenBefore();
+    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
+
+    const dispatched: string[] = [];
+    const failing = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = (async (c: unknown, op: { name: string }, i: unknown) => {
+      dispatched.push(op.name);
+      return (failing as (c: unknown, op: unknown, i: unknown) => Promise<unknown>)(c, op, i);
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    expect(dispatched).toContain("full-suite-gate");
+    expect(dispatched).not.toContain("verifier");
+  });
+
+  test("control — the main (non-nbf) path keeps the carve-out: a red gate is still discarded when the verifier passed", async () => {
+    const ctx = makeCtx();
+    // Seed via gatherRectificationFindings: lint red pre-rectification, verifier green.
+    const phaseOutputs: Record<string, unknown> = {
+      verifier: { success: true, passed: true, findings: [] },
+      "lint-check": { success: false, passed: false, findings: [LINT_FINDING] },
+    };
+    let cycle: FixCycle<Finding> | null = null;
+    let cycleCtx: FixCycleContext | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (c: FixCycle<Finding>, cc: FixCycleContext) => {
+      cycle = c;
+      cycleCtx = cc;
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as FixCycleExitReason, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    await runRectification(ctx, makeRectifyState(), {}, phaseOutputs);
+    failGateOnly();
+
+    const result = await (cycle as unknown as FixCycle<Finding>).validate(cycleCtx as unknown as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["autofix-implementer"],
+    });
+
+    // Unchanged main-path semantics: the verifier's pass still exempts the gate.
+    expect(result.findings.some((f) => f.source === "test-runner")).toBe(false);
+    expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1401 — the consequence the two tests above buy: `review.nonBlockingFix
+// .regressionAttempts` becomes spendable. `runNonBlockingFix` passes
+// `1 + regressionAttempts` as the cycle's maxAttemptsTotal; while the gate
+// regression was discarded the cycle always exited "resolved" on iteration 1, so
+// the budget could never be reached on any verifier-bearing (three-session) plan.
+// This drives the REAL runFixCycle to prove the second attempt now happens.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("nbf regressionAttempts is actually spendable once the gate regression surfaces (#1401)", () => {
+  const ADVISORY = {
+    source: "adversarial-review",
+    severity: "warning",
+    category: "style",
+    message: "advisory — seeds the nbf pass",
+  } as unknown as Finding;
+
+  const GATE_FAILURE = {
+    source: "test-runner",
+    severity: "error",
+    category: "",
+    message: "the regression the nbf pass introduced",
+    file: "test/integration/tdd/story-orchestrator-verdict.test.ts",
+    rule: "verifier session fails",
+  } as unknown as Finding;
+
+  test("a gate that stays red drives a SECOND fix attempt instead of exiting 'resolved' after one", async () => {
+    const ctx = makeCtx();
+
+    const attempts: string[] = [];
+    _storyOrchestratorDeps.callOp = mock(async (_c: unknown, op: { name: string }) => {
+      if (op.name === "implementer") {
+        attempts.push("fix");
+        return { success: true };
+      }
+      // The nbf edit broke the suite and the repair does not clear it, so the gate
+      // stays red across both iterations — the worst case for the budget.
+      if (op.name === "full-suite-gate") return { success: false, passed: false, findings: [GATE_FAILURE] };
+      return { success: true, passed: true, findings: [] };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const strategy = {
+      name: "autofix-implementer",
+      appliesTo: (f: Finding) => f.source === "adversarial-review" || f.source === "test-runner",
+      fixOp: mockImplementerOp,
+      buildInput: () => ({ story: "US-1401" }),
+      maxAttempts: 2,
+    };
+
+    const state = {
+      fullSuiteGate: { kind: "full-suite-gate", slot: { op: mockFullSuiteGateOp, input: { story: "US-1401" } } },
+      verifier: { kind: "verifier", slot: { op: mockVerifierOp, input: { story: "US-1401" } } },
+      lintCheck: { kind: "lint-check", slot: { op: mockLintCheckOp, input: { story: "US-1401" } } },
+      rectification: { maxAttempts: 3, strategies: [strategy], abortOnIncreasingFailures: false },
+    } as unknown as Parameters<typeof runRectification>[1];
+
+    await runRectification(
+      ctx,
+      state,
+      {},
+      // Pre-rectification: green, verifier included — the stale pass that used to
+      // exempt the gate for the whole sweep.
+      { verifier: { success: true, passed: true, findings: [] } },
+      {
+        initialFindings: [ADVISORY],
+        extraRevalidationKinds: ["verifier"],
+        // 1 + review.nonBlockingFix.regressionAttempts (default 1).
+        maxAttempts: 2,
+      } as unknown as Parameters<typeof runRectification>[4],
+    );
+
+    // Iteration 1 fixes the advisory; the gate then goes red and that finding now
+    // reaches the cycle, so iteration 2 dispatches the repair attempt.
+    expect(attempts).toHaveLength(2);
   });
 });

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -68,6 +68,24 @@ const mockTypecheckCheckOp = makePhaseOp("typecheck-check", "verify", "verifier"
 const mockSemanticReviewOp = makePhaseOp("semantic-review", "review", "reviewer-semantic");
 const mockAdversarialReviewOp = makePhaseOp("adversarial-review", "review", "reviewer-adversarial");
 
+// #1401 nbf fixtures — shared by both nbf describes below.
+const ADVISORY = {
+  source: "adversarial-review",
+  severity: "warning",
+  category: "style",
+  message: "advisory — seeds the nbf pass",
+} as unknown as Finding;
+
+/** The regression an nbf pass introduces: a test-runner failure with a stable identity. */
+const GATE_FAILURE = {
+  source: "test-runner",
+  severity: "error",
+  category: "",
+  message: "the regression the nbf pass introduced",
+  file: "test/integration/tdd/story-orchestrator-verdict.test.ts",
+  rule: "verifier session fails",
+} as unknown as Finding;
+
 const LINT_FINDING: Finding = {
   source: "lint",
   tool: "biome",
@@ -573,22 +591,6 @@ describe("orderGateLast — pure ordering helper", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("verifier-SSOT carve-out — nbf revalidation must not inherit a stale verifier pass (#1401)", () => {
-  const ADVISORY = {
-    source: "adversarial-review",
-    severity: "warning",
-    category: "style",
-    message: "advisory — seeds the nbf pass",
-  } as unknown as Finding;
-
-  const GATE_FAILURE = {
-    source: "test-runner",
-    severity: "error",
-    category: "",
-    message: "the regression the nbf pass introduced",
-    file: "test/integration/tdd/story-orchestrator-verdict.test.ts",
-    rule: "verifier session fails",
-  } as unknown as Finding;
-
   /** Gate + verifier + the cheap checks: the minimum to reproduce the stale read. */
   function makeRectifyState(strategies: unknown[] = []): Parameters<typeof runRectification>[1] {
     return {
@@ -705,6 +707,25 @@ describe("verifier-SSOT carve-out — nbf revalidation must not inherit a stale 
     expect(result.findings.some((f) => f.source === "test-runner")).toBe(false);
     expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(false);
   });
+
+  // #1383 parity. `describeGateRegression` excludes already-quarantined keys from the
+  // blame set, so a known flake firing inside the revalidation window must KEEP the pass.
+  // Turning the carve-out off exposed the sweep to that same gate output, so the sweep has
+  // to apply the same exclusion — otherwise the flake seeds a fix attempt (and a test-code
+  // edit via full-suite-rectify) and the pass is discarded, reversing #1383.
+  test("nbf path: a failure the run already quarantined does NOT seed a fix attempt", async () => {
+    const ctx = makeCtx();
+    ctx.runtime.quarantineMemo.add(`${GATE_FAILURE.file}::${GATE_FAILURE.rule}`);
+
+    const phaseOutputs = greenBefore();
+    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
+
+    const result = await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    // No blame ⇒ no finding ⇒ the cycle resolves and `keptTreeRegressed` (which excludes
+    // the same key) keeps the pass, exactly as it did before #1401.
+    expect(result.findings.some((f) => f.source === "test-runner")).toBe(false);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -717,22 +738,6 @@ describe("verifier-SSOT carve-out — nbf revalidation must not inherit a stale 
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("nbf regressionAttempts is actually spendable once the gate regression surfaces (#1401)", () => {
-  const ADVISORY = {
-    source: "adversarial-review",
-    severity: "warning",
-    category: "style",
-    message: "advisory — seeds the nbf pass",
-  } as unknown as Finding;
-
-  const GATE_FAILURE = {
-    source: "test-runner",
-    severity: "error",
-    category: "",
-    message: "the regression the nbf pass introduced",
-    file: "test/integration/tdd/story-orchestrator-verdict.test.ts",
-    rule: "verifier session fails",
-  } as unknown as Finding;
-
   test("a gate that stays red drives a SECOND fix attempt instead of exiting 'resolved' after one", async () => {
     const ctx = makeCtx();
 


### PR DESCRIPTION
Fixes #1401.

## Problem

`review.nonBlockingFix.regressionAttempts` (default `1`) is documented as *"fix attempts to clear a regression the best-effort fix introduced"*, and ADR-024 §4 promises it. `runNonBlockingFix` spends it as `maxAttempts = 1 + regressionAttempts`. **On any verifier-bearing (three-session) plan the budget was unreachable** — so the code did not implement §4.

`phasesToRevalidate` orders `full-suite-gate` before `verifier` in the sweep, so when the verifier-SSOT carve-out was evaluated `phaseOutputs[verifier]` still held the verifier's *pre-rectification* pass. On the nbf path that stale green made the carve-out `continue` past the gate, which:

1. discarded the regression the pass had just introduced → the cycle exited `resolved` at iteration 1 → the repair was never requested; and
2. bypassed the halt-on-failure short-circuit → lint, typecheck and a full **verifier agent session** ran against a red gate.

`runNonBlockingFix` then read the same gate output raw via `describeGateRegression`, saw red, and restored anyway. Two consumers of one gate output under opposite policies, only the second authoritative.

Observed on `otlp-logs-exporter` run `run-2026-07-31T04-16-49-175Z` US-003: two commits discarded — one of them a real production fix (`workdir` missing from `OtelReporterConfigSchema`, so Zod stripped the key and the otel reporter's git branch/SHA resolution was dead code) — over a single first-observation flake, after spending 3m11s of verifier session on an already-condemned tree.

## Change

**`68bf836f`** — turn the carve-out off on the nbf path. `shouldSkipPhaseForRectification` takes an options object (a 4th positional param would breach the ≤3 cap) with `nbfPath`, assigned *by* the same `if (overrides?.initialFindings)` branch that governs the triage skip so the two cannot disagree.

Rationale: the carve-out exists so a story is not rolled back over regressions it did not cause. nbf never fails a story — it only chooses keep-vs-discard of its own edits. Blast radius is bounded by the §5 entry condition (`execution-plan.ts:308-310`): nbf runs only when *every* phase output passes, gate included, so a red gate inside the pass is always newly introduced.

The alternative — "require the verifier to have re-run in-sweep" — was rejected: `autofix-implementer` / `autofix-test-writer` deliberately exclude `verifier` from `STRATEGY_TO_REVALIDATION_PHASES`, so it would have switched the carve-out off on the main path too.

**`d07596aa`** — making the regression visible moved *which branch* restores in the gate-red case (it now exhausts rather than resolves), so #1382's regressing-identity diagnostic would have vanished from that path. Log the same detail there, gated on `regressed` so ordinary exhaustion stays quiet.

**`e4e6b7a7`** — review fixes. The important one: exposing the gate output to the sweep also exposed a divergence with `describeGateRegression`, which excludes already-quarantined flakes (#1383) while the sweep did not. A known flake firing in the revalidation window would have bought an agent session to "fix" it (via `full-suite-rectify`, which edits **test** code) and then discarded a pass #1383 arranged to keep — the one case where this branch was worse than `main`. The sweep now applies the same exclusion via `isQuarantinedFlake`, sharing `gateFindingKey` with `gateFailureKeys` so the two cannot drift. Main path untouched (triage relabels to `flaky-test` there, which `gatherRectificationFindings` already drops).

## Behaviour changes recorded in the ADR

- **`execution-failure` costs one attempt** — the synthetic `"::"` finding now seeds the cycle, so the pass spends one repair attempt before restoring. Bounded by `regressionAttempts`. *Timeout does not* — `full-suite-gate` returns `findings: []` there.
- **Pre-existing failures the pass re-breaks are now visible** — `describeGateRegression` exempts the verifier-time baseline; the sweep has no baseline. Such a failure was previously kept red (and laundered into a story pass by the SSOT carve-out); it now earns a repair attempt and is restored if the repair fails. Strictly safer, but a real outcome change.

## Not in scope

#1383 option 1 (read-only flake triage on the nbf revalidation). Without it a *first-observation* flake will now send an implementer to "fix" a test that was never broken — bounded by `regressionAttempts`, and still better than silently discarding a real fix, but the two belong together. Worth filing before enabling widely.

## Test plan

- [x] 7 tests added. Each verified to **fail without the fix** (flag flipped, 3 fail; memo filter removed, 1 fail) — not vacuous.
  - gate regression surfaces as a finding instead of being discarded
  - verifier is not dispatched after the gate goes red
  - control: main path keeps the carve-out (unchanged semantics)
  - quarantined failure does not seed a fix attempt (#1383 parity)
  - real `runFixCycle` drives a **second** fix attempt — the budget is actually spendable
  - exhausted restore names the regressing keys
  - exhausted restore stays quiet when the gate did not regress
- [x] `bun run test` — 10596 pass / 13 skip / 848 files, integration + ui green.
- [x] `bun run typecheck` clean; `bun run lint` clean (9 gates, no baselines moved).

One unrelated flake surfaced on the first full-suite run — `test/unit/runtime/middleware/logging.test.ts` read a `Skipping OTLP export` line via `parseLastEntry`. Passes in isolation, passes on full re-run, and originates in `otel-reporter/index.ts` which this branch does not touch. Pre-existing test-isolation race; worth its own issue.
