### PR TITLE
fix(review): detect truncation by JSON completeness, not output length

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -67,7 +67,6 @@ export type { BuildTurnResultInput } from "./adapter-output";
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-export const MAX_AGENT_OUTPUT_CHARS = 5000;
 const INTERACTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 min for human to respond
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/acp/index.ts
+++ b/src/agents/acp/index.ts
@@ -8,7 +8,6 @@ export {
   AcpSessionHandleImpl,
   _acpAdapterDeps,
   _fallbackDeps,
-  MAX_AGENT_OUTPUT_CHARS,
   buildTurnResult,
 } from "./adapter";
 export type { BuildTurnResultInput } from "./adapter";

--- a/src/agents/retry/tiered-parse-retry.ts
+++ b/src/agents/retry/tiered-parse-retry.ts
@@ -1,5 +1,5 @@
 import { getSafeLogger } from "@/logger";
-import { MAX_AGENT_OUTPUT_CHARS } from "../acp/adapter";
+import { looksLikeTruncatedJson } from "../../review/truncation";
 import { ParseValidationError } from "./types";
 import type { RetryStrategy } from "./types";
 
@@ -37,7 +37,7 @@ export function makeTieredParseRetryStrategy<TOutput, TKind extends string, TPar
         return { retry: false, fallback: opts.exhaustedFallback(inspection, ctx.lastOutput) };
       }
 
-      const isTruncated = ctx.lastOutput.trimEnd().length >= MAX_AGENT_OUTPUT_CHARS - 100;
+      const isTruncated = looksLikeTruncatedJson(ctx.lastOutput);
       const logger = opts._logger ?? getSafeLogger();
       logger?.warn(opts.reviewerKind, `Parse retry — ${inspection.kind ?? "unknown"}`, {
         storyId: ctx.storyId,

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -47,8 +47,6 @@ export function releaseHeavyPipelineContext(ctx: PipelineContext): void {
   ctx.constitution = undefined;
   ctx.acceptanceFailures = undefined;
   ctx.autofixPriorIterations = undefined;
-  ctx.priorSemanticIterations = undefined;
-  ctx.priorAdversarialIterations = undefined;
   ctx.reviewFindings = undefined;
   ctx.selfVerification = undefined;
   ctx.tddIsolations = undefined;

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -350,7 +350,6 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           diff: prepared.diff,
           excludePatterns: prepared.excludePatterns,
           featureCtxBlock: buildFeatureCtxBlock(ctx, "reviewer-semantic"),
-          priorSemanticIterations: ctx.priorSemanticIterations,
           // Also set at the top level (not only inside `_refresh`) so the fix-lane
           // override (#1368) still applies when the dispatch-time refresh fails and
           // run-phase falls back to this stale input.
@@ -403,7 +402,6 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           testGlobs: prepared.testGlobs,
           refExcludePatterns: prepared.refExcludePatterns,
           featureCtxBlock: buildFeatureCtxBlock(ctx, "reviewer-adversarial"),
-          priorAdversarialIterations: ctx.priorAdversarialIterations,
           // See the semantic input above — survives a failed dispatch-time refresh.
           resolvedTestPatterns,
           // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -199,9 +199,6 @@ export interface PipelineContext extends DispatchContext {
    * addressed / still-blocking / never-an-issue. Forwarded into the review op input
    * by plan-inputs.ts.
    */
-  priorSemanticIterations?: Iteration[];
-  /** Mirror of priorSemanticIterations for adversarial review. */
-  priorAdversarialIterations?: Iteration[];
   /** Git HEAD ref captured before agent ran this attempt (FEAT-010: precise smart-runner diff) */
   storyGitRef?: string;
   /** Collected story metrics (set by completionStage) */

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -6,6 +6,7 @@
 
 export * from "./ac-quote-validator";
 export * from "./review-iteration-store";
+export * from "./truncation";
 export * from "./ac-structural-counterfactual";
 export * from "./adversarial";
 export * from "./semantic-evidence";

--- a/src/review/truncation.ts
+++ b/src/review/truncation.ts
@@ -1,25 +1,62 @@
 /**
- * Shared helpers for detecting ACP output-cap truncation in LLM reviewer responses.
+ * Detects a structurally unfinished JSON response from an LLM reviewer.
  *
- * Both adversarial and semantic reviewers parse JSON responses from the agent. The ACP
- * adapter tail-truncates output at MAX_AGENT_OUTPUT_CHARS, so a near-cap response is
- * almost certainly corrupted mid-stream. Detecting this lets reviewers choose a condensed
- * retry prompt (vs. a standard "return valid JSON" retry) to avoid re-triggering the cap.
+ * Both reviewers parse JSON from the agent. When parsing fails, the retry
+ * strategy picks between two prompts: a condensed one ("your response was
+ * truncated — keep every blocking finding, cap advisories") and a plain one
+ * ("return valid JSON"). This predicate makes that choice.
+ *
+ * It used to answer by length — `raw.length >= MAX_AGENT_OUTPUT_CHARS - 100` —
+ * on the premise that the ACP adapter tail-truncates output at 5000 chars. It
+ * does not: `MAX_AGENT_OUTPUT_CHARS` was declared and never applied to any
+ * output path. The predicate therefore meant "is this review long", and July
+ * 2026 review payloads run p90 = 4,340 bytes with 164 records over 4,500 — so
+ * complete, finding-rich reviews were told their response was truncated and
+ * asked to send less. See docs/findings/2026-08-01-review-pipeline-gap-analysis.md.
  */
-
-import { MAX_AGENT_OUTPUT_CHARS } from "../agents/acp/adapter";
-
-export { MAX_AGENT_OUTPUT_CHARS };
 
 /**
- * Returns true when the raw response was almost certainly truncated by the
- * ACP adapter's MAX_AGENT_OUTPUT_CHARS tail-truncation cap.
+ * True when `raw` opened a JSON structure it never closed — an unbalanced
+ * `{`/`[`, or a string literal left open. Braces and quotes inside string
+ * values are ignored, as are escaped quotes.
  *
- * The adapter keeps the LAST N chars (tail truncation), so a truncated response
- * ends at the cap boundary — not at a natural JSON close. Checking for a near-cap
- * length is more reliable than heuristics on the string content, since the tail
- * may start anywhere inside the JSON and may or may not end with `}`.
+ * Deliberately false for output that is *complete but invalid* (prose, a
+ * trailing comma, a stray closing brace). That output is not truncated, so the
+ * plain "return valid JSON" retry is the right prompt — asking a model to
+ * shorten a response it already finished does not fix a syntax error, and on a
+ * finding-rich review it costs advisory findings.
  */
 export function looksLikeTruncatedJson(raw: string): boolean {
-  return raw.trimEnd().length >= MAX_AGENT_OUTPUT_CHARS - 100;
+  const text = raw.trimEnd();
+  if (text.length === 0) return false;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let opened = false;
+
+  for (const ch of text) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{" || ch === "[") {
+      depth++;
+      opened = true;
+    } else if (ch === "}" || ch === "]") {
+      depth--;
+    }
+  }
+
+  // `opened` guards prose: a bare sentence has no structure to leave unfinished.
+  return opened && (inString || depth > 0);
 }

--- a/test/unit/execution/iteration-runner-memory.test.ts
+++ b/test/unit/execution/iteration-runner-memory.test.ts
@@ -17,8 +17,6 @@ describe("releaseHeavyPipelineContext", () => {
       constitution: { content: largeText },
       acceptanceFailures: { failedACs: [], findings: [], testOutput: largeText },
       autofixPriorIterations: [{ feedback: largeText }],
-      priorSemanticIterations: [{ feedback: largeText }],
-      priorAdversarialIterations: [{ feedback: largeText }],
       reviewFindings: [{ message: largeText }],
       selfVerification: { evidence: largeText },
       tddIsolations: { implementer: { output: largeText } },
@@ -37,8 +35,6 @@ describe("releaseHeavyPipelineContext", () => {
     expect(ctx.constitution).toBeUndefined();
     expect(ctx.acceptanceFailures).toBeUndefined();
     expect(ctx.autofixPriorIterations).toBeUndefined();
-    expect(ctx.priorSemanticIterations).toBeUndefined();
-    expect(ctx.priorAdversarialIterations).toBeUndefined();
     expect(ctx.reviewFindings).toBeUndefined();
     expect(ctx.selfVerification).toBeUndefined();
     expect(ctx.tddIsolations).toBeUndefined();

--- a/test/unit/execution/plan-inputs-review-wiring.test.ts
+++ b/test/unit/execution/plan-inputs-review-wiring.test.ts
@@ -163,24 +163,6 @@ describe("assemblePlanInputsFromCtx — review + rectification wiring", () => {
     expect(inputs.adversarialReview!.refExcludePatterns?.length ?? 0).toBeGreaterThan(0);
   });
 
-  test("priorSemanticIterations on ctx threads into semantic input", async () => {
-    const ctx = makeCtx({
-      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["semantic"] },
-    });
-    ctx.storyGitRef = "abc123";
-    const priorIter = {
-      iterationNum: 1,
-      findingsBefore: [],
-      fixesApplied: [],
-      findingsAfter: [],
-      outcome: "unchanged" as const,
-      startedAt: "2026-01-01T00:00:00Z",
-      finishedAt: "2026-01-01T00:00:01Z",
-    };
-    ctx.priorSemanticIterations = [priorIter];
-    const inputs = await assemblePlanInputsFromCtx(ctx);
-    expect(inputs.semanticReview!.priorSemanticIterations).toEqual([priorIter]);
-  });
 
   test("AC#4 (#1120): resolveTestFilePatterns result is shared between semantic and adversarial helpers via resolvedTestPatterns", async () => {
     // Both checks enabled — two prepare-inputs calls. plan-inputs.ts resolves patterns

--- a/test/unit/operations/adversarial-review-retry-flip.test.ts
+++ b/test/unit/operations/adversarial-review-retry-flip.test.ts
@@ -98,7 +98,9 @@ describe("AC3: retry behavior — truncated JSON response", () => {
     };
     const strategy = (adversarialReviewOp.retry as any)(inputWithThreshold, opCtx);
 
-    const truncatedOutput = "x".repeat(4950);
+    // Unfinished JSON — an object opened and never closed, which is what
+    // looksLikeTruncatedJson() detects now that nothing truncates by length.
+    const truncatedOutput = `{"passed": false, "findings": [{"severity": "error", "issue": "cut`;
 
     const retryCtx = {
       site: "complete" as const,
@@ -132,7 +134,7 @@ describe("AC3: retry behavior — truncated JSON response", () => {
         agentName: "claude",
         stage: "review" as const,
         storyId: SAMPLE_STORY.id,
-        lastOutput: "x".repeat(4950),
+        lastOutput: '{"passed": false, "findings": [{"severity": "error", "issue": "cut',
       },
     );
 
@@ -284,7 +286,9 @@ describe("AC7: logging — storyId is first key in data object", () => {
       const opCtx = { packageView: ctx.packageView, config: ctx.config };
       const strategy = (adversarialReviewOp.retry as any)(SAMPLE_INPUT, opCtx);
 
-      const truncatedOutput = "x".repeat(4950);
+      // Unfinished JSON — an object opened and never closed, which is what
+    // looksLikeTruncatedJson() detects now that nothing truncates by length.
+    const truncatedOutput = `{"passed": false, "findings": [{"severity": "error", "issue": "cut`;
 
       const retryCtx = {
         site: "complete" as const,

--- a/test/unit/review/adversarial-retry-truncation.test.ts
+++ b/test/unit/review/adversarial-retry-truncation.test.ts
@@ -40,8 +40,10 @@ const DEFAULT_ADVERSARIAL_CONFIG: AdversarialReviewConfig = {
   maxConcurrentSessions: 1,
 };
 
-// A response at 4950 chars is within 100 of the cap, so looksLikeTruncatedJson() returns true.
-const AT_CAP_UNPARSEABLE = "x".repeat(4950);
+// A response whose JSON structure was opened and never closed — what
+// looksLikeTruncatedJson() now detects. Long, so it also covers the case the old
+// length-based rule conflated with truncation.
+const UNFINISHED_JSON = `{"passed": false, "findings": [${'{"severity": "error", "file": "src/a.ts", "issue": "xxxxxxxxxx"},'.repeat(60)}{"severity": "error", "file": "src/b.ts", "issue": "cut off here`;
 
 // ─── Logger mock ─────────────────────────────────────────────────────────────
 
@@ -85,7 +87,7 @@ function makeRetryCtx(lastOutput: string, storyId = STORY.id) {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("adversarialReviewOp.retry — truncation-detected condensed retry", () => {
-  test("uses condensed retry prompt when response length is at the ACP output cap", () => {
+  test("uses condensed retry prompt when the JSON structure is unfinished", () => {
     const ctx = makeBuildCtx();
     const strategy = (adversarialReviewOp.retry as any)(
       { story: STORY, adversarialConfig: DEFAULT_ADVERSARIAL_CONFIG, mode: "embedded" },
@@ -95,14 +97,14 @@ describe("adversarialReviewOp.retry — truncation-detected condensed retry", ()
     const result = strategy.shouldRetry(
       new ParseValidationError("parse failed"),
       0,
-      makeRetryCtx(AT_CAP_UNPARSEABLE),
+      makeRetryCtx(UNFINISHED_JSON),
     );
 
     expect(result.retry).toBe(true);
     expect(result.nextPrompt).toContain("truncated");
   });
 
-  test("uses standard retry prompt when response is short unparseable text (not at cap)", () => {
+  test("uses standard retry prompt when response is short unparseable text (structurally complete)", () => {
     const ctx = makeBuildCtx();
     const strategy = (adversarialReviewOp.retry as any)(
       { story: STORY, adversarialConfig: DEFAULT_ADVERSARIAL_CONFIG, mode: "embedded" },
@@ -119,7 +121,7 @@ describe("adversarialReviewOp.retry — truncation-detected condensed retry", ()
     expect(result.nextPrompt).not.toContain("truncated");
   });
 
-  test("fires retry when response is at cap even before attempting parse", () => {
+  test("fires retry when JSON is unfinished, even before attempting parse", () => {
     const ctx = makeBuildCtx();
     const strategy = (adversarialReviewOp.retry as any)(
       { story: STORY, adversarialConfig: DEFAULT_ADVERSARIAL_CONFIG, mode: "embedded" },
@@ -129,7 +131,7 @@ describe("adversarialReviewOp.retry — truncation-detected condensed retry", ()
     const result = strategy.shouldRetry(
       new ParseValidationError("parse failed"),
       0,
-      makeRetryCtx(AT_CAP_UNPARSEABLE),
+      makeRetryCtx(UNFINISHED_JSON),
     );
 
     expect(result.retry).toBe(true);
@@ -137,7 +139,7 @@ describe("adversarialReviewOp.retry — truncation-detected condensed retry", ()
 });
 
 describe("adversarialReviewOp.retry — truncation logging", () => {
-  test("logs warn 'JSON parse retry — likely truncated' when response is at cap", () => {
+  test("logs warn 'JSON parse retry — likely truncated' when the JSON is unfinished", () => {
     const logger = makeLogger();
     const loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
 
@@ -150,7 +152,7 @@ describe("adversarialReviewOp.retry — truncation logging", () => {
     strategy.shouldRetry(
       new ParseValidationError("parse failed"),
       0,
-      makeRetryCtx(AT_CAP_UNPARSEABLE),
+      makeRetryCtx(UNFINISHED_JSON),
     );
 
     const truncatedLog = logger.warnCalls.find((c) => c.message.includes("truncated"));
@@ -185,7 +187,7 @@ describe("adversarialReviewOp.retry — truncation logging", () => {
 });
 
 describe("adversarialReviewOp.retry — Bug 4 regression: parser-first, length is a hint not a veto", () => {
-  test("parseable near-cap response is NOT retried (Bug 4 regression)", () => {
+  test("parseable long response is NOT retried (Bug 4 regression)", () => {
     const validNearCap = JSON.stringify({
       passed: false,
       findings: Array.from({ length: 7 }, (_, i) => ({
@@ -215,7 +217,7 @@ describe("adversarialReviewOp.retry — Bug 4 regression: parser-first, length i
     expect(result.retry).toBe(false);
   });
 
-  test("unparseable near-cap response still triggers condensed retry", () => {
+  test("unparseable unfinished response still triggers condensed retry", () => {
     const ctx = makeBuildCtx();
     const strategy = (adversarialReviewOp.retry as any)(
       { story: STORY, adversarialConfig: DEFAULT_ADVERSARIAL_CONFIG, mode: "embedded" },
@@ -225,7 +227,7 @@ describe("adversarialReviewOp.retry — Bug 4 regression: parser-first, length i
     const result = strategy.shouldRetry(
       new ParseValidationError("parse failed"),
       0,
-      makeRetryCtx(AT_CAP_UNPARSEABLE),
+      makeRetryCtx(UNFINISHED_JSON),
     );
 
     expect(result.retry).toBe(true);

--- a/test/unit/review/semantic-retry-truncation.test.ts
+++ b/test/unit/review/semantic-retry-truncation.test.ts
@@ -35,10 +35,10 @@ const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
 
 const PASSING_LLM_RESPONSE = JSON.stringify({ passed: true, findings: [] });
 
-// A response at 4950 chars is within 100 of the cap, so looksLikeTruncatedJson() returns true.
-// This fixture is intentionally NOT valid JSON — the parser-first logic still retries unparseable
-// near-cap responses. Valid JSON near the cap is the Bug 4 regression scenario (see below).
-const AT_CAP_UNPARSEABLE = "x".repeat(4950);
+// A response whose JSON structure was opened and never closed — what
+// looksLikeTruncatedJson() now detects. Long, so it also covers the case the old
+// length-based rule conflated with truncation.
+const UNFINISHED_JSON = `{"passed": false, "findings": [${'{"severity": "error", "file": "src/a.ts", "issue": "xxxxxxxxxx"},'.repeat(60)}{"severity": "error", "file": "src/b.ts", "issue": "cut off here`;
 
 // ─── Logger mock helpers ─────────────────────────────────────────────────────
 
@@ -114,9 +114,9 @@ async function runSemanticOp(
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("truncation-detected condensed retry", () => {
-  test("uses condensed retry prompt when response length is at the ACP output cap", async () => {
+  test("uses condensed retry prompt when the JSON structure is unfinished", async () => {
     const { runtime, capturedPrompts } = makeCallOpRuntime([
-      { output: AT_CAP_UNPARSEABLE },
+      { output: UNFINISHED_JSON },
       { output: PASSING_LLM_RESPONSE },
     ]);
 
@@ -126,7 +126,7 @@ describe("truncation-detected condensed retry", () => {
     expect(capturedPrompts[1]).toContain("truncated");
   });
 
-  test("uses standard retry prompt when response is short unparseable text (not at cap)", async () => {
+  test("uses standard retry prompt when response is short unparseable text (structurally complete)", async () => {
     const { runtime, capturedPrompts } = makeCallOpRuntime([
       { output: "here is my analysis: the code looks fine overall" },
       { output: PASSING_LLM_RESPONSE },
@@ -138,9 +138,9 @@ describe("truncation-detected condensed retry", () => {
     expect(capturedPrompts[1]).not.toContain("truncated");
   });
 
-  test("fires retry when response is at cap even before attempting parse", async () => {
+  test("fires retry when JSON is unfinished, even before attempting parse", async () => {
     const { runtime, capturedPrompts } = makeCallOpRuntime([
-      { output: AT_CAP_UNPARSEABLE },
+      { output: UNFINISHED_JSON },
       { output: PASSING_LLM_RESPONSE },
     ]);
 
@@ -168,7 +168,7 @@ describe("truncation-detected condensed retry", () => {
       ],
     });
     const { runtime } = makeCallOpRuntime([
-      { output: AT_CAP_UNPARSEABLE },
+      { output: UNFINISHED_JSON },
       { output: condensedResponse },
     ]);
 
@@ -186,12 +186,12 @@ describe("truncation logging", () => {
     loggerSpy?.mockRestore();
   });
 
-  test("logs warn 'truncated' when response is at cap", async () => {
+  test("logs warn 'truncated' when the JSON is unfinished", async () => {
     const logger = makeLogger();
     loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
 
     const { runtime } = makeCallOpRuntime([
-      { output: AT_CAP_UNPARSEABLE },
+      { output: UNFINISHED_JSON },
       { output: PASSING_LLM_RESPONSE },
     ]);
 
@@ -202,7 +202,7 @@ describe("truncation logging", () => {
     expect(truncatedLog?.stage).toBe("semantic");
   });
 
-  test("does not log truncation warning when response is short unparseable text (not at cap)", async () => {
+  test("does not log truncation warning when response is short unparseable text (structurally complete)", async () => {
     const logger = makeLogger();
     loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
 
@@ -219,7 +219,7 @@ describe("truncation logging", () => {
 });
 
 describe("Bug 4 regression: parser-first, length is a hint not a veto", () => {
-  test("parseable near-cap response is NOT retried (Bug 4 regression)", async () => {
+  test("parseable long response is NOT retried (Bug 4 regression)", async () => {
     const validNearCap = JSON.stringify({
       passed: false,
       findings: Array.from({ length: 7 }, (_, i) => ({
@@ -240,9 +240,9 @@ describe("Bug 4 regression: parser-first, length is a hint not a veto", () => {
     expect(capturedPrompts).toHaveLength(1);
   });
 
-  test("unparseable near-cap response still triggers condensed retry", async () => {
+  test("unparseable unfinished response still triggers condensed retry", async () => {
     const { runtime, capturedPrompts } = makeCallOpRuntime([
-      { output: AT_CAP_UNPARSEABLE },
+      { output: UNFINISHED_JSON },
       { output: PASSING_LLM_RESPONSE },
     ]);
 

--- a/test/unit/review/truncation.test.ts
+++ b/test/unit/review/truncation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { looksLikeTruncatedJson } from "@/review";
+
+/**
+ * `looksLikeTruncatedJson` decides which retry prompt an unparseable reviewer
+ * response gets: the condensed one ("your response was truncated, drop advisory
+ * findings") or the plain one ("return valid JSON").
+ *
+ * It used to answer that by length — `raw.length >= MAX_AGENT_OUTPUT_CHARS - 100`
+ * — on the premise that the ACP adapter tail-truncates at 5000 chars. Nothing
+ * truncates: the constant is declared and never applied. So the predicate really
+ * meant "is this review long", and July-2026 review payloads run p90 = 4,340
+ * bytes with 164 records over 4,500 — complete, finding-rich reviews were being
+ * told their response was truncated and asked to send less. See
+ * `docs/findings/2026-08-01-review-pipeline-gap-analysis.md` (F2).
+ *
+ * It now answers the question it claims to: is the JSON structurally unfinished?
+ */
+describe("looksLikeTruncatedJson", () => {
+  describe("genuinely unfinished JSON", () => {
+    test("object opened and never closed", () => {
+      expect(looksLikeTruncatedJson('{"passed": false, "findings": [')).toBe(true);
+    });
+    test("nested structure cut mid-array", () => {
+      expect(looksLikeTruncatedJson('{"findings": [{"file": "a.ts"}, {"file": "b.ts"')).toBe(true);
+    });
+    test("cut inside a string value", () => {
+      expect(looksLikeTruncatedJson('{"issue": "the handler never checks expiry and so')).toBe(true);
+    });
+    test("fenced block whose JSON never closes", () => {
+      expect(looksLikeTruncatedJson('```json\n{"passed": true, "findings": [\n')).toBe(true);
+    });
+  });
+
+  describe("complete output — not truncated, whatever its length", () => {
+    test("a long but complete review", () => {
+      const findings = Array.from({ length: 40 }, (_v, i) => ({
+        severity: "warning",
+        file: `src/file-${i}.ts`,
+        issue: "x".repeat(120),
+      }));
+      const raw = JSON.stringify({ passed: false, findings });
+      expect(raw.length).toBeGreaterThan(5000); // would have been "truncated" under the old rule
+      expect(looksLikeTruncatedJson(raw)).toBe(false);
+    });
+    test("complete but invalid JSON gets the plain retry, not the condensed one", () => {
+      expect(looksLikeTruncatedJson('{"passed": true, "findings": [],}')).toBe(false);
+    });
+    test("prose with no JSON at all", () => {
+      expect(looksLikeTruncatedJson("I was unable to review this change because the diff was empty.")).toBe(false);
+    });
+    test("empty output", () => {
+      expect(looksLikeTruncatedJson("")).toBe(false);
+      expect(looksLikeTruncatedJson("   \n ")).toBe(false);
+    });
+    test("braces inside string values do not count as structure", () => {
+      expect(looksLikeTruncatedJson('{"issue": "use {foo} here", "line": 3}')).toBe(false);
+    });
+    test("an escaped quote does not leave the string open", () => {
+      expect(looksLikeTruncatedJson('{"issue": "he said \\"hi\\" loudly"}')).toBe(false);
+    });
+    test("stray closing brace is not truncation", () => {
+      expect(looksLikeTruncatedJson('{"a": 1}}')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #1412 / #1414. Fixes a defect the review-pipeline analysis documented but left, and removes the artifact that caused it.

## The predicate measured the wrong thing

`looksLikeTruncatedJson` decided which retry prompt an unparseable reviewer response gets, by length:

```ts
return raw.trimEnd().length >= MAX_AGENT_OUTPUT_CHARS - 100;   // 4900
```

The premise — stated in the file's own docstring — was that the ACP adapter tail-truncates output at 5000 chars.

**Nothing truncates.** `MAX_AGENT_OUTPUT_CHARS` was declared in `adapter.ts` and never applied to any output path; its only readers were this predicate and a copy of the same heuristic in `tiered-parse-retry.ts`. July 2026 review payloads reach **11,750 bytes**, well past the supposed cap.

So the predicate really meant *"is this review long"*:

```
July review result payloads:  p50 959   p90 4,340   p99 7,640   max 11,750
records over 4,500 bytes:     164
```

On any parse hiccup, a large share of **complete, finding-rich** reviews were routed to the condensed retry prompt — which opens *"Your previous response was truncated and could not be parsed"* (false) and caps advisory findings at 3. Blast radius was limited because that prompt preserves every blocking finding, but it was measuring the wrong property and saying something untrue to the model.

## What it does now

Scans for an unbalanced `{`/`[` or an unterminated string, ignoring braces and escaped quotes inside string values.

**Complete-but-invalid output is deliberately NOT truncated** — prose, a trailing comma, a stray closing brace all get the plain "return valid JSON" retry. Asking a model to shorten a response it already finished cannot fix a syntax error, and on a finding-rich review it costs advisory findings.

## Cleanups that follow

- `tiered-parse-retry.ts` shares the predicate instead of duplicating the length rule.
- **`MAX_AGENT_OUTPUT_CHARS` is deleted.** With both readers fixed it had none left, and leaving a declared-but-unapplied cap invites exactly the wrong inference — it is what made truncation look real while diagnosing the review pipeline.
- **The dead `priorSemanticIterations` / `priorAdversarialIterations` chain on `PipelineContext` is removed.** Both fields were only ever assigned `undefined` and then unconditionally overwritten by `runPhase`, so plan-inputs' reads looked like live wiring and were not — the same false signal that hid the never-populated semantic history until #1414. Removing only the reads would have left unread fields, so the chain goes whole: context fields, plan-inputs reads, and the now-pointless clearing in `releaseHeavyPipelineContext`.

## Test plan

- [x] `bun run test` — 10757 + 1092 + 24 pass, 0 fail
- [x] `bun run lint` / `bun run typecheck` clean
- [x] New `truncation.test.ts` written RED first (5 fail), covering unfinished objects, cut-mid-string, fenced blocks, and the long-but-complete case
- [x] **Verified by reverting:** restoring the length rule fails 5 of the 11 new tests
- [x] Fixtures that encoded the length rule (`"x".repeat(4950)`) replaced with genuinely unfinished JSON; test intent unchanged

## Not in scope

The **fail-open verdict on give-up is still untouched** (`exhaustedFallback`'s `/"passed"\s*:\s*false/` regex). 7 of 13 July give-ups fell through to fail-open and shipped a story with no review, but choosing between retrying harder and treating exhaustion as blocking needs the `unparsedPreview` evidence #1412 added — and none has been collected yet, because the installed nax (0.75.4) predates all of these fixes.
