### PR TITLE
feat: add post-run action hooks and finish notifications

### DIFF
--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -714,7 +714,7 @@ This wiring is internal to the fix cycle (`runFixCycle`, §Fix Cycle above).
 
 ## §27 Hooks & Lifecycle
 
-### Hook Events (11 types)
+### Hook Events (12 types)
 
 `src/hooks/types.ts`:
 
@@ -731,6 +731,7 @@ This wiring is internal to the fix cycle (`runFixCycle`, §Fix Cycle above).
 | `on-complete` | Run finishes successfully |
 | `on-error` | Unrecoverable run error |
 | `on-final-regression-fail` | Post-run regression fails |
+| `on-post-run-action` | A registered post-run action settles (success, failure, skip, or error) |
 
 ### Hook Definition
 
@@ -761,6 +762,9 @@ interface HookContext {
   model?: string;
   agent?: string;
   iteration?: number;
+  pluginName?: string;
+  actionName?: string;
+  url?: string;
 }
 ```
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -465,6 +465,7 @@ escalates** instead of guessing. It never merges.
       "enabled": true,
       "reviewers": { "spec": "nax-spec-reviewer", "quality": "nax-quality-reviewer" },
       "escalate": { "telegram": true },
+      "notify": { "mode": "escalation" },
       "timeouts": { "acceptanceMs": 600000, "gateMs": 900000, "flowMs": 5400000 }
     }
   }
@@ -478,6 +479,7 @@ escalates** instead of guessing. It never merges.
 | `defaultAgent` | `null` | acpx `--default-agent` for nodes with no pinned profile. |
 | `reviewers.spec` / `reviewers.quality` | `null` | acpx agent profiles (from `~/.acpx/config.json`) for the two review phases — each runs in its own isolated session, so they can be different agents/models. Unset → `defaultAgent`. |
 | `escalate.telegram` | `true` | Prefer Telegram for escalations when `interaction.plugin` is `telegram` (or `NAX_TELEGRAM_TOKEN` + `NAX_TELEGRAM_CHAT_ID` are set). With no credentials it falls back to a PR/MR comment. |
+| `notify.mode` | `"escalation"` | `escalation` preserves escalation-only reporting; `always` also reports clean outcomes and crashes; `off` disables Telegram and uses the escalation comment fallback. |
 | `timeouts.acceptanceMs` | 10 min | Cap per acceptance-test group. |
 | `timeouts.gateMs` | 15 min | Cap per quality gate. |
 | `timeouts.flowMs` | 90 min | Cap on the whole `acpx flow run` subprocess. |

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -39,6 +39,7 @@ Integrate notifications, CI triggers, or custom scripts via lifecycle hooks.
 | `on-final-regression-fail` | Deferred regression failed after rectification *(v0.34.0)* |
 | `on-complete` | Everything finished and verified (including regression gate) |
 | `on-error` | Unhandled error terminates the run |
+| `on-post-run-action` | A post-run plugin action succeeds, fails, skips, or throws |
 
 **Hook lifecycle:**
 
@@ -49,6 +50,7 @@ on-start
             └─ deferred regression gate (if enabled)
                  └─ on-final-regression-fail                 ← if regression fails
        └─ on-complete                                        ← everything verified
+            └─ on-post-run-action                            ← once per action during cleanup
 ```
 
 Each hook receives context via `NAX_*` environment variables and full JSON on stdin.
@@ -66,5 +68,12 @@ Each hook receives context via `NAX_*` environment variables and full JSON on st
 | `NAX_MODEL` | Current model |
 | `NAX_AGENT` | Current agent |
 | `NAX_ITERATION` | Current iteration number |
+| `NAX_PLUGIN_NAME` | Plugin that owns the settled post-run action |
+| `NAX_ACTION_NAME` | Settled post-run action name |
+| `NAX_RESULT_URL` | URL returned by the action, when present |
+
+For `on-post-run-action`, `NAX_STATUS` is one of `succeeded`, `failed`, `skipped`, or `error`. `NAX_REASON`
+contains the action message, skip reason, or thrown error. The hook is non-blocking and fires exactly once for every
+registered action, including actions whose `shouldRun()` returns `false`.
 
 **Global vs project hooks:** Global hooks (`~/.nax/hooks.json`) fire alongside project hooks. Set `"skipGlobal": true` in your project `hooks.json` to disable global hooks.

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -180,6 +180,7 @@ post-run driver treats it as non-blocking and logs a warning).
         "quality": "nax-quality-reviewer"
       },
       "escalate": { "telegram": true },
+      "notify": { "mode": "escalation" },
       "timeouts": {
         "acceptanceMs": 600000,
         "gateMs": 900000,
@@ -199,6 +200,7 @@ post-run driver treats it as non-blocking and logs a warning).
 | `reviewers.spec` | `null` | acpx agent profile for the spec-review phase — see §4. |
 | `reviewers.quality` | `null` | acpx agent profile for the quality-review phase. |
 | `escalate.telegram` | `true` | Prefer Telegram for escalations when credentials resolve; else PR/MR comment. |
+| `notify.mode` | `"escalation"` | Terminal notification policy: `escalation` preserves escalation-only behavior, `always` also reports success/failure, and `off` disables Telegram notifications. |
 | `timeouts.acceptanceMs` | 600000 (10 min) | Cap per acceptance-test group, in both the `acceptance` node and gate zero of `quality_gates`. |
 | `timeouts.gateMs` | 900000 (15 min) | Cap per quality gate. |
 | `timeouts.flowMs` | 5400000 (90 min) | Cap on the whole `acpx flow run`. |
@@ -348,6 +350,12 @@ backticks and underscores that Markdown parsing would reject outright.
 **PR/MR comment (fallback).** With `escalate.telegram: false`, or no credentials,
 the flow comments on the branch's existing PR/MR — opening a *draft* to hold the
 comment only if none exists. It never opens a ready PR while escalating.
+
+**Terminal notification policy.** `notify.mode: "always"` sends a best-effort Telegram report for every
+non-escalation terminal result and for flow crashes. A rejected or failed ordinary notification is logged but does
+not change the action result. Escalation delivery keeps its stronger guarantee: when Telegram is the selected
+escalation channel, a failed send is reported as an undelivered escalation. `notify.mode: "off"` forces escalation
+through the PR/MR-comment fallback so disabling Telegram cannot silently suppress both channels.
 
 **Delivery is never fatal.** The result file is written *before* delivery is
 attempted, so a rate limit, an expired token or an unrecognised remote cannot

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -439,6 +439,9 @@ export const NaxConfigSchema = z
               })
               .default({ spec: null, quality: null }),
             escalate: z.object({ telegram: z.boolean().default(true) }).default({ telegram: true }),
+            notify: z
+              .object({ mode: z.enum(["escalation", "always", "off"]).default("escalation") })
+              .default({ mode: "escalation" }),
             // Wall-clock caps. Every one of these bounds a subprocess the flow
             // awaits; without them a hung gate stalls the whole run's
             // completion phase, which has no timeout of its own.
@@ -465,6 +468,7 @@ export const NaxConfigSchema = z
             defaultAgent: null,
             reviewers: { spec: null, quality: null },
             escalate: { telegram: true },
+            notify: { mode: "escalation" },
             timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000, stepMs: null },
           }),
       })
@@ -475,6 +479,7 @@ export const NaxConfigSchema = z
           defaultAgent: null,
           reviewers: { spec: null, quality: null },
           escalate: { telegram: true },
+          notify: { mode: "escalation" },
           timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000, stepMs: null },
         },
       }),

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -45,6 +45,7 @@ export {
   type RunCompletionOptions,
   type RunCompletionResult,
   cleanupRun,
+  _runCleanupDeps,
   type RunCleanupOptions,
 } from "./lifecycle";
 export {

--- a/src/execution/lifecycle/index.ts
+++ b/src/execution/lifecycle/index.ts
@@ -17,7 +17,7 @@ export {
   type RunCompletionResult,
 } from "./run-completion";
 export { synthesizeBackfillMetric, type BackfillMetricArgs } from "./backfill-story-metrics";
-export { cleanupRun, type RunCleanupOptions } from "./run-cleanup";
+export { cleanupRun, _runCleanupDeps, type RunCleanupOptions } from "./run-cleanup";
 export { setupRun, type RunSetupOptions, type RunSetupResult } from "./run-setup";
 export {
   runDeferredRegression,

--- a/src/execution/lifecycle/run-cleanup.ts
+++ b/src/execution/lifecycle/run-cleanup.ts
@@ -10,15 +10,28 @@
  * - Release lock
  */
 
-import { disposeFeatureResolver } from "../../context";
-import type { InteractionChain } from "../../interaction";
-import { getSafeLogger } from "../../logger";
-import type { PostRunContext } from "../../plugins/extensions";
-import type { PluginRegistry } from "../../plugins/registry";
-import type { PluginLogger } from "../../plugins/types";
-import { countStories } from "../../prd";
-import type { PRD } from "../../prd";
+import { disposeFeatureResolver } from "@/context";
+import { type HookContext, type LoadedHooksConfig, fireHook } from "@/hooks";
+import type { InteractionChain } from "@/interaction";
+import { getSafeLogger } from "@/logger";
+import type {
+  IPostRunAction,
+  PluginLogger,
+  PluginRegistry,
+  PostRunActionRegistration,
+  PostRunActionResult,
+  PostRunContext,
+} from "@/plugins";
+import { type PRD, countStories } from "@/prd";
 import { releaseLock } from "../helpers";
+
+type PostRunActionOutcome =
+  | { status: "succeeded"; message: string; url?: string }
+  | { status: "failed"; message: string; url?: string }
+  | { status: "skipped"; reason: string }
+  | { status: "error"; reason: string };
+
+export const _runCleanupDeps = { fireHook };
 
 export interface RunCleanupOptions {
   runId: string;
@@ -33,6 +46,7 @@ export interface RunCleanupOptions {
   prdPath: string;
   branch: string;
   version: string;
+  hooks: LoadedHooksConfig;
   /**
    * True when run:completed was already emitted (success path).
    * When true, skip the direct onRunEnd call — the reporters.ts subscriber
@@ -52,6 +66,71 @@ export interface RunCleanupOptions {
   logFilePath?: string;
   /** Full nax config (for curator and other plugins) */
   config?: unknown;
+}
+
+async function settlePostRunAction(action: IPostRunAction, ctx: PostRunContext): Promise<PostRunActionOutcome> {
+  try {
+    if (!(await action.shouldRun(ctx))) return { status: "skipped", reason: "shouldRun=false" };
+    return outcomeFromResult(await action.execute(ctx));
+  } catch (error) {
+    return { status: "error", reason: String(error) };
+  }
+}
+
+function outcomeFromResult(result: PostRunActionResult): PostRunActionOutcome {
+  if (result.skipped) return { status: "skipped", reason: result.reason ?? result.message };
+  if (!result.success) return { status: "failed", message: result.message, url: result.url };
+  return { status: "succeeded", message: result.message, url: result.url };
+}
+
+function logPostRunOutcome(actionName: string, outcome: PostRunActionOutcome): void {
+  const logger = getSafeLogger();
+  if (outcome.status === "skipped") {
+    const level = outcome.reason === "shouldRun=false" ? "debug" : "info";
+    logger?.[level]("post-run", `[post-run] ${actionName}: skipped — ${outcome.reason}`);
+  } else if (outcome.status === "failed") {
+    logger?.warn("post-run", `[post-run] ${actionName}: failed — ${outcome.message}`);
+  } else if (outcome.status === "error") {
+    logger?.warn("post-run", `[post-run] ${actionName}: error — ${outcome.reason}`);
+  } else {
+    const suffix = outcome.url ? `${outcome.message} (${outcome.url})` : outcome.message;
+    logger?.info("post-run", `[post-run] ${actionName}: ${suffix}`);
+  }
+}
+
+function postRunHookContext(
+  feature: string,
+  registration: PostRunActionRegistration,
+  outcome: PostRunActionOutcome,
+): HookContext {
+  const reason = outcome.status === "succeeded" || outcome.status === "failed" ? outcome.message : outcome.reason;
+  return {
+    event: "on-post-run-action",
+    feature,
+    pluginName: registration.pluginName,
+    actionName: registration.action.name,
+    status: outcome.status,
+    reason,
+    url: "url" in outcome ? outcome.url : undefined,
+  };
+}
+
+async function runPostRunActions(options: RunCleanupOptions, ctx: PostRunContext): Promise<void> {
+  const registrations = options.pluginRegistry.getPostRunActionRegistrations();
+  for (const registration of registrations) {
+    const outcome = await settlePostRunAction(registration.action, ctx);
+    logPostRunOutcome(registration.action.name, outcome);
+    try {
+      await _runCleanupDeps.fireHook(
+        options.hooks,
+        "on-post-run-action",
+        postRunHookContext(options.feature, registration, outcome),
+        options.workdir,
+      );
+    } catch (error) {
+      getSafeLogger()?.warn("hooks", `on-post-run-action hook failed for '${registration.pluginName}'`, { error });
+    }
+  }
 }
 
 /**
@@ -143,7 +222,6 @@ export async function cleanupRun(options: RunCleanupOptions): Promise<void> {
   }
 
   // Execute post-run actions sequentially after reporters.onRunEnd()
-  const actions = pluginRegistry.getPostRunActions();
   // `data` must be forwarded, not dropped: PluginLogger's contract is
   // (message, data), and every post-run action relies on it — each one's catch
   // path logs `{ error: String(err) }`, and nax-finish logs the finish flow's
@@ -158,28 +236,7 @@ export async function cleanupRun(options: RunCleanupOptions): Promise<void> {
   };
   const ctx = buildPostRunContext(options, durationMs, pluginLogger);
 
-  for (const action of actions) {
-    try {
-      const shouldRun = await action.shouldRun(ctx);
-      if (!shouldRun) {
-        logger?.debug("post-run", `[post-run] ${action.name}: shouldRun=false, skipping`);
-        continue;
-      }
-      const result = await action.execute(ctx);
-      if (result.skipped) {
-        logger?.info("post-run", `[post-run] ${action.name}: skipped — ${result.reason}`);
-      } else if (!result.success) {
-        logger?.warn("post-run", `[post-run] ${action.name}: failed — ${result.message}`);
-      } else {
-        const msg = result.url
-          ? `[post-run] ${action.name}: ${result.message} (${result.url})`
-          : `[post-run] ${action.name}: ${result.message}`;
-        logger?.info("post-run", msg);
-      }
-    } catch (error) {
-      logger?.warn("post-run", `[post-run] ${action.name}: error — ${error}`);
-    }
-  }
+  await runPostRunActions(options, ctx);
 
   // Teardown plugins
   try {

--- a/src/execution/lifecycle/run-cleanup.ts
+++ b/src/execution/lifecycle/run-cleanup.ts
@@ -23,6 +23,7 @@ import type {
   PostRunContext,
 } from "@/plugins";
 import { type PRD, countStories } from "@/prd";
+import { errorMessage } from "@/utils/errors";
 import { releaseLock } from "../helpers";
 
 type PostRunActionOutcome =
@@ -73,7 +74,7 @@ async function settlePostRunAction(action: IPostRunAction, ctx: PostRunContext):
     if (!(await action.shouldRun(ctx))) return { status: "skipped", reason: "shouldRun=false" };
     return outcomeFromResult(await action.execute(ctx));
   } catch (error) {
-    return { status: "error", reason: String(error) };
+    return { status: "error", reason: errorMessage(error) };
   }
 }
 

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -372,6 +372,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
         prdPath,
         branch,
         version: NAX_VERSION,
+        hooks,
         runCompleted,
         outputDir: runtime.outputDir,
         globalDir: runtime.globalDir,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export type { HookEvent, HookDef, HooksConfig, HookContext } from "./types";
+export { HOOK_EVENTS } from "./types";
 export { loadHooksConfig, fireHook, type LoadedHooksConfig } from "./runner";

--- a/src/hooks/runner.ts
+++ b/src/hooks/runner.ts
@@ -106,6 +106,9 @@ function buildEnv(ctx: HookContext): Record<string, string> {
   if (ctx.model) env.NAX_MODEL = escapeEnvValue(ctx.model);
   if (ctx.agent) env.NAX_AGENT = escapeEnvValue(ctx.agent);
   if (ctx.iteration !== undefined) env.NAX_ITERATION = String(ctx.iteration);
+  if (ctx.pluginName) env.NAX_PLUGIN_NAME = escapeEnvValue(ctx.pluginName);
+  if (ctx.actionName) env.NAX_ACTION_NAME = escapeEnvValue(ctx.actionName);
+  if (ctx.url) env.NAX_RESULT_URL = escapeEnvValue(ctx.url);
 
   return env;
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -17,6 +17,7 @@ export const HOOK_EVENTS = [
   "on-complete",
   "on-error",
   "on-final-regression-fail",
+  "on-post-run-action",
 ] as const;
 
 /** All supported hook events */
@@ -58,9 +59,9 @@ export interface HookContext {
   feature: string;
   /** Current story ID */
   storyId?: string;
-  /** Status (pass/fail/paused/error) */
+  /** Event-specific status (for example pass/fail or a post-run action outcome) */
   status?: string;
-  /** Reason for pause/error */
+  /** Event-specific reason or result message */
   reason?: string;
   /** Accumulated cost (USD) */
   cost?: number;
@@ -76,4 +77,10 @@ export interface HookContext {
   affectedStories?: string[];
   /** Number of sub-stories created (on-story-complete with status "decomposed") */
   subStoryCount?: number;
+  /** Plugin that owns the settled post-run action. */
+  pluginName?: string;
+  /** Settled post-run action name. */
+  actionName?: string;
+  /** Optional result URL produced by a post-run action. */
+  url?: string;
 }

--- a/src/plugins/builtin/nax-finish/config.ts
+++ b/src/plugins/builtin/nax-finish/config.ts
@@ -18,6 +18,7 @@ export interface FinishAutoFlowSettings {
   defaultAgent: string | null;
   reviewers: { spec: string | null; quality: string | null };
   escalate: { telegram: boolean };
+  notify: { mode: "escalation" | "always" | "off" };
   timeouts: { acceptanceMs: number; gateMs: number; flowMs: number; stepMs: number | null };
 }
 
@@ -32,6 +33,7 @@ const DEFAULT_FINISH_AUTO_FLOW_CONFIG: FinishAutoFlowSettings = {
   defaultAgent: null,
   reviewers: { spec: null, quality: null },
   escalate: { telegram: true },
+  notify: { mode: "escalation" },
   timeouts: { acceptanceMs: 600_000, gateMs: 900_000, flowMs: 5_400_000, stepMs: null },
 };
 
@@ -56,6 +58,7 @@ export function getFinishAutoFlowConfig(ctx: { config?: unknown }): FinishAutoFl
       quality: autoFlow.reviewers?.quality ?? null,
     },
     escalate: { telegram: autoFlow.escalate?.telegram !== false },
+    notify: { mode: autoFlow.notify?.mode ?? defaults.notify.mode },
     timeouts: {
       acceptanceMs: autoFlow.timeouts?.acceptanceMs ?? defaults.timeouts.acceptanceMs,
       gateMs: autoFlow.timeouts?.gateMs ?? defaults.timeouts.gateMs,

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -7,7 +7,7 @@
  * spec/quality reviewer profiles to the flow module via env vars (the flow
  * module reloads fresh on every `acpx flow run` invocation, so profiles are
  * read at module-load time rather than passed as flow input), and notifies
- * via Telegram when the flow escalates.
+ * terminal outcomes according to `finish.autoFlow.notify.mode`.
  *
  * Note: the flow contract types below (`FinishResult`, `RunFn`) are declared
  * locally rather than imported from `flows/nax-finish/` — `src/` must never
@@ -21,7 +21,8 @@
 import * as path from "node:path";
 import type { IPostRunAction, NaxPlugin, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
 import { type FinishAutoFlowSettings, getFinishAutoFlowConfig, telegramCreds } from "./config";
-import { buildEscalationMessage, sendTelegramNotify } from "./telegram";
+import { logTail, stderrTail } from "./output";
+import { buildEscalationMessage, buildTerminalMessage, sendTelegramNotify } from "./telegram";
 
 interface FinishResult {
   feature: string;
@@ -34,6 +35,14 @@ interface FinishResult {
   deliveryError?: string;
 }
 
+type TelegramCreds = NonNullable<ReturnType<typeof telegramCreds>>;
+
+interface FinishTerminalOutcome {
+  actionResult: PostRunActionResult;
+  result?: FinishResult;
+  escalateTelegram: boolean;
+}
+
 type RunFn = (
   cmd: string[],
   opts: { cwd: string; env?: Record<string, string>; timeoutMs?: number },
@@ -44,43 +53,6 @@ const PLUGIN_VERSION = "0.1.0";
 
 /** How far up from this module to look for the nax package root (`src/…` in dev, `dist/` when built). */
 const PACKAGE_ROOT_SEARCH_DEPTH = 6;
-
-/**
- * How much of the flow's stderr to inline in the failure message.
- *
- * The message goes to the run's exit summary, so it has to stay short — but it
- * must carry *something*. Reporting only the exit code (the previous behaviour)
- * made a hard flow crash indistinguishable from a clean failure: a
- * `ReferenceError: Bun is not defined` on the flow's first node was reported as
- * a bare "exited 1 (no result file)" with the real cause discarded. A larger
- * slice of both streams still goes to the logger below.
- */
-const STDERR_TAIL_CHARS = 400;
-
-/**
- * How much of each stream to put in the log payload.
- *
- * Not unbounded: on a flow that ran to completion and only failed to write its
- * result, acpx's stdout carries every node's output — including full LLM review
- * text — which would land in the JSONL log as a single multi-megabyte line.
- * The tail is the useful end (that is where a crash reports itself), so
- * truncation drops from the front and says so.
- */
-const LOG_TAIL_CHARS = 20_000;
-
-/** Last `LOG_TAIL_CHARS` of a stream, with an explicit marker when anything was dropped. */
-function logTail(stream: string): string {
-  if (stream.length <= LOG_TAIL_CHARS) return stream;
-  return `[…${stream.length - LOG_TAIL_CHARS} chars truncated…]\n${stream.slice(-LOG_TAIL_CHARS)}`;
-}
-
-/** Last `STDERR_TAIL_CHARS` of the flow's stderr, whitespace-collapsed for one-line log output. */
-function stderrTail(stderr: string): string {
-  const trimmed = stderr.trim();
-  if (!trimmed) return "";
-  const tail = trimmed.length > STDERR_TAIL_CHARS ? `…${trimmed.slice(-STDERR_TAIL_CHARS)}` : trimmed;
-  return tail.replace(/\s+/g, " ");
-}
 
 /**
  * Default subprocess runner — wraps Bun.spawn with concurrent stdout/stderr
@@ -128,6 +100,12 @@ async function defaultReadResult(workdir: string): Promise<FinishResult | null> 
   return JSON.parse(await f.text()) as FinishResult;
 }
 
+/** Remove an earlier run's terminal artifact before starting a new flow. */
+async function defaultClearResult(workdir: string): Promise<void> {
+  const file = Bun.file(path.join(workdir, ".nax", "nax-finish-result.json"));
+  if (await file.exists()) await file.delete();
+}
+
 /**
  * Module-level deps for testability (`_deps` pattern).
  *
@@ -137,6 +115,7 @@ async function defaultReadResult(workdir: string): Promise<FinishResult | null> 
 export const _naxFinishDeps: {
   run: RunFn;
   readResult: (workdir: string) => Promise<FinishResult | null>;
+  clearResult: (workdir: string) => Promise<void>;
   /** Path-existence probe — used to resolve the flow module and the nax package root. */
   exists: (p: string) => Promise<boolean>;
   /** Directory this module was loaded from; overridable so package-root walking is testable. */
@@ -152,6 +131,7 @@ export const _naxFinishDeps: {
 } = {
   run: defaultRun,
   readResult: defaultReadResult,
+  clearResult: defaultClearResult,
   exists: (p) => Bun.file(p).exists(),
   moduleDir: import.meta.dir,
   notify: sendTelegramNotify,
@@ -230,6 +210,151 @@ function buildFlowEnv(cfg: FinishAutoFlowSettings): Record<string, string> {
   return env;
 }
 
+interface ExecuteFinishOptions {
+  ctx: PostRunContext;
+  cfg: FinishAutoFlowSettings;
+  creds: TelegramCreds | null;
+  escalateTelegram: boolean;
+}
+
+function missingResultOutcome(
+  ctx: PostRunContext,
+  res: { exitCode: number; stdout: string; stderr: string },
+  escalateTelegram: boolean,
+): FinishTerminalOutcome {
+  ctx.logger.warn("nax-finish flow produced no result file", {
+    exitCode: res.exitCode,
+    stdout: logTail(res.stdout),
+    stderr: logTail(res.stderr),
+  });
+  const tail = stderrTail(res.stderr);
+  return {
+    actionResult: {
+      success: false,
+      message: `nax-finish flow exited ${res.exitCode} (no result file)${tail ? `: ${tail}` : ""}`,
+    },
+    escalateTelegram,
+  };
+}
+
+async function executeFinishFlow(options: ExecuteFinishOptions): Promise<FinishTerminalOutcome> {
+  const { ctx, cfg, escalateTelegram } = options;
+  const flowPath = await resolveFlowPath(ctx.workdir, cfg.flowPath);
+  if (!flowPath) {
+    return {
+      actionResult: {
+        success: false,
+        message: `nax-finish: flow module "${cfg.flowPath}" not found in the nax install or ${ctx.workdir}`,
+      },
+      escalateTelegram,
+    };
+  }
+
+  await _naxFinishDeps.clearResult(ctx.workdir);
+  const input = {
+    feature: ctx.feature,
+    workdir: ctx.workdir,
+    branch: ctx.branch,
+    prdPath: ctx.prdPath,
+    escalateTelegram,
+    timeouts: { acceptanceMs: cfg.timeouts.acceptanceMs, gateMs: cfg.timeouts.gateMs },
+  };
+  const cmd = buildFlowArgv(flowPath, JSON.stringify(input), cfg.defaultAgent, cfg.timeouts.stepMs);
+  const res = await _naxFinishDeps.run(cmd, {
+    cwd: ctx.workdir,
+    env: buildFlowEnv(cfg),
+    timeoutMs: cfg.timeouts.flowMs,
+  });
+  const result = await _naxFinishDeps.readResult(ctx.workdir);
+  if (!result) return missingResultOutcome(ctx, res, escalateTelegram);
+  return {
+    actionResult: { success: true, message: `nax-finish: ${result.status}`, url: result.url },
+    result,
+    escalateTelegram,
+  };
+}
+
+async function settleFinishFlow(
+  options: Omit<ExecuteFinishOptions, "escalateTelegram">,
+): Promise<FinishTerminalOutcome> {
+  const escalateTelegram = options.cfg.notify.mode !== "off" && options.cfg.escalate.telegram && options.creds !== null;
+  try {
+    return await executeFinishFlow({ ...options, escalateTelegram });
+  } catch (error) {
+    options.ctx.logger.warn("nax-finish execute failed", { error: String(error) });
+    return {
+      actionResult: { success: false, message: `nax-finish failed: ${String(error)}` },
+      escalateTelegram,
+    };
+  }
+}
+
+async function notifyBestEffort(ctx: PostRunContext, creds: TelegramCreds | null, message: string): Promise<void> {
+  if (!creds) {
+    ctx.logger.warn("nax-finish terminal notification skipped: Telegram credentials are unavailable");
+    return;
+  }
+  try {
+    if (!(await _naxFinishDeps.notify(creds, message))) {
+      ctx.logger.warn("nax-finish terminal notification was rejected", { feature: ctx.feature });
+    }
+  } catch (error) {
+    ctx.logger.warn("nax-finish terminal notification failed", { feature: ctx.feature, error: String(error) });
+  }
+}
+
+async function finalizeEscalation(
+  ctx: PostRunContext,
+  outcome: FinishTerminalOutcome,
+  creds: TelegramCreds | null,
+): Promise<PostRunActionResult> {
+  const result = outcome.result;
+  if (!result) return outcome.actionResult;
+  const problems: string[] = [];
+  let delivered = !outcome.escalateTelegram && !result.deliveryError;
+  if (outcome.escalateTelegram && creds) {
+    try {
+      delivered = await _naxFinishDeps.notify(
+        creds,
+        buildEscalationMessage(result.feature, result.escalationReason ?? "", result.findings ?? []),
+      );
+      if (!delivered) problems.push("Telegram rejected the message");
+    } catch (error) {
+      problems.push(`Telegram failed: ${String(error)}`);
+    }
+  }
+  if (delivered) return outcome.actionResult;
+  if (result.deliveryError) problems.push(`the flow could not post it: ${result.deliveryError}`);
+  if (problems.length === 0) problems.push("no escalation channel was reachable");
+  ctx.logger.warn("nax-finish escalation was not delivered", {
+    feature: result.feature,
+    reasons: problems,
+    escalationReason: result.escalationReason,
+  });
+  return {
+    success: false,
+    message: `nax-finish: escalated but undelivered — ${problems.join("; ")}`,
+    url: result.url,
+  };
+}
+
+async function finalizeFinishOutcome(
+  options: Omit<ExecuteFinishOptions, "escalateTelegram"> & { outcome: FinishTerminalOutcome },
+): Promise<PostRunActionResult> {
+  const { ctx, cfg, creds, outcome } = options;
+  if (outcome.result?.status === "escalated") return finalizeEscalation(ctx, outcome, creds);
+  if (cfg.notify.mode === "always") {
+    const status = outcome.result?.status ?? "failed";
+    const detail = outcome.result ? undefined : outcome.actionResult.message;
+    await notifyBestEffort(
+      ctx,
+      creds,
+      buildTerminalMessage({ feature: ctx.feature, status, detail, url: outcome.actionResult.url }),
+    );
+  }
+  return outcome.actionResult;
+}
+
 const naxFinishAction: IPostRunAction = {
   name: PLUGIN_NAME,
   description:
@@ -246,102 +371,10 @@ const naxFinishAction: IPostRunAction = {
   },
 
   async execute(ctx: PostRunContext): Promise<PostRunActionResult> {
-    try {
-      const cfg = getFinishAutoFlowConfig(ctx);
-      const flowPath = await resolveFlowPath(ctx.workdir, cfg.flowPath);
-      if (!flowPath) {
-        return {
-          success: false,
-          message: `nax-finish: flow module "${cfg.flowPath}" not found in the nax install or ${ctx.workdir}`,
-        };
-      }
-
-      const creds = telegramCreds(ctx.config);
-      // Telegram is the escalation channel only when it is both enabled AND
-      // credentialed; otherwise the flow falls back to a PR/MR comment. It has
-      // to know which, so it doesn't do both (or open a draft it won't need).
-      const escalateTelegram = cfg.escalate.telegram && creds !== null;
-
-      // No `reviewers` field on the flow input — profiles flow to the flow
-      // module via env vars instead (see module header comment).
-      const input = {
-        feature: ctx.feature,
-        workdir: ctx.workdir,
-        branch: ctx.branch,
-        prdPath: ctx.prdPath,
-        escalateTelegram,
-        timeouts: { acceptanceMs: cfg.timeouts.acceptanceMs, gateMs: cfg.timeouts.gateMs },
-      };
-
-      const cmd = buildFlowArgv(flowPath, JSON.stringify(input), cfg.defaultAgent, cfg.timeouts.stepMs);
-      const res = await _naxFinishDeps.run(cmd, {
-        cwd: ctx.workdir,
-        env: buildFlowEnv(cfg),
-        timeoutMs: cfg.timeouts.flowMs,
-      });
-      const result = await _naxFinishDeps.readResult(ctx.workdir);
-      if (!result) {
-        // The flow produced no result file, so its stdout/stderr is the only
-        // evidence of what went wrong — log it before it is dropped.
-        ctx.logger.warn("nax-finish flow produced no result file", {
-          exitCode: res.exitCode,
-          stdout: logTail(res.stdout),
-          stderr: logTail(res.stderr),
-        });
-        // Always a failure, including on exit 0: both of the flow's terminal
-        // nodes (open_pr, escalate) write the result file on every branch, so
-        // its absence means the graph ended without reaching one. There is no
-        // outcome to report, and calling that success logged the anomaly at
-        // info — the same "broken state wearing an unremarkable label" that hid
-        // the crash this message now carries. The action is fail-open either
-        // way: `success` only selects the post-run log level.
-        const tail = stderrTail(res.stderr);
-        return {
-          success: false,
-          message: `nax-finish flow exited ${res.exitCode} (no result file)${tail ? `: ${tail}` : ""}`,
-        };
-      }
-
-      // An escalation nobody receives is the same broken-state-wearing-an-
-      // unremarkable-label failure as a missing result file.
-      //
-      // Which channel counts is not symmetric: the flow posts the PR/MR comment
-      // itself ONLY when Telegram is not the channel, so on the Telegram path
-      // its `deliveryError` means just that the URL lookup failed — the comment
-      // was never meant to be posted. Treating that as undelivered would raise
-      // a false alarm on the path that actually worked.
-      if (result.status === "escalated") {
-        const problems: string[] = [];
-        let delivered = !escalateTelegram && !result.deliveryError;
-        if (escalateTelegram && creds) {
-          const sent = await _naxFinishDeps.notify(
-            creds,
-            buildEscalationMessage(result.feature, result.escalationReason ?? "", result.findings ?? []),
-          );
-          if (sent) delivered = true;
-          else problems.push("Telegram rejected the message");
-        }
-        if (!delivered) {
-          if (result.deliveryError) problems.push(`the flow could not post it: ${result.deliveryError}`);
-          if (problems.length === 0) problems.push("no escalation channel was reachable");
-          ctx.logger.warn("nax-finish escalation was not delivered", {
-            feature: result.feature,
-            reasons: problems,
-            escalationReason: result.escalationReason,
-          });
-          return {
-            success: false,
-            message: `nax-finish: escalated but undelivered — ${problems.join("; ")}`,
-            url: result.url,
-          };
-        }
-      }
-
-      return { success: true, message: `nax-finish: ${result.status}`, url: result.url };
-    } catch (err) {
-      ctx.logger.warn("nax-finish execute failed", { error: String(err) });
-      return { success: false, message: `nax-finish failed: ${String(err)}` };
-    }
+    const cfg = getFinishAutoFlowConfig(ctx);
+    const creds = telegramCreds(ctx.config);
+    const outcome = await settleFinishFlow({ ctx, cfg, creds });
+    return finalizeFinishOutcome({ ctx, cfg, creds, outcome });
   },
 };
 

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -20,6 +20,7 @@
 
 import * as path from "node:path";
 import type { IPostRunAction, NaxPlugin, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
+import { errorMessage } from "@/utils/errors";
 import { type FinishAutoFlowSettings, getFinishAutoFlowConfig, telegramCreds } from "./config";
 import { logTail, stderrTail } from "./output";
 import { buildEscalationMessage, buildTerminalMessage, sendTelegramNotify } from "./telegram";
@@ -121,7 +122,7 @@ export const _naxFinishDeps: {
   /** Directory this module was loaded from; overridable so package-root walking is testable. */
   moduleDir: string;
   /**
-   * Escalation notifier. Routed through `_deps` (rather than called as a direct
+   * Terminal-outcome notifier. Routed through `_deps` (rather than called as a direct
    * import) because `telegramCreds` falls back to ambient `TELEGRAM_BOT_TOKEN` /
    * `NAX_TELEGRAM_CHAT_ID` env vars — so a test that stubs only `run`/`readResult`
    * and returns an "escalated" status would otherwise send a REAL Telegram
@@ -281,9 +282,9 @@ async function settleFinishFlow(
   try {
     return await executeFinishFlow({ ...options, escalateTelegram });
   } catch (error) {
-    options.ctx.logger.warn("nax-finish execute failed", { error: String(error) });
+    options.ctx.logger.warn("nax-finish execute failed", { error: errorMessage(error) });
     return {
-      actionResult: { success: false, message: `nax-finish failed: ${String(error)}` },
+      actionResult: { success: false, message: `nax-finish failed: ${errorMessage(error)}` },
       escalateTelegram,
     };
   }
@@ -299,7 +300,7 @@ async function notifyBestEffort(ctx: PostRunContext, creds: TelegramCreds | null
       ctx.logger.warn("nax-finish terminal notification was rejected", { feature: ctx.feature });
     }
   } catch (error) {
-    ctx.logger.warn("nax-finish terminal notification failed", { feature: ctx.feature, error: String(error) });
+    ctx.logger.warn("nax-finish terminal notification failed", { feature: ctx.feature, error: errorMessage(error) });
   }
 }
 
@@ -320,7 +321,7 @@ async function finalizeEscalation(
       );
       if (!delivered) problems.push("Telegram rejected the message");
     } catch (error) {
-      problems.push(`Telegram failed: ${String(error)}`);
+      problems.push(`Telegram failed: ${errorMessage(error)}`);
     }
   }
   if (delivered) return outcome.actionResult;

--- a/src/plugins/builtin/nax-finish/output.ts
+++ b/src/plugins/builtin/nax-finish/output.ts
@@ -1,0 +1,19 @@
+/** Maximum stderr characters included in a one-line action result. */
+const STDERR_TAIL_CHARS = 400;
+
+/** Maximum characters retained per subprocess stream in structured logs. */
+const LOG_TAIL_CHARS = 20_000;
+
+/** Last `LOG_TAIL_CHARS` of a stream, with an explicit truncation marker. */
+export function logTail(stream: string): string {
+  if (stream.length <= LOG_TAIL_CHARS) return stream;
+  return `[…${stream.length - LOG_TAIL_CHARS} chars truncated…]\n${stream.slice(-LOG_TAIL_CHARS)}`;
+}
+
+/** Bounded stderr tail, whitespace-collapsed for one-line action output. */
+export function stderrTail(stderr: string): string {
+  const trimmed = stderr.trim();
+  if (!trimmed) return "";
+  const tail = trimmed.length > STDERR_TAIL_CHARS ? `…${trimmed.slice(-STDERR_TAIL_CHARS)}` : trimmed;
+  return tail.replace(/\s+/g, " ");
+}

--- a/src/plugins/builtin/nax-finish/telegram.ts
+++ b/src/plugins/builtin/nax-finish/telegram.ts
@@ -15,6 +15,24 @@ export const TELEGRAM_MAX_MESSAGE_CHARS = 4096;
 /** Per-finding title budget, so one verbose title can't crowd out every other finding. */
 const MAX_FINDING_TITLE_CHARS = 120;
 
+interface TerminalMessageOptions {
+  feature: string;
+  status: string;
+  detail?: string;
+  url?: string;
+}
+
+/** Build a bounded plain-text terminal notification for non-escalation outcomes. */
+export function buildTerminalMessage(options: TerminalMessageOptions): string {
+  const lines = [`nax-finish ${options.status} ${options.feature}`];
+  if (options.detail) lines.push(options.detail);
+  if (options.url) lines.push(options.url);
+  const message = lines.join("\n");
+  return message.length <= TELEGRAM_MAX_MESSAGE_CHARS
+    ? message
+    : `${message.slice(0, TELEGRAM_MAX_MESSAGE_CHARS - 1)}…`;
+}
+
 /**
  * Compose the escalation message: the reason, then each finding by severity and
  * title.

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -32,7 +32,7 @@ export type {
 
 export { validatePlugin } from "./validator";
 export { loadPlugins } from "./loader";
-export { PluginRegistry } from "./registry";
+export { PluginRegistry, type PostRunActionRegistration } from "./registry";
 export { createPluginLogger } from "./plugin-logger";
 
 // Built-in auto-route plugin (US-005) — exposed for test injection (`_autoRouteDeps`)

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -20,8 +20,8 @@ import { naxFinishPlugin } from "./builtin/nax-finish";
 import { createOtelReporterPlugin } from "./builtin/otel-reporter";
 import { createWebhookReporterPlugin } from "./builtin/webhook-reporter";
 import { createPluginLogger } from "./plugin-logger";
-import { PluginRegistry } from "./registry";
-import type { IPostRunAction, NaxPlugin, PluginConfigEntry } from "./types";
+import { PluginRegistry, type PostRunActionRegistration } from "./registry";
+import type { NaxPlugin, PluginConfigEntry } from "./types";
 import { validatePlugin } from "./validator";
 
 /**
@@ -114,7 +114,7 @@ export async function loadPlugins(
   reporters?: ReportersConfig,
 ): Promise<PluginRegistry> {
   const loadedPlugins: LoadedPlugin[] = [];
-  const builtinPostRunActions: IPostRunAction[] = [];
+  const builtinPostRunActions: PostRunActionRegistration[] = [];
   const effectiveProjectRoot = projectRoot || projectDir;
   const pluginNames = new Set<string>();
   const disabledSet = new Set(disabledPlugins ?? []);
@@ -148,7 +148,7 @@ export async function loadPlugins(
     // exists for branch". auto-route follows the same side-channel layout.
     const autoPrAction = autoPrPlugin.extensions.postRunAction;
     if (autoPrAction) {
-      builtinPostRunActions.push(autoPrAction);
+      builtinPostRunActions.push({ pluginName: autoPrPlugin.name, action: autoPrAction });
     }
   } else {
     logger?.info("plugins", `Skipping disabled plugin: '${autoPrPlugin.name}' (built-in)`);
@@ -161,7 +161,7 @@ export async function loadPlugins(
     }
     // Side-channel action only (same layout as auto-pr) — not added to loadedPlugins.
     const action = naxFinishPlugin.extensions.postRunAction;
-    if (action) builtinPostRunActions.push(action);
+    if (action) builtinPostRunActions.push({ pluginName: naxFinishPlugin.name, action });
   } else {
     logger?.info("plugins", `Skipping disabled plugin: '${naxFinishPlugin.name}' (built-in)`);
   }
@@ -173,7 +173,7 @@ export async function loadPlugins(
     }
     const autoRouteAction = autoRoutePlugin.extensions.postRunAction;
     if (autoRouteAction) {
-      builtinPostRunActions.push(autoRouteAction);
+      builtinPostRunActions.push({ pluginName: autoRoutePlugin.name, action: autoRouteAction });
     }
   } else {
     logger?.info("plugins", `Skipping disabled plugin: '${autoRoutePlugin.name}' (built-in)`);

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -40,10 +40,15 @@ export class PluginRegistry {
    *    logic treat it as transparent — opt-in semantics live in the action's
    *    own `shouldRun()` (e.g. `config.autoPr.enabled`).
    */
-  private readonly builtinPostRunActions: ReadonlyArray<IPostRunAction>;
+  private readonly builtinPostRunActions: ReadonlyArray<PostRunActionRegistration>;
 
-  constructor(loadedPlugins: LoadedPlugin[] | NaxPlugin[], builtinPostRunActions: IPostRunAction[] = []) {
-    this.builtinPostRunActions = builtinPostRunActions;
+  constructor(
+    loadedPlugins: LoadedPlugin[] | NaxPlugin[],
+    builtinPostRunActions: Array<IPostRunAction | PostRunActionRegistration> = [],
+  ) {
+    this.builtinPostRunActions = builtinPostRunActions.map((registration) =>
+      "action" in registration ? registration : { pluginName: registration.name, action: registration },
+    );
     // Support both LoadedPlugin[] and NaxPlugin[] for backward compatibility
     if (loadedPlugins.length > 0 && "plugin" in loadedPlugins[0]) {
       // New format: LoadedPlugin[]
@@ -186,8 +191,7 @@ export class PluginRegistry {
       const action = plugin.extensions.postRunAction;
       return plugin.provides.includes("post-run-action") && action ? [{ pluginName: plugin.name, action }] : [];
     });
-    const builtinActions = this.builtinPostRunActions.map((action) => ({ pluginName: action.name, action }));
-    return [...pluginActions, ...builtinActions];
+    return [...pluginActions, ...this.builtinPostRunActions];
   }
 
   /**

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -10,6 +10,11 @@ import type { RoutingStrategy } from "../routing/router";
 import type { LoadedPlugin, PluginSource } from "./loader";
 import type { IContextProvider, IPostRunAction, IPromptOptimizer, IReporter, IReviewPlugin, NaxPlugin } from "./types";
 
+export interface PostRunActionRegistration {
+  pluginName: string;
+  action: IPostRunAction;
+}
+
 /**
  * Plugin registry with typed getters for each extension type.
  *
@@ -172,11 +177,17 @@ export class PluginRegistry {
    * @returns Array of post-run action implementations
    */
   getPostRunActions(): IPostRunAction[] {
-    const pluginActions = this.plugins
-      .filter((p) => p.provides.includes("post-run-action"))
-      .map((p) => p.extensions.postRunAction)
-      .filter((action): action is IPostRunAction => action !== undefined);
-    return [...pluginActions, ...this.builtinPostRunActions];
+    return this.getPostRunActionRegistrations().map(({ action }) => action);
+  }
+
+  /** Return post-run actions together with their owning plugin identity. */
+  getPostRunActionRegistrations(): PostRunActionRegistration[] {
+    const pluginActions = this.plugins.flatMap((plugin) => {
+      const action = plugin.extensions.postRunAction;
+      return plugin.provides.includes("post-run-action") && action ? [{ pluginName: plugin.name, action }] : [];
+    });
+    const builtinActions = this.builtinPostRunActions.map((action) => ({ pluginName: action.name, action }));
+    return [...pluginActions, ...builtinActions];
   }
 
   /**

--- a/test/unit/config/finish-autoflow-schema.test.ts
+++ b/test/unit/config/finish-autoflow-schema.test.ts
@@ -9,6 +9,7 @@ describe("finish.autoFlow schema", () => {
     expect(c.finish.autoFlow.defaultAgent).toBeNull();
     expect(c.finish.autoFlow.reviewers).toEqual({ spec: null, quality: null });
     expect(c.finish.autoFlow.escalate.telegram).toBe(true);
+    expect(c.finish.autoFlow.notify.mode).toBe("escalation");
     // Every subprocess the flow awaits is capped — nothing defaults to unbounded.
     expect(c.finish.autoFlow.timeouts.acceptanceMs).toBeGreaterThan(0);
     expect(c.finish.autoFlow.timeouts.gateMs).toBeGreaterThan(0);
@@ -36,10 +37,21 @@ describe("finish.autoFlow schema", () => {
   test("accepts overrides", () => {
     const c = NaxConfigSchema.parse({
       version: 1,
-      finish: { autoFlow: { enabled: true, reviewers: { spec: "adversarial", quality: "balanced" }, escalate: { telegram: false } } },
+      finish: {
+        autoFlow: {
+          enabled: true,
+          reviewers: { spec: "adversarial", quality: "balanced" },
+          escalate: { telegram: false },
+          notify: { mode: "always" },
+        },
+      },
     });
     expect(c.finish.autoFlow.enabled).toBe(true);
     expect(c.finish.autoFlow.reviewers.spec).toBe("adversarial");
     expect(c.finish.autoFlow.escalate.telegram).toBe(false);
+    expect(c.finish.autoFlow.notify.mode).toBe("always");
+    expect(
+      NaxConfigSchema.safeParse({ version: 1, finish: { autoFlow: { notify: { mode: "sometimes" } } } }).success,
+    ).toBe(false);
   });
 });

--- a/test/unit/execution/lifecycle/run-cleanup.test.ts
+++ b/test/unit/execution/lifecycle/run-cleanup.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { _runCleanupDeps, cleanupRun } from "@/execution";
 import type { IPostRunAction, PostRunActionResult, PostRunContext } from "../../../../src/plugins/extensions";
 import type { RunCleanupOptions } from "../../../../src/execution/lifecycle/run-cleanup";
 import * as loggerModule from "../../../../src/logger";
@@ -34,6 +35,9 @@ function makePluginRegistry(actions: IPostRunAction[] = [], reporters: unknown[]
   const teardownAll = mock(async () => {});
   return {
     getPostRunActions: mock(() => actions),
+    getPostRunActionRegistrations: mock(() =>
+      actions.map((action) => ({ pluginName: `plugin-${action.name}`, action })),
+    ),
     getReporters: mock(() => reporters),
     teardownAll,
   } as unknown as import("../../../../src/plugins/registry").PluginRegistry;
@@ -53,6 +57,7 @@ function makeCleanupOptions(overrides: Partial<RunCleanupOptions> = {}): RunClea
     prdPath: "/tmp/test/.nax/features/my-feature/prd.json",
     branch: "feat/my-feature",
     version: "1.2.3",
+    hooks: { hooks: {} },
     ...overrides,
   };
 }
@@ -198,7 +203,7 @@ describe("cleanupRun — post-run action loop", () => {
       shouldRun: mock(async () => true),
       execute: mock(async () => { callOrder.push("action.execute"); return { success: true, message: "done" }; }),
     };
-    registry.getPostRunActions = mock(() => [action]) as typeof registry.getPostRunActions;
+    registry.getPostRunActionRegistrations = mock(() => [{ pluginName: "action-plugin", action }]);
 
     const opts = makeCleanupOptions({ pluginRegistry: registry });
     await cleanupRun(opts);
@@ -209,6 +214,74 @@ describe("cleanupRun — post-run action loop", () => {
     expect(reporterIdx).toBeGreaterThanOrEqual(0);
     expect(actionIdx).toBeGreaterThan(reporterIdx);
     expect(teardownIdx).toBeGreaterThan(actionIdx);
+  });
+});
+
+describe("cleanupRun — on-post-run-action hook", () => {
+  const originalFireHook = _runCleanupDeps.fireHook;
+
+  afterEach(() => {
+    _runCleanupDeps.fireHook = originalFireHook;
+  });
+
+  test.each([
+    ["succeeded", { success: true, message: "published", url: "https://example.com/result" }],
+    ["failed", { success: false, message: "connection refused" }],
+    ["skipped", { success: true, message: "nothing", skipped: true, reason: "no changes" }],
+  ] as const)("fires once with plugin metadata for a %s result", async (status, result) => {
+    const calls: Array<{ event: string; ctx: Record<string, unknown> }> = [];
+    _runCleanupDeps.fireHook = mock(async (_hooks, event, ctx) => {
+      calls.push({ event, ctx: ctx as unknown as Record<string, unknown> });
+    });
+    const action: IPostRunAction = {
+      name: "publisher",
+      description: "desc",
+      shouldRun: async () => true,
+      execute: async () => result,
+    };
+
+    await cleanupRun(makeCleanupOptions({ pluginRegistry: makePluginRegistry([action]) }));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      event: "on-post-run-action",
+      ctx: { pluginName: "plugin-publisher", actionName: "publisher", status },
+    });
+  });
+
+  test("fires skipped when shouldRun is false and error when action evaluation throws", async () => {
+    const statuses: string[] = [];
+    _runCleanupDeps.fireHook = mock(async (_hooks, _event, ctx) => {
+      statuses.push(ctx.status ?? "");
+    });
+    const actions: IPostRunAction[] = [
+      { name: "skip", description: "desc", shouldRun: async () => false, execute: async () => ({ success: true, message: "x" }) },
+      { name: "error", description: "desc", shouldRun: async () => { throw new Error("boom"); }, execute: async () => ({ success: true, message: "x" }) },
+    ];
+
+    await cleanupRun(makeCleanupOptions({ pluginRegistry: makePluginRegistry(actions) }));
+
+    expect(statuses).toEqual(["skipped", "error"]);
+  });
+
+  test("a hook failure does not prevent the next post-run action", async () => {
+    const executed: string[] = [];
+    _runCleanupDeps.fireHook = mock(async () => {
+      throw new Error("hook crashed");
+    });
+    const actions: IPostRunAction[] = ["first", "second"].map((name) => ({
+      name,
+      description: "desc",
+      shouldRun: async () => true,
+      execute: async () => {
+        executed.push(name);
+        return { success: true, message: "ok" };
+      },
+    }));
+
+    await cleanupRun(makeCleanupOptions({ pluginRegistry: makePluginRegistry(actions) }));
+
+    expect(executed).toEqual(["first", "second"]);
   });
 });
 
@@ -409,6 +482,7 @@ describe("runner.ts — cleanupRun receives feature/prdPath/branch/version", () 
       prdPath: "/path/prd.json",
       branch: "feat/test",
       version: "1.0.0",
+      hooks: { hooks: {} },
     };
 
     expect(opts.feature).toBe("my-feature");
@@ -433,6 +507,7 @@ describe("runner.ts — cleanupRun receives feature/prdPath/branch/version", () 
     expect(cleanupBlock).toContain("prdPath");
     expect(cleanupBlock).toContain("branch");
     expect(cleanupBlock).toContain("version");
+    expect(cleanupBlock).toContain("hooks");
   });
 });
 

--- a/test/unit/hooks/runner-post-run-action.test.ts
+++ b/test/unit/hooks/runner-post-run-action.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { fireHook, HOOK_EVENTS, type HooksConfig } from "@/hooks";
+import { withTempDir } from "@test/helpers";
+
+describe("on-post-run-action hook", () => {
+  test("is a supported hook event", () => {
+    expect(HOOK_EVENTS).toContain("on-post-run-action");
+  });
+
+  test("exports plugin and action metadata to the hook process", async () => {
+    await withTempDir(async (dir) => {
+      const output = join(dir, "hook-env.json");
+      const script = join(dir, "capture.ts");
+      await Bun.write(
+        script,
+        `await Bun.write(${JSON.stringify(output)}, JSON.stringify({
+          pluginName: process.env.NAX_PLUGIN_NAME,
+          actionName: process.env.NAX_ACTION_NAME,
+          status: process.env.NAX_STATUS,
+          reason: process.env.NAX_REASON,
+          url: process.env.NAX_RESULT_URL,
+        }));`,
+      );
+      const config: HooksConfig = {
+        hooks: { "on-post-run-action": { command: `bun ${script}`, timeout: 10_000 } },
+      };
+
+      await fireHook(
+        config,
+        "on-post-run-action",
+        {
+          event: "on-post-run-action",
+          feature: "payments",
+          pluginName: "report-plugin",
+          actionName: "publish-report",
+          status: "succeeded",
+          reason: "published",
+          url: "https://example.com/report",
+        },
+        dir,
+      );
+
+      expect(JSON.parse(await Bun.file(output).text())).toEqual({
+        pluginName: "report-plugin",
+        actionName: "publish-report",
+        status: "succeeded",
+        reason: "published",
+        url: "https://example.com/report",
+      });
+    });
+  });
+});

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -105,6 +105,26 @@ describe("nax-finish post-run action", () => {
       expect(r.message).toContain("Bun is not defined");
     });
 
+    test("notifies a failure in always mode before returning", async () => {
+      const sent: string[] = [];
+      _naxFinishDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "flow crashed" });
+      _naxFinishDeps.readResult = async () => null;
+      _naxFinishDeps.notify = async (_creds, message) => {
+        sent.push(message);
+        return true;
+      };
+      const config = {
+        finish: { autoFlow: { enabled: true, notify: { mode: "always" } } },
+        interaction: { plugin: "telegram", config: { botToken: "t", chatId: "c" } },
+      };
+
+      const result = await action.execute(baseCtx({ config } as never));
+
+      expect(result.success).toBe(false);
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toContain("flow crashed");
+    });
+
     test("logs the flow's full stdout and stderr", async () => {
       _naxFinishDeps.run = async () => ({ exitCode: 1, stdout: "step one\n", stderr: "boom\n" });
       _naxFinishDeps.readResult = async () => null;
@@ -315,6 +335,35 @@ describe("nax-finish post-run action", () => {
       expect(sent).toHaveLength(0);
     });
 
+    test("notifies successful terminal results in always mode", async () => {
+      const sent = stubRun({ feature: "x", status: "opened" });
+      const config = {
+        finish: { autoFlow: { enabled: true, notify: { mode: "always" } } },
+        interaction: CONFIG_WITH_TELEGRAM.interaction,
+      };
+
+      const result = await action.execute(baseCtx({ config } as never));
+
+      expect(result.success).toBe(true);
+      expect(sent).toHaveLength(1);
+      expect(sent[0].text).toContain("nax-finish opened x");
+    });
+
+    test("ordinary notification rejection or exception does not change a successful result", async () => {
+      const config = {
+        finish: { autoFlow: { enabled: true, notify: { mode: "always" } } },
+        interaction: CONFIG_WITH_TELEGRAM.interaction,
+      };
+      _naxFinishDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+      _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
+      _naxFinishDeps.notify = async () => false;
+      expect((await action.execute(baseCtx({ config } as never))).success).toBe(true);
+      _naxFinishDeps.notify = async () => {
+        throw new Error("network down");
+      };
+      expect((await action.execute(baseCtx({ config } as never))).success).toBe(true);
+    });
+
     test("does not notify when escalate.telegram is disabled", async () => {
       const sent = stubRun({ feature: "x", status: "escalated", escalationReason: "design call" });
       const config = {
@@ -334,6 +383,22 @@ describe("nax-finish post-run action", () => {
 
       expect(sent).toHaveLength(0);
     });
+  });
+
+  test("clears any stale result before starting the flow", async () => {
+    const order: string[] = [];
+    _naxFinishDeps.clearResult = async () => {
+      order.push("clear");
+    };
+    _naxFinishDeps.run = async () => {
+      order.push("run");
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
+
+    await action.execute(baseCtx());
+
+    expect(order).toEqual(["clear", "run"]);
   });
 
   test("execute sets reviewer profile env vars from config.finish.autoFlow.reviewers", async () => {
@@ -407,6 +472,12 @@ describe("nax-finish post-run action", () => {
     // Enabled but with no credentials → the flow must fall back to a PR comment.
     const uncredentialed = await inputsFor({ finish: { autoFlow: { enabled: true } }, interaction: { plugin: "cli" } });
     expect(uncredentialed.escalateTelegram).toBe(false);
+
+    const notificationsOff = await inputsFor({
+      finish: { autoFlow: { enabled: true, notify: { mode: "off" } } },
+      interaction: { plugin: "telegram", config: { botToken: "t", chatId: "c" } },
+    });
+    expect(notificationsOff.escalateTelegram).toBe(false);
   });
 
   test("execute reports a clear failure when the flow module cannot be found", async () => {

--- a/test/unit/plugins/registry.test.ts
+++ b/test/unit/plugins/registry.test.ts
@@ -198,14 +198,21 @@ describe("PluginRegistry.getPostRunActions", () => {
 
   it("retains the owning plugin name for post-run hook attribution", () => {
     const action = { name: "publish-report" } as any;
-    const builtin = { name: "auto-pr" } as any;
+    const builtin = { name: "publish-pr" } as any;
     const registry = new PluginRegistry(
       [createMockPlugin("report-plugin", ["post-run-action"], { postRunAction: action })],
-      [builtin],
+      [{ pluginName: "auto-pr", action: builtin }],
     );
 
     expect(registry.getPostRunActionRegistrations()).toEqual([
       { pluginName: "report-plugin", action },
+      { pluginName: "auto-pr", action: builtin },
+    ]);
+  });
+
+  it("keeps legacy action-only registrations compatible", () => {
+    const builtin = { name: "auto-pr" } as any;
+    expect(new PluginRegistry([], [builtin]).getPostRunActionRegistrations()).toEqual([
       { pluginName: "auto-pr", action: builtin },
     ]);
   });

--- a/test/unit/plugins/registry.test.ts
+++ b/test/unit/plugins/registry.test.ts
@@ -195,6 +195,20 @@ describe("PluginRegistry.getPostRunActions", () => {
     expect(filtered.length).toBe(1);
     expect(filtered[0]).toBe(action1);
   });
+
+  it("retains the owning plugin name for post-run hook attribution", () => {
+    const action = { name: "publish-report" } as any;
+    const builtin = { name: "auto-pr" } as any;
+    const registry = new PluginRegistry(
+      [createMockPlugin("report-plugin", ["post-run-action"], { postRunAction: action })],
+      [builtin],
+    );
+
+    expect(registry.getPostRunActionRegistrations()).toEqual([
+      { pluginName: "report-plugin", action },
+      { pluginName: "auto-pr", action: builtin },
+    ]);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a generic `on-post-run-action` lifecycle hook with `pluginName`, `actionName`, terminal status, reason, and result URL
- fire the hook once for succeeded, failed, skipped, and thrown post-run action outcomes without blocking later actions
- add `finish.autoFlow.notify.mode` with `escalation`, `always`, and `off` modes, defaulting to the existing escalation behavior
- send best-effort notifications for ordinary nax-finish terminal outcomes in `always` mode while preserving escalation delivery guarantees
- clear stale nax-finish result artifacts before each flow and preserve true plugin ownership for built-in action attribution
- document the new hook environment variables and notification configuration

## Why

The existing completion hook fires before post-run actions, so it cannot observe whether actions such as `nax-finish` or `auto-pr` actually succeeded. This adds a single action-terminal event and makes nax-finish notification coverage configurable without coupling generic hooks to Telegram.

Closes #1394.

## Impact

Existing configurations retain escalation-only notifications. Hook and ordinary notification failures are non-fatal. The escalation path continues to surface delivery failures, and `notify.mode: "off"` disables Telegram preference while retaining the PR/MR fallback.

## Validation

- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 11,836 passed, 51 skipped, 0 failed
