### PR TITLE
feat(review): wire the semantic reviewer's round history, and add opt-in recurrence-demotion

### DIFF
--- a/src/config/schemas-review.ts
+++ b/src/config/schemas-review.ts
@@ -49,6 +49,23 @@ const SemanticReviewConfigSchema = z.object({
    * Mirrors the adversarial field so the guard is configurable on both reviewers.
    */
   demandInspectionTrail: z.boolean().default(true),
+  /**
+   * Semantic counterpart of the adversarial setting below. A non-blocking-lane
+   * error finding blocks for at most `maxBlockingRounds` rounds; once its
+   * fingerprint recurs beyond that it auto-demotes to advisory (coverage-gap),
+   * so one disputed finding cannot deadlock a story indefinitely.
+   *
+   * Defaults to `enabled: false` — unlike adversarial, which has shipped this
+   * for several releases. Semantic findings drive the source fix lane directly,
+   * so demoting one stops a real defect from blocking; this is opt-in until the
+   * coverage-gap telemetry shows what it would actually be demoting.
+   */
+  recurrenceDemotion: z
+    .object({
+      enabled: z.boolean().default(false),
+      maxBlockingRounds: z.number().int().min(1).default(2),
+    })
+    .default({ enabled: false, maxBlockingRounds: 2 }),
 });
 
 /**

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -245,6 +245,7 @@ export const NaxConfigSchema = z
         rules: [],
         timeoutMs: 600_000,
         demandInspectionTrail: true,
+        recurrenceDemotion: { enabled: false, maxBlockingRounds: 2 },
         substantiation: {
           requote: true,
           maxRequotes: 5,

--- a/src/execution/story-orchestrator/run-phase.ts
+++ b/src/execution/story-orchestrator/run-phase.ts
@@ -8,11 +8,11 @@ import { pipelineEventBus } from "@/pipeline";
 import type { StoryPhaseCompletedEvent } from "@/pipeline/event-bus";
 import type { PhaseDetails } from "@/plugins/types";
 import {
-  getAdversarialIterations,
+  getReviewIterations,
   isBlockingSeverity,
   prepareAdversarialReviewInput,
   prepareSemanticReviewInput,
-  recordAdversarialIteration,
+  recordReviewIteration,
 } from "@/review";
 import { errorMessage } from "@/utils/errors";
 import { _gitDeps, captureGitRef } from "@/utils/git";
@@ -170,11 +170,21 @@ export async function runPhase(
   dispatchInput = await refreshReviewInputForDispatch(opName, dispatchInput);
   let advIterationBefore = 0;
   if (opName === "adversarial-review" && ctx.storyId) {
-    const priorIterations = getAdversarialIterations(ctx.runtime.adversarialIterations, ctx.storyId);
+    const priorIterations = getReviewIterations(ctx.runtime.adversarialIterations, ctx.storyId);
     advIterationBefore = priorIterations.length;
     dispatchInput = {
       ...(dispatchInput as Record<string, unknown>),
       priorAdversarialIterations: priorIterations,
+    };
+  }
+  // Same carry-forward for the semantic reviewer. Its whole chain — context
+  // field, plan-inputs threading, op input, prompt block — already existed and
+  // was unit-tested, but nothing ever populated it, so the semantic reviewer
+  // entered every round blind to the ones before it while adversarial did not.
+  if (opName === "semantic-review" && ctx.storyId) {
+    dispatchInput = {
+      ...(dispatchInput as Record<string, unknown>),
+      priorSemanticIterations: getReviewIterations(ctx.runtime.semanticIterations, ctx.storyId),
     };
   }
 
@@ -202,9 +212,16 @@ export async function runPhase(
     emitReviewDecision(ctx, opName, output);
     if (opName === "adversarial-review" && ctx.storyId) {
       const advOut = output as { normalizedFindings?: Finding[]; advisoryFindings?: Finding[] };
-      recordAdversarialIteration(ctx.runtime.adversarialIterations, ctx.storyId, [
+      recordReviewIteration(ctx.runtime.adversarialIterations, ctx.storyId, [
         ...(advOut.normalizedFindings ?? []),
         ...(advOut.advisoryFindings ?? []),
+      ]);
+    }
+    if (opName === "semantic-review" && ctx.storyId) {
+      const semOut = output as { normalizedFindings?: Finding[]; advisoryFindings?: Finding[] };
+      recordReviewIteration(ctx.runtime.semanticIterations, ctx.storyId, [
+        ...(semOut.normalizedFindings ?? []),
+        ...(semOut.advisoryFindings ?? []),
       ]);
     }
     logUnifiedReviewPhaseResult(ctx.storyId, opName, output);

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -17,6 +17,7 @@ import {
   validateLLMShape,
 } from "../review/finding-filters";
 import type { AcDroppedEntry, AcGroundingMinimalRejection, LLMFinding } from "../review/finding-filters";
+import { classifyRecurrence, tagCoverageGap } from "../review/recurrence-demotion";
 import { parseRequoteResponse } from "../review/requote-response";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
@@ -111,6 +112,8 @@ export interface SemanticReviewOutput {
   acDropped: AcDroppedEntry<LLMFinding, AcGroundingMinimalRejection>[];
   failOpen?: boolean;
   looksLikeFail?: boolean;
+  /** Blocking-severity findings that did NOT block: oscillation-suppressed or recurrence-demoted. */
+  advisoryFindings?: Finding[];
   /**
    * Clipped preview of the output that could not be parsed, carried to the
    * review-audit record. The raw reviewer response is retained nowhere else, so
@@ -386,7 +389,33 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
 
     const { accepted, dropped } = filterByAcGroundingMinimal(substantiated, input.story.acceptanceCriteria);
 
-    const blocking = accepted.filter((f) => isBlockingSeverity(f.severity, threshold));
+    const isTestFile = semanticTestFileMatch(input);
+    // Recurrence-demotion (opt-in for semantic — see schemas-review.ts). A
+    // finding whose fingerprint has recurred past maxBlockingRounds stops
+    // blocking and is surfaced as a coverageGap-tagged advisory, so one
+    // disputed finding cannot deadlock the story indefinitely.
+    const recurrenceCfg = input.semanticConfig.recurrenceDemotion ?? { enabled: false, maxBlockingRounds: 2 };
+    const {
+      blocking,
+      advisory: subThreshold,
+      demoted,
+    } = classifyRecurrence(
+      accepted,
+      input.priorSemanticIterations ?? [],
+      recurrenceCfg,
+      isTestFile,
+      threshold,
+      "semantic-review",
+    );
+    // Tag AFTER conversion: llmFindingToFinding rebuilds `meta` from scratch, so
+    // a coverageGap tag applied to the LLMFinding would be silently dropped.
+    const advisoryFindings = [
+      ...toReviewFindings(
+        subThreshold.filter((f) => isBlockingSeverity(f.severity, threshold)),
+        { isTestFile },
+      ),
+      ...tagCoverageGap(toReviewFindings(demoted, { isTestFile })),
+    ];
     // Honour blockingThreshold: the verdict fails only when a blocking finding
     // survives. The model's raw `passed:false` must NOT fail the review when every
     // surviving finding is advisory (sub-threshold) — that was nax#1347. The
@@ -399,7 +428,8 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
       ...parsed,
       passed,
       findings: accepted,
-      normalizedFindings: toReviewFindings(blocking, { isTestFile: semanticTestFileMatch(input) }),
+      normalizedFindings: toReviewFindings(blocking, { isTestFile }),
+      advisoryFindings,
       acDropped: dropped,
     };
   },

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -5,7 +5,7 @@
  */
 
 export * from "./ac-quote-validator";
-export * from "./adversarial-iteration-store";
+export * from "./review-iteration-store";
 export * from "./ac-structural-counterfactual";
 export * from "./adversarial";
 export * from "./semantic-evidence";

--- a/src/review/recurrence-demotion.ts
+++ b/src/review/recurrence-demotion.ts
@@ -100,12 +100,15 @@ export function lookupPriorAppearance(
  * fingerprint (cumulative within run). `lastSeverity` is the severity in the
  * most-recent iteration containing it (iterations are chronological).
  */
-export function countPriorAppearances(priorIterations: Iteration[]): Map<string, PriorAppearance> {
+export function countPriorAppearances(
+  priorIterations: Iteration[],
+  source: Finding["source"] = "adversarial-review",
+): Map<string, PriorAppearance> {
   const counts = new Map<string, PriorAppearance>();
   for (const it of priorIterations) {
     const seenThisIter = new Map<string, string>();
     for (const f of (it.findingsAfter ?? []) as Finding[]) {
-      if (f.source !== "adversarial-review") continue;
+      if (f.source !== source) continue;
       // Index under BOTH keys. `finding-projection.ts` persists a valid 1-based
       // acIndex into meta, but iterations recorded before that — or by an older
       // nax — carry only prose. A current-round finding looks itself up under
@@ -132,11 +135,24 @@ export function tagCoverageGap<T extends { meta?: Record<string, unknown> }>(fin
 }
 
 export type RecurrenceConfig = { enabled: boolean; maxBlockingRounds: number };
-export type RecurrenceResult = {
-  blocking: AdversarialLLMFinding[];
-  advisory: AdversarialLLMFinding[];
-  demoted: AdversarialLLMFinding[];
+export type RecurrenceResult<T = AdversarialLLMFinding> = {
+  blocking: T[];
+  advisory: T[];
+  demoted: T[];
 };
+
+/**
+ * Structural minimum `classifyRecurrence` reads. Both AdversarialLLMFinding and
+ * the semantic LLMFinding satisfy it; semantic findings carry no `category`,
+ * which only means the test-gap carve-out never fires for them.
+ */
+export interface RecurrenceCandidate {
+  severity: string;
+  file: string;
+  issue: string;
+  category?: string;
+  acIndex?: number;
+}
 
 /**
  * Partition accepted adversarial findings into block / advisory / demoted.
@@ -150,23 +166,24 @@ export type RecurrenceResult = {
  * `demoted` is a subset reported separately for coverage-gap logging; callers
  * surface it through advisoryFindings.
  */
-export function classifyRecurrence(
-  accepted: AdversarialLLMFinding[],
+export function classifyRecurrence<T extends RecurrenceCandidate>(
+  accepted: T[],
   priorIterations: Iteration[],
   cfg: RecurrenceConfig,
   testFileMatch: (file: string) => boolean,
   threshold: "error" | "warning" | "info",
-): RecurrenceResult {
-  const blocking: AdversarialLLMFinding[] = [];
-  const advisory: AdversarialLLMFinding[] = [];
-  const demoted: AdversarialLLMFinding[] = [];
+  source: Finding["source"] = "adversarial-review",
+): RecurrenceResult<T> {
+  const blocking: T[] = [];
+  const advisory: T[] = [];
+  const demoted: T[] = [];
 
   if (!cfg.enabled) {
     for (const f of accepted) (isBlockingSeverity(f.severity, threshold) ? blocking : advisory).push(f);
     return { blocking, advisory, demoted };
   }
 
-  const priorCounts = countPriorAppearances(priorIterations);
+  const priorCounts = countPriorAppearances(priorIterations, source);
 
   for (const f of accepted) {
     // test-gap carve-out applies only to blocking severities (mirrors the

--- a/src/review/review-iteration-store.ts
+++ b/src/review/review-iteration-store.ts
@@ -1,19 +1,22 @@
 import type { Finding, Iteration } from "../findings";
 import { classifyOutcome } from "../findings";
 
-/** Run-scoped, per-story adversarial-review round history. Keyed by storyId. */
-export function getAdversarialIterations(store: Map<string, Iteration[]>, storyId: string): Iteration[] {
+/** Run-scoped, per-story review round history. Keyed by storyId. One store per reviewer. */
+export function getReviewIterations(store: Map<string, Iteration[]>, storyId: string): Iteration[] {
   return store.get(storyId) ?? [];
 }
 
 /**
- * Append one adversarial round to the per-story history. `fixesApplied` is `[]`
+ * Append one review round to the per-story history. `fixesApplied` is `[]`
  * because the fix ran in the implementation session outside the FixCycle (see
  * the ADR-022 note on `Iteration.fixesApplied`). `findingsAfter` is this round's
- * adversarial findings (source "adversarial-review"), which recurrence-demotion
- * (`countPriorAppearances`) and the carry-forward prompt both read.
+ * source-tagged findings, which recurrence-demotion (`countPriorAppearances`)
+ * and the carry-forward prompt both read.
+ *
+ * Reviewer-agnostic: callers pass the store for their own reviewer, so the
+ * semantic and adversarial histories never mix.
  */
-export function recordAdversarialIteration(
+export function recordReviewIteration(
   store: Map<string, Iteration[]>,
   storyId: string,
   roundFindings: readonly Finding[],

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -95,6 +95,8 @@ export interface SemanticReviewConfig {
    * reviewer actually open the code before passing (#3A inspection-trail guard).
    */
   demandInspectionTrail?: boolean;
+  /** Opt-in for semantic (default disabled) — see schemas-review.ts. */
+  recurrenceDemotion?: { enabled: boolean; maxBlockingRounds: number };
 }
 
 /** Review check result */

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -131,6 +131,8 @@ export interface NaxRuntime {
   readonly quarantineMemo: QuarantineMemo;
   /** Run-scoped per-story adversarial-review round history (ADR-022 carry-forward + recurrence-demotion). Keyed by storyId. */
   readonly adversarialIterations: Map<string, Iteration[]>;
+  /** Run-scoped per-story semantic-review round history. Separate map so the two reviewers' histories never mix. */
+  readonly semanticIterations: Map<string, Iteration[]>;
   /** Run-scoped per-story rectification oscillation totals. */
   readonly rectificationOscillations: Map<string, number>;
   close(): Promise<void>;
@@ -254,6 +256,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const logger = getLogger();
   const quarantineMemo = createQuarantineMemo();
   const adversarialIterations = new Map<string, Iteration[]>();
+  const semanticIterations = new Map<string, Iteration[]>();
   const rectificationOscillations = new Map<string, number>();
 
   let closed = false;
@@ -279,6 +282,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     logger,
     quarantineMemo,
     adversarialIterations,
+    semanticIterations,
     rectificationOscillations,
 
     get signal() {

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -36,7 +36,8 @@ describe("SemanticReviewConfig", () => {
     const config: SemanticReviewConfig = {
       model: "balanced",
       diffMode: "embedded",
-      resetRefOnRerun: false,
+      recurrenceDemotion: { enabled: false, maxBlockingRounds: 2 },
+        resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
       substantiation: { requote: true, maxRequotes: 5 },
@@ -50,7 +51,8 @@ describe("SemanticReviewConfig", () => {
     const config: SemanticReviewConfig = {
       model: { agent: "codex", model: "gpt-5.4" },
       diffMode: "embedded",
-      resetRefOnRerun: false,
+      recurrenceDemotion: { enabled: false, maxBlockingRounds: 2 },
+        resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
       substantiation: { requote: true, maxRequotes: 5 },
@@ -63,7 +65,8 @@ describe("SemanticReviewConfig", () => {
     const config: SemanticReviewConfig = {
       model: "balanced",
       diffMode: "embedded",
-      resetRefOnRerun: false,
+      recurrenceDemotion: { enabled: false, maxBlockingRounds: 2 },
+        resetRefOnRerun: false,
       rules: ["rule1", "rule2"],
       timeoutMs: 600_000,
       substantiation: { requote: true, maxRequotes: 5 },
@@ -80,6 +83,7 @@ describe("SemanticReviewConfig", () => {
       const config: SemanticReviewConfig = {
         model: tier,
         diffMode: "embedded",
+        recurrenceDemotion: { enabled: false, maxBlockingRounds: 2 },
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
@@ -109,6 +113,7 @@ describe("ReviewConfig semantic field", () => {
       expect(result.data.review.semantic).toEqual({
         model: "balanced",
         diffMode: "ref",
+        recurrenceDemotion: { enabled: false, maxBlockingRounds: 2 },
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
@@ -252,7 +257,8 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
     expect(DEFAULT_CONFIG.review.semantic).toEqual({
       model: "balanced",
       diffMode: "ref",
-      resetRefOnRerun: false,
+      recurrenceDemotion: { enabled: false, maxBlockingRounds: 2 },
+        resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
       demandInspectionTrail: true,

--- a/test/unit/execution/story-orchestrator/semantic-iteration-wiring.test.ts
+++ b/test/unit/execution/story-orchestrator/semantic-iteration-wiring.test.ts
@@ -1,0 +1,105 @@
+/**
+ * runPhase — semantic-review round history wiring (F1b-a).
+ *
+ * `priorSemanticIterations` was declared on PipelineContext, threaded through
+ * plan-inputs, accepted by semanticReviewOp, and rendered by
+ * ReviewPromptBuilder — every layer built and unit-tested — but the only
+ * assignment anywhere in src/ was `ctx.priorSemanticIterations = undefined`.
+ * Nothing ever populated it, so the semantic reviewer never saw its own prior
+ * rounds while the adversarial reviewer did. See
+ * `docs/findings/2026-08-01-review-pipeline-gap-analysis.md`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { _storyOrchestratorDeps, runPhase } from "@/execution";
+import type { AnySlot } from "@/execution";
+import type { Finding, Iteration } from "@/findings";
+import { makeMockCallContext } from "@test/helpers";
+
+function makeSlot(opName: string): AnySlot {
+  return {
+    op: {
+      kind: "run" as const,
+      name: opName,
+      stage: "review" as const,
+      session: { role: "reviewer-semantic" as const, lifetime: "fresh" as const },
+      build: () => ({ prompt: "" }),
+      parse: () => ({}),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal op shape for runPhase
+    } as any,
+    input: {},
+  };
+}
+
+function semanticFinding(issue: string): Finding {
+  return {
+    source: "semantic-review",
+    severity: "error",
+    file: "src/thing.ts",
+    message: issue,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Finding shape
+  } as any;
+}
+
+/** Runs one semantic-review phase, returning the input the op was dispatched with. */
+async function dispatchSemanticPhase(
+  store: Map<string, Iteration[]>,
+  output: unknown,
+): Promise<Record<string, unknown>> {
+  const origCallOp = _storyOrchestratorDeps.callOp;
+  let seenInput: Record<string, unknown> = {};
+  _storyOrchestratorDeps.callOp = (async (_ctx: unknown, _op: unknown, input: unknown) => {
+    seenInput = input as Record<string, unknown>;
+    return output;
+    // biome-ignore lint/suspicious/noExplicitAny: test double
+  }) as any;
+  try {
+    const ctx = makeMockCallContext({ storyId: "US-001" });
+    // biome-ignore lint/suspicious/noExplicitAny: runtime store injection
+    (ctx.runtime as any).semanticIterations = store;
+    await runPhase(ctx, makeSlot("semantic-review"), {}, {});
+  } finally {
+    _storyOrchestratorDeps.callOp = origCallOp;
+  }
+  return seenInput;
+}
+
+describe("runPhase — semantic-review iteration history", () => {
+  test("injects priorSemanticIterations from the runtime store", async () => {
+    const store = new Map<string, Iteration[]>();
+    const prior: Iteration = {
+      iterationNum: 1,
+      findingsBefore: [],
+      fixesApplied: [],
+      findingsAfter: [semanticFinding("round one finding")],
+      outcome: "fixes-applied",
+      startedAt: "2026-08-01T00:00:00.000Z",
+      finishedAt: "2026-08-01T00:00:01.000Z",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal Iteration shape
+    } as any;
+    store.set("US-001", [prior]);
+
+    const input = await dispatchSemanticPhase(store, { passed: true, findings: [] });
+
+    expect(input.priorSemanticIterations).toEqual([prior]);
+  });
+
+  test("records this round's findings so the next round can see them", async () => {
+    const store = new Map<string, Iteration[]>();
+
+    await dispatchSemanticPhase(store, {
+      passed: false,
+      findings: [],
+      normalizedFindings: [semanticFinding("first round defect")],
+    });
+
+    const recorded = store.get("US-001");
+    expect(recorded).toHaveLength(1);
+    expect(recorded?.[0].findingsAfter).toEqual([semanticFinding("first round defect")]);
+  });
+
+  test("injects an empty history on the first round rather than undefined", async () => {
+    const input = await dispatchSemanticPhase(new Map(), { passed: true, findings: [] });
+    expect(input.priorSemanticIterations).toEqual([]);
+  });
+});

--- a/test/unit/operations/semantic-review-verify.test.ts
+++ b/test/unit/operations/semantic-review-verify.test.ts
@@ -351,3 +351,69 @@ describe("semanticReviewOp.verify() — filter pipeline (AC1 semantic)", () => {
     });
   });
 });
+
+/**
+ * Recurrence-demotion for semantic review (F1b). Opt-in: default disabled.
+ *
+ * The coverageGap assertion is the load-bearing one — `llmFindingToFinding`
+ * rebuilds `meta` from scratch, so tagging before the LLMFinding -> Finding
+ * conversion would silently drop the tag and the review-audit record would
+ * show a plain advisory.
+ */
+describe("semanticReviewOp.verify() — recurrence demotion", () => {
+  const RECURRING = "AC0 is not implemented — the handler returns 500";
+
+  function priorSemanticRound(n: number, message: string) {
+    return {
+      iterationNum: n,
+      findingsBefore: [],
+      fixesApplied: [],
+      findingsAfter: [
+        { source: "semantic-review", severity: "error", category: "", file: "src/h.ts", message, meta: { acIndex: 1 } },
+      ],
+      outcome: "fixes-applied",
+      startedAt: "2026-08-01T00:00:00.000Z",
+      finishedAt: "2026-08-01T00:00:01.000Z",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal Iteration shape
+    } as any;
+  }
+
+  const finding = {
+    severity: "error",
+    file: "src/h.ts",
+    line: 1,
+    issue: "AC0 still unimplemented — reworded entirely this round",
+    suggestion: "implement it",
+    acIndex: 1,
+  };
+
+  async function runVerify(enabled: boolean) {
+    const input: SemanticReviewInput = {
+      ...BASE_INPUT,
+      mode: "embedded", // skip evidence substantiation (ref-mode only)
+      semanticConfig: { ...BASE_INPUT.semanticConfig, recurrenceDemotion: { enabled, maxBlockingRounds: 2 } },
+      priorSemanticIterations: [priorSemanticRound(1, RECURRING), priorSemanticRound(2, `${RECURRING} again`)],
+    };
+    const parsed = { passed: false, findings: [finding], normalizedFindings: [], acDropped: [] };
+    // biome-ignore lint/suspicious/noExplicitAny: verify ctx is unused on this path
+    return (await semanticReviewOp.verify!(parsed as any, input, {} as any)) as SemanticReviewOutput;
+  }
+
+  test("demotes a third-round recurrence to advisory and lets the story pass", async () => {
+    const out = await runVerify(true);
+    expect(out.normalizedFindings).toHaveLength(0);
+    expect(out.passed).toBe(true);
+  });
+
+  test("tags the demoted finding coverageGap so the audit record can distinguish it", async () => {
+    const out = await runVerify(true);
+    expect(out.advisoryFindings).toHaveLength(1);
+    expect(out.advisoryFindings?.[0].meta?.coverageGap).toBe(true);
+  });
+
+  test("keeps the finding blocking when demotion is disabled (the default)", async () => {
+    const out = await runVerify(false);
+    expect(out.normalizedFindings).toHaveLength(1);
+    expect(out.passed).toBe(false);
+  });
+});

--- a/test/unit/review/recurrence-demotion.test.ts
+++ b/test/unit/review/recurrence-demotion.test.ts
@@ -291,3 +291,69 @@ describe("tagCoverageGap", () => {
     expect(tagCoverageGap([])).toEqual([]);
   });
 });
+
+describe("classifyRecurrence — semantic source (F1b)", () => {
+  const semanticIter = (n: number, message: string, acIndex?: number): Iteration =>
+    ({
+      iterationNum: n,
+      findingsBefore: [],
+      fixesApplied: [],
+      findingsAfter: [
+        {
+          source: "semantic-review",
+          severity: "error",
+          category: "",
+          file: REPLAY_STORE,
+          message,
+          ...(acIndex !== undefined ? { meta: { acIndex } } : {}),
+        },
+      ],
+      outcome: "fixes-applied",
+      startedAt: "2026-08-01T00:00:00.000Z",
+      finishedAt: "2026-08-01T00:00:01.000Z",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal Iteration shape
+    }) as any;
+
+  // Semantic findings carry no `category`, so the fingerprint's prose fallback
+  // sees category undefined — the AC anchor is what has to carry them.
+  const semFinding = (issue: string, acIndex?: number) =>
+    ({ severity: "error", file: REPLAY_STORE, issue, acIndex }) as AdversarialLLMFinding;
+
+  test("counts semantic-source priors and demotes on the third sighting", () => {
+    const priors = [semanticIter(1, AC3_KEY_FORMAT[0], 3), semanticIter(2, AC3_KEY_FORMAT[1], 3)];
+    const r = classifyRecurrence(
+      [semFinding(AC3_KEY_FORMAT[2], 3)],
+      priors,
+      CFG,
+      noTest,
+      "error",
+      "semantic-review",
+    );
+    expect(r.demoted.length).toBe(1);
+    expect(r.blocking.length).toBe(0);
+  });
+
+  test("ignores adversarial-source priors when counting for semantic", () => {
+    const advPriors = [1, 2].map((n) =>
+      iter(n, [{ file: REPLAY_STORE, category: "", message: AC3_KEY_FORMAT[0], severity: "error", acIndex: 3 }]),
+    );
+    const r = classifyRecurrence(
+      [semFinding(AC3_KEY_FORMAT[2], 3)],
+      advPriors,
+      CFG,
+      noTest,
+      "error",
+      "semantic-review",
+    );
+    expect(r.blocking.length).toBe(1);
+    expect(r.demoted.length).toBe(0);
+  });
+
+  test("disabled config leaves every blocking finding blocking", () => {
+    const priors = [semanticIter(1, AC3_KEY_FORMAT[0], 3), semanticIter(2, AC3_KEY_FORMAT[1], 3)];
+    const off = { enabled: false, maxBlockingRounds: 2 };
+    const r = classifyRecurrence([semFinding(AC3_KEY_FORMAT[2], 3)], priors, off, noTest, "error", "semantic-review");
+    expect(r.blocking.length).toBe(1);
+    expect(r.demoted.length).toBe(0);
+  });
+});

--- a/test/unit/review/review-iteration-store.test.ts
+++ b/test/unit/review/review-iteration-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Finding, Iteration } from "@/findings";
-import { countPriorAppearances, fingerprintFor, getAdversarialIterations, recordAdversarialIteration } from "@/review";
+import { countPriorAppearances, fingerprintFor, getReviewIterations, recordReviewIteration } from "@/review";
 
 function advFinding(message: string): Finding {
   return {
@@ -13,11 +13,11 @@ function advFinding(message: string): Finding {
 }
 
 describe("adversarial iteration store", () => {
-  test("records rounds; getAdversarialIterations returns them; count reflects recurrence", () => {
+  test("records rounds; getReviewIterations returns them; count reflects recurrence", () => {
     const store = new Map<string, Iteration[]>();
-    recordAdversarialIteration(store, "US-1", [advFinding("window expiry non-atomic")]);
-    recordAdversarialIteration(store, "US-1", [advFinding("window expiry non-atomic")]);
-    const iters = getAdversarialIterations(store, "US-1");
+    recordReviewIteration(store, "US-1", [advFinding("window expiry non-atomic")]);
+    recordReviewIteration(store, "US-1", [advFinding("window expiry non-atomic")]);
+    const iters = getReviewIterations(store, "US-1");
     expect(iters.length).toBe(2);
     expect(iters[1].iterationNum).toBe(2);
     expect(iters[1].fixesApplied).toEqual([]);
@@ -27,7 +27,7 @@ describe("adversarial iteration store", () => {
 
   test("is scoped by storyId; unknown story returns empty", () => {
     const store = new Map<string, Iteration[]>();
-    recordAdversarialIteration(store, "US-1", [advFinding("x padded padded padded")]);
-    expect(getAdversarialIterations(store, "US-2")).toEqual([]);
+    recordReviewIteration(store, "US-1", [advFinding("x padded padded padded")]);
+    expect(getReviewIterations(store, "US-2")).toEqual([]);
   });
 });


### PR DESCRIPTION
Follow-up to #1412. Extends recurrence-demotion to the semantic reviewer — and first fixes the reason it could not work at all.

## 1. `priorSemanticIterations` was never populated (`49adc947`)

The semantic reviewer's round-history chain existed at every layer and was unit-tested at every layer:

| layer | status |
|---|---|
| `PipelineContext.priorSemanticIterations` | declared (`pipeline/types.ts:202`) |
| plan-inputs threading | wired + tested (`plan-inputs.ts:353`) |
| `semanticReviewOp` input | accepted + tested (`semantic-review.ts:331`) |
| `ReviewPromptBuilder` carry-forward block | rendered + tested (`review-builder.ts:122`) |

The only assignment anywhere in `src/` was:

```ts
ctx.priorSemanticIterations = undefined;   // iteration-runner.ts:50
```

Every test set the value by hand. **In production it was always `undefined`** — so the semantic reviewer entered every round blind to the ones before it, while the adversarial reviewer got its carry-forward block from `runtime.adversarialIterations`.

Semantic carries **2× the >=8-round stories** that adversarial does (10 vs 5, July 2026). Having no memory of prior rounds is a plausible direct cause, independent of any suppression mechanism.

Adds `runtime.semanticIterations` as a **separate** store — the two reviewers' histories must never mix — and injects/records it in `runPhase` exactly as the adversarial path does. The store was already reviewer-agnostic apart from its name, so it is renamed `adversarial-iteration-store` -> `review-iteration-store` (`getReviewIterations` / `recordReviewIteration`) rather than duplicated.

**This half changes no gating behaviour at all.** It turns on a prompt block the builder already knew how to render.

## 2. Recurrence-demotion for semantic, opt-in (`7f32c3a6`)

A blocking finding whose fingerprint recurs past `maxBlockingRounds` stops blocking and is surfaced as a `coverageGap`-tagged advisory, so one disputed finding cannot deadlock a story indefinitely.

`countPriorAppearances` and `classifyRecurrence` take a `source` parameter (defaulting to `adversarial-review`), so the two reviewers' histories are counted separately. `classifyRecurrence` is generic over the finding shape.

### Why the default differs from adversarial

**`enabled: false`**, where adversarial ships `true`. Semantic findings default to `fixTarget: "source"` and drive the implementer lane directly, so demoting one stops a **real defect** from blocking. Adversarial findings are more often out-of-scope-but-true. Until the coverage-gap telemetry restored in #1412 shows what this would actually be demoting, off is the honest default — turning it on is a config change, not a release.

### The subtle one

The `coverageGap` tag is applied **after** the `LLMFinding -> Finding` conversion. `llmFindingToFinding` rebuilds `meta` from scratch:

```ts
const metaExtras: Record<string, unknown> = {};
if (f.verifiedBy) metaExtras.verifiedBy = f.verifiedBy;
// ... nothing carries an existing meta through
```

Tagging first would have silently dropped the tag and written a plain advisory to the audit — a second instance of the exact bug #1412 fixed. There is a dedicated test asserting `advisoryFindings[0].meta.coverageGap === true`.

## Review notes

- **Off-by-default is provably a no-op**, not assumed: with `enabled: false`, `classifyRecurrence` short-circuits to `(isBlockingSeverity ? blocking : advisory).push(f)` — identical to the previous `accepted.filter(isBlockingSeverity)`. `blocking`, `normalizedFindings` and `passed` are unchanged, and `advisoryFindings` comes out `[]`.
- **No double-counting:** `classifyRecurrence`'s `advisory` bucket holds sub-threshold findings *and* oscillation-suppressed blocking ones. Sub-threshold findings already ship in `findings: accepted`, so the `.filter(isBlockingSeverity)` on the advisory bucket is load-bearing.
- **`plan-inputs.ts:353` is now vestigial** — `run-phase.ts:187` unconditionally overwrites it. Left in place deliberately: removing it breaks `plan-inputs-review-wiring.test.ts:166`, and the mirror adversarial line is still live. Follow-up cleanup, not a drive-by here.
- **Neither iteration store is cleared per story.** `semanticIterations` grows for the run, matching the long-shipped `adversarialIterations` behaviour. Run-scoped and bounded by stories x rounds — flagging because this doubles that footprint.
- **The `test-gap` carve-out never fires for semantic** (semantic findings carry no `category`). Correct, but it is an invariant that holds only because a field is absent, so it is documented on `RecurrenceCandidate`.

## Test plan

- [x] `bun run test` — 10747 + 1092 + 24 pass, 0 fail (rebased onto `main` incl. #1413)
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] New wiring tests written RED first — failed with `undefined` before the store existed
- [x] **Re-verified by reverting:** neutering the config read fails 2 of the 3 new `verify()` tests, so they are not vacuous
- [x] Two pre-existing exhaustive config-shape assertions updated for the new field
- [ ] Confirm on a live run that the semantic prompt now contains the carry-forward block, and that semantic `advisoryFindings` reach `~/.nax/<project>/review-audit/`

## Follow-ups

| | item |
|---|---|
| F2b | give-up semantics, once #1412's `unparsedPreview` samples accumulate |
| — | drop the vestigial `plan-inputs.ts:353` semantic threading |
| — | decide whether to flip `recurrenceDemotion.enabled` on for semantic, from coverage-gap data |
| F5 | spec-review Phase 8: request-direction cross-package contracts |
