### PR TITLE
fix(execution): triage nbf gate flakes transactionally (#1404)

### DIFF
--- a/docs/adr/ADR-024-non-blocking-adversarial-fix.md
+++ b/docs/adr/ADR-024-non-blocking-adversarial-fix.md
@@ -48,7 +48,7 @@ After a best-effort fix, re-validate with `lint` + `typecheck` + `full-suite-gat
 #### Amendment (2026-07-30, #1383): a deterministic red must be *attributable*
 
 §3 called a deterministic red "trustworthy". That holds for the main gate path, where flake
-triage runs before findings are read — but **the nbf revalidation gate is never triaged**
+triage runs before findings are read — but **the nbf revalidation gate was not triaged**
 (`rectification.ts` triages only on the branch that reads findings from `phaseOutputs`; the
 nbf path supplies `overrides.initialFindings` and skips it). So a single flaky test firing
 inside the revalidation window deterministically discarded the best-effort pass, was
@@ -66,11 +66,12 @@ Three deliberate limits:
 - **`keyless` is still decided on the unfiltered key set.** Excluding quarantined keys first
   would empty the set on a still-failing gate, which §3's keyless rule would then read as a
   timeout — so the single-known-flake case would still revert, now mislabelled.
-- **First-observation flakes are not covered.** Only the memo is consulted; no probing runs
+- **First-observation flakes were not covered by this amendment.** Only the memo was consulted; no probing ran
   inside a pass that may be rolled back. Running real triage there would let it flip the
   gate's `success` to `true` (its `allTestRunnersQuarantined` branch), so nbf would keep
   trees that are red-modulo-quarantine — a semantics change deferred to its own decision.
-  The restore log therefore states `flakeTriageRan: false` so the gap is visible.
+  The restore log therefore stated `flakeTriageRan: false` so the gap was visible. The
+  #1404 amendment below resolves this limit without mutating the gate verdict.
 - **A quarantined test that the pass then genuinely breaks is masked**, so nbf may keep a
   tree where that test is red. This is inherent to a run-scoped memo — the main path already
   ignores quarantined tests for the rest of the run — so it is parity with the main path
@@ -126,6 +127,25 @@ Two consequences beyond the budget itself:
   baseline. Such a failure previously stayed hidden and the pass was kept with a red gate;
   it now earns a repair attempt and is restored if the repair fails. Strictly safer, but it
   is an outcome change, recorded here rather than treated as a pure bug fix.
+
+#### Amendment (2026-07-31, #1404): NBF triages first-observation flakes transactionally
+
+NBF revalidation now probes newly failing test identities through a read-only path. The
+gate output remains untouched: triage neither replaces its findings nor flips
+`success`/`passed`. Instead, quarantined keys enter a transaction-local memo overlay shared
+by the revalidation finding filter and `describeGateRegression`, so both consumers reach
+the same verdict while the raw gate evidence remains available.
+
+The overlay reads the run-scoped memo but buffers new keys. `runNonBlockingFix` commits them
+only after the gate comparison and source-diff cap both accept the pass; every restore path
+drops them. Identities present in the verifier-time baseline, already memoized identities,
+and identities already attempted in this transaction are not probed again.
+
+A red gate whose structured findings are all confirmed flakes no longer short-circuits the
+NBF sweep. This is control-flow equivalence with the main path's red-modulo-quarantine
+handling, not a gate-output mutation. Keyless failures and mixed flake/genuine failures stay
+blocking. Restore diagnostics carry the transaction's actual `flakeTriageRan` state rather
+than a hardcoded value.
 
 ### 4. Bounded, transactional
 

--- a/docs/specs/flaky-test-quarantine-design.md
+++ b/docs/specs/flaky-test-quarantine-design.md
@@ -82,9 +82,9 @@ flaky earlier in the run.
 - `gateFailureKeys()` and `describeGateRegression()` (phase-eval) skip
   `flaky-test` findings so a flake flipping state mid-story does not read as a
   rectification regression. #1383 extended this: `describeGateRegression` also
-  excludes keys already in the run-scoped quarantine memo, since the ADR-024 nbf
-  revalidation gate is never triaged and so can never carry the `flaky-test`
-  category itself.
+  excludes keys in its effective quarantine memo. #1404 adds read-only NBF triage:
+  first-observation verdicts enter a transaction-local overlay because the raw gate
+  output deliberately never carries the `flaky-test` category itself.
 
 ### Touched: regression gate (`src/execution/lifecycle/run-regression.ts`)
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -61,6 +61,7 @@ export {
   orderGateLast,
   gateFailureKeys,
   describeGateRegression,
+  createNbfFlakeTriageTransaction,
   refreshReviewInputForDispatch,
   withIncreasingFailuresBail,
   extractPhaseFindings,
@@ -68,6 +69,7 @@ export {
   type GateRegressionDetail,
   type GateRegressionInput,
   type InternalBuildState,
+  type NbfFlakeTriageTransaction,
   type OrchestratorSlot,
   type PhaseKind,
   type RectificationOverrides,
@@ -80,6 +82,7 @@ export {
   logDeterministicPhaseOutcome,
 } from "./story-orchestrator-logging";
 export { assemblePlanInputs, assemblePlanInputsFromCtx, type PlanInputs } from "./plan-inputs";
+export { runNonBlockingFix } from "./non-blocking-fix";
 export { buildPlanForStrategy } from "./build-plan-for-strategy";
 export {
   CheckpointWriter,

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -19,7 +19,9 @@ import { captureSnapshotRef, rollbackToRef } from "../tdd/rollback";
 import { createTestFileClassifier, resolveTestFilePatterns } from "../test-runners";
 import { typedSpawn } from "../utils/bun-deps";
 import { packageDirRelative } from "../utils/paths";
+import type { QuarantineMemo } from "../verification";
 import type { GateRegressionDetail, PhaseKind } from "./story-orchestrator";
+import { type NbfFlakeTriageTransaction, createNbfFlakeTriageTransaction } from "./story-orchestrator/nbf-flake-triage";
 
 /** Phase kinds to strip from revalidation — always the LLM reviews. */
 const REVIEW_PHASE_KINDS = ["semantic-review", "adversarial-review"] as const satisfies readonly PhaseKind[];
@@ -122,8 +124,15 @@ export interface NonBlockingFixArgs {
    * middleware / CostAggregator, the SSOT; this is the diagnostic per-phase split.)
    */
   phaseCosts: Record<string, number>;
+  /** Run-scoped memo; new NBF verdicts are buffered until the pass is kept. */
+  quarantineMemo?: QuarantineMemo;
+  /** Verifier-time failures excluded from NBF first-observation probing. */
+  gateBaselineKeys?: ReadonlySet<string>;
   /** Runs the harness; returns true when it exhausted without resolving. */
-  runRectify: (maxAttempts: number) => Promise<{ rectificationExhausted?: boolean }>;
+  runRectify: (
+    maxAttempts: number,
+    flakeTriage: NbfFlakeTriageTransaction,
+  ) => Promise<{ rectificationExhausted?: boolean }>;
   /**
    * Reports whether the KEPT working tree regressed the deterministic full-suite
    * gate relative to the adversarial-passed baseline. ADR-024 §3: a deterministic
@@ -146,7 +155,7 @@ export interface NonBlockingFixArgs {
    *
    * Absent ⇒ no gate check (backward-compatible).
    */
-  keptTreeRegressed?: () => GateRegressionDetail;
+  keptTreeRegressed?: (quarantineMemo?: QuarantineMemo) => GateRegressionDetail;
 }
 
 export interface NonBlockingFixResult {
@@ -231,10 +240,14 @@ export async function runNonBlockingFix(
     return { ran: false, kept: false, restored: false };
   }
   const maxAttempts = 1 + args.cfg.regressionAttempts;
+  const flakeTriage = createNbfFlakeTriageTransaction({
+    baseMemo: args.quarantineMemo,
+    baselineKeys: args.gateBaselineKeys ?? new Set(),
+  });
 
   let exhausted = false;
   try {
-    const result = await args.runRectify(maxAttempts);
+    const result = await args.runRectify(maxAttempts, flakeTriage);
     exhausted = result.rectificationExhausted === true;
   } catch (err) {
     logger?.warn("non-blocking-fix", "best-effort pass threw — restoring", {
@@ -250,18 +263,19 @@ export async function runNonBlockingFix(
     // resolved via the verifier-SSOT exemption while leaving the full-suite gate red.
     // Reuse the caller's staleness predicate (identical to the final verdict's) so a
     // "kept then failed by the downstream guard" contradiction is impossible.
-    const gateVerdict = args.keptTreeRegressed?.();
+    const gateVerdict = args.keptTreeRegressed?.(flakeTriage.memo);
     if (gateVerdict?.regressed) {
       // Name the regressing identities here: this is the only point where they exist.
       // `restoreToSnapshot` clears `phaseOutputs` (so the gate's rawOutput goes with it)
       // and `rollbackToRef` hard-resets the offending edit, leaving `git reflog` with
       // only the destination. Without this record the revert is unattributable (#1382).
-      logGateRegression(
+      logGateRegression({
         logger,
-        args.storyId,
-        "kept tree regressed the full-suite gate — restoring (ADR-024 §3)",
-        gateVerdict,
-      );
+        storyId: args.storyId,
+        message: "kept tree regressed the full-suite gate — restoring (ADR-024 §3)",
+        verdict: gateVerdict,
+        flakeTriageRan: flakeTriage.flakeTriageRan,
+      });
       return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
     }
     // Enforce sourceDiffCap over the post-pass snapshot. A pass whose source
@@ -288,6 +302,7 @@ export async function runNonBlockingFix(
         return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
       }
     }
+    flakeTriage.commit();
     logger?.info("non-blocking-fix", "best-effort fix kept", { storyId: args.storyId });
     return { ran: true, kept: true, restored: false };
   }
@@ -305,14 +320,15 @@ export async function runNonBlockingFix(
   // half-finished sweep. The verdict is log-only and the restore happens regardless, so a
   // partial read is harmless — but the keys named on that path describe an aborted
   // validation, not a completed one.
-  const exhaustedGateVerdict = args.keptTreeRegressed?.();
+  const exhaustedGateVerdict = args.keptTreeRegressed?.(flakeTriage.memo);
   if (exhaustedGateVerdict?.regressed) {
-    logGateRegression(
+    logGateRegression({
       logger,
-      args.storyId,
-      "best-effort fix exhausted with the full-suite gate red",
-      exhaustedGateVerdict,
-    );
+      storyId: args.storyId,
+      message: "best-effort fix exhausted with the full-suite gate red",
+      verdict: exhaustedGateVerdict,
+      flakeTriageRan: flakeTriage.flakeTriageRan,
+    });
   }
 
   return restoreToSnapshot(args, _deps, restoreRef, phaseOutputsSnapshot, phaseCostsSnapshot, logger);
@@ -322,15 +338,19 @@ export async function runNonBlockingFix(
  * Emit the #1382 regression evidence: which test identities the pass is being blamed for.
  *
  * Shared by both restore paths — the gate-regressed keep-decision and the exhausted tail —
- * because they must report the same fields. `flakeTriageRan` in particular is stated, not
- * computed, and two hardcoded copies would drift the moment #1383's triage lands.
+ * because they must report the same fields. `flakeTriageRan` comes from the pass's
+ * transaction-local triage state rather than a restore-path constant (#1404).
  */
-function logGateRegression(
-  logger: ReturnType<typeof getSafeLogger>,
-  storyId: string,
-  message: string,
-  verdict: GateRegressionDetail,
-): void {
+interface LogGateRegressionInput {
+  logger: ReturnType<typeof getSafeLogger>;
+  storyId: string;
+  message: string;
+  verdict: GateRegressionDetail;
+  flakeTriageRan: boolean;
+}
+
+function logGateRegression(input: LogGateRegressionInput): void {
+  const { logger, storyId, message, verdict, flakeTriageRan } = input;
   logger?.info("non-blocking-fix", message, {
     storyId,
     regressedKeys: verdict.regressedKeys.slice(0, MAX_LOGGED_REGRESSED_KEYS),
@@ -342,12 +362,7 @@ function logGateRegression(
     keyless: verdict.keyless,
     // Failures excluded as already-quarantined flakes (#1383).
     memoExcludedKeyCount: verdict.memoExcludedKeys.length,
-    // Stated, not computed: this pass's revalidation gate is never flake-triaged — triage
-    // owns the main gate path only (`rectification.ts`, the non-override branch). So a
-    // FIRST-observation flake inside the revalidation window still reads as a regression,
-    // and an operator must be able to see that was possible rather than infer a real
-    // break (#1383 option 3).
-    flakeTriageRan: false,
+    flakeTriageRan,
   });
 }
 

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -2,6 +2,7 @@ import type { Finding } from "@/findings";
 import { getSafeLogger } from "@/logger";
 import type { CallContext } from "@/operations";
 import { errorMessage } from "@/utils/errors";
+import type { QuarantineMemo } from "@/verification";
 import { hydrateFromResumePlan } from "../checkpoint/resume-hydrate";
 import {
   actionableAdvisoryFindings,
@@ -42,16 +43,16 @@ export class ExecutionPlan {
   private describeGateRegressionNow(
     phaseOutputs: Record<string, unknown>,
     gateName: string | undefined,
-    baselineKeys: ReadonlySet<string>,
+    options: { baselineKeys: ReadonlySet<string>; quarantineMemo?: QuarantineMemo },
   ): GateRegressionDetail {
     return describeGateRegression({
       gateOutput: gateName === undefined ? undefined : phaseOutputs[gateName],
-      baselineKeys,
+      baselineKeys: options.baselineKeys,
       gateName,
       storyId: this.ctx.storyId,
       // Run-scoped: a test this run already probed and quarantined is not attributable
       // to this story, on either path (#1383).
-      quarantineMemo: this.ctx.runtime.quarantineMemo,
+      quarantineMemo: options.quarantineMemo ?? this.ctx.runtime.quarantineMemo,
     });
   }
 
@@ -330,9 +331,12 @@ export class ExecutionPlan {
           cfg: advCfg,
           phaseOutputs,
           phaseCosts,
-          runRectify: (maxAttempts) =>
+          quarantineMemo: this.ctx.runtime.quarantineMemo,
+          gateBaselineKeys: preRectGateFailureKeys,
+          runRectify: (maxAttempts, nbfFlakeTriage) =>
             runRectification(this.ctx, this.state, phaseCosts, phaseOutputs, {
               initialFindings: advisoryFindings,
+              nbfFlakeTriage,
               strategies: this.state.nonBlockingFixStrategies ?? [],
               excludePhaseKinds: nonBlockingExcludePhases(),
               extraRevalidationKinds: nonBlockingExtraPhases(advCfg),
@@ -346,7 +350,11 @@ export class ExecutionPlan {
           // here instead, leaving the story green with zero net change.
           // Detail-returning (not boolean) so the restore log can name the regressing
           // test identities — the only point at which they still exist (#1382).
-          keptTreeRegressed: () => this.describeGateRegressionNow(phaseOutputs, gateName, preRectGateFailureKeys),
+          keptTreeRegressed: (quarantineMemo) =>
+            this.describeGateRegressionNow(phaseOutputs, gateName, {
+              baselineKeys: preRectGateFailureKeys,
+              quarantineMemo,
+            }),
         },
         {
           measureSourceDiff: createMeasureSourceDiff({
@@ -380,11 +388,9 @@ export class ExecutionPlan {
     const verifierExplicitlyPassed = verifierName !== undefined && phaseExplicitlyPassed(phaseOutputs[verifierName]);
     // Compares the FINAL gate against the verifier-time baseline, including keyless
     // (timeout / execution-failure) regressions the raw key-diff is blind to (audit #3).
-    const gateRegressedDuringRect = this.describeGateRegressionNow(
-      phaseOutputs,
-      gateName,
-      preRectGateFailureKeys,
-    ).regressed;
+    const gateRegressedDuringRect = this.describeGateRegressionNow(phaseOutputs, gateName, {
+      baselineKeys: preRectGateFailureKeys,
+    }).regressed;
     const verifierPassedSsot = verifierExplicitlyPassed && !gateRegressedDuringRect;
     if (verifierExplicitlyPassed && gateRegressedDuringRect) {
       logger?.warn(

--- a/src/execution/story-orchestrator/flake-triage-seam.ts
+++ b/src/execution/story-orchestrator/flake-triage-seam.ts
@@ -12,16 +12,18 @@ import { getSafeLogger } from "@/logger";
 import type { CallContext } from "@/operations";
 import { detectFramework } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
-import { resolveFlakeBaselineDiff, triageFlakyFindings } from "@/verification";
+import { type QuarantineMemo, resolveFlakeBaselineDiff, triageFlakyFindings } from "@/verification";
 
 /** Triage result tuple shape — produced by `_storyOrchestratorDeps.triage`. */
-export type TriageResult = readonly [Finding[], { quarantinedKeys: readonly string[] }];
+export type TriageResult = readonly [Finding[], { quarantinedKeys: readonly string[]; flakeTriageRan?: boolean }];
 
 /** Context the seam needs beyond the gate's findings — supplied by the caller (`triageGateFindings`). */
 export interface TriageSeamContext {
   readonly ctx: CallContext;
   /** Raw full-suite-gate test-runner output, for `detectFramework()`. */
   readonly rawOutput: string;
+  /** Optional transaction-local memo used by ADR-024 NBF revalidation. */
+  readonly quarantineMemo?: QuarantineMemo;
 }
 
 /**
@@ -44,7 +46,10 @@ export type TriageSeam = (gateFindings: Finding[], seamCtx: TriageSeamContext) =
  * unchanged with an empty quarantine report. Used only where no real story
  * context is available (never wired in production — see `productionTriageSeam`).
  */
-export const defaultTriageSeam: TriageSeam = async (gateFindings) => [gateFindings, { quarantinedKeys: [] }];
+export const defaultTriageSeam: TriageSeam = async (gateFindings) => [
+  gateFindings,
+  { quarantinedKeys: [], flakeTriageRan: false },
+];
 
 /**
  * Production triage seam — binds `triageFlakyFindings` (US-002) to the
@@ -58,16 +63,16 @@ export const defaultTriageSeam: TriageSeam = async (gateFindings) => [gateFindin
  * findings unchanged (no quarantine) rather than risking a false quarantine.
  * `triageFlakyFindings` itself already fails closed on probe errors.
  */
-export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawOutput }) => {
+export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawOutput, quarantineMemo }) => {
   const config = ctx.packageView.config;
   const flakeDetection = config.execution?.flakeDetection;
   if (!flakeDetection?.enabled) {
-    return [gateFindings, { quarantinedKeys: [] }];
+    return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
   }
 
   const framework = detectFramework(rawOutput);
   if (framework === "unknown") {
-    return [gateFindings, { quarantinedKeys: [] }];
+    return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
   }
 
   const workdir = ctx.runtime.workdir;
@@ -78,12 +83,12 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
     const { testCommand } = await resolveQualityTestCommands(config, workdir, storyWorkdir);
     const baseCommand = testCommand ?? config.quality?.commands?.test;
     if (!baseCommand) {
-      return [gateFindings, { quarantinedKeys: [] }];
+      return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
     }
 
     const diff = await resolveFlakeBaselineDiff(config, workdir, storyWorkdir);
     if (diff === null) {
-      return [gateFindings, { quarantinedKeys: [] }];
+      return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
     }
 
     const result = await triageFlakyFindings({
@@ -93,9 +98,9 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
       baseCommand,
       cwd: ctx.packageDir,
       framework,
-      quarantineMemo: ctx.runtime.quarantineMemo,
+      quarantineMemo: quarantineMemo ?? ctx.runtime.quarantineMemo,
     });
-    return [result.findings, { quarantinedKeys: result.quarantineReport.keys }];
+    return [result.findings, { quarantinedKeys: result.quarantineReport.keys, flakeTriageRan: true }];
   } catch (err) {
     getSafeLogger()?.warn(
       "story-orchestrator",
@@ -105,6 +110,6 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
         error: errorMessage(err),
       },
     );
-    return [gateFindings, { quarantinedKeys: [] }];
+    return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
   }
 };

--- a/src/execution/story-orchestrator/index.ts
+++ b/src/execution/story-orchestrator/index.ts
@@ -15,6 +15,11 @@ export {
 } from "./phase-eval";
 export { runRectification, triageGateFindings, gatherRectificationFindings, type TriageResult } from "./rectification";
 export {
+  createNbfFlakeTriageTransaction,
+  type CreateNbfFlakeTriageTransactionInput,
+  type NbfFlakeTriageTransaction,
+} from "./nbf-flake-triage";
+export {
   _storyOrchestratorDeps,
   refreshReviewInputForDispatch,
   runPhase,

--- a/src/execution/story-orchestrator/nbf-flake-triage.ts
+++ b/src/execution/story-orchestrator/nbf-flake-triage.ts
@@ -1,0 +1,96 @@
+import type { Finding } from "@/findings";
+import { getSafeLogger } from "@/logger";
+import type { CallContext } from "@/operations";
+import type { QuarantineMemo } from "@/verification";
+import type { TriageSeam } from "./flake-triage-seam";
+import { extractPhaseFindings, gateFindingKey } from "./phase-eval";
+
+export interface CreateNbfFlakeTriageTransactionInput {
+  readonly baseMemo?: QuarantineMemo;
+  readonly baselineKeys: ReadonlySet<string>;
+}
+
+/** Transaction-local flake state for one ADR-024 best-effort pass. */
+export interface NbfFlakeTriageTransaction {
+  readonly memo: QuarantineMemo;
+  readonly flakeTriageRan: boolean;
+  candidates(findings: readonly Finding[]): Finding[];
+  recordAttempt(findings: readonly Finding[], ran: boolean): void;
+  commit(): void;
+}
+
+interface CandidateInput {
+  readonly finding: Finding;
+  readonly transactionInput: CreateNbfFlakeTriageTransactionInput;
+  readonly memo: QuarantineMemo;
+  readonly attemptedKeys: ReadonlySet<string>;
+}
+
+function isCandidate(input: CandidateInput): boolean {
+  if (input.finding.source !== "test-runner" || input.finding.category !== "failed-test") return false;
+  const key = gateFindingKey(input.finding);
+  return !input.transactionInput.baselineKeys.has(key) && !input.memo.has(key) && !input.attemptedKeys.has(key);
+}
+
+export function createNbfFlakeTriageTransaction(
+  input: CreateNbfFlakeTriageTransactionInput,
+): NbfFlakeTriageTransaction {
+  const pendingKeys = new Set<string>();
+  const attemptedKeys = new Set<string>();
+  let flakeTriageRan = false;
+  const memo: QuarantineMemo = {
+    has: (key) => pendingKeys.has(key) || input.baseMemo?.has(key) === true,
+    add: (key) => pendingKeys.add(key),
+  };
+
+  return {
+    memo,
+    get flakeTriageRan() {
+      return flakeTriageRan;
+    },
+    candidates: (findings) =>
+      findings.filter((finding) => isCandidate({ finding, transactionInput: input, memo, attemptedKeys })),
+    recordAttempt: (findings, ran) => {
+      if (!ran) return;
+      flakeTriageRan = true;
+      for (const finding of findings) attemptedKeys.add(gateFindingKey(finding));
+    },
+    commit: () => {
+      for (const key of pendingKeys) input.baseMemo?.add(key);
+    },
+  };
+}
+
+interface TriageNbfGateInput {
+  readonly output: unknown;
+  readonly gateName: string;
+  readonly ctx: CallContext;
+  readonly transaction: NbfFlakeTriageTransaction;
+  readonly triage: TriageSeam;
+}
+
+/** Probe NBF-only failures without rewriting the gate output or the run memo. */
+export async function triageNbfGate(input: TriageNbfGateInput): Promise<void> {
+  const candidates = input.transaction.candidates(extractPhaseFindings(input.output));
+  if (candidates.length === 0) return;
+  const record = input.output as Record<string, unknown>;
+  const rawOutput = typeof record.rawOutput === "string" ? record.rawOutput : "";
+  try {
+    const [, report] = await input.triage(candidates, {
+      ctx: input.ctx,
+      rawOutput,
+      quarantineMemo: input.transaction.memo,
+    });
+    const ran = report.flakeTriageRan ?? true;
+    if (ran) {
+      for (const key of report.quarantinedKeys) input.transaction.memo.add(key);
+    }
+    input.transaction.recordAttempt(candidates, ran);
+  } catch (err) {
+    getSafeLogger()?.warn("story-orchestrator", "NBF flake triage threw — keeping findings blocking", {
+      storyId: input.ctx.storyId,
+      gateName: input.gateName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/execution/story-orchestrator/phase-eval.ts
+++ b/src/execution/story-orchestrator/phase-eval.ts
@@ -131,25 +131,22 @@ export function gateFindingKey(finding: Finding): string {
   return `${finding.file ?? ""}::${finding.rule ?? ""}`;
 }
 
+/** Synthetic key for a gate failure with no comparable test identity. */
+const KEYLESS_GATE_FAILURE_KEY = "::";
+
 /**
  * True when this finding is a test failure the run has already quarantined as a flake.
  *
  * Mirrors the exclusion `describeGateRegression` applies before assigning blame, so a
  * consumer that filters findings and a consumer that diffs keys reach the same verdict
- * about the same gate output.
+ * about the same gate output. Keyless failures are never quarantinable: the regression
+ * predicate treats them as attributable regardless of memo contents.
  */
 export function isQuarantinedFlake(finding: Finding, quarantineMemo: QuarantineMemo | undefined): boolean {
   if (finding.source !== "test-runner") return false;
-  return quarantineMemo?.has(gateFindingKey(finding)) === true;
+  const key = gateFindingKey(finding);
+  return key !== KEYLESS_GATE_FAILURE_KEY && quarantineMemo?.has(key) === true;
 }
-
-/**
- * The key `gateFailureKeys` emits for a gate failure with no identity — both `file`
- * and `rule` empty. Produced by execution-failure synth findings (non-zero exit, no
- * structured failures). Such a key cannot be diffed against a baseline, so the
- * staleness guard must treat it as a regression rather than a comparable identity.
- */
-const KEYLESS_GATE_FAILURE_KEY = "::";
 
 /**
  * A gate-regression verdict together with the identities behind it.

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -2,6 +2,7 @@ import type { Finding, FixCycle, FixCycleContext } from "@/findings";
 import { getSafeLogger } from "@/logger";
 import type { CallContext, Operation, RunOperation } from "@/operations";
 import { countOscillationOutcomes, recordOscillations } from "../oscillation-store";
+import { triageNbfGate } from "./nbf-flake-triage";
 import { extractPhaseFindings, orderGateLast, phasesToRevalidate } from "./phase-eval";
 import { isQuarantinedFlake, phaseExplicitlyPassed, phasePassed } from "./phase-eval";
 import { _storyOrchestratorDeps, runPhase, withIncreasingFailuresBail } from "./run-phase";
@@ -190,6 +191,14 @@ export function collectRectificationPhases(state: InternalBuildState): InternalP
   ].filter((phase): phase is InternalPhase => phase !== undefined);
 }
 
+function isQuarantinedOnlyGateFailure(
+  phase: InternalPhase,
+  rawFindings: readonly Finding[],
+  blockingFindings: readonly Finding[],
+): boolean {
+  return phase.kind === "full-suite-gate" && rawFindings.length > 0 && blockingFindings.length === 0;
+}
+
 /**
  * @internal
  * Run the rectification loop and return a structured result describing the exit.
@@ -229,10 +238,9 @@ export async function runRectification(
     nbfPath = true;
     // ADR-024 nbf path — triage is a separate concern owned by the main gate path.
     //
-    // This branch is what `runNonBlockingFix`'s restore log asserts as
-    // `flakeTriageRan: false` (#1383). If triage is ever wired in here, update that
-    // log field too — otherwise it silently reports a gap that no longer exists, and
-    // an operator reading it will misjudge a genuine break as a possible flake.
+    // Seed findings are advisory-review findings, so they still bypass gate triage.
+    // #1404 triages only newly failing gate findings later, inside validate(), using
+    // the optional transaction-local `nbfFlakeTriage` state.
     initialFindings = [...overrides.initialFindings];
   } else {
     // US-003 — Flake triage runs on the gate's failed-test findings BEFORE
@@ -337,6 +345,16 @@ export async function runRectification(
         await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
         if (shouldSkipPhaseForRectification({ phase, state, phaseOutputs, nbfPath })) continue;
         const output = phaseOutputs[phase.slot.op.name];
+        const nbfFlakeTriage = overrides?.nbfFlakeTriage;
+        if (nbfPath && phase.kind === "full-suite-gate" && nbfFlakeTriage) {
+          await triageNbfGate({
+            output,
+            gateName: phase.slot.op.name,
+            ctx,
+            transaction: nbfFlakeTriage,
+            triage: _storyOrchestratorDeps.triage,
+          });
+        }
         // #1383 parity. `describeGateRegression` — the predicate that actually decides
         // keep-vs-discard for this pass — excludes failures the run already quarantined as
         // flakes. Until #1401 the carve-out hid the whole gate output from the nbf sweep, so
@@ -349,16 +367,18 @@ export async function runRectification(
         // relabels quarantined failures to `flaky-test`, which `gatherRectificationFindings`
         // already drops), so widening this would be an unrelated behaviour change.
         const phaseFindings = extractPhaseFindings(output);
-        findings.push(
-          ...(nbfPath
-            ? phaseFindings.filter((f) => !isQuarantinedFlake(f, ctx.runtime.quarantineMemo))
-            : phaseFindings),
-        );
+        const blockingFindings = nbfPath
+          ? phaseFindings.filter(
+              (finding) => !isQuarantinedFlake(finding, nbfFlakeTriage?.memo ?? ctx.runtime.quarantineMemo),
+            )
+          : phaseFindings;
+        findings.push(...blockingFindings);
         // Mirror the main loop's halt-on-failure contract (spec §2C, PR #1127):
         // verifier and reviews must never judge broken-gate code, even inside the
         // rectification revalidation sweep. Findings collected so far feed the next
         // fix iteration; downstream phases are skipped to avoid stale-verdict pollution.
-        if (!phasePassed(phase.slot.op.name, output, ctx.storyId)) {
+        const quarantinedOnly = nbfPath && isQuarantinedOnlyGateFailure(phase, phaseFindings, blockingFindings);
+        if (!phasePassed(phase.slot.op.name, output, ctx.storyId) && !quarantinedOnly) {
           getSafeLogger()?.warn("story-orchestrator", "Short-circuiting revalidation on phase failure", {
             storyId: ctx.storyId,
             phase: phase.slot.op.name,

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -1,6 +1,7 @@
 import type { NonBlockingFixConfig } from "@/config/selectors";
 import type { Finding, FixCycleContext, FixStrategy } from "@/findings";
 import type { DeterministicOperation, RunOperation } from "@/operations";
+import type { NbfFlakeTriageTransaction } from "./nbf-flake-triage";
 
 export const EXHAUSTED_EXIT_REASONS = new Set<string>([
   "max-attempts-total",
@@ -210,6 +211,8 @@ export interface RectificationOverrides {
    * the only such caller; a second one should promote this to an explicit flag.
    */
   initialFindings?: readonly Finding[];
+  /** Transaction-local, read-only gate triage for the ADR-024 NBF path (#1404). */
+  nbfFlakeTriage?: NbfFlakeTriageTransaction;
   /** Strategy set instead of state.rectification.strategies (scope filtering). */
   strategies?: FixStrategy<Finding, unknown, unknown, unknown>[];
   /** Phase kinds removed from validationPhases (e.g. the LLM reviews). */

--- a/test/unit/execution/nbf-readonly-flake-triage.test.ts
+++ b/test/unit/execution/nbf-readonly-flake-triage.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { DEFAULT_CONFIG } from "@/config";
+import { pickSelector } from "@/config";
+import {
+  _storyOrchestratorDeps,
+  createNbfFlakeTriageTransaction,
+  runNonBlockingFix,
+  runRectification,
+} from "@/execution";
+import type { Finding, FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings";
+import type { CallContext, RunOperation } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+import type { QuarantineMemo } from "@/verification";
+import { makeTestRuntime, withInfoSpy } from "@test/helpers";
+
+const GATE_NAME = "full-suite-gate";
+const FLAKE_KEY = "test/unit/flaky.test.ts::sometimes";
+const REAL_KEY = "test/unit/real.test.ts::breaks";
+const testSelector = pickSelector("nbf-readonly-flake-triage", "execution");
+
+const ADVISORY: Finding = {
+  source: "adversarial-review",
+  severity: "warning",
+  category: "style",
+  message: "advisory",
+};
+
+function failedTest(key: string): Finding {
+  const [file, rule] = key.split("::");
+  return {
+    source: "test-runner",
+    severity: "error",
+    category: "failed-test",
+    message: `failure: ${key}`,
+    file,
+    rule,
+  };
+}
+
+function memoFixture(): { memo: QuarantineMemo; keys: Set<string> } {
+  const keys = new Set<string>();
+  return {
+    keys,
+    memo: {
+      has: (key) => keys.has(key),
+      add: (key) => {
+        keys.add(key);
+      },
+    },
+  };
+}
+
+function gateOp(): RunOperation<{ story: string }, { success: boolean; findings: Finding[] }, typeof DEFAULT_CONFIG> {
+  return {
+    kind: "run",
+    name: GATE_NAME,
+    stage: "verify",
+    config: testSelector,
+    session: { role: "verifier", lifetime: "fresh" },
+    build: () => ({
+      role: { id: "role", content: "gate", overridable: false },
+      task: { id: "task", content: "", overridable: false },
+    }),
+    parse: () => ({ success: false, findings: [] }),
+  };
+}
+
+function rectifyState(): Parameters<typeof runRectification>[1] {
+  return {
+    fullSuiteGate: { kind: "full-suite-gate", slot: { op: gateOp(), input: { story: "US-1404" } } },
+    rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+  } as Parameters<typeof runRectification>[1];
+}
+
+let runtime: NaxRuntime | undefined;
+let originalCallOp: typeof _storyOrchestratorDeps.callOp;
+let originalRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
+let originalTriage: typeof _storyOrchestratorDeps.triage;
+
+function makeCtx(): CallContext {
+  runtime = makeTestRuntime();
+  return {
+    runtime,
+    packageView: runtime.packages.repo(),
+    packageDir: "/tmp",
+    agentName: "claude",
+    storyId: "US-1404",
+  } as CallContext;
+}
+
+async function captureValidate(
+  ctx: CallContext,
+  phaseOutputs: Record<string, unknown>,
+  flakeTriage: ReturnType<typeof createNbfFlakeTriageTransaction>,
+): Promise<FixCycle<Finding>["validate"]> {
+  let captured: FixCycle<Finding> | undefined;
+  _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>) => {
+    captured = cycle;
+    return {
+      iterations: [],
+      finalFindings: [],
+      exitReason: "resolved" as FixCycleExitReason,
+      costUsd: 0,
+    };
+  }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+  await runRectification(ctx, rectifyState(), {}, phaseOutputs, {
+    initialFindings: [ADVISORY],
+    maxAttempts: 2,
+    nbfFlakeTriage: flakeTriage,
+  });
+  if (!captured) throw new Error("[test] rectification did not expose its validation cycle");
+  return captured.validate;
+}
+
+beforeEach(() => {
+  originalCallOp = _storyOrchestratorDeps.callOp;
+  originalRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+  originalTriage = _storyOrchestratorDeps.triage;
+});
+
+afterEach(async () => {
+  _storyOrchestratorDeps.callOp = originalCallOp;
+  _storyOrchestratorDeps.runFixCycle = originalRunFixCycle;
+  _storyOrchestratorDeps.triage = originalTriage;
+  await runtime?.close();
+  runtime = undefined;
+});
+
+describe("createNbfFlakeTriageTransaction", () => {
+  test("buffers quarantined keys until commit while reading the run-scoped memo", () => {
+    const base = memoFixture();
+    base.memo.add("known.test.ts::known");
+    const transaction = createNbfFlakeTriageTransaction({ baseMemo: base.memo, baselineKeys: new Set() });
+
+    transaction.memo.add(FLAKE_KEY);
+
+    expect(transaction.memo.has("known.test.ts::known")).toBe(true);
+    expect(transaction.memo.has(FLAKE_KEY)).toBe(true);
+    expect(base.keys.has(FLAKE_KEY)).toBe(false);
+    transaction.commit();
+    expect(base.keys.has(FLAKE_KEY)).toBe(true);
+  });
+
+  test("offers only new, unknown test failures for one probe per transaction", () => {
+    const base = memoFixture();
+    base.memo.add("known.test.ts::known");
+    const transaction = createNbfFlakeTriageTransaction({
+      baseMemo: base.memo,
+      baselineKeys: new Set(["baseline.test.ts::before"]),
+    });
+    const findings = [
+      failedTest(FLAKE_KEY),
+      failedTest("known.test.ts::known"),
+      failedTest("baseline.test.ts::before"),
+      { ...failedTest("lint.ts::rule"), source: "lint" as const },
+    ];
+
+    expect(transaction.candidates(findings)).toEqual([findings[0]]);
+    transaction.recordAttempt([findings[0] as Finding], true);
+    expect(transaction.candidates(findings)).toEqual([]);
+    expect(transaction.flakeTriageRan).toBe(true);
+  });
+});
+
+describe("runRectification read-only NBF triage", () => {
+  test("confirmed first-observation flake neither seeds repair nor short-circuits, without mutating the gate output", async () => {
+    const ctx = makeCtx();
+    const base = memoFixture();
+    const transaction = createNbfFlakeTriageTransaction({ baseMemo: base.memo, baselineKeys: new Set() });
+    const gateOutput = {
+      success: false,
+      passed: false,
+      rawOutput: "bun test: 1 fail",
+      findings: [failedTest(FLAKE_KEY)],
+    };
+    const phaseOutputs: Record<string, unknown> = { [GATE_NAME]: { success: true, passed: true, findings: [] } };
+    const validate = await captureValidate(ctx, phaseOutputs, transaction);
+    _storyOrchestratorDeps.callOp = mock(async () => gateOutput) as typeof _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.triage = mock(async (findings: Finding[]) => [
+      findings.map((finding) => ({ ...finding, category: "flaky-test" })),
+      { quarantinedKeys: [FLAKE_KEY], flakeTriageRan: true },
+    ]) as typeof _storyOrchestratorDeps.triage;
+
+    const result = await validate(ctx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    expect(result).toEqual({ findings: [], shortCircuited: false });
+    expect(phaseOutputs[GATE_NAME]).toBe(gateOutput);
+    expect(gateOutput).toEqual({
+      success: false,
+      passed: false,
+      rawOutput: "bun test: 1 fail",
+      findings: [failedTest(FLAKE_KEY)],
+    });
+    expect(transaction.memo.has(FLAKE_KEY)).toBe(true);
+    expect(base.keys.has(FLAKE_KEY)).toBe(false);
+  });
+
+  test("mixed flake and genuine regression filters only the flake and keeps the gate blocking", async () => {
+    const ctx = makeCtx();
+    const base = memoFixture();
+    const transaction = createNbfFlakeTriageTransaction({ baseMemo: base.memo, baselineKeys: new Set() });
+    const findings = [failedTest(FLAKE_KEY), failedTest(REAL_KEY)];
+    const phaseOutputs: Record<string, unknown> = { [GATE_NAME]: { success: true, passed: true, findings: [] } };
+    const validate = await captureValidate(ctx, phaseOutputs, transaction);
+    _storyOrchestratorDeps.callOp = mock(async () => ({
+      success: false,
+      rawOutput: "1 fail",
+      findings,
+    })) as typeof _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.triage = mock(async () => [
+      [{ ...findings[0], category: "flaky-test" }, findings[1]],
+      { quarantinedKeys: [FLAKE_KEY], flakeTriageRan: true },
+    ]) as typeof _storyOrchestratorDeps.triage;
+
+    const result = await validate(ctx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    expect(result).toEqual({ findings: [findings[1]], shortCircuited: true });
+    expect(transaction.memo.has(FLAKE_KEY)).toBe(true);
+    expect(base.keys.has(FLAKE_KEY)).toBe(false);
+  });
+
+  test("keyless execution failure remains blocking even when a memo contains its synthetic key", async () => {
+    const ctx = makeCtx();
+    const base = memoFixture();
+    base.memo.add("::");
+    const transaction = createNbfFlakeTriageTransaction({ baseMemo: base.memo, baselineKeys: new Set() });
+    const executionFailure: Finding = {
+      source: "test-runner",
+      severity: "error",
+      category: "execution-failed",
+      message: "test command crashed",
+    };
+    const phaseOutputs: Record<string, unknown> = { [GATE_NAME]: { success: true, findings: [] } };
+    const validate = await captureValidate(ctx, phaseOutputs, transaction);
+    _storyOrchestratorDeps.callOp = mock(async () => ({
+      success: false,
+      rawOutput: "process exited 1",
+      findings: [executionFailure],
+    })) as typeof _storyOrchestratorDeps.callOp;
+    const triage = mock(
+      async (findings: Finding[]) => [findings, { quarantinedKeys: [], flakeTriageRan: true }] as const,
+    );
+    _storyOrchestratorDeps.triage = triage as typeof _storyOrchestratorDeps.triage;
+
+    const result = await validate(ctx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    expect(result).toEqual({ findings: [executionFailure], shortCircuited: true });
+    expect(triage).not.toHaveBeenCalled();
+  });
+});
+
+describe("runNonBlockingFix quarantine transaction", () => {
+  const baseArgs = {
+    workdir: "/tmp/nax-1404",
+    storyId: "US-1404",
+    advisoryFindings: [ADVISORY],
+    cfg: { enabled: true, scope: "triage", regressionAttempts: 1, verifierGuard: true } as const,
+    phaseOutputs: { [GATE_NAME]: { success: true } } as Record<string, unknown>,
+    phaseCosts: {} as Record<string, number>,
+  };
+  const deps = {
+    captureSnapshotRef: async () => "snapshot",
+    rollbackToRef: async () => {},
+    measureSourceDiff: async () => ({ fileCount: 0, sourceLineCount: 0 }),
+  };
+
+  test("commits a confirmed flake only after the pass is kept", async () => {
+    const base = memoFixture();
+    const result = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        quarantineMemo: base.memo,
+        gateBaselineKeys: new Set(),
+        runRectify: async (_maxAttempts, transaction) => {
+          transaction.memo.add(FLAKE_KEY);
+          transaction.recordAttempt([failedTest(FLAKE_KEY)], true);
+          return { rectificationExhausted: false };
+        },
+        keptTreeRegressed: (memo) => ({
+          regressed: !memo?.has(FLAKE_KEY),
+          regressedKeys: memo?.has(FLAKE_KEY) ? [] : [FLAKE_KEY],
+          memoExcludedKeys: memo?.has(FLAKE_KEY) ? [FLAKE_KEY] : [],
+          baselineKeySize: 0,
+          keyless: false,
+        }),
+      },
+      deps,
+    );
+
+    expect(result).toEqual({ ran: true, kept: true, restored: false });
+    expect(base.keys.has(FLAKE_KEY)).toBe(true);
+  });
+
+  test("drops a buffered flake when the pass is restored", async () => {
+    const base = memoFixture();
+    let rolledBack = false;
+    const result = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        quarantineMemo: base.memo,
+        gateBaselineKeys: new Set(),
+        runRectify: async (_maxAttempts, transaction) => {
+          transaction.memo.add(FLAKE_KEY);
+          transaction.recordAttempt([failedTest(FLAKE_KEY)], true);
+          return { rectificationExhausted: true };
+        },
+      },
+      {
+        ...deps,
+        rollbackToRef: async () => {
+          rolledBack = true;
+        },
+      },
+    );
+
+    expect(result).toEqual({ ran: true, kept: false, restored: true });
+    expect(rolledBack).toBe(true);
+    expect(base.keys.has(FLAKE_KEY)).toBe(false);
+  });
+
+  test("restore diagnostics report that transaction-local triage ran", async () => {
+    const data = await withInfoSpy(async (infoSpy) => {
+      await runNonBlockingFix(
+        {
+          ...baseArgs,
+          runRectify: async (_maxAttempts, transaction) => {
+            transaction.recordAttempt([failedTest(REAL_KEY)], true);
+            return { rectificationExhausted: true };
+          },
+          keptTreeRegressed: () => ({
+            regressed: true,
+            regressedKeys: [REAL_KEY],
+            memoExcludedKeys: [],
+            baselineKeySize: 0,
+            keyless: false,
+          }),
+        },
+        deps,
+      );
+      return infoSpy.mock.calls.find((call) => String(call[1]).includes("exhausted with"))?.[2] as
+        | Record<string, unknown>
+        | undefined;
+    });
+
+    expect(data?.flakeTriageRan).toBe(true);
+  });
+
+  test("source-diff-cap restore does not commit buffered flakes", async () => {
+    const base = memoFixture();
+    const result = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        cfg: { ...baseArgs.cfg, sourceDiffCap: { maxFiles: 1, maxLines: 1 } },
+        quarantineMemo: base.memo,
+        gateBaselineKeys: new Set(),
+        runRectify: async (_maxAttempts, transaction) => {
+          transaction.memo.add(FLAKE_KEY);
+          transaction.recordAttempt([failedTest(FLAKE_KEY)], true);
+          return { rectificationExhausted: false };
+        },
+      },
+      {
+        ...deps,
+        measureSourceDiff: async () => ({ fileCount: 2, sourceLineCount: 2 }),
+      },
+    );
+
+    expect(result).toEqual({ ran: true, kept: false, restored: true });
+    expect(base.keys.has(FLAKE_KEY)).toBe(false);
+  });
+});

--- a/test/unit/execution/non-blocking-fix.test.ts
+++ b/test/unit/execution/non-blocking-fix.test.ts
@@ -289,10 +289,9 @@ describe("runNonBlockingFix keep vs restore", () => {
     expect(data?.regressedKeyCount).toBe(25);
   });
 
-  // #1383 — nbf's revalidation gate is never flake-triaged, so a first-observation flake
-  // is indistinguishable from a real break. The log must disclose that, and report how
-  // many failures were dropped as already-known flakes.
-  test("restore log discloses the triage gap and the memo exclusions (#1383)", async () => {
+  // Backward-compatible/no-probe path: diagnostics must report that triage did not run,
+  // while preserving the count of failures excluded by an existing memo.
+  test("restore log reports an untriaged pass and its memo exclusions", async () => {
     const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
     const data = await withInfoSpy(async (infoSpy) => {
       await runNonBlockingFix(

--- a/test/unit/execution/story-orchestrator-flake-integration.test.ts
+++ b/test/unit/execution/story-orchestrator-flake-integration.test.ts
@@ -689,16 +689,14 @@ describe("describeGateRegression — quarantine-memo filter (#1383)", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// #1383 — the invariant behind the restore log's `flakeTriageRan: false`.
+// #1383 — seeded advisory findings themselves do not invoke gate triage.
 //
-// `runNonBlockingFix` states that literal because the nbf path seeds
-// `overrides.initialFindings` and so takes the branch that never calls the triage
-// seam. The log-field test in non-blocking-fix.test.ts supplies that value itself,
-// so it cannot catch the claim going stale. These two pin the branch directly:
-// the negative case, and a control proving this fixture would see a triage call.
+// #1404 adds triage later, when the NBF validate sweep produces a newly failing gate,
+// through `overrides.nbfFlakeTriage`. These tests retain the narrower seed-branch
+// invariant and a control proving the fixture observes main-path triage.
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("runRectification — nbf path never invokes flake triage (#1383)", () => {
+describe("runRectification — seeded findings do not invoke initial gate triage", () => {
   /** Minimal state: rectification needs one validation phase, and triage needs the gate slot. */
   function makeRectifyState() {
     return {


### PR DESCRIPTION
Fixes #1404

## Summary

- triage first-observation failed-test flakes during non-blocking-fix revalidation without mutating phase outputs
- add a transaction-local flaky-test memo overlay that reads the global memo, buffers discoveries, and commits only when a candidate is kept after gate and source-diff-cap checks
- apply the same overlay to regression description and sweep decisions
- keep mixed failures, keyless failures, and red-modulo-confirmed flakes blocking
- report whether flake triage actually ran and document the transactional behavior

## Manual code review

Performed a manual review of the implementation and fixed two issues before publishing:

- replaced a runtime barrel import with a direct leaf import to avoid an ExecutionPlan/non-blocking-fix circular dependency
- prevented the keyless execution failure identity `::` from being classified as quarantined during the sweep

Also restricted transaction triage candidates to actual `failed-test` regressions and added regression coverage for keyless failures and rollback after the source-diff cap.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- focused tests: 78 passed, 0 failed
- full suite: 11,823 passed, 51 skipped, 0 failed
