### PR TITLE
fix(otel): populate nax.project from the run's project identity

### DIFF
--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -89,7 +89,7 @@ export async function executeUnified(
   _prevRunUnsubscribers = [];
   const thisRunUnsubscribers = [
     wireHooks(pipelineEventBus, ctx.hooks, ctx.workdir, ctx.feature),
-    wireReporters(pipelineEventBus, ctx.pluginRegistry, ctx.runId, ctx.startTime),
+    wireReporters(pipelineEventBus, ctx.pluginRegistry, ctx.runId, ctx.startTime, ctx.runtime.projectKey),
     wireInteraction(pipelineEventBus, ctx.interactionChain, ctx.config),
     wireEventsWriter(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir),
     wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir, ctx.runtime.outputDir),

--- a/src/pipeline/subscribers/reporters.ts
+++ b/src/pipeline/subscribers/reporters.ts
@@ -43,6 +43,9 @@ async function fanOutReporters(
  * @param pluginRegistry - Plugin registry exposing getReporters()
  * @param runId          - Current run ID (for reporter events)
  * @param startTime      - Run start timestamp in ms (for duration calculation)
+ * @param projectKey     - Project identity name (`runtime.projectKey`) — the same value
+ *                         `claimProjectIdentity` writes as `.identity`'s `name` field, so
+ *                         reporters scope telemetry by project without reading that file.
  * @returns Unsubscribe function
  */
 export function wireReporters(
@@ -50,6 +53,7 @@ export function wireReporters(
   pluginRegistry: PluginRegistry,
   runId: string,
   startTime: number,
+  projectKey: string,
 ): UnsubscribeFn {
   const logger = getSafeLogger();
 
@@ -124,6 +128,7 @@ export function wireReporters(
                 feature: ev.feature,
                 totalStories: ev.totalStories,
                 startTime: new Date(startTime).toISOString(),
+                project: projectKey,
               });
             } catch (err) {
               logger?.warn("plugins", `Reporter '${r.name}' onRunStart failed`, { error: err });

--- a/test/unit/pipeline/subscribers/reporters.test.ts
+++ b/test/unit/pipeline/subscribers/reporters.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import * as loggerModule from "@/logger";
 import { PipelineEventBus, wireReporters } from "@/pipeline";
 import type { PluginRegistry } from "@/plugins";
-import type { IReporter, PhaseCompleteEvent, PhaseStartEvent } from "@/plugins/types";
+import type { IReporter, PhaseCompleteEvent, PhaseStartEvent, RunStartEvent } from "@/plugins/types";
 
 function makeReporter(): IReporter & { calls: string[] } {
   const calls: string[] = [];
@@ -33,7 +33,7 @@ describe("wireReporters", () => {
   test("run:started fires onRunStart", async () => {
     const bus = new PipelineEventBus();
     const reporter = makeReporter();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "run:started", feature: "test", totalStories: 5, workdir: "/tmp" });
 
@@ -41,10 +41,27 @@ describe("wireReporters", () => {
     expect(reporter.calls).toContain("onRunStart");
   });
 
+  test("run:started passes the project key through to onRunStart", async () => {
+    const bus = new PipelineEventBus();
+    let received: RunStartEvent | undefined;
+    const reporter: IReporter = {
+      name: "capture-reporter",
+      async onRunStart(ev) {
+        received = ev;
+      },
+    };
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "my-project");
+
+    bus.emit({ type: "run:started", feature: "test", totalStories: 5, workdir: "/tmp" });
+
+    await Promise.resolve();
+    expect(received?.project).toBe("my-project");
+  });
+
   test("story:completed fires onStoryComplete(completed)", async () => {
     const bus = new PipelineEventBus();
     const reporter = makeReporter();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({
       type: "story:completed",
@@ -61,7 +78,7 @@ describe("wireReporters", () => {
   test("story:failed fires onStoryComplete(failed)", async () => {
     const bus = new PipelineEventBus();
     const reporter = makeReporter();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({
       type: "story:failed",
@@ -78,7 +95,7 @@ describe("wireReporters", () => {
   test("story:paused fires onStoryComplete(paused)", async () => {
     const bus = new PipelineEventBus();
     const reporter = makeReporter();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "story:paused", storyId: "US-001", reason: "needs review", cost: 0.5 });
 
@@ -89,7 +106,7 @@ describe("wireReporters", () => {
   test("story:escalated fires onEscalation", async () => {
     const bus = new PipelineEventBus();
     const reporter = makeReporter();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "story:escalated", storyId: "US-001", fromTier: "fast", toTier: "balanced" });
 
@@ -100,7 +117,7 @@ describe("wireReporters", () => {
   test("run:completed fires onRunEnd", async () => {
     const bus = new PipelineEventBus();
     const reporter = makeReporter();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "run:completed", totalStories: 5, passedStories: 4, failedStories: 1, durationMs: 60000 });
 
@@ -116,7 +133,7 @@ describe("wireReporters", () => {
         throw new Error("reporter crash");
       },
     };
-    wireReporters(bus, makeRegistry(badReporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(badReporter), "run-1", Date.now(), "test-project");
 
     expect(() =>
       bus.emit({
@@ -138,7 +155,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "story:step", storyId: "US-005", step: "implementer" });
     await bus.drain();
@@ -157,7 +174,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({
       type: "story:phase:completed",
@@ -190,7 +207,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "postrun:phase:started", phase: "acceptance" });
     await bus.drain();
@@ -209,7 +226,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "postrun:phase:completed", phase: "acceptance", passed: true, durationMs: 15 });
     await bus.drain();
@@ -228,7 +245,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
 
     bus.emit({ type: "postrun:phase:completed", phase: "regression", passed: true, durationMs: 10 });
     await bus.drain();
@@ -238,7 +255,7 @@ describe("wireReporters", () => {
 
   test("AC10: skips reporters without onPhaseComplete", async () => {
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry({ name: "legacy" }), "run-1", Date.now());
+    wireReporters(bus, makeRegistry({ name: "legacy" }), "run-1", Date.now(), "test-project");
 
     bus.emit({
       type: "story:phase:completed",
@@ -267,7 +284,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry(first, second), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(first, second), "run-1", Date.now(), "test-project");
 
     bus.emit({
       type: "story:phase:completed",
@@ -300,7 +317,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    wireReporters(bus, makeRegistry(first, second), "run-1", Date.now());
+    wireReporters(bus, makeRegistry(first, second), "run-1", Date.now(), "test-project");
 
     bus.emit({
       type: "story:phase:completed",
@@ -325,7 +342,7 @@ describe("wireReporters", () => {
       },
     };
     const bus = new PipelineEventBus();
-    const unsubscribe = wireReporters(bus, makeRegistry(reporter), "run-1", Date.now());
+    const unsubscribe = wireReporters(bus, makeRegistry(reporter), "run-1", Date.now(), "test-project");
     const event = {
       type: "story:phase:completed" as const,
       storyId: "US-005",


### PR DESCRIPTION
## Problem

`RunStartEvent.project` is declared and documented as *"basename of workdir"* (`src/plugins/extensions.ts:318`), but `wireReporters` — its only emitter — never set it. Every reporter received `project: undefined`, so the otel reporter wrote an **empty `nax.project` resource attribute** on all three signals (logs, traces, metrics) and on every heartbeat tick.

Observed live against a real run: `nax_project=` (present but empty) while `nax_feature`, `nax_run_id`, and `nax_git_branch` were all populated. Since `service.name` is `nax` for every repo, telemetry from concurrent runs across different projects was indistinguishable — the only workaround was a per-repo `serviceName` override.

## Fix

Thread `runtime.projectKey` through `wireReporters` into the `onRunStart` payload.

That is the identical string `claimProjectIdentity` writes as `.identity`'s `name` field, so the value is **inherited from the project identity by construction** — no file read, no null case, and it is populated on the very first run before `.identity` exists.

The otel reporter stores it once into `RunState` at `onRunStart`, so one fix propagates to every downstream emission: resource attributes on logs/traces/metrics, heartbeat attributes, and phase spans.

Six lines of production code:

- `src/pipeline/subscribers/reporters.ts` — new `projectKey: string` param, passed as `project`
- `src/execution/unified-executor.ts:92` — sole call site passes `ctx.runtime.projectKey`

## Why 11k tests missed it

Both halves of the chain were covered **in isolation**:

- `otel-otlp.test.ts:211` asserts `buildResourceAttributes` maps `project` → `nax.project`
- `otel-reporter-lifecycle.test.ts` hand-constructs `onRunStart({ ..., project: "nax" })`

Nothing asserted what the *emitter* actually sends. The new test covers exactly that seam. A second reporter-level test was deliberately **not** added — it would hand-build the event and replicate the same blind spot.

Note `tsconfig.json` excludes `test/`, so making the param required guards `src/` callers (where the bug lived) but not test call sites; all 16 existing calls were updated to pass a real value rather than leave `undefined` against a `string` type.

## Verification

| Gate | Result |
|:---|:---|
| RED (new test, pre-fix) | `Expected: "my-project"` / `Received: undefined` |
| Unit | 10738 pass, 0 fail |
| Integration | 1092 pass, 0 fail |
| UI | 24 pass, 0 fail |
| `bun run typecheck` | exit 0 |
| `bun run lint` | all checks OK |

## Spec alignment

This makes the implementation match specs that already required it — `SPEC-otlp-logs-exporter.md:171` maps `nax.project → RunState.project`, and `SPEC-otel-telemetry-expansion.md:190` lists it as a resource attribute. No doc changes needed.

## Follow-ups (not in this PR)

1. **`projectKey` derivation is duplicated at 5 sites** — `config.name?.trim() || basename(...)` appears in `runtime/index.ts:179`, `run-setup.ts:330`, `migrate.ts:230`, `resume.ts:179`, and `curator.ts:79`. This fix's correctness depends on the first two agreeing. `curator.ts:79` already wraps it as a function; promoting that to a shared `getProjectKey()` would satisfy the "One source of truth per concept" rule.
2. **Webhook payload is now wider** — the webhook reporter forwards events verbatim, so consumers gain a `project` field. Additive and backward-compatible, but worth a changelog line.