### PR TITLE
fix(tests): isolate OTLP heartbeat logging

### DIFF
--- a/test/unit/plugins/builtin/otel-reporter-lifecycle.test.ts
+++ b/test/unit/plugins/builtin/otel-reporter-lifecycle.test.ts
@@ -63,58 +63,62 @@ describe("otel-reporter heartbeat", () => {
     const plugin = createOtelReporterPlugin({ ...baseCfg, heartbeatIntervalMs: 40 }, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({
-      runId: "hb1",
-      feature: "f",
-      totalStories: 2,
-      startTime: new Date().toISOString(),
-      project: "nax-proj",
-    });
-    await r.onPhaseComplete?.({
-      runId: "hb1",
-      scope: "story",
-      storyId: "s1",
-      phase: "test-writer",
-      outcome: "passed",
-      durationMs: 10,
-      costUsd: 0.05,
-      tier: "fast",
-      testStrategy: "tdd-simple",
-    });
-    await r.onPhaseComplete?.({
-      runId: "hb1",
-      scope: "story",
-      storyId: "s2",
-      phase: "implementer",
-      outcome: "passed",
-      durationMs: 10,
-      costUsd: 0.07,
-      tier: "balanced",
-      testStrategy: "tdd-simple",
-    });
+    try {
+      await r.onRunStart?.({
+        runId: "hb1",
+        feature: "f",
+        totalStories: 2,
+        startTime: new Date().toISOString(),
+        project: "nax-proj",
+      });
+      await r.onPhaseComplete?.({
+        runId: "hb1",
+        scope: "story",
+        storyId: "s1",
+        phase: "test-writer",
+        outcome: "passed",
+        durationMs: 10,
+        costUsd: 0.05,
+        tier: "fast",
+        testStrategy: "tdd-simple",
+      });
+      await r.onPhaseComplete?.({
+        runId: "hb1",
+        scope: "story",
+        storyId: "s2",
+        phase: "implementer",
+        outcome: "passed",
+        durationMs: 10,
+        costUsd: 0.07,
+        tier: "balanced",
+        testStrategy: "tdd-simple",
+      });
 
-    await sleep(200); // > heartbeatIntervalMs (40ms)
+      await sleep(200); // > heartbeatIntervalMs (40ms)
 
-    const hbPosts = metricsPosts(posts);
-    expect(hbPosts.length).toBeGreaterThan(0); // AC1
+      const hbPosts = metricsPosts(posts);
+      expect(hbPosts.length).toBeGreaterThan(0); // AC1
 
-    const metrics = hbPosts[0].body.resourceMetrics[0].scopeMetrics[0].metrics;
-    const active = findMetric(metrics, "nax.run.active");
-    const elapsed = findMetric(metrics, "nax.run.phase_elapsed_ms");
-    const cost = findMetric(metrics, "nax.run.cost_usd");
+      const metrics = hbPosts[0].body.resourceMetrics[0].scopeMetrics[0].metrics;
+      const active = findMetric(metrics, "nax.run.active");
+      const elapsed = findMetric(metrics, "nax.run.phase_elapsed_ms");
+      const cost = findMetric(metrics, "nax.run.cost_usd");
 
-    expect(active?.gauge?.dataPoints?.[0]?.asDouble).toBe(1); // AC1
-    expect(elapsed?.gauge?.dataPoints?.[0]?.asDouble).toBeGreaterThanOrEqual(0); // AC2
-    expect(cost?.gauge?.dataPoints?.[0]?.asDouble).toBeCloseTo(0.12, 5); // AC3
+      expect(active?.gauge?.dataPoints?.[0]?.asDouble).toBe(1); // AC1
+      expect(elapsed?.gauge?.dataPoints?.[0]?.asDouble).toBeGreaterThanOrEqual(0); // AC2
+      expect(cost?.gauge?.dataPoints?.[0]?.asDouble).toBeCloseTo(0.12, 5); // AC3
 
-    const attrs = active?.gauge?.dataPoints?.[0]?.attributes ?? [];
-    expect(attrs).toContainEqual(attr("phase", "implementer")); // AC4 — most recently completed phase
-    expect(attrs).toContainEqual(attr("run_id", "hb1")); // AC5
-    expect(attrs).toContainEqual(attr("feature", "f"));
-    expect(attrs).toContainEqual(attr("project", "nax-proj"));
-    expect(attrs).toContainEqual(attr("story_id", "s2"));
-    expect(attrs).toContainEqual(attr("tier", "balanced"));
-    expect(attrs).toContainEqual(attr("test_strategy", "tdd-simple"));
+      const attrs = active?.gauge?.dataPoints?.[0]?.attributes ?? [];
+      expect(attrs).toContainEqual(attr("phase", "implementer")); // AC4 — most recently completed phase
+      expect(attrs).toContainEqual(attr("run_id", "hb1")); // AC5
+      expect(attrs).toContainEqual(attr("feature", "f"));
+      expect(attrs).toContainEqual(attr("project", "nax-proj"));
+      expect(attrs).toContainEqual(attr("story_id", "s2"));
+      expect(attrs).toContainEqual(attr("tier", "balanced"));
+      expect(attrs).toContainEqual(attr("test_strategy", "tdd-simple"));
+    } finally {
+      await plugin.teardown?.();
+    }
   });
 
   // Spec: `flush` already warns ("Skipping OTLP export — unresolved env vars")
@@ -132,11 +136,15 @@ describe("otel-reporter heartbeat", () => {
       );
       const r = plugin.extensions.reporter!;
 
-      await r.onRunStart?.({ runId: "hbwarn", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
-      await sleep(150); // > heartbeatIntervalMs (40ms) — allow at least one tick
+      try {
+        await r.onRunStart?.({ runId: "hbwarn", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+        await sleep(150); // > heartbeatIntervalMs (40ms) — allow at least one tick
 
-      const otelWarnings = warnSpy.mock.calls.filter((c) => c[0] === "otel-reporter");
-      expect(otelWarnings.length).toBeGreaterThan(0);
+        const otelWarnings = warnSpy.mock.calls.filter((c) => c[0] === "otel-reporter");
+        expect(otelWarnings.length).toBeGreaterThan(0);
+      } finally {
+        await plugin.teardown?.();
+      }
     });
   });
 

--- a/test/unit/runtime/middleware/agent-stream-logging.test.ts
+++ b/test/unit/runtime/middleware/agent-stream-logging.test.ts
@@ -94,9 +94,9 @@ async function parseAllEntries(logFile: string): Promise<LogEntry[]> {
     .map((line) => JSON.parse(line) as LogEntry);
 }
 
-async function parseLastEntry(logFile: string): Promise<LogEntry> {
+async function findEntry(logFile: string, message: string): Promise<LogEntry | undefined> {
   const entries = await parseAllEntries(logFile);
-  return entries[entries.length - 1];
+  return entries.find((entry) => entry.stage === "agent-stream" && entry.message === message);
 }
 
 describe("attachAgentStreamLogging", () => {
@@ -132,10 +132,10 @@ describe("attachAgentStreamLogging", () => {
     );
     await getLogger().flush();
 
-    const entry = await parseLastEntry(logFile);
-    expect(entry.level).toBe("info");
-    expect(entry.message).toBe("Agent call started");
-    expect(entry.data).toMatchObject({
+    const entry = await findEntry(logFile, "Agent call started");
+    expect(entry).toBeDefined();
+    expect(entry?.level).toBe("info");
+    expect(entry?.data).toMatchObject({
       storyId: "s-42",
       callId: "call-001",
       agentName: "claude",

--- a/test/unit/runtime/middleware/logging.test.ts
+++ b/test/unit/runtime/middleware/logging.test.ts
@@ -62,10 +62,14 @@ function makeErrorEvent(overrides: Partial<DispatchErrorEvent> = {}): DispatchEr
   };
 }
 
-async function parseLastEntry(logFile: string): Promise<LogEntry> {
+async function findEntry(logFile: string, message: string): Promise<LogEntry | undefined> {
   const content = await Bun.file(logFile).text();
-  const lines = content.trim().split("\n").filter(Boolean);
-  return JSON.parse(lines[lines.length - 1]) as LogEntry;
+  return content
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as LogEntry)
+    .find((entry) => entry.stage === "middleware" && entry.message === message);
 }
 
 describe("attachLoggingSubscriber", () => {
@@ -91,10 +95,10 @@ describe("attachLoggingSubscriber", () => {
     bus.emitDispatch(makeSessionTurnEvent({ agentName: "codex", stage: "verify", durationMs: 350 }));
     await getLogger().flush();
 
-    const entry = await parseLastEntry(logFile);
-    expect(entry.level).toBe("info");
-    expect(entry.message).toBe("Agent call complete");
-    expect(entry.data).toMatchObject({
+    const entry = await findEntry(logFile, "Agent call complete");
+    expect(entry).toBeDefined();
+    expect(entry?.level).toBe("info");
+    expect(entry?.data).toMatchObject({
       agentName: "codex",
       kind: "session-turn",
       stage: "verify",
@@ -111,11 +115,11 @@ describe("attachLoggingSubscriber", () => {
     bus.emitDispatch(makeCompleteEvent({ agentName: "claude", stage: "plan" }));
     await getLogger().flush();
 
-    const entry = await parseLastEntry(logFile);
-    expect(entry.level).toBe("info");
-    expect(entry.message).toBe("Agent call complete");
-    expect(entry.data?.agentName).toBe("claude");
-    expect(entry.data?.kind).toBe("complete");
+    const entry = await findEntry(logFile, "Agent call complete");
+    expect(entry).toBeDefined();
+    expect(entry?.level).toBe("info");
+    expect(entry?.data?.agentName).toBe("claude");
+    expect(entry?.data?.kind).toBe("complete");
   });
 
   test("logs Agent call failed on dispatch error", async () => {
@@ -125,10 +129,10 @@ describe("attachLoggingSubscriber", () => {
     bus.emitDispatchError(makeErrorEvent({ agentName: "claude", stage: "run", durationMs: 100 }));
     await getLogger().flush();
 
-    const entry = await parseLastEntry(logFile);
-    expect(entry.level).toBe("warn");
-    expect(entry.message).toBe("Agent call failed");
-    expect(entry.data).toMatchObject({
+    const entry = await findEntry(logFile, "Agent call failed");
+    expect(entry).toBeDefined();
+    expect(entry?.level).toBe("warn");
+    expect(entry?.data).toMatchObject({
       agentName: "claude",
       stage: "run",
       durationMs: 100,


### PR DESCRIPTION
## Summary

Fixes #1403 by ensuring OTLP heartbeat tests tear down their reporters and by making logging assertions select their own structured record rather than relying on global write order.

## Root cause

A heartbeat test started timer-driven OTLP export work without stopping it. A later tick could write through the process-wide logger after another test had initialized its JSONL sink, causing cross-file flakes.

## Changes

- Tear down fast-heartbeat reporters in `finally`, including on assertion failure.
- Match middleware and agent-stream log records by their stage and message.

## Validation

- `bun test test/unit/plugins/builtin/otel-reporter-lifecycle.test.ts test/unit/runtime/middleware/logging.test.ts test/unit/runtime/middleware/agent-stream-logging.test.ts --timeout=30000`
- `bun run lint`
- `bun run typecheck`
- `bun run test`