### PR TITLE
fix(execution): bound completion memory usage

### DIFF
--- a/src/context/engine/effectiveness.ts
+++ b/src/context/engine/effectiveness.ts
@@ -18,6 +18,7 @@ import type { ChunkEffectiveness } from "./types";
 
 export const _effectivenessDeps = {
   getLogger,
+  tokenize,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -68,26 +69,73 @@ const STOPWORDS = new Set([
   "your",
 ]);
 const MIN_TOKEN_LEN = 4;
+const TOKEN_PATTERN = /[^\s_\-./:,;()\[\]{}'"!?]+/g;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tokenizer (local copy — avoids a circular dep between staleness ↔ effectiveness)
 // ─────────────────────────────────────────────────────────────────────────────
 
 function tokenize(text: string): Set<string> {
-  if (!text) return new Set();
-  const raw = text
-    .toLowerCase()
-    .split(/[\s_\-./:,;()\[\]{}'"!?]+/)
-    .filter((t) => t.length >= MIN_TOKEN_LEN && !STOPWORDS.has(t));
-  return new Set(raw);
+  const terms = new Set<string>();
+  for (const match of text.matchAll(TOKEN_PATTERN)) {
+    const term = match[0].toLowerCase();
+    if (term.length >= MIN_TOKEN_LEN && !STOPWORDS.has(term)) terms.add(term);
+  }
+  return terms;
 }
 
-function sharedTermCount(a: Set<string>, b: Set<string>): number {
+function sharedTermCount(a: ReadonlySet<string>, b: ReadonlySet<string>): number {
   let count = 0;
   for (const term of a) {
     if (b.has(term)) count++;
   }
   return count;
+}
+
+interface EffectivenessEvidenceTerms {
+  findings: Array<{ message: string; terms: ReadonlySet<string> }>;
+  diff?: ReadonlySet<string>;
+  combined?: ReadonlySet<string>;
+}
+
+function buildEvidenceTerms(
+  agentOutput: string,
+  diffText: string,
+  findingMessages: string[],
+): EffectivenessEvidenceTerms {
+  const diffTerms = diffText ? _effectivenessDeps.tokenize(diffText) : undefined;
+  const outputTerms = agentOutput ? _effectivenessDeps.tokenize(agentOutput) : undefined;
+  let combined: Set<string> | undefined;
+  if (diffTerms || outputTerms) {
+    combined = new Set(diffTerms);
+    for (const term of outputTerms ?? []) combined.add(term);
+  }
+  return {
+    findings: findingMessages.map((message) => ({ message, terms: _effectivenessDeps.tokenize(message) })),
+    diff: diffTerms,
+    combined,
+  };
+}
+
+function classifyWithTerms(chunkSummary: string, evidence: EffectivenessEvidenceTerms): ChunkEffectiveness {
+  const summaryTerms = _effectivenessDeps.tokenize(chunkSummary);
+  if (summaryTerms.size < MIN_SIGNIFICANT_TERMS) return { signal: "unknown" };
+
+  for (const finding of evidence.findings) {
+    if (sharedTermCount(summaryTerms, finding.terms) >= MIN_SIGNIFICANT_TERMS) {
+      return { signal: "contradicted", evidence: finding.message.slice(0, 200) };
+    }
+  }
+
+  if (evidence.diff && sharedTermCount(summaryTerms, evidence.diff) >= MIN_SIGNIFICANT_TERMS) {
+    return { signal: "followed", evidence: "terms found in diff" };
+  }
+
+  if (evidence.combined && sharedTermCount(summaryTerms, evidence.combined) < MIN_SIGNIFICANT_TERMS) {
+    return { signal: "ignored" };
+  }
+
+  return { signal: "unknown" };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -116,44 +164,7 @@ export function classifyEffectiveness(
   diffText: string,
   findingMessages: string[],
 ): ChunkEffectiveness {
-  const summaryTerms = tokenize(chunkSummary);
-
-  // Too few terms → cannot classify meaningfully
-  if (summaryTerms.size < MIN_SIGNIFICANT_TERMS) {
-    return { signal: "unknown" };
-  }
-
-  // 1. Contradicted: review finding text overlaps with chunk summary
-  for (const finding of findingMessages) {
-    const findingTerms = tokenize(finding);
-    if (sharedTermCount(summaryTerms, findingTerms) >= MIN_SIGNIFICANT_TERMS) {
-      return {
-        signal: "contradicted",
-        evidence: finding.slice(0, 200),
-      };
-    }
-  }
-
-  // 2. Followed: diff overlaps with chunk summary
-  if (diffText) {
-    const diffTerms = tokenize(diffText);
-    if (sharedTermCount(summaryTerms, diffTerms) >= MIN_SIGNIFICANT_TERMS) {
-      return {
-        signal: "followed",
-        evidence: "terms found in diff",
-      };
-    }
-  }
-
-  // 3. Ignored: terms appear in neither diff nor agent output
-  if (diffText || agentOutput) {
-    const combinedTerms = tokenize(`${diffText} ${agentOutput}`);
-    if (sharedTermCount(summaryTerms, combinedTerms) < MIN_SIGNIFICANT_TERMS) {
-      return { signal: "ignored" };
-    }
-  }
-
-  return { signal: "unknown" };
+  return classifyWithTerms(chunkSummary, buildEvidenceTerms(agentOutput, diffText, findingMessages));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -185,16 +196,18 @@ export async function annotateManifestEffectiveness(
   },
 ): Promise<void> {
   const stored = await loadContextManifests(projectDir, storyId, featureId);
+  let evidenceTerms: EffectivenessEvidenceTerms | undefined;
 
   for (const item of stored) {
     const { manifest } = item;
     if (!manifest.chunkSummaries || manifest.includedChunks.length === 0) continue;
+    evidenceTerms ??= buildEvidenceTerms(agentOutput, diffText, findingMessages);
 
     const effectiveness: Record<string, ChunkEffectiveness> = {};
     for (const id of manifest.includedChunks) {
       const summary = manifest.chunkSummaries[id];
       if (!summary) continue;
-      effectiveness[id] = classifyEffectiveness(summary, agentOutput, diffText, findingMessages);
+      effectiveness[id] = classifyWithTerms(summary, evidenceTerms);
     }
 
     if (Object.keys(effectiveness).length === 0) continue;

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -4,6 +4,7 @@ export { inspectOscillationBreaker, type BreakerDecision } from "./oscillation-b
 export { run, _runnerDeps, _runnerReentrancyGuard } from "./runner";
 export type { FailureCategory } from "../tdd/types";
 export { appendProgress } from "./progress";
+export { releaseHeavyPipelineContext } from "./iteration-runner";
 export { groupStoriesIntoBatches, type StoryBatch } from "./batching";
 export { escalateTier, getTierConfig, calculateMaxIterations, resolveMaxAttemptsOutcome } from "./escalation";
 export { readQueueFile, clearQueueFile } from "./queue-handler";

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -36,6 +36,24 @@ export interface IterationResult {
   subStoryCount?: number;
 }
 
+/** Drop per-story payloads after result handlers persist the data needed by later iterations. */
+export function releaseHeavyPipelineContext(ctx: PipelineContext): void {
+  ctx.agentResult = undefined;
+  ctx.prompt = undefined;
+  ctx.contextMarkdown = undefined;
+  ctx.featureContextMarkdown = undefined;
+  ctx.builtContext = undefined;
+  ctx.contextBundle = undefined;
+  ctx.constitution = undefined;
+  ctx.acceptanceFailures = undefined;
+  ctx.autofixPriorIterations = undefined;
+  ctx.priorSemanticIterations = undefined;
+  ctx.priorAdversarialIterations = undefined;
+  ctx.reviewFindings = undefined;
+  ctx.selfVerification = undefined;
+  ctx.tddIsolations = undefined;
+}
+
 export async function runIteration(
   ctx: SequentialExecutionContext,
   prd: PRD,
@@ -282,12 +300,7 @@ export async function runIteration(
     };
   }
 
-  // Release heavy context fields after handlers are done reading them.
-  pipelineContext.agentResult = undefined;
-  pipelineContext.prompt = undefined;
-  pipelineContext.contextMarkdown = undefined;
-  pipelineContext.builtContext = undefined;
-  pipelineContext.constitution = undefined;
+  releaseHeavyPipelineContext(pipelineContext);
 
   return iterResult;
 }

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -23,6 +23,22 @@ import { errorMessage } from "../../utils/errors";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
+const MAX_EFFECTIVENESS_DIFF_CHARS = 8_000;
+const HIGH_MEMORY_TELEMETRY_BYTES = 512 * 1_024 * 1_024;
+
+function logHighMemoryCheckpoint(logger: ReturnType<typeof getLogger>, ctx: PipelineContext): void {
+  const usage = process.memoryUsage();
+  if (usage.heapUsed < HIGH_MEMORY_TELEMETRY_BYTES && usage.rss < HIGH_MEMORY_TELEMETRY_BYTES) return;
+  logger.debug("completion.memory", "High memory at completion boundary", {
+    storyId: ctx.story.id,
+    heapUsedBytes: usage.heapUsed,
+    rssBytes: usage.rss,
+    externalBytes: usage.external,
+    arrayBuffersBytes: usage.arrayBuffers,
+    agentOutputChars: ctx.agentResult?.output.length ?? 0,
+  });
+}
+
 export const completionStage: PipelineStage = {
   name: "completion",
   enabled: () => true,
@@ -129,6 +145,8 @@ export const completionStage: PipelineStage = {
       await _completionDeps.savePRD(ctx.prd, prdPath);
     }
 
+    logHighMemoryCheckpoint(logger, ctx);
+
     // Display progress
     const updatedCounts = countStories(ctx.prd);
     logger.info("completion", "Progress update", {
@@ -143,14 +161,42 @@ export const completionStage: PipelineStage = {
   },
 };
 
+async function readTextStreamPrefix(stream: ReadableStream<Uint8Array>, maxChars: number): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (output.length >= maxChars) continue;
+      const decoded = decoder.decode(value, { stream: true });
+      output += decoded.slice(0, maxChars - output.length);
+    }
+    if (output.length < maxChars) {
+      output += decoder.decode().slice(0, maxChars - output.length);
+    }
+    return output;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 /** Get a git diff text between baseRef and HEAD. Best-effort, returns "" on failure. */
 async function getDiffText(workdir: string, baseRef: string | undefined): Promise<string> {
   if (!baseRef) return "";
   try {
-    const proc = Bun.spawn(["git", "diff", `${baseRef}..HEAD`], { cwd: workdir, stdout: "pipe", stderr: "pipe" });
-    const output = await new Response(proc.stdout).text();
-    await proc.exited;
-    return output.slice(0, 8000); // cap to avoid bloating effectiveness inputs
+    const proc = _completionDeps.spawn(["git", "diff", `${baseRef}..HEAD`], {
+      cwd: workdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [output] = await Promise.all([
+      readTextStreamPrefix(proc.stdout, MAX_EFFECTIVENESS_DIFF_CHARS),
+      readTextStreamPrefix(proc.stderr, 0),
+      proc.exited,
+    ]);
+    return output;
   } catch {
     return "";
   }
@@ -164,4 +210,6 @@ export const _completionDeps = {
   persistSemanticVerdict,
   savePRD,
   getDiffText,
+  readTextStreamPrefix,
+  spawn: Bun.spawn,
 };

--- a/test/unit/context/engine/effectiveness.test.ts
+++ b/test/unit/context/engine/effectiveness.test.ts
@@ -104,12 +104,14 @@ describe("annotateManifestEffectiveness — #506 catch block logging", () => {
   let origListManifestFiles: typeof _manifestStoreDeps.listManifestFiles;
   let origFileExists: typeof _manifestStoreDeps.fileExists;
   let origGetLogger: typeof _effectivenessDeps.getLogger;
+  let origTokenize: typeof _effectivenessDeps.tokenize;
 
   beforeEach(() => {
     origReadFile = _manifestStoreDeps.readFile;
     origListManifestFiles = _manifestStoreDeps.listManifestFiles;
     origFileExists = _manifestStoreDeps.fileExists;
     origGetLogger = _effectivenessDeps.getLogger;
+    origTokenize = _effectivenessDeps.tokenize;
   });
 
   afterEach(() => {
@@ -117,6 +119,7 @@ describe("annotateManifestEffectiveness — #506 catch block logging", () => {
     _manifestStoreDeps.listManifestFiles = origListManifestFiles;
     _manifestStoreDeps.fileExists = origFileExists;
     _effectivenessDeps.getLogger = origGetLogger;
+    _effectivenessDeps.tokenize = origTokenize;
   });
 
   test("calls logger.warn when manifest read-modify-write throws", async () => {
@@ -178,5 +181,42 @@ describe("annotateManifestEffectiveness — #506 catch block logging", () => {
 
     // At least one manifest was still written (the non-failing one)
     expect(written.length).toBeGreaterThan(0);
+  });
+
+  test("tokenizes shared evidence once across all included chunks", async () => {
+    const manifest = JSON.stringify({
+      ...JSON.parse(VALID_MANIFEST),
+      includedChunks: ["chunk-a", "chunk-b", "chunk-c"],
+      chunkSummaries: {
+        "chunk-a": "Authentication authorization validation configuration",
+        "chunk-b": "Database transaction isolation consistency",
+        "chunk-c": "Observability tracing metrics instrumentation",
+      },
+    });
+    const originalTokenize = _effectivenessDeps.tokenize;
+    let tokenizeCalls = 0;
+    let readCount = 0;
+
+    _effectivenessDeps.tokenize = (text) => {
+      tokenizeCalls++;
+      return originalTokenize(text);
+    };
+    _manifestStoreDeps.listManifestFiles = async () => ["context-manifest-execution.json"];
+    _manifestStoreDeps.fileExists = async () => true;
+    _manifestStoreDeps.readFile = async () => {
+      readCount++;
+      return manifest;
+    };
+    _manifestStoreDeps.writeFile = async () => 0;
+
+    await annotateManifestEffectiveness("/repo", "feat", "US-001", {
+      agentOutput: "unrelated agent response content",
+      diffText: "+unrelated source modification",
+      findingMessages: ["unrelated review observation"],
+    });
+
+    expect(readCount).toBe(2);
+    // Three chunk summaries plus one agent output, diff, and finding tokenization.
+    expect(tokenizeCalls).toBe(6);
   });
 });

--- a/test/unit/execution/iteration-runner-memory.test.ts
+++ b/test/unit/execution/iteration-runner-memory.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { releaseHeavyPipelineContext } from "@/execution";
+import type { PipelineContext } from "@/pipeline/types";
+
+describe("releaseHeavyPipelineContext", () => {
+  test("drops per-story payloads without clearing durable execution state", () => {
+    const largeText = "payload".repeat(1_000);
+    const ctx = {
+      prd: { feature: "memory-fix" },
+      story: { id: "US-001" },
+      agentResult: { output: largeText },
+      prompt: largeText,
+      contextMarkdown: largeText,
+      featureContextMarkdown: largeText,
+      builtContext: { markdown: largeText },
+      contextBundle: { pushMarkdown: largeText },
+      constitution: { content: largeText },
+      acceptanceFailures: { failedACs: [], findings: [], testOutput: largeText },
+      autofixPriorIterations: [{ feedback: largeText }],
+      priorSemanticIterations: [{ feedback: largeText }],
+      priorAdversarialIterations: [{ feedback: largeText }],
+      reviewFindings: [{ message: largeText }],
+      selfVerification: { evidence: largeText },
+      tddIsolations: { implementer: { output: largeText } },
+    } as unknown as PipelineContext;
+    const prd = ctx.prd;
+    const story = ctx.story;
+
+    releaseHeavyPipelineContext(ctx);
+
+    expect(ctx.agentResult).toBeUndefined();
+    expect(ctx.prompt).toBeUndefined();
+    expect(ctx.contextMarkdown).toBeUndefined();
+    expect(ctx.featureContextMarkdown).toBeUndefined();
+    expect(ctx.builtContext).toBeUndefined();
+    expect(ctx.contextBundle).toBeUndefined();
+    expect(ctx.constitution).toBeUndefined();
+    expect(ctx.acceptanceFailures).toBeUndefined();
+    expect(ctx.autofixPriorIterations).toBeUndefined();
+    expect(ctx.priorSemanticIterations).toBeUndefined();
+    expect(ctx.priorAdversarialIterations).toBeUndefined();
+    expect(ctx.reviewFindings).toBeUndefined();
+    expect(ctx.selfVerification).toBeUndefined();
+    expect(ctx.tddIsolations).toBeUndefined();
+    expect(ctx.prd).toBe(prd);
+    expect(ctx.story).toBe(story);
+  });
+});

--- a/test/unit/pipeline/stages/completion-skip-persistence.test.ts
+++ b/test/unit/pipeline/stages/completion-skip-persistence.test.ts
@@ -20,6 +20,7 @@ import { makeMockRuntime } from "../../../helpers/runtime";
 const origSavePRD = _completionDeps.savePRD;
 const origGetDiffText = _completionDeps.getDiffText;
 const origCheckReviewGate = _completionDeps.checkReviewGate;
+const origSpawn = _completionDeps.spawn;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -50,6 +51,7 @@ afterEach(() => {
   _completionDeps.savePRD = origSavePRD;
   _completionDeps.getDiffText = origGetDiffText;
   _completionDeps.checkReviewGate = origCheckReviewGate;
+  _completionDeps.spawn = origSpawn;
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -99,5 +101,66 @@ describe("completionStage skipPrdPersistence", () => {
     const result = await completionStage.execute(ctx);
 
     expect(result.action).toBe("continue");
+  });
+});
+
+describe("completionStage bounded stream reading", () => {
+  test("getDiffText retains 8,000 characters and drains stderr", async () => {
+    const encoder = new TextEncoder();
+    let stderrPulls = 0;
+    _completionDeps.spawn = (() => ({
+      stdout: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("x".repeat(9_000)));
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (stderrPulls++ === 0) controller.enqueue(encoder.encode("warning"));
+          else controller.close();
+        },
+      }),
+      exited: Promise.resolve(0),
+    })) as unknown as typeof _completionDeps.spawn;
+
+    const output = await _completionDeps.getDiffText("/repo", "base-ref");
+
+    expect(output).toBe("x".repeat(8_000));
+    expect(stderrPulls).toBe(2);
+  });
+
+  test("retains only the requested prefix while draining the full stream", async () => {
+    const encoder = new TextEncoder();
+    let pulls = 0;
+    const chunks = ["abc", "def", "ghi"];
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const chunk = chunks[pulls++];
+        if (chunk) controller.enqueue(encoder.encode(chunk));
+        else controller.close();
+      },
+    });
+
+    const output = await _completionDeps.readTextStreamPrefix(stream, 5);
+
+    expect(output).toBe("abcde");
+    expect(pulls).toBe(4);
+  });
+
+  test("decodes multibyte characters split across stream chunks", async () => {
+    const bytes = new TextEncoder().encode("A😀BC");
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.slice(0, 2));
+        controller.enqueue(bytes.slice(2, 4));
+        controller.enqueue(bytes.slice(4));
+        controller.close();
+      },
+    });
+
+    const output = await _completionDeps.readTextStreamPrefix(stream, 4);
+
+    expect(output).toBe("A😀B");
   });
 });


### PR DESCRIPTION
## Summary

- bound completion-stage git diff capture to 8,000 characters while continuing to drain stdout and stderr
- precompute shared effectiveness evidence once per annotation pass instead of rebuilding large token sets for every context chunk
- release heavy per-story pipeline payloads after result handlers persist the data needed by later iterations
- emit scalar-only debug telemetry when completion reaches a high-memory boundary

## Root cause

The `Progress update` log was the visible checkpoint immediately after completion work, but it was not itself allocating the spike. Effectiveness annotation repeatedly tokenized the full agent output and diff for every included context chunk, creating large temporary strings, arrays, and sets. Diff capture also materialized the complete `git diff` before truncating it.

## Risk and impact

The behavioral classification order and public API remain unchanged. Diff evidence is intentionally limited to the same 8,000-character prefix previously used after full materialization. Heavy context is cleared only after success/failure result handlers finish consuming it. New tests cover shared evidence reuse, bounded/drained subprocess streams, split UTF-8 decoding, and durable context preservation.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` — 11,814 passed, 51 skipped, 0 failed
- `git diff --check`

## Review

Final direct code review completed with no blocking findings.