### PR TITLE
fix(review): stop recurrence-demotion silently no-opping, and restore dead review-audit telemetry

### DIFF
--- a/docs/findings/2026-08-01-review-pipeline-gap-analysis.md
+++ b/docs/findings/2026-08-01-review-pipeline-gap-analysis.md
@@ -1,0 +1,303 @@
+# nax review-pipeline gap analysis — 2026-08-01
+
+**Scope:** semantic + adversarial review behaviour during July 2026, with an emphasis on runs
+where the reviewer agent gave up (unparseable output) or failed to converge.
+
+**Evidence base:** 1,857 review-audit records dated `2026-07-01` or later, read from
+`~/.nax/<project>/review-audit/**/*.json` across `nax`, `rs-stock`, `nathapp-nestjs`,
+`nathapp-nestjs-platform`, `nathapp-nestjs-starter`, `nathapp-nestjs-outbox-providers`
+(plus `koda` and `iot-system`, which share the schema).
+
+**Code base:** `repos/nax` @ `c8f74c5f` (v0.75.5). Cross-checked against
+`repos/nax-spec-kit-skills` @ `c82da98` (v0.2.9).
+
+All line references below were read at those commits.
+
+---
+
+## 0. Corrections to the first-pass analysis
+
+Recorded so the retracted claims do not get re-cited from an earlier draft.
+
+| Claim (first pass) | Verdict | Why |
+|:---|:---|:---|
+| "ACP tail-truncates agent output at 5,000 chars, so truncation systematically eats the leading `"passed"` key" | **Retracted** | `MAX_AGENT_OUTPUT_CHARS = 5000` (`src/agents/acp/adapter.ts:70`) is exported but never applied. Its only consumers are two truncation *detectors* (`src/review/truncation.ts:24`, `src/agents/retry/tiered-parse-retry.ts:40`). The adapter's only `.slice()` calls are on error messages. July records confirm it: parsed `result` payloads reach 11,750 bytes. The docstring in `truncation.ts` asserting adapter-side tail truncation is stale. |
+| "Reviewer file paths are unanchored, so evidence substantiation breaks in monorepos" | **Retracted as stated** | `checkFindingEvidence` (`src/review/semantic-evidence.ts:81`) already tries `repoRoot` then `workdir` as a dual-root fallback. Findings are not wrongly downgraded by prefix drift. The path instability is real but lands on fingerprinting instead — see F1. |
+| "Reviewers report one finding at a time; they should enumerate" | **Retracted** | Round-by-round read of the worst case shows 9 findings in round 1 and 4 in round 9. The reviewer does enumerate; it enumerates a *different subset* each round. See F4. |
+
+Everything else below survived verification unchanged.
+
+---
+
+## Findings
+
+### F1 — Convergence control is inert; this is the dominant cost
+
+**Severity: high. This is the largest item in the data.**
+
+Review rounds per `(feature, story, reviewer)` in July:
+
+| | pairs | mean | p50 | ≥5 rounds | ≥8 rounds | max |
+|:---|---:|---:|---:|---:|---:|---:|
+| adversarial | 519 | 1.73 | 1 | 28 | 5 | 17 |
+| semantic | 525 | 1.83 | 1 | 35 | 10 | 15 |
+| **total** | **1044** | **1.78** | **1** | **63** | **15** | **17** |
+
+Worst offenders:
+
+```
+17  auth-security-hardening US-004  adversarial
+15  notif-dlq-hardening US-001      semantic
+13  oauth-idempotency US-002        semantic
+12  backtest-sweep US-004           semantic
+11  w1-observability-pages US-003   semantic
+11  backtest-robustness US-005      semantic
+```
+
+Reading all 17 rounds of `auth-security-hardening US-004` end to end, the story never converges:
+
+```
+errors per round: 3 1 2 1 1 2 2 2 1 1 1 0 1 3 3 1 1
+```
+
+Round 12 **passed** (0 errors), round 13 failed again, and rounds 14–15 carried *more* errors
+than round 2. Four defects recur from round 1 through round 9+ — expired rows never checked,
+replay-key format mismatch, non-atomic window expiry, nullable `tenantId` — and none is ever
+fixed.
+
+Recurrence-demotion was enabled for this run and **never fired**. Root cause is the fingerprint
+at `src/review/recurrence-demotion.ts:29`:
+
+```ts
+fingerprintFor(file, category, text)
+  => `${file.replace(/\\/g,"/")}|${category ?? ""}|${normalizeIssueText(text).slice(0,48)}`
+```
+
+All three components are reviewer-controlled and unstable:
+
+1. **`category` churns.** One defect — "expired replay rows are never removed" — is filed as
+   `assumption` (r3), `error-path` (r4), `input` (r5), `error-path` (r6, r8).
+2. **The 48-char issue prefix churns.** The function's own comment claims the truncation
+   survives "a tail rephrase." The reviewer does not rephrase the tail — it rewrites the
+   **opening clause** every round:
+   - r3 `"the stored expiresat is never consulted and expired…"`
+   - r5 `"ttl is only written to expiresat; existing rows are…"`
+   - r6 `"expired replay rows are never removed or ignored. a…"`
+   - r8 `"the stored expiresat is never consulted and replay …"`
+3. **`file` churns in monorepos.** In `backtest-sweep US-004` the same file is cited as
+   `components/SweepForm.tsx`, `apps/web/components/SweepForm.tsx`, and
+   `../../apps/api/src/stock_api/dto.py` across rounds. `fingerprintFor` only does a
+   backslash replace — no resolution against `repoRoot`.
+
+Consequence: `countPriorAppearances` never reaches 2, nothing is demoted, and the suppressor
+no-ops on exactly the stories that need it. **This also means the `coverageGap` tag is never
+applied**, so the telemetry F3 restores would still read empty until F1 is fixed.
+
+Secondary, same theme: recurrence-demotion is **adversarial-only**
+(`src/operations/adversarial-review.ts:545`; `countPriorAppearances` skips any finding where
+`f.source !== "adversarial-review"`). Semantic review has no suppression at all and carries 2×
+the ≥8-round stories (10 vs 5). Extending it is worthless until the fingerprint is stable.
+
+---
+
+### F2 — Give-ups are undiagnosable; 7 stories shipped unreviewed
+
+**Severity: medium-high. 13 occurrences / 1,857 (0.7%).**
+
+`parsed: false` means the reviewer's output could not be parsed after the retry budget was spent.
+
+| reviewer | total | parsed=false | fail-**open** (silently green) | fail-closed |
+|:---|---:|---:|---:|---:|
+| adversarial | 896 | 5 | 3 | 2 |
+| semantic | 961 | 8 | 4 | 4 |
+
+The 13, oldest first:
+
+```
+07-08  secrets-at-rest-encryption US-003   adversarial  OPEN    codex
+07-09  nestjs-storage-modernization US-002 adversarial  OPEN    opencode
+07-12  w1-observability-pages US-006       semantic     OPEN    —
+07-12  notify-delivery-tracking US-001     semantic     OPEN    —
+07-16  notif-dlq-hardening US-001          semantic     closed  codex
+07-16  notif-dlq-hardening US-001          adversarial  closed  codex
+07-16  auth-security-hardening US-003      semantic     OPEN    codex
+07-19  position-reconcile US-002           semantic     closed  opencode
+07-21  backtest-sweep US-004               semantic     closed  codex
+07-23  oauth-idempotency US-002            adversarial  closed  codex
+07-23  oauth-idempotency US-002            semantic     closed  codex
+07-26  redis-seams-inline US-002           semantic     OPEN    —
+07-29  portfolio-strategy-mandate US-003   adversarial  OPEN    codex
+```
+
+6 of the 13 occurred on **round 1**, so this is not purely an artifact of long loops.
+
+**Mechanism.** `maxAttempts: 2` (`src/operations/semantic-review.ts:308`,
+`adversarial-review.ts:249`) combined with `attempt >= maxAttempts - 1`
+(`src/agents/retry/parse-retry.ts:86`) yields exactly **one** retry. On exhaustion
+(`semantic-review.ts:313`):
+
+```ts
+exhaustedFallback: (lastOutput) =>
+  /"passed"\s*:\s*false/.test(lastOutput)
+    ? { passed: false, ..., looksLikeFail: true }   // blocks
+    : FAIL_OPEN,                                    // story passes, unreviewed
+```
+
+7 of 13 resolved to `FAIL_OPEN`. `logUnifiedReviewPhaseResult` emits a `warn`, nothing gates on
+it, and the run summary reads as a clean pass.
+
+**Why the fix is blocked on evidence.** `makeParseRetryStrategy` accepts `outputPreviewBytes`,
+which logs the unparseable text. It is set by exactly one op — `src/operations/verify.ts:169`
+(600 bytes). **Neither review op sets it.** `~/.nax/<project>/prompt-audit/` stores prompts
+only, never responses. So for all 13 July give-ups the only surviving record is
+`originalByteSize`; the content is gone. There is no basis on which to choose between "retry
+harder", "reprompt differently", and "treat exhaustion as blocking".
+
+**Related, lower impact.** `looksLikeTruncatedJson` (`src/review/truncation.ts:24`) returns true
+for any output ≥ 4,900 chars. Since nothing truncates, that is simply "any long review". July
+`result` payloads are p50 959 / p90 4,340 / p99 7,640 bytes, with 164 records over 4,500 — so a
+meaningful share of *complete*, finding-rich reviews get routed to the condensed retry prompt on
+any parse hiccup and told "Your previous response was truncated", which is false. Blast radius
+is small because `ReviewPromptBuilder.jsonRetryCondensed` is well-built (it preserves **all**
+blocking findings and caps only advisories at 3), but the detector should key on actual JSON
+incompleteness rather than length.
+
+---
+
+### F3 — Four review-audit fields are dead in 100% of records
+
+**Severity: medium. Cheapest item to fix.**
+
+Across all 1,857 July records, these are `null` in **every single one**:
+
+- `advisoryFindings`
+- `diffAvailable`
+- `adversarialDropAnalysis`
+- `adversarialAcceptAnalysis`
+
+`acDropped` never reaches the audit file at all.
+
+**Cause — an unreconciled fork.** `src/review/adversarial.ts:372-453` computes the full
+issue-#986 counterfactual analysis and emits it via `adversarial-audit-event.ts`. That path is
+dead: `runAdversarialReview` / `runSemanticReview` have no live callers (the only surviving
+references are comments at `src/execution/plan-inputs.ts:312`). Live reviews go through
+`story-orchestrator/run-phase.ts:202 → review-decision.ts:51`, whose `emitReviewDecision` builds
+the event from `toReviewDecisionPayload` and forwards **none** of the above — not even
+`acDropped`, which it computes at `review-decision.ts:23` and then drops at the emit call.
+
+`ReviewDecisionEvent` declares all of these fields (`src/runtime/dispatch-events.ts:104-112`)
+and the middleware forwards them faithfully
+(`src/runtime/middleware/review-audit.ts:53-61`). The break is solely in the emitter.
+
+**Consequences:**
+
+- `filterByAcGroundingMinimal` drops any finding whose `acIndex` is missing or out of range
+  (`src/review/ac-quote-validator.ts:215`). A genuine wiring bug the adversarial reviewer found
+  but could not pin to an AC is deleted with **no record anywhere**.
+- The `nax-coverage-gap` skill reads `advisoryFindings[].meta.coverageGap`
+  (`nax-toolkit-skills/.../nax-coverage-gap/SKILL.md:59`). It reports empty on every run and
+  reads as "recurrence-demotion is not dropping anything" when the truth is unknown.
+  **Note the ordering dependency: fixing F3 alone does not make this skill meaningful, because
+  F1 means nothing is ever tagged `coverageGap`.**
+
+---
+
+### F4 — Fixes are not landing; investigate the rectification lane
+
+**Severity: unknown — needs its own read-through. Do not prescribe yet.**
+
+The enumeration hypothesis is dead (see §0). The reviewer returns 9 findings in round 1 and 4 in
+round 9; it is enumerating. What it is doing is sampling a *different* subset of a large space of
+true defects each round, while the same four defects survive all 17 rounds unfixed.
+
+That points at the fix lane, not the review prompt. The equivalent artifact read-through
+(rectifier sessions, `non-blocking-fix`, autofix strategies) has not been done, and no fix should
+be proposed for this until it has. Prompt-tweaking the reviewer here would not address it.
+
+---
+
+### F5 — spec-kit: already covers the July failure shapes, one narrow gap
+
+**Severity: low.**
+
+The July oscillations were dominated by wiring and cross-package contract defects. spec-kit
+v0.2.9 already encodes those lessons — the two-anchor seam rule, seam-altitude ("name the entry
+point, not 'the production path'"), guarded-seam re-trigger ACs, and the data-availability seam
+(`spec-writing/SKILL.md:195-205`, `spec-review/checklists/phase-8-seam-deletion-audit.md:91`).
+The monorepo guide's worked example is literally the `backtest-sweep` shape
+(`spec-writing/reference/spec-writing-guide.md:301`). The specs that oscillated predate those
+rules. **No re-open warranted.**
+
+One direction remains uncovered. Phase 8's data-availability seam checks *consumer reads fields
+the producer emits*. `backtest-sweep`'s single most-repeated finding was the reverse — the
+consumer **sends** `param_grid` as an array of `{key, values}` rows where the producer declares
+`param_grid: dict[str, list[Any]]`. Phase 2's shape audit covers response and event payloads,
+not request bodies crossing a package boundary.
+
+`nax plan` was checked on the same axes and found clean: it preserves every spec AC (never
+drops), rewrites deprecated `[grep]` / `[file]` / `[verbatim]` tags into behavioural assertions
+(`plan-builder.ts:196,204,263`), and restores `outOfScope` verbatim (`plan-builder.ts:233`).
+
+---
+
+## Suggested fix order
+
+The ordering is driven by two hard dependencies, not by severity alone:
+
+- **F3 → F1 for telemetry:** F3 restores the field, F1 makes the field non-empty. Either alone
+  leaves `nax-coverage-gap` useless.
+- **F2-preview → F2-semantics:** the verdict-on-exhaustion decision cannot be made without
+  evidence about what the give-ups actually emitted.
+
+| # | Item | Why here | Size |
+|:--|:---|:---|:---|
+| **1** | **F2a — set `outputPreviewBytes` on both review ops; persist the preview into the review-audit record alongside `parsed: false`** | Two lines. Unblocks every downstream decision about give-up handling, and starts accumulating evidence immediately while later items are in flight. Do this first purely for the lead time. | XS |
+| **2** | **F3 — forward `advisoryFindings`, `acDropped`, `diffAvailable`, and the drop/accept counterfactuals from `emitReviewDecision`** | Self-contained; the event type and middleware already support it. Immediately un-blinds AC-grounding drops (independent of F1). Delete or reconcile the dead `src/review/adversarial.ts` emit path in the same change — two emitters where one is unreachable is how this drifted. | S |
+| **3** | **F1a — stabilise `fingerprintFor`: resolve `file` against `repoRoot`, drop `category` from the key, replace the 48-char prefix with a token-set signature** | The dominant cost driver, and a prerequisite for the F3 telemetry being meaningful. Ship with a regression test that feeds the r3/r5/r6/r8 issue strings from F1 and asserts a single fingerprint. | M |
+| **4** | **F2b — decide give-up semantics from the evidence item 1 collects** | Needs ~a month of previews, or a handful of reproductions. Safe interim if you want it sooner: make exhaustion block regardless of the regex — 7 unreviewed stories/month is a worse failure than a few spurious blocks. Also re-key `looksLikeTruncatedJson` on JSON completeness rather than length. | S–M |
+| **5** | **F1b — extend recurrence-demotion to semantic review** | Worthless before item 3. Semantic carries 2× the ≥8-round stories, so this is where the remaining oscillation cost sits once the fingerprint is stable. | M |
+| **6** | **F4 — read the rectification-lane artifacts the way the review lane was read here** | Fresh investigation, no fix proposed. Likely the deepest remaining issue but currently unevidenced. | L |
+| **7** | **F5 — extend spec-review Phase 8 to request-direction cross-package contracts** | Independent of everything above; fold in whenever spec-kit is next touched. | S |
+
+Items 1 and 2 are independent of each other and of everything else — they can go in parallel or
+in one PR. Items 3 and 5 are strictly sequential. Item 6 can start at any time since it is
+read-only.
+
+---
+
+## Reproduction
+
+```bash
+# July give-ups
+cd ~/.nax && jq -s -r '
+  map(select(.timestamp >= "2026-07-01" and (.parsed==false or .failOpen==true)))
+  | sort_by(.timestamp) | .[]
+  | [.timestamp, .featureName, .storyId, .reviewer,
+     "failOpen=\(.failOpen)", "agent=\(.agentName)"] | @tsv
+' */review-audit/*/*.json
+
+# rounds per story/reviewer
+cd ~/.nax && jq -s -r '
+  map(select(.timestamp>="2026-07-01"))
+  | group_by(.featureName+"|"+(.storyId//"?")+"|"+.reviewer)
+  | map({k:(.[0].featureName+" "+(.[0].storyId//"?")+" "+.[0].reviewer), n:length})
+  | sort_by(.n) | reverse | .[0:18] | .[] | "\(.n)\t\(.k)"
+' */review-audit/*/*.json
+
+# dead fields
+cd ~/.nax && jq -s -r '
+  map(select(.timestamp>="2026-07-01"))
+  | {total:length,
+     advisory:(map(select(.advisoryFindings!=null))|length),
+     dropAn:(map(select(.adversarialDropAnalysis!=null))|length),
+     acceptAn:(map(select(.adversarialAcceptAnalysis!=null))|length),
+     diffAvail:(map(select(.diffAvailable!=null))|length)}
+' */review-audit/*/*.json
+
+# the 17-round non-convergence
+cd ~/.nax/nathapp-nestjs-platform/review-audit/auth-security-hardening && jq -s -r '
+  map(select(.storyId=="US-004" and .reviewer=="adversarial"))
+  | sort_by(.timestamp) | .[]
+  | "\(.timestamp[5:16])\tpassed=\(.passed)\tn=\((.result.findings//[])|length)\terrors=\((.result.findings//[])|map(select(.severity=="error"))|length)"
+' *.json
+```

--- a/src/agents/retry/index.ts
+++ b/src/agents/retry/index.ts
@@ -3,7 +3,7 @@ export { ParseValidationError } from "./types";
 export { defaultRetryStrategy } from "./default-strategy";
 export { resolveRetryPreset } from "./presets";
 export { composeRetry } from "./compose";
-export { makeParseRetryStrategy } from "./parse-retry";
+export { UNPARSED_PREVIEW_BYTES, makeParseRetryStrategy, previewOutput } from "./parse-retry";
 export type { ParseRetryOpts } from "./parse-retry";
 export { makeTieredParseRetryStrategy } from "./tiered-parse-retry";
 export type { TieredInspection, TieredParseRetryOpts } from "./tiered-parse-retry";

--- a/src/agents/retry/parse-retry.ts
+++ b/src/agents/retry/parse-retry.ts
@@ -34,8 +34,15 @@ export interface ParseRetryOpts {
   readonly _logger?: { warn(kind: string, msg: string, data: Record<string, unknown>): void };
 }
 
+/**
+ * Bytes of unparseable agent output retained when a parse-retry budget is
+ * exhausted. Enough to tell a prose preamble from a refusal from a malformed
+ * JSON body, without bloating the log line or the audit record.
+ */
+export const UNPARSED_PREVIEW_BYTES = 600;
+
 /** Collapse whitespace and clip to `maxBytes` so the preview stays a single, log-friendly line. */
-function previewOutput(output: string, maxBytes: number): string {
+export function previewOutput(output: string, maxBytes: number): string {
   const collapsed = output.replace(/\s+/g, " ").trim();
   return collapsed.length > maxBytes ? `${collapsed.slice(0, maxBytes)}…` : collapsed;
 }

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -67,6 +67,7 @@ export {
   withIncreasingFailuresBail,
   extractPhaseFindings,
   phasePassed,
+  toReviewDecisionPayload,
   type GateRegressionDetail,
   type GateRegressionInput,
   type InternalBuildState,

--- a/src/execution/story-orchestrator/index.ts
+++ b/src/execution/story-orchestrator/index.ts
@@ -25,6 +25,7 @@ export {
   runPhase,
   withIncreasingFailuresBail,
 } from "./run-phase";
+export { toReviewDecisionPayload } from "./review-decision";
 export {
   EXHAUSTED_EXIT_REASONS,
   CANONICAL_ORDER,

--- a/src/execution/story-orchestrator/review-decision.ts
+++ b/src/execution/story-orchestrator/review-decision.ts
@@ -9,11 +9,12 @@ export function toReviewDecisionPayload(opName: string, output: unknown): Review
   const reviewer = opName === "semantic-review" ? "semantic" : opName === "adversarial-review" ? "adversarial" : null;
   if (!reviewer) return null;
 
+  const unparsedPreview = typeof record.unparsedPreview === "string" ? record.unparsedPreview : undefined;
   if (record.failOpen === true) {
-    return { reviewer, parsed: false, passed: true, failOpen: true, result: null };
+    return { reviewer, parsed: false, passed: true, failOpen: true, result: null, unparsedPreview };
   }
   if (record.looksLikeFail === true) {
-    return { reviewer, parsed: false, passed: false, looksLikeFail: true, result: null };
+    return { reviewer, parsed: false, passed: false, looksLikeFail: true, result: null, unparsedPreview };
   }
 
   if (typeof record.passed !== "boolean" || !Array.isArray(record.findings)) {
@@ -41,6 +42,7 @@ export function toReviewDecisionPayload(opName: string, output: unknown): Review
     passed: record.passed,
     result: { passed: record.passed, findings: record.findings },
     acDropped,
+    ...(Array.isArray(record.advisoryFindings) ? { advisoryFindings: record.advisoryFindings } : {}),
   };
 }
 
@@ -63,6 +65,12 @@ export function emitReviewDecision(ctx: CallContext, opName: string, output: unk
     failOpen: payload.parsed ? false : payload.failOpen,
     passed: payload.passed,
     result: payload.result,
+    // These three were computed by both review ops and then dropped here, so
+    // every review-audit record wrote them as null. See F3 of
+    // docs/findings/2026-08-01-review-pipeline-gap-analysis.md.
+    advisoryFindings: payload.parsed ? payload.advisoryFindings : undefined,
+    acDropped: payload.parsed ? payload.acDropped : undefined,
+    unparsedPreview: payload.parsed ? undefined : payload.unparsedPreview,
   });
 }
 

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -93,6 +93,8 @@ export type ReviewDecisionPayload =
       passed: boolean;
       result: { passed: boolean; findings: unknown[] };
       acDropped?: DroppedFindingSummary[];
+      /** Sub-threshold findings retained as advisory — carries `meta.coverageGap`. */
+      advisoryFindings?: unknown[];
     }
   | {
       reviewer: "semantic" | "adversarial";
@@ -101,6 +103,12 @@ export type ReviewDecisionPayload =
       failOpen?: boolean;
       looksLikeFail?: boolean;
       result: null;
+      /**
+       * Clipped preview of the output that could not be parsed. Without it a
+       * give-up leaves only a byte count behind and is undiagnosable after the
+       * fact — the raw response is not retained anywhere else.
+       */
+      unparsedPreview?: string;
     };
 
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous slot list is intentionally erased internally

--- a/src/operations/_review-fallback.ts
+++ b/src/operations/_review-fallback.ts
@@ -1,0 +1,25 @@
+import { UNPARSED_PREVIEW_BYTES, previewOutput } from "../agents/retry";
+
+/**
+ * Shared parse-retry `exhaustedFallback` for the semantic and adversarial review
+ * ops. Both reach the same decision when the retry budget is spent, and both must
+ * carry a preview of the output that defeated the parser — the raw reviewer
+ * response is retained nowhere else (prompt-audit stores prompts only), so
+ * without it a give-up leaves only a byte count behind and cannot be diagnosed
+ * after the run. See `docs/findings/2026-08-01-review-pipeline-gap-analysis.md` (F2).
+ *
+ * The `looksLikeFail` regex decides block-vs-fail-open. It is a weak signal —
+ * 7 of 13 July-2026 give-ups fell through to fail-open, shipping the story with
+ * no story-level review — but changing that verdict needs evidence this preview
+ * is what collects. Behaviour is deliberately unchanged here.
+ */
+export function reviewExhaustedFallback<T extends { passed: boolean; failOpen?: boolean }>(
+  lastOutput: string,
+  failOpen: T,
+): T {
+  const unparsedPreview = previewOutput(lastOutput, UNPARSED_PREVIEW_BYTES);
+  if (!/"passed"\s*:\s*false/.test(lastOutput)) return { ...failOpen, unparsedPreview };
+  // FAIL_OPEN already carries the empty findings/normalizedFindings/acDropped
+  // arrays both shapes need; only the verdict flags differ.
+  return { ...failOpen, passed: false, failOpen: false, looksLikeFail: true, unparsedPreview };
+}

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -1,4 +1,4 @@
-import { ParseValidationError, makeParseRetryStrategy } from "../agents/retry";
+import { ParseValidationError, UNPARSED_PREVIEW_BYTES, makeParseRetryStrategy } from "../agents/retry";
 import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
@@ -26,6 +26,7 @@ import { parseRequoteResponse } from "../review/requote-response";
 import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
 import type { ResolvedTestPatterns } from "../test-runners";
 import { tryParseLLMJson } from "../utils/llm-json";
+import { reviewExhaustedFallback } from "./_review-fallback";
 import type { HopBodyContext, RunOperation } from "./types";
 
 export type { AdversarialReviewConfig, SemanticStory, TestInventory };
@@ -137,6 +138,8 @@ export interface AdversarialReviewOutput {
    * Callers should treat this as a hard failure rather than fail-open.
    */
   looksLikeFail?: boolean;
+  /** Clipped preview of unparseable output — retained nowhere else. See semantic-review.ts. */
+  unparsedPreview?: string;
   /**
    * Set when hopBody executed a reprompt (second turn). Used by adversarial.ts
    * to emit review-reprompt-on-drop telemetry event.
@@ -251,10 +254,8 @@ const adversarialParseRetry = (input: AdversarialReviewInput) =>
       invalid: () => ReviewPromptBuilder.jsonRetry(),
       truncated: () => ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: input.blockingThreshold }),
     },
-    exhaustedFallback: (lastOutput) =>
-      /"passed"\s*:\s*false/.test(lastOutput)
-        ? { passed: false, findings: [], normalizedFindings: [], acDropped: [], looksLikeFail: true }
-        : FAIL_OPEN,
+    exhaustedFallback: (lastOutput) => reviewExhaustedFallback(lastOutput, FAIL_OPEN),
+    outputPreviewBytes: UNPARSED_PREVIEW_BYTES,
     logContext: { blockingThreshold: input.blockingThreshold ?? "error" },
   });
 

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,4 +1,4 @@
-import { makeParseRetryStrategy } from "../agents/retry";
+import { UNPARSED_PREVIEW_BYTES, makeParseRetryStrategy, previewOutput } from "../agents/retry";
 import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
@@ -20,6 +20,7 @@ import type { AcDroppedEntry, AcGroundingMinimalRejection, LLMFinding } from "..
 import { parseRequoteResponse } from "../review/requote-response";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
+import { reviewExhaustedFallback } from "./_review-fallback";
 import type { HopBodyContext, RunOperation } from "./types";
 
 export type { SemanticReviewConfig, SemanticStory };
@@ -110,6 +111,12 @@ export interface SemanticReviewOutput {
   acDropped: AcDroppedEntry<LLMFinding, AcGroundingMinimalRejection>[];
   failOpen?: boolean;
   looksLikeFail?: boolean;
+  /**
+   * Clipped preview of the output that could not be parsed, carried to the
+   * review-audit record. The raw reviewer response is retained nowhere else, so
+   * a give-up was previously undiagnosable after the run.
+   */
+  unparsedPreview?: string;
   repromptEvent?: {
     dropCount: number;
     outcome: "recovered-blocking" | "recovered-advisory-only" | "still-dropped" | "parse-failed";
@@ -310,10 +317,8 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
         invalid: () => ReviewPromptBuilder.jsonRetry(),
         truncated: () => ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: input.blockingThreshold }),
       },
-      exhaustedFallback: (lastOutput) =>
-        /"passed"\s*:\s*false/.test(lastOutput)
-          ? { passed: false, findings: [], normalizedFindings: [], acDropped: [], looksLikeFail: true }
-          : FAIL_OPEN,
+      exhaustedFallback: (lastOutput) => reviewExhaustedFallback(lastOutput, FAIL_OPEN),
+      outputPreviewBytes: UNPARSED_PREVIEW_BYTES,
       logContext: { blockingThreshold: input.blockingThreshold ?? "error" },
     }),
   hopBody: semanticReviewHopBody,
@@ -345,6 +350,9 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
         repromptEvent,
       };
     }
+    // Both give-up branches carry a preview of the output that defeated the
+    // parser — it is retained nowhere else once the turn is discarded.
+    const unparsedPreview = previewOutput(output, UNPARSED_PREVIEW_BYTES);
     if (/"passed"\s*:\s*false/.test(output)) {
       return {
         passed: false,
@@ -352,10 +360,11 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
         normalizedFindings: [],
         acDropped: [],
         looksLikeFail: true,
+        unparsedPreview,
         repromptEvent,
       };
     }
-    return FAIL_OPEN;
+    return { ...FAIL_OPEN, unparsedPreview };
   },
   async verify(parsed, input, _verifyCtx) {
     if (parsed.failOpen || parsed.looksLikeFail) return parsed;

--- a/src/review/recurrence-demotion.ts
+++ b/src/review/recurrence-demotion.ts
@@ -19,18 +19,81 @@ export function normalizeIssueText(s: string): string {
 }
 
 /**
- * Fingerprint = file + category + normalized issue TOPIC PREFIX. Excludes line
- * number (shifts as code changes) and acIndex (only in Finding.meta on prior
- * rounds, which is not load-bearing-branchable). The issue text is truncated to
- * FP_ISSUE_PREFIX so tail rephrasing does not create a new fingerprint. Used as
- * a plain Map key.
+ * Path key for a fingerprint. Backslashes normalized, then leading `./` and
+ * `../` segments stripped: the reviewer's cwd drifts between rounds in a
+ * monorepo (the same file has been cited as `components/X.tsx`,
+ * `apps/web/components/X.tsx`, and `../../apps/api/src/y.py` within one story),
+ * and an unnormalized prefix fragments the key.
  */
-export function fingerprintFor(file: string | undefined, category: string | undefined, text: string): string {
-  const normFile = (file ?? "").replace(/\\/g, "/");
+function normalizeFingerprintPath(file: string | undefined): string {
+  return (file ?? "").replace(/\\/g, "/").replace(/^(?:\.{1,2}\/)+/, "");
+}
+
+/**
+ * Fingerprint identifying "the same finding" across review rounds. Excludes the
+ * line number (shifts as code changes).
+ *
+ * **AC-anchored path (preferred).** When the finding carries an `acIndex`, the
+ * key is `file + acIndex` and the prose is not consulted at all. That pair is
+ * structurally stable: `acIndex` is a validated 1-based index into the story's
+ * acceptance criteria, mandatory for every blocking finding (the reviewer prompt
+ * requires it and `filterByAcGroundingMinimal` drops findings whose index is
+ * absent or out of range), so every recurrence-demotion decision takes this path.
+ *
+ * **Prose fallback.** Without an `acIndex` the key degrades to
+ * file + category + issue topic prefix. Retained for non-blocking findings and
+ * for iterations recorded before `meta.acIndex` was persisted.
+ *
+ * Why the prose cannot be the primary key: the reviewer re-words the *opening
+ * clause* of a finding every round, not just its tail. One defect in
+ * `auth-security-hardening` US-004 was filed 8 times across 17 rounds as
+ * "The stored expiresAt is never consulted…", "TTL is only written to
+ * expiresAt…", "Expired replay rows are never removed or ignored…" — three
+ * different keys under a prefix fingerprint, so `countPriorAppearances` never
+ * reached the demotion threshold and the story never converged. Bag-of-words
+ * similarity was measured against that corpus and rejected: no threshold
+ * separated the story's distinct defects without also merging unrelated ones,
+ * and over-merging demotes genuine blocking findings to advisory.
+ */
+export function fingerprintFor(
+  file: string | undefined,
+  category: string | undefined,
+  text: string,
+  acIndex?: number,
+): string {
+  const normFile = normalizeFingerprintPath(file);
+  if (typeof acIndex === "number" && Number.isInteger(acIndex) && acIndex >= 1) {
+    return `${normFile}|ac${acIndex}`;
+  }
   return `${normFile}|${category ?? ""}|${normalizeIssueText(text).slice(0, FP_ISSUE_PREFIX)}`;
 }
 
 export type PriorAppearance = { count: number; lastSeverity: string };
+
+/**
+ * Resolve a finding's prior-appearance record, trying the AC-anchored key first
+ * and falling back to the prose key.
+ *
+ * Both directions of the mixed case are real: a story mid-flight when nax is
+ * upgraded has prose-only priors and AC-anchored current findings, and a
+ * reviewer that omits `acIndex` on one round produces the reverse. Whichever
+ * identity has seen the defect more often wins — an undercount here silently
+ * re-blocks a finding that should have demoted, which is the loop this whole
+ * mechanism exists to break.
+ */
+export function lookupPriorAppearance(
+  priorCounts: Map<string, PriorAppearance>,
+  finding: { file: string; category?: string; issue: string; acIndex?: number },
+): PriorAppearance | undefined {
+  const acKey =
+    finding.acIndex === undefined
+      ? undefined
+      : priorCounts.get(fingerprintFor(finding.file, finding.category, finding.issue, finding.acIndex));
+  const proseKey = priorCounts.get(fingerprintFor(finding.file, finding.category, finding.issue));
+  if (!acKey) return proseKey;
+  if (!proseKey) return acKey;
+  return acKey.count >= proseKey.count ? acKey : proseKey;
+}
 
 /**
  * One increment per prior iteration whose adversarial findings contain the
@@ -43,8 +106,17 @@ export function countPriorAppearances(priorIterations: Iteration[]): Map<string,
     const seenThisIter = new Map<string, string>();
     for (const f of (it.findingsAfter ?? []) as Finding[]) {
       if (f.source !== "adversarial-review") continue;
-      const fp = fingerprintFor(f.file, f.category, f.message);
-      seenThisIter.set(fp, f.severity);
+      // Index under BOTH keys. `finding-projection.ts` persists a valid 1-based
+      // acIndex into meta, but iterations recorded before that — or by an older
+      // nax — carry only prose. A current-round finding looks itself up under
+      // exactly one key, so indexing both is what lets an AC-anchored lookup
+      // still match a prose-only prior (and vice versa). Two entries per finding
+      // never double-count: each lookup reads one key.
+      const acIndex = typeof f.meta?.acIndex === "number" ? f.meta.acIndex : undefined;
+      seenThisIter.set(fingerprintFor(f.file, f.category, f.message), f.severity);
+      if (acIndex !== undefined) {
+        seenThisIter.set(fingerprintFor(f.file, f.category, f.message, acIndex), f.severity);
+      }
     }
     for (const [fp, sev] of seenThisIter) {
       const cur = counts.get(fp);
@@ -108,7 +180,7 @@ export function classifyRecurrence(
       advisory.push(f);
       continue;
     }
-    const prior = priorCounts.get(fingerprintFor(f.file, f.category, f.issue));
+    const prior = lookupPriorAppearance(priorCounts, f);
     const n = (prior?.count ?? 0) + 1;
     const prevWasBlocking = prior !== undefined && isBlockingSeverity(prior.lastSeverity, threshold);
 

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -59,6 +59,18 @@ export interface ReviewAuditEntry {
   result: { passed: boolean; findings: unknown[] } | null;
   /** Findings retained as advisory after threshold handling. */
   advisoryFindings?: unknown[];
+  /**
+   * Findings deleted by the AC-grounding filter (missing / out-of-range acIndex).
+   * Persisted because nothing else records them: a real defect the reviewer could
+   * not pin to an AC otherwise vanishes without trace.
+   */
+  acDropped?: unknown[];
+  /**
+   * Clipped preview of a reviewer response that could not be parsed. The raw
+   * response is not retained anywhere else (prompt-audit stores prompts only),
+   * so without this a give-up leaves only a byte count behind.
+   */
+  unparsedPreview?: string;
   /** Issue #986 — true when diff file list was available; false signals "diff unavailable" (excluded from telemetry %). */
   diffAvailable?: boolean;
   /** Issue #986 — per-drop counterfactual analysis. Adversarial only. */
@@ -169,6 +181,8 @@ export function toPersistedEntry(entry: ReviewAuditEntry, epochMs: number): stri
       blockingThreshold: entry.blockingThreshold ?? "error",
       result: entry.result,
       advisoryFindings: entry.advisoryFindings ?? null,
+      acDropped: entry.acDropped ?? null,
+      ...(entry.parsed ? {} : { unparsedPreview: entry.unparsedPreview ?? null }),
       // Issue #986 — adversarial-only structural counterfactual telemetry.
       diffAvailable: entry.diffAvailable ?? null,
       adversarialDropAnalysis: entry.adversarialDropAnalysis ?? null,

--- a/src/runtime/dispatch-events.ts
+++ b/src/runtime/dispatch-events.ts
@@ -107,6 +107,10 @@ export interface ReviewDecisionEvent {
   readonly blockingThreshold?: "error" | "warning" | "info";
   readonly result: { passed: boolean; findings: unknown[] } | null;
   readonly advisoryFindings?: unknown[];
+  /** Findings deleted by the AC-grounding filter — invisible everywhere else. */
+  readonly acDropped?: readonly unknown[];
+  /** Clipped preview of output that failed to parse, for post-hoc give-up diagnosis. */
+  readonly unparsedPreview?: string;
   /** Issue #986 — adversarial-only structural-gate counterfactual telemetry. */
   readonly diffAvailable?: boolean;
   readonly adversarialDropAnalysis?: readonly unknown[];

--- a/src/runtime/middleware/review-audit.ts
+++ b/src/runtime/middleware/review-audit.ts
@@ -51,6 +51,8 @@ export function attachReviewAuditSubscriber(
       blockingThreshold: event.blockingThreshold,
       result: event.result,
       advisoryFindings: event.advisoryFindings,
+      acDropped: event.acDropped ? [...event.acDropped] : undefined,
+      unparsedPreview: event.unparsedPreview,
       diffAvailable: event.diffAvailable,
       // Cast unknown[] from the event boundary to the typed audit shapes.
       adversarialDropAnalysis: event.adversarialDropAnalysis as

--- a/test/unit/execution/story-orchestrator/review-decision.test.ts
+++ b/test/unit/execution/story-orchestrator/review-decision.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { toReviewDecisionPayload } from "@/execution";
+
+/**
+ * Regression — F3 of `docs/findings/2026-08-01-review-pipeline-gap-analysis.md`.
+ *
+ * `advisoryFindings` and `acDropped` were computed by both review ops and then
+ * dropped on the floor by the unified emitter, so every one of 1,857 July-2026
+ * review-audit records carried `advisoryFindings: null` and no drop record at
+ * all. That blinded two things: the AC-grounding filter silently deleting
+ * findings, and the `coverageGap` tag the nax-coverage-gap skill reads.
+ */
+describe("toReviewDecisionPayload", () => {
+  const base = { passed: false, findings: [{ severity: "error", file: "a.ts", issue: "boom" }] };
+
+  test("returns null for non-review ops", () => {
+    expect(toReviewDecisionPayload("implementer", base)).toBeNull();
+  });
+
+  test("forwards advisoryFindings from the op output", () => {
+    const advisory = [{ severity: "warning", file: "a.ts", message: "nit", meta: { coverageGap: true } }];
+    const payload = toReviewDecisionPayload("adversarial-review", { ...base, advisoryFindings: advisory });
+    expect(payload?.parsed).toBe(true);
+    expect(payload?.parsed === true && payload.advisoryFindings).toEqual(advisory);
+  });
+
+  test("omits advisoryFindings when the op produced none", () => {
+    const payload = toReviewDecisionPayload("semantic-review", base);
+    expect(payload?.parsed === true && payload.advisoryFindings).toBeUndefined();
+  });
+
+  test("summarises acDropped entries", () => {
+    const payload = toReviewDecisionPayload("semantic-review", {
+      ...base,
+      acDropped: [
+        { code: "missing_ac_index", finding: { severity: "error", file: "b.ts", line: 4, issue: "x", acIndex: 9 } },
+      ],
+    });
+    expect(payload?.parsed === true && payload.acDropped).toEqual([
+      { code: "missing_ac_index", severity: "error", file: "b.ts", line: 4, issue: "x", acIndex: 9 },
+    ]);
+  });
+
+  test("carries the unparsed-output preview on a fail-open give-up", () => {
+    const payload = toReviewDecisionPayload("semantic-review", {
+      failOpen: true,
+      unparsedPreview: "I was unable to complete this review because…",
+    });
+    expect(payload?.parsed).toBe(false);
+    expect(payload?.parsed === false && payload.failOpen).toBe(true);
+    expect(payload?.parsed === false && payload.unparsedPreview).toBe(
+      "I was unable to complete this review because…",
+    );
+  });
+
+  test("carries the preview on a looksLikeFail give-up too", () => {
+    const payload = toReviewDecisionPayload("adversarial-review", {
+      looksLikeFail: true,
+      unparsedPreview: '{"passed": false, "findings": [ …',
+    });
+    expect(payload?.parsed === false && payload.looksLikeFail).toBe(true);
+    expect(payload?.parsed === false && payload.unparsedPreview).toBe('{"passed": false, "findings": [ …');
+  });
+});

--- a/test/unit/review/recurrence-demotion.test.ts
+++ b/test/unit/review/recurrence-demotion.test.ts
@@ -9,17 +9,52 @@ import {
 import type { AdversarialLLMFinding } from "@/review/adversarial-helpers";
 import type { Iteration } from "@/findings";
 
-function iter(num: number, findings: Array<{ file: string; category: string; message: string; severity: string }>): Iteration {
+function iter(
+  num: number,
+  findings: Array<{ file: string; category: string; message: string; severity: string; acIndex?: number }>,
+): Iteration {
   return {
     iterationNum: num,
     findingsBefore: [],
     fixesApplied: [],
-    findingsAfter: findings.map((f) => ({ source: "adversarial-review", severity: f.severity as any, category: f.category, file: f.file, message: f.message })),
+    findingsAfter: findings.map((f) => ({
+      source: "adversarial-review",
+      severity: f.severity as any,
+      category: f.category,
+      file: f.file,
+      message: f.message,
+      ...(f.acIndex !== undefined ? { meta: { acIndex: f.acIndex } } : {}),
+    })),
     outcome: "fixes-applied" as any,
     startedAt: "2026-07-17T00:00:00.000Z",
     finishedAt: "2026-07-17T00:00:01.000Z",
   };
 }
+
+/**
+ * Verbatim leading clauses from `auth-security-hardening` US-004, the 17-round
+ * adversarial non-convergence recorded in
+ * `docs/findings/2026-08-01-review-pipeline-gap-analysis.md` (F1).
+ *
+ * Every one of these is the SAME defect re-worded. Under the pre-fix prose
+ * fingerprint each round produced a distinct key, so `countPriorAppearances`
+ * never reached `maxBlockingRounds + 1` and demotion never fired.
+ */
+const AC3_KEY_FORMAT = [
+  "The implementation rejects the key format produced by DefaultMfaService. That service emits tenantId:userId:code",
+  "checkAndReserve rejects the three-part replay keys produced by DefaultMfaService, so it returns false without",
+  "The implementation rejects the three-part key format emitted by DefaultMfaService (tenantId:userId:code) because",
+  "The IAM MFA service constructs replay keys with three colon-separated components, but this adapter requires four",
+];
+const AC4_TIMESTEP = [
+  "The production replay key is tenant:user:code, but this implementation treats the code as codeHash and derives",
+  "When callers provide the actual IAM replay-key format (tenant:user:code), timeStep falls back to Date.now()",
+  "For the actual IAM key format (tenantId:userId:code), timeStep falls back to the current millisecond clock",
+  "The IAM service supplies keys in the form tenantId:userId:code, so timeStepRaw is absent and a new Date is",
+  "When callers provide the actual IAM replay key, no time step is present, so timeStep is derived from Date.now()",
+  "When the IAM key has the actual format tenantId:userId:code, timeStep falls back to Date.now() in milliseconds",
+];
+const REPLAY_STORE = "lib/prisma-totp-replay.store.ts";
 
 describe("normalizeIssueText", () => {
   test("strips backticks, collapses whitespace, lowercases, truncates to 160", () => {
@@ -40,6 +75,39 @@ describe("fingerprintFor", () => {
   });
   test("normalizes backslash paths to forward slashes", () => {
     expect(fingerprintFor("lib\\store.ts", "x", "text")).toBe(fingerprintFor("lib/store.ts", "x", "text"));
+  });
+  test("normalizes ./ and ../ prefixes so a reviewer's cwd drift does not fragment the key", () => {
+    const canonical = fingerprintFor("lib/store.ts", "x", "text");
+    expect(fingerprintFor("./lib/store.ts", "x", "text")).toBe(canonical);
+    expect(fingerprintFor("../../lib/store.ts", "x", "text")).toBe(canonical);
+  });
+
+  // Regression — auth-security-hardening US-004 (F1).
+  describe("AC-anchored fingerprint", () => {
+    test("is stable across a full prose rewrite when acIndex is present", () => {
+      const fps = new Set(AC3_KEY_FORMAT.map((issue) => fingerprintFor(REPLAY_STORE, "input", issue, 3)));
+      expect(fps.size).toBe(1);
+    });
+    test("is stable across a prose rewrite that also changes category", () => {
+      // The same AC-4 defect was filed as `assumption` in most rounds and
+      // `error-path` in round 12 — category is reviewer-assigned and drifts.
+      const a = fingerprintFor(REPLAY_STORE, "assumption", AC4_TIMESTEP[0], 4);
+      const b = fingerprintFor(REPLAY_STORE, "error-path", AC4_TIMESTEP[3], 4);
+      expect(a).toBe(b);
+    });
+    test("keeps distinct ACs in the same file distinct — no over-merge", () => {
+      const ac3 = fingerprintFor(REPLAY_STORE, "input", AC3_KEY_FORMAT[0], 3);
+      const ac4 = fingerprintFor(REPLAY_STORE, "assumption", AC4_TIMESTEP[0], 4);
+      expect(ac3).not.toBe(ac4);
+    });
+    test("keeps the same AC in different files distinct", () => {
+      expect(fingerprintFor("a.ts", "input", "text", 3)).not.toBe(fingerprintFor("b.ts", "input", "text", 3));
+    });
+    test("falls back to the prose fingerprint when acIndex is absent or invalid", () => {
+      const prose = fingerprintFor(REPLAY_STORE, "input", AC3_KEY_FORMAT[0]);
+      expect(fingerprintFor(REPLAY_STORE, "input", AC3_KEY_FORMAT[0], 0)).toBe(prose);
+      expect(fingerprintFor(REPLAY_STORE, "input", AC3_KEY_FORMAT[0], undefined)).toBe(prose);
+    });
   });
 });
 
@@ -67,6 +135,15 @@ describe("countPriorAppearances", () => {
     priors[0].findingsAfter[0].source = "lint" as any;
     expect(countPriorAppearances(priors).size).toBe(0);
   });
+
+  // Regression — auth-security-hardening US-004 (F1).
+  test("counts a re-worded finding as recurrent when prior rounds carry meta.acIndex", () => {
+    const priors = AC3_KEY_FORMAT.slice(0, 3).map((message, i) =>
+      iter(i + 1, [{ file: REPLAY_STORE, category: "input", message, severity: "error", acIndex: 3 }]),
+    );
+    const fp = fingerprintFor(REPLAY_STORE, "input", AC3_KEY_FORMAT[3], 3);
+    expect(countPriorAppearances(priors).get(fp)?.count).toBe(3);
+  });
 });
 
 const CFG = { enabled: true, maxBlockingRounds: 2 };
@@ -87,6 +164,55 @@ describe("classifyRecurrence", () => {
     const r3 = classifyRecurrence([adv("error")], priorAdv("error", 2), CFG, noTest, "error");           // n=3
     expect(r3.blocking.length).toBe(0);
     expect(r3.demoted.length).toBe(1);
+  });
+
+  // Regression — auth-security-hardening US-004 (F1). Before the AC-anchored
+  // fingerprint this sequence ran 17 rounds without a single demotion, because
+  // each round's re-worded prose produced a fresh key.
+  test("re-worded blocking finding demotes on round 3 when anchored by acIndex", () => {
+    const priors = AC3_KEY_FORMAT.slice(0, 2).map((message, i) =>
+      iter(i + 1, [{ file: REPLAY_STORE, category: "input", message, severity: "error", acIndex: 3 }]),
+    );
+    const round3 = adv("error", { file: REPLAY_STORE, category: "input", issue: AC3_KEY_FORMAT[2], acIndex: 3 });
+    const r = classifyRecurrence([round3], priors, CFG, noTest, "error");
+    expect(r.demoted.length).toBe(1);
+    expect(r.blocking.length).toBe(0);
+  });
+
+  // Mixed-key migration: a story mid-flight across a nax upgrade has prose-only
+  // priors and AC-anchored current findings. Both directions must still match,
+  // or the fix would re-introduce the very loop it removes.
+  test("AC-anchored current finding still matches prose-only priors", () => {
+    const priors = [1, 2].map((n) =>
+      iter(n, [{ file: REPLAY_STORE, category: "input", message: "identical prose", severity: "error" }]),
+    );
+    const current = adv("error", { file: REPLAY_STORE, category: "input", issue: "identical prose", acIndex: 3 });
+    expect(classifyRecurrence([current], priors, CFG, noTest, "error").demoted.length).toBe(1);
+  });
+
+  test("prose-only current finding still matches AC-anchored priors", () => {
+    const priors = [1, 2].map((n) =>
+      iter(n, [
+        { file: REPLAY_STORE, category: "input", message: "identical prose", severity: "error", acIndex: 3 },
+      ]),
+    );
+    const current = adv("error", { file: REPLAY_STORE, category: "input", issue: "identical prose" });
+    expect(classifyRecurrence([current], priors, CFG, noTest, "error").demoted.length).toBe(1);
+  });
+
+  test("a different AC in the same file still blocks — demotion does not bleed across ACs", () => {
+    const priors = AC3_KEY_FORMAT.slice(0, 2).map((message, i) =>
+      iter(i + 1, [{ file: REPLAY_STORE, category: "input", message, severity: "error", acIndex: 3 }]),
+    );
+    const otherAc = adv("error", {
+      file: REPLAY_STORE,
+      category: "assumption",
+      issue: AC4_TIMESTEP[0],
+      acIndex: 4,
+    });
+    const r = classifyRecurrence([otherAc], priors, CFG, noTest, "error");
+    expect(r.blocking.length).toBe(1);
+    expect(r.demoted.length).toBe(0);
   });
 
   test("oscillating w,e,w,e: never blocks (entry guard)", () => {


### PR DESCRIPTION
Fixes the two review-pipeline defects that an analysis of **1,857 July-2026 review-audit records** identified as the highest-value items. Full analysis lands in `docs/findings/2026-08-01-review-pipeline-gap-analysis.md`.

## 1. Recurrence-demotion never fired (`d0c27456`)

`fingerprintFor` keyed on `file + category + issue.slice(0, 48)`. All three drift between rounds, so `countPriorAppearances` never reached `maxBlockingRounds + 1` and demotion never fired.

Measured on `auth-security-hardening` US-004 — **17 adversarial rounds, zero demotions**, error counts `3 1 2 1 1 2 2 2 1 1 1 0 1 3 3 1 1` (it even passed at round 12, then failed again). Three defects recur ~8× each and none is ever fixed.

Why the prose key fails: the reviewer rewrites the **opening** clause each round, not the tail the prefix truncation assumed.

| round | same defect, different key |
|---|---|
| r3 | `The stored expiresAt is never consulted and expired…` |
| r5 | `TTL is only written to expiresAt; existing rows are…` |
| r6 | `Expired replay rows are never removed or ignored. A…` |
| r8 | `The stored expiresAt is never consulted and replay …` |

`category` drifts too — that one defect was filed as `assumption`, `error-path`, and `input`.

**`file + acIndex` is stable across all of it** (`ac=3` for rounds 5–8, `ac=4` for rounds 9–15) and is structurally constrained rather than reviewer-styled: `acIndex` is a validated 1-based index that every blocking finding must carry (the prompt requires it; `filterByAcGroundingMinimal` drops findings without a valid one), so every demotion decision takes that path. Prose remains the fallback for non-blocking findings and older iterations.

Under the fix that story demotes at round 7 instead of running to 17.

### Rejected alternative

A token-set similarity matcher was tuned against the real 26-finding corpus and **rejected** — purity and recall do not coexist:

```
th=0.5   clusters=24  impure=0  maxSize=2   -> demotion needs n>=3, never fires
th=0.4   clusters=19  impure=2  maxSize=5   -> merges two unrelated defects
th=0.3   clusters=12  impure=3  maxSize=7   -> worse
```

The impure direction is the dangerous one: over-merging demotes genuine blocking findings to advisory.

### Migration

Priors are indexed under **both** keys and lookups try both. The first implementation broke 4 existing parity tests because prose-only priors stopped matching AC-anchored current findings — which is the state of any story mid-flight across this change. Regression tests cover both directions.

Also normalizes `./` and `../` path prefixes: the reviewer's cwd drifts between rounds in a monorepo (`components/X.tsx` vs `apps/web/components/X.tsx` for one file, one story), fragmenting the key a second way.

## 2. Review-audit telemetry was dead (`0e2d99c7`)

`advisoryFindings` was `null` in **100% of 1,857 records**, and AC-grounding drops were recorded nowhere. Both are computed by the review ops; `emitReviewDecision` built its event from `toReviewDecisionPayload` and forwarded neither. `ReviewDecisionEvent` already declared the fields and the middleware already forwarded them — the emitter was the only break.

- `filterByAcGroundingMinimal` deletes findings whose `acIndex` is missing or out of range. A real defect the reviewer could not pin to an AC vanished with no trace.
- The `nax-coverage-gap` skill reads `advisoryFindings[].meta.coverageGap`, so it reported empty on every run. (It needed **both** fixes: without #1 nothing is ever tagged.)

Also retains a 600-byte preview of reviewer output that failed to parse. 13 July give-ups left only a byte count behind — `prompt-audit/` stores prompts, not responses — so none could be diagnosed after the fact.

## Deliberately not changed

- **The fail-open verdict.** `exhaustedFallback` decides block-vs-pass by regexing `/"passed"\s*:\s*false/` over raw text; **7 of the 13 give-ups fell through to fail-open, shipping the story with no story-level review**. Choosing between retrying harder and treating exhaustion as blocking needs the evidence the new preview collects. Tracked as F2b.
- **`diffAvailable` and the #986 drop/accept counterfactuals** are still `null`. They are computed only in the dead `src/review/adversarial.ts` path (`runAdversarialReview`/`runSemanticReview` have no live callers); restoring them means porting that computation into the op's `verify()`. Separate change.

## Test plan

- [x] `bun run test` — 10737 + 1092 + 24 pass, 0 fail
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] New regression tests written RED first, verified failing against the old implementation (5 fail), then GREEN
- [x] Regression fixtures use verbatim issue strings from the real 17-round corpus, not synthesized prose
- [ ] Confirm on the next real run that `advisoryFindings` / `acDropped` are non-null in `~/.nax/<project>/review-audit/`, and that a `coverageGap` tag appears once a story recurs past `maxBlockingRounds`

## Follow-ups

| | item |
|---|---|
| F2b | give-up semantics, once previews accumulate |
| F1b | extend recurrence-demotion to semantic review (has none; 2× the >=8-round stories) |
| F4 | why reviewer findings never get fixed — the fix lane needs the same read-through |
| F5 | spec-review Phase 8: request-direction cross-package contracts |
