### PR TITLE
feat(finish): review gate fixes, narrow re-reviews, and move the finish audit to ~/.nax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ test/integration/tmp/
 TEST_SUMMARY_*.md
 .nax-pids
 .nax/metrics.json
-.nax/nax-finish-result.json
+.nax/finish-audit/
 
 .nax/**/runs/
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -505,7 +505,10 @@ one completed), HEAD is not `main`/`master`, and `enabled` is true.
 | Spec conflicts, contradictions, design calls, or anything it can't get green | Commits and pushes what it fixed, then escalates via Telegram or a PR/MR comment. No ready PR. |
 | Branch has no commits ahead of base | Reports `nothing-to-finish` and stops. |
 
-The flow's terminal state is written to `.nax/nax-finish-result.json` (gitignored).
+The flow's audit trail — one line per fix round, plus the terminal state — is
+written to `~/.nax/<project>/finish-audit/<feature>/`, beside `prompt-audit/`
+and `review-audit/`. See
+[nax-finish-autoflow.md](./nax-finish-autoflow.md#audit-trail).
 
 The interactive, approval-gated `nax-finish` skill still exists for manual
 finishes — this is the autonomous path, not a replacement.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -477,6 +477,7 @@ escalates** instead of guessing. It never merges.
 | `enabled` | `false` | Master gate. The flow never fires unless this is true. |
 | `flowPath` | `flows/nax-finish/nax-finish.flow.ts` | Relative paths resolve against the **nax install** first, then your repo (so you can vendor a variant). Absolute paths are used as-is. |
 | `defaultAgent` | `agent.default` | acpx `--default-agent` for nodes with no pinned profile. Defaults to the agent the run itself used — setting only `reviewers` no longer leaves the `fix_*` nodes on acpx's own default. |
+| `model` | `null` | acpx `--model`, a run-wide model *floor* (`node.model ?? agent.model ?? --model`). Reaches the `fix_*` nodes; cannot override a profile-pinned reviewer whose agent entry names its own model. Opt-in — requires an acpx build that reads `model` from agent entries. Never derived from `config.models`. |
 | `reviewers.spec` / `reviewers.quality` | `null` | acpx agent profiles (from `~/.acpx/config.json`) for the two review phases — each runs in its own isolated session, so they can be different agents/models. Unset → `defaultAgent`. |
 | `escalate.telegram` | `true` | Prefer Telegram for escalations when `interaction.plugin` is `telegram` (or `NAX_TELEGRAM_TOKEN` + `NAX_TELEGRAM_CHAT_ID` are set). With no credentials it falls back to a PR/MR comment. |
 | `notify.mode` | `"escalation"` | `escalation` preserves escalation-only reporting; `always` also reports clean outcomes and crashes; `off` disables Telegram and uses the escalation comment fallback. |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -476,7 +476,7 @@ escalates** instead of guessing. It never merges.
 |:---|:---|:---|
 | `enabled` | `false` | Master gate. The flow never fires unless this is true. |
 | `flowPath` | `flows/nax-finish/nax-finish.flow.ts` | Relative paths resolve against the **nax install** first, then your repo (so you can vendor a variant). Absolute paths are used as-is. |
-| `defaultAgent` | `null` | acpx `--default-agent` for nodes with no pinned profile. |
+| `defaultAgent` | `agent.default` | acpx `--default-agent` for nodes with no pinned profile. Defaults to the agent the run itself used — setting only `reviewers` no longer leaves the `fix_*` nodes on acpx's own default. |
 | `reviewers.spec` / `reviewers.quality` | `null` | acpx agent profiles (from `~/.acpx/config.json`) for the two review phases — each runs in its own isolated session, so they can be different agents/models. Unset → `defaultAgent`. |
 | `escalate.telegram` | `true` | Prefer Telegram for escalations when `interaction.plugin` is `telegram` (or `NAX_TELEGRAM_TOKEN` + `NAX_TELEGRAM_CHAT_ID` are set). With no credentials it falls back to a PR/MR comment. |
 | `notify.mode` | `"escalation"` | `escalation` preserves escalation-only reporting; `always` also reports clean outcomes and crashes; `off` disables Telegram and uses the escalation comment fallback. |

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -38,8 +38,8 @@ review_quality    code-quality review, isolated session, own agent profile
 quality_gates     re-run the feature's acceptance tests (gate zero), then the
                   repo's own quality.commands at the repo root
   ↳ red → fix_gate (agent) → commit → re-review     [max 3 attempts → escalate]
-          (a gate fix that committed re-enters review_quality; one that
-           changed nothing goes straight back to the gates)
+          (a gate fix that touched production code re-enters review_quality;
+           a test-only fix, or one that changed nothing, returns to the gates)
   ↳ none configured → escalate (a gate that verified nothing is not a pass)
   ↓
 open_pr           commit + push the fixes, then open a ready PR
@@ -56,11 +56,25 @@ whose body lists the findings behind it, so a human reviewing the PR can triage
 the flow's commits without reading every diff. It also appends the round to the
 [audit trail](#audit-trail).
 
-**No fix reaches the PR unreviewed.** The gate loop is the last loop to edit the
-tree, and it used to route straight back to `quality_gates` — which proves the
-repo's commands are green, something a bad fix can satisfy. A gate fix that
-commits now re-enters `review_quality` first. Both loops keep their own 3-attempt
-caps, so the re-entry cannot run away; it costs one review per gate round.
+**Gate fixes to production code are reviewed.** The gate loop is the last loop
+to edit the tree, and it used to route straight back to `quality_gates` — which
+proves the repo's commands are green, something a bad fix can satisfy. A gate fix
+that touches non-test files now re-enters `review_quality` first. Both loops keep
+their own 3-attempt caps, so the re-entry cannot run away.
+
+> **Known gap — test-only gate fixes are not re-reviewed.** The re-review is the
+> flow's most expensive node and a gate fix is usually a mechanical test repair,
+> so a commit whose every path matches the repo's test-file patterns skips it.
+> This is a deliberate cost tradeoff with a real edge: the defect that motivated
+> the re-entry in the first place was itself test-only — eight copy-pasted stubs
+> across three test files. If test-quality regressions start reaching your PRs,
+> widen `gateCommitRoute` in `nax-finish.flow.ts`.
+>
+> Classification comes from `nax features resolve --json` (`testPatterns`), which
+> reports the repo's own patterns via the ADR-009 resolver — so it is correct for
+> Go, Python and Rust packages, not just `*.test.ts`. When the patterns cannot be
+> resolved at all, the fix is treated as non-test and **is** reviewed.
+
 The fix agent itself is still told not to commit; the flow owns the history.
 
 These are internal checkpoints, so they skip your pre-commit hooks: a hook that
@@ -71,6 +85,29 @@ unless they pass. The terminal commit before pushing runs hooks normally.
 
 Both terminal nodes (`open_pr`, `escalate`) commit and push first, so the PR — or
 the escalation — describes state a human can actually see.
+
+### Why re-reviews are narrower than the first pass
+
+A reviewer's first pass reads the spec in full and the whole
+`git diff <base>...HEAD`. Re-running that verbatim on every round made reviews
+**58% of the flow's wall clock** on one measured run (7 review calls, 1306s of
+2232s), most of it re-reading code an earlier round had already cleared.
+
+So a re-review is scoped: it is given the findings it raised last round and
+`git diff <shaAtLastReview>..HEAD` — the fix, and nothing else — and asked two
+questions. Are these findings actually resolved (a weakened assertion, a deleted
+test or a disabled check is **not** resolved)? And did the fix break anything,
+including in the unchanged code it now calls into?
+
+Scope here means *what is judged*, not *what may be read*: the reviewer still has
+the spec and the whole repo, and is told so explicitly.
+
+The narrowing only applies when it is provably safe — when exactly one commit
+separates the two reviews, so that commit's parent **is** the tree the previous
+verdict passed on. Anything else (the first review of a phase, or two commits in
+the window, which happens when the acceptance loop commits between a spec fix and
+its re-review) falls back to a full review rather than guessing at a window and
+silently hiding code from the reviewer.
 
 ### Why acceptance runs twice
 
@@ -243,7 +280,7 @@ post-run driver treats it as non-blocking and logs a warning).
 |:---|:---|:---|
 | `enabled` | `false` | Master gate. |
 | `flowPath` | `flows/nax-finish/nax-finish.flow.ts` | Resolved against the **nax install** first, then your repo (vendor a variant by putting a file at the same relative path), then used as-is if absolute. |
-| `defaultAgent` | `null` | acpx agent for any node without a pinned profile. Unset → acpx's own `defaultAgent`. |
+| `defaultAgent` | `agent.default` | acpx agent for any node without a pinned profile. Unset → the agent the run used, never acpx's own default. |
 | `reviewers.spec` | `null` | acpx agent profile for the spec-review phase — see §4. |
 | `reviewers.quality` | `null` | acpx agent profile for the quality-review phase. |
 | `escalate.telegram` | `true` | Prefer Telegram for escalations when credentials resolve; else PR/MR comment. |
@@ -346,8 +383,14 @@ You can also redefine a built-in name — useful for a local checkout or extra e
 
 1. the node's pinned profile — `reviewers.spec` / `reviewers.quality`
 2. else `finish.autoFlow.defaultAgent` (passed to acpx as `--default-agent`)
-3. else acpx config `defaultAgent`
-4. else acpx's built-in fallback
+3. else **`agent.default` — the agent the run itself used**
+
+Step 3 is the important one. Setting only `reviewers` used to leave
+`--default-agent` off the argv entirely, so acpx fell back to its *own* default:
+the reviewers ran on the models you named, and every `fix_*` node — the nodes
+that actually edit your code — ran on whatever acpx happened to be configured
+with. The flow now inherits the run's agent instead, so a profile that
+configures only reviewers behaves the way it reads.
 
 Fix nodes (`fix_acceptance`, `fix_spec`, `fix_quality`, `fix_gate`) are never
 pinned — they always use the default agent.

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -281,6 +281,7 @@ post-run driver treats it as non-blocking and logs a warning).
 | `enabled` | `false` | Master gate. |
 | `flowPath` | `flows/nax-finish/nax-finish.flow.ts` | Resolved against the **nax install** first, then your repo (vendor a variant by putting a file at the same relative path), then used as-is if absolute. |
 | `defaultAgent` | `agent.default` | acpx agent for any node without a pinned profile. Unset → the agent the run used, never acpx's own default. |
+| `model` | `null` | acpx `--model` — a run-wide model *floor*. Opt-in; see [Pinning the model](#pinning-the-model). |
 | `reviewers.spec` | `null` | acpx agent profile for the spec-review phase — see §4. |
 | `reviewers.quality` | `null` | acpx agent profile for the quality-review phase. |
 | `escalate.telegram` | `true` | Prefer Telegram for escalations when credentials resolve; else PR/MR comment. |
@@ -394,6 +395,47 @@ configures only reviewers behaves the way it reads.
 
 Fix nodes (`fix_acceptance`, `fix_spec`, `fix_quality`, `fix_gate`) are never
 pinned — they always use the default agent.
+
+### Pinning the model
+
+`agent.default` and `defaultAgent` name an **agent**, never a model. In acpx an
+agent entry carries its own model, so that is where the model normally lives:
+
+```json
+// ~/.acpx/config.json
+"nax-quality-reviewer-codex": {
+  "argv": ["npx", "-y", "@agentclientprotocol/codex-acp@^1.1.5"],
+  "model": "gpt-5.6-terra"
+}
+```
+
+acpx resolves each node's model as:
+
+```
+node.model  ??  agent.model  ??  --model
+```
+
+`finish.autoFlow.model` supplies that last term. It is a **floor, not an
+override**: a reviewer pinned to an agent entry that names its own model keeps
+that model, and `--model` reaches only the nodes with nothing above it — in
+practice the `fix_*` nodes.
+
+```json
+"finish": { "autoFlow": {
+  "defaultAgent": "claude",
+  "model": "sonnet",
+  "reviewers": { "spec": "nax-spec-reviewer-codex", "quality": "nax-quality-reviewer-codex" }
+}}
+```
+
+> **Requires an acpx that reads `model` from agent entries.** That precedence is
+> what keeps `--model` from reaching your reviewers. On a build without it,
+> `agent.model` is always absent, `--model` becomes the only model signal, and it
+> *would* override the reviewers. This is why the key defaults to `null` and is
+> never derived from `config.models` — leave it unset and the argv is unchanged.
+
+A run's own `config.models[agent][tier]` is **not** consulted here. That map is
+tier-keyed and the flow has no tier, so nax does not guess one for you.
 
 Verify a profile resolves before enabling the flow:
 

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -37,7 +37,9 @@ review_quality    code-quality review, isolated session, own agent profile
   ↓
 quality_gates     re-run the feature's acceptance tests (gate zero), then the
                   repo's own quality.commands at the repo root
-  ↳ red → fix_gate (agent) → commit → re-run        [max 3 attempts → escalate]
+  ↳ red → fix_gate (agent) → commit → re-review     [max 3 attempts → escalate]
+          (a gate fix that committed re-enters review_quality; one that
+           changed nothing goes straight back to the gates)
   ↳ none configured → escalate (a gate that verified nothing is not a pass)
   ↓
 open_pr           commit + push the fixes, then open a ready PR
@@ -48,6 +50,17 @@ Every fix node is followed by a `commit_*` node that commits the agent's edits
 locally (no push, `--no-verify`). The reviewers read `git diff <base>...HEAD`, so
 a fix left uncommitted is invisible to the re-review — the loop would re-report
 findings it had already fixed and escalate at the cap ([#1397](https://github.com/nathapp-io/nax/issues/1397)).
+
+Each `commit_*` node writes a commit whose subject names what was fixed and
+whose body lists the findings behind it, so a human reviewing the PR can triage
+the flow's commits without reading every diff. It also appends the round to the
+[audit trail](#audit-trail).
+
+**No fix reaches the PR unreviewed.** The gate loop is the last loop to edit the
+tree, and it used to route straight back to `quality_gates` — which proves the
+repo's commands are green, something a bad fix can satisfy. A gate fix that
+commits now re-enters `review_quality` first. Both loops keep their own 3-attempt
+caps, so the re-entry cannot run away; it costs one review per gate round.
 The fix agent itself is still told not to commit; the flow owns the history.
 
 These are internal checkpoints, so they skip your pre-commit hooks: a hook that
@@ -89,14 +102,48 @@ the redundant run costs seconds against a flow that spends minutes in review.
 | Spec conflict, contradiction, design call, or can't reach green | Partial fixes pushed, escalation sent, **no ready PR**. |
 | Branch not ahead of base | `nothing-to-finish`, stops. |
 
-The terminal state is written to `.nax/nax-finish-result.json`:
+### Audit trail
+
+The flow writes two files per run, under nax's per-project output directory
+alongside `prompt-audit/` and `review-audit/` — not in your repo:
+
+```
+~/.nax/<project>/finish-audit/<feature>/<runId>.jsonl        one line per fix round
+~/.nax/<project>/finish-audit/<feature>/<runId>.result.json  terminal state
+```
+
+A `config.outputDir` override is honoured. Files are named by run id, so
+finishing the same feature twice keeps both trails.
+
+The result file:
 
 ```json
 { "feature": "auth-hardening", "status": "promoted", "url": "https://github.com/o/r/pull/42" }
 ```
 
 `status` is one of `opened`, `promoted`, `already-ready`, `escalated`,
-`nothing-to-finish`. Add it to `.gitignore`.
+`nothing-to-finish`.
+
+Every terminal status — not just `escalated` — carries a `rounds` array
+replaying what the flow fixed to get there. A finish that needed four rounds is
+the case most worth reading afterwards: each round is a defect the run's own
+review gates let through.
+
+```json
+{
+  "feature": "auth-hardening",
+  "status": "promoted",
+  "rounds": [
+    {
+      "ts": "2026-08-01T05:31:00.000Z",
+      "phase": "quality",
+      "attempt": 1,
+      "committed": true,
+      "findings": [{ "severity": "HIGH", "title": "…", "problem": "…", "fix": "…" }]
+    }
+  ]
+}
+```
 
 On `escalated` the file also carries `escalationReason` and the `findings` that
 caused it:

--- a/flows/nax-finish/commit-message.ts
+++ b/flows/nax-finish/commit-message.ts
@@ -1,0 +1,136 @@
+/**
+ * Commit messages for the flow's `commit_<phase>` checkpoints.
+ *
+ * These commits are shipped history — they land on the feature branch and a
+ * human reviews them in the PR. Every one of them used to read
+ * `fix(<feature>): nax-finish <phase> fixes` with an empty body, so a reviewer
+ * looking at six such commits could not tell which one re-enabled a disabled
+ * market gate and which one renamed a variable. The reviewer already produced
+ * exactly the material needed to say so — severity, title, problem, fix — and
+ * it was being discarded at the one moment it could have been recorded.
+ *
+ * Subject lines follow the repo's conventional-commit rule and the 72-column
+ * git summary convention; the findings go in the body, one bullet each.
+ */
+import type { Finding, FinishPhase } from "./types";
+
+/** Git's conventional soft cap for a commit summary line. */
+const MAX_SUBJECT_LEN = 72;
+
+/** Worst-first, so the subject of a mixed batch reports the severity that matters. */
+const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW"] as const;
+
+/** How much gate output to quote in the body before it stops being a commit message. */
+const MAX_GATE_OUTPUT_LINES = 20;
+
+interface MessageCtx {
+  outputs: Record<string, unknown>;
+}
+
+interface PhaseOutputs {
+  findings?: Finding[];
+  failing?: string[];
+  output?: string;
+}
+
+function outputsFor(ctx: MessageCtx, nodeId: string): PhaseOutputs {
+  return (ctx.outputs[nodeId] ?? {}) as PhaseOutputs;
+}
+
+function findingsFor(ctx: MessageCtx, phase: FinishPhase): Finding[] {
+  const raw = outputsFor(ctx, `review_${phase}`).findings;
+  return Array.isArray(raw) ? raw.filter((f): f is Finding => Boolean(f?.title)) : [];
+}
+
+function worstSeverity(findings: Finding[]): string {
+  const present = new Set(findings.map((f) => f.severity));
+  return SEVERITY_ORDER.find((s) => present.has(s)) ?? findings[0]?.severity ?? "LOW";
+}
+
+/**
+ * Lowercase a finding title's leading word for the subject line.
+ *
+ * Reviewers write titles as sentences ("Market gate skip branch is
+ * unreachable"); conventional-commit subjects read better in lower case. Only
+ * the first character is touched — an all-caps leading token is an acronym
+ * (`SSRF guard …`) and must survive intact.
+ */
+function subjectCase(title: string): string {
+  const [first = "", ...rest] = title.split(" ");
+  const isAcronym = first.length > 1 && first === first.toUpperCase();
+  return isAcronym
+    ? title
+    : `${first.charAt(0).toLowerCase()}${first.slice(1)}${rest.length ? ` ${rest.join(" ")}` : ""}`;
+}
+
+function truncate(s: string): string {
+  return s.length <= MAX_SUBJECT_LEN ? s : `${s.slice(0, MAX_SUBJECT_LEN - 3)}...`;
+}
+
+/** "lint and test", "lint, test and typecheck" — a readable list for the subject. */
+function humanList(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+}
+
+function reviewSubject(phase: FinishPhase, findings: Finding[]): string {
+  if (findings.length === 1) return subjectCase(findings[0].title);
+  return `address ${findings.length} ${phase} review findings (worst: ${worstSeverity(findings)})`;
+}
+
+function subjectFor(phase: FinishPhase, ctx: MessageCtx): string {
+  if (phase === "gate") {
+    const failing = outputsFor(ctx, "quality_gates").failing ?? [];
+    return failing.length > 0 ? `repair failing ${humanList(failing)} gates` : "repair failing quality gates";
+  }
+  if (phase === "acceptance") return "repair failing acceptance tests";
+  const findings = findingsFor(ctx, phase);
+  return findings.length > 0 ? reviewSubject(phase, findings) : `apply ${phase} review fixes`;
+}
+
+function bodyFor(phase: FinishPhase, ctx: MessageCtx): string[] {
+  if (phase === "gate") {
+    const gate = outputsFor(ctx, "quality_gates");
+    const failing = gate.failing ?? [];
+    const tail = (gate.output ?? "").trim().split("\n").slice(-MAX_GATE_OUTPUT_LINES).join("\n");
+    return [...(failing.length > 0 ? [`Failing: ${failing.join(", ")}`] : []), ...(tail ? [tail] : [])];
+  }
+  if (phase === "acceptance") {
+    const tail = (outputsFor(ctx, "acceptance").output ?? "")
+      .trim()
+      .split("\n")
+      .slice(-MAX_GATE_OUTPUT_LINES)
+      .join("\n");
+    return tail ? [tail] : [];
+  }
+  const findings = findingsFor(ctx, phase);
+  if (findings.length === 0) return [];
+  return [
+    findings
+      .map((f) =>
+        [`- [${f.severity}] ${f.title}`, f.problem ? `  ${f.problem}` : "", f.fix ? `  Fix: ${f.fix}` : ""]
+          .filter(Boolean)
+          .join("\n"),
+      )
+      .join("\n"),
+  ];
+}
+
+/** Human-readable phase label for the attribution trailer. */
+function phaseLabel(phase: FinishPhase): string {
+  return phase === "gate" ? "quality gate" : phase === "acceptance" ? "acceptance" : `${phase} review`;
+}
+
+/**
+ * Build the commit message for a `commit_<phase>` checkpoint.
+ *
+ * Never throws and never returns an empty subject: a missing or malformed
+ * reviewer output degrades to the phase label. A commit that cannot be
+ * described is still a commit that must happen — failing here would strand the
+ * fix uncommitted and reintroduce the stale-diff bug (#1397).
+ */
+export function buildFixCommitMessage(phase: FinishPhase, feature: string, ctx: MessageCtx): string {
+  const subject = truncate(`fix(${feature}): ${subjectFor(phase, ctx)}`);
+  const body = bodyFor(phase, ctx);
+  return [subject, ...body, `nax-finish: ${phaseLabel(phase)} fixes`].join("\n\n");
+}

--- a/flows/nax-finish/flow-ctx.ts
+++ b/flows/nax-finish/flow-ctx.ts
@@ -6,17 +6,22 @@
  * functions of `ctx.input` / `ctx.outputs` / `ctx.state.steps`; anything that
  * shells out lives under `./steps/`.
  *
- * The recurring constraint they exist to work around: acpx keeps only the
- * **latest** output per node id. In a graph whose whole shape is loops, that
- * means a node's own previous-round output is gone by the time it runs again,
- * and `ctx.state.steps` — the ordered history — is the only record of what
- * happened when.
+ * Two views of the same run, and the difference matters in a graph whose whole
+ * shape is loops:
+ *
+ * - `ctx.outputs` is a map keyed by node id, so it holds only each node's
+ *   **latest** output. A node re-entering a loop cannot see its own previous
+ *   round there.
+ * - `ctx.state.steps` is the ordered history and carries every step's `output`,
+ *   so an earlier round IS recoverable from it. A step is appended on its
+ *   *outcome*, so the currently-executing node is never in this list — which is
+ *   what lets `incrementalSince` find the *previous* review rather than itself.
  */
 import type { AcceptanceGroup, Finding, FinishInput, FinishPhase, ReviewVerdict } from "./types";
 
 /** Minimal shapes so each reader takes only the part of the context it reads. */
 export interface StepsCtx {
-  state: { steps: { nodeId: string }[] };
+  state: { steps: { nodeId: string; output?: unknown }[] };
 }
 export interface OutputsCtx {
   outputs: unknown;
@@ -62,26 +67,29 @@ export function findingsOf(ctx: OutputsCtx, phase: FinishPhase): Finding[] {
  * A reviewer node re-reads the spec in full and the entire `git diff
  * base...HEAD` on every round. Reviews were 58% of the wall clock on
  * rs-stock/pipeline-run-outcome (7 calls, 1306s of 2232s), and round 3 re-read
- * everything rounds 1–2 had already cleared. When exactly one `commit_*` ran
- * since this phase last reviewed, that commit's `shaBefore` *is* the tree the
- * previous review passed on, so the new work is `shaBefore..HEAD` and the round
- * can be scoped to it.
+ * everything rounds 1-2 had already cleared.
  *
- * Returns null — a full review — whenever that identity does not hold:
- *   - no prior review of this phase (round 1)
- *   - no commit since it, so there is nothing new to look at anyway
- *   - two or more commit nodes since it. `ctx.outputs` keeps only the latest
- *     output per node id, so the *earliest* commit's `shaBefore` in that window
- *     may already be lost; guessing would silently under-scope the review.
- *     (Happens when the acceptance loop commits between a spec fix and its
- *     re-review.)
+ * The scoping ref is the `shaBefore` of the **first** `commit_*` step after this
+ * phase's last review — that commit's parent is, by construction, the tree the
+ * previous verdict passed on, since only `commit_*` nodes commit. Taking the
+ * first (not the last) is what makes the window complete when more than one
+ * commit landed in it, which happens when the acceptance loop commits between a
+ * spec fix and its re-review: `firstCommit.shaBefore..HEAD` spans both.
+ *
+ * Read from `ctx.state.steps[].output`, not `ctx.outputs` — the latter keeps
+ * only each node's newest output, which for two commit steps of the same node id
+ * would have discarded the earlier `shaBefore` and silently under-scoped the
+ * review.
+ *
+ * Returns null — a full review — when there is no prior review of this phase
+ * (round 1), no commit since it (nothing new to look at), or the commit step
+ * recorded no `shaBefore`.
  */
 export function incrementalSince(ctx: OutputsCtx & StepsCtx, phase: "spec" | "quality"): string | null {
   const steps = ctx.state.steps ?? [];
   const lastReview = steps.map((s) => s.nodeId).lastIndexOf(`review_${phase}`);
   if (lastReview < 0) return null;
-  const commitsSince = steps.slice(lastReview + 1).filter((s) => s.nodeId.startsWith("commit_"));
-  if (commitsSince.length !== 1) return null;
-  const out = (ctx.outputs as Record<string, { shaBefore?: string | null } | undefined>)[commitsSince[0].nodeId];
-  return out?.shaBefore ?? null;
+  const firstCommit = steps.slice(lastReview + 1).find((s) => s.nodeId.startsWith("commit_"));
+  if (!firstCommit) return null;
+  return (firstCommit.output as { shaBefore?: string | null } | undefined)?.shaBefore ?? null;
 }

--- a/flows/nax-finish/flow-ctx.ts
+++ b/flows/nax-finish/flow-ctx.ts
@@ -1,0 +1,87 @@
+/**
+ * Readers over an acpx `FlowNodeContext` — the flow graph's view of its own
+ * state.
+ *
+ * Split out of `nax-finish.flow.ts` (600-line source cap). These are all pure
+ * functions of `ctx.input` / `ctx.outputs` / `ctx.state.steps`; anything that
+ * shells out lives under `./steps/`.
+ *
+ * The recurring constraint they exist to work around: acpx keeps only the
+ * **latest** output per node id. In a graph whose whole shape is loops, that
+ * means a node's own previous-round output is gone by the time it runs again,
+ * and `ctx.state.steps` — the ordered history — is the only record of what
+ * happened when.
+ */
+import type { AcceptanceGroup, Finding, FinishInput, FinishPhase, ReviewVerdict } from "./types";
+
+/** Minimal shapes so each reader takes only the part of the context it reads. */
+export interface StepsCtx {
+  state: { steps: { nodeId: string }[] };
+}
+export interface OutputsCtx {
+  outputs: unknown;
+}
+
+export const inputOf = (ctx: { input: unknown }) => ctx.input as FinishInput;
+
+/** What `load_ctx` resolves once, for every downstream node to read. */
+export interface LoadCtxOutput {
+  base?: string;
+  specPath?: string;
+  groups?: AcceptanceGroup[];
+  /** `nax features resolve`'s acceptance status: "ok" | "disabled" | "no-prd". */
+  acceptanceStatus?: string;
+  /** Test-file regex sources from `nax features resolve`; empty = cannot classify. */
+  testFileRegex?: string[];
+  route?: string;
+}
+
+export function fixAttemptCount(ctx: StepsCtx, fixNodeId: string): number {
+  return (ctx.state.steps ?? []).filter((s) => s.nodeId === fixNodeId).length;
+}
+
+export function loadCtxOf(ctx: OutputsCtx): LoadCtxOutput {
+  return ((ctx.outputs as Record<string, LoadCtxOutput | undefined>).load_ctx ?? {}) as LoadCtxOutput;
+}
+
+export function gateOutputs(ctx: OutputsCtx): { failing?: string[] } {
+  return ((ctx.outputs as Record<string, { failing?: string[] } | undefined>).quality_gates ?? {}) as {
+    failing?: string[];
+  };
+}
+
+/** The findings the `fix_<phase>` node was asked to resolve; empty for non-review phases. */
+export function findingsOf(ctx: OutputsCtx, phase: FinishPhase): Finding[] {
+  if (phase !== "spec" && phase !== "quality") return [];
+  return (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`]?.findings ?? [];
+}
+
+/**
+ * The ref a re-review should diff from, or null to review the whole branch.
+ *
+ * A reviewer node re-reads the spec in full and the entire `git diff
+ * base...HEAD` on every round. Reviews were 58% of the wall clock on
+ * rs-stock/pipeline-run-outcome (7 calls, 1306s of 2232s), and round 3 re-read
+ * everything rounds 1–2 had already cleared. When exactly one `commit_*` ran
+ * since this phase last reviewed, that commit's `shaBefore` *is* the tree the
+ * previous review passed on, so the new work is `shaBefore..HEAD` and the round
+ * can be scoped to it.
+ *
+ * Returns null — a full review — whenever that identity does not hold:
+ *   - no prior review of this phase (round 1)
+ *   - no commit since it, so there is nothing new to look at anyway
+ *   - two or more commit nodes since it. `ctx.outputs` keeps only the latest
+ *     output per node id, so the *earliest* commit's `shaBefore` in that window
+ *     may already be lost; guessing would silently under-scope the review.
+ *     (Happens when the acceptance loop commits between a spec fix and its
+ *     re-review.)
+ */
+export function incrementalSince(ctx: OutputsCtx & StepsCtx, phase: "spec" | "quality"): string | null {
+  const steps = ctx.state.steps ?? [];
+  const lastReview = steps.map((s) => s.nodeId).lastIndexOf(`review_${phase}`);
+  if (lastReview < 0) return null;
+  const commitsSince = steps.slice(lastReview + 1).filter((s) => s.nodeId.startsWith("commit_"));
+  if (commitsSince.length !== 1) return null;
+  const out = (ctx.outputs as Record<string, { shaBefore?: string | null } | undefined>)[commitsSince[0].nodeId];
+  return out?.shaBefore ?? null;
+}

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -40,6 +40,7 @@
  */
 import { defineFlow, extractJsonObject } from "acpx/flows";
 import { buildFixCommitMessage } from "./commit-message";
+import { findingsOf, fixAttemptCount, gateOutputs, incrementalSince, inputOf, loadCtxOf } from "./flow-ctx";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
 import {
   _contextDeps,
@@ -48,8 +49,10 @@ import {
   commitAndPush,
   commitFixes,
   detectBaseBranch,
+  filesInCommit,
   loadQualityCommands,
   openOrPromotePr,
+  partitionTestFiles,
   postEscalation,
   preflight,
   resolveFeature,
@@ -57,9 +60,7 @@ import {
   runQualityGates,
   writeResult,
 } from "./steps";
-import type { AcceptanceGroup, Finding, FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
-
-const inputOf = (ctx: { input: unknown }) => ctx.input as FinishInput;
+import type { FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
 
 /**
  * Cap on fix-and-reverify iterations, per phase, before escalating instead of
@@ -68,35 +69,6 @@ const inputOf = (ctx: { input: unknown }) => ctx.input as FinishInput;
  * time) hangs `acpx flow run` — and the post-run plugin awaits that subprocess.
  */
 const MAX_FIX_ATTEMPTS = 3;
-
-interface LoadCtxOutput {
-  base?: string;
-  specPath?: string;
-  groups?: AcceptanceGroup[];
-  /** `nax features resolve`'s acceptance status: "ok" | "disabled" | "no-prd". */
-  acceptanceStatus?: string;
-  route?: string;
-}
-
-function fixAttemptCount(ctx: { state: { steps: { nodeId: string }[] } }, fixNodeId: string): number {
-  return (ctx.state.steps ?? []).filter((s) => s.nodeId === fixNodeId).length;
-}
-
-function loadCtxOf(ctx: { outputs: unknown }): LoadCtxOutput {
-  return ((ctx.outputs as Record<string, LoadCtxOutput | undefined>).load_ctx ?? {}) as LoadCtxOutput;
-}
-
-function gateOutputs(ctx: { outputs: unknown }): { failing?: string[] } {
-  return ((ctx.outputs as Record<string, { failing?: string[] } | undefined>).quality_gates ?? {}) as {
-    failing?: string[];
-  };
-}
-
-/** The findings the `fix_<phase>` node was asked to resolve; empty for non-review phases. */
-function findingsOf(ctx: { outputs: unknown }, phase: FinishPhase): Finding[] {
-  if (phase !== "spec" && phase !== "quality") return [];
-  return (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`]?.findings ?? [];
-}
 
 /**
  * Re-run the acceptance gate, routing on the shared fix-cap rules.
@@ -195,6 +167,45 @@ function routeReview(
  * output per node, so a round not recorded here is a round no terminal node
  * can reconstruct.
  */
+/**
+ * Route for `commit_gate`, whose successor depends on what the fix touched.
+ *
+ * - `unchanged` — nothing committed; no new diff, so nothing to review.
+ * - `tests-only` — every touched path matched the repo's test-file patterns.
+ *   Skipped by explicit choice: the re-review is the flow's most expensive node
+ *   and a gate fix is usually a mechanical test repair. **This is a real hole.**
+ *   The defect that motivated the re-entry (rs-stock `b6fb66dd`) was itself
+ *   test-only — 8 copy-pasted stubs across 3 test files — so this route would
+ *   not have caught it. Widen it here if test-quality regressions start
+ *   shipping.
+ * - `changed` — production code was touched, or the paths could not be
+ *   classified at all. "Cannot classify" reviews rather than skips.
+ */
+async function gateCommitRoute(
+  i: FinishInput,
+  committed: boolean,
+  shaAfter: string | null,
+  testFileRegex: string[],
+): Promise<string> {
+  if (!committed || !shaAfter) return "unchanged";
+  const files = await filesInCommit(i.workdir, shaAfter);
+  if (files.length === 0) return "changed";
+  return partitionTestFiles(files, testFileRegex).nonTest.length > 0 ? "changed" : "tests-only";
+}
+
+/**
+ * Build the `commit_<phase>` node that follows `fix_<phase>`.
+ *
+ * One node per phase rather than a single shared one because each returns to a
+ * different successor, and acpx routes on the node id — a shared node would
+ * need a switch reconstructing which fix ran from the step history.
+ *
+ * Also the audit seam: this is the only point in the graph where a round's
+ * findings and its commit are both known. `ctx.outputs` keeps only the latest
+ * output per node, so a round not recorded here is a round no terminal node
+ * can reconstruct. `shaBefore` is recorded for the same reason — it is what the
+ * next review of this phase diffs from (see `incrementalSince`).
+ */
 function commitFixNode(phase: FinishPhase) {
   return {
     nodeType: "action" as const,
@@ -202,15 +213,17 @@ function commitFixNode(phase: FinishPhase) {
       input: unknown;
       outputs: unknown;
       state: { steps: { nodeId: string }[] };
-    }): Promise<{ committed: boolean; route: string }> {
+    }): Promise<{ committed: boolean; route: string; shaBefore: string | null; shaAfter: string | null }> {
       const i = inputOf(ctx);
       const messageCtx = { outputs: ctx.outputs as Record<string, unknown> };
       // skipHooks: an intermediate checkpoint must not be rejected by a repo's
       // pre-commit hook — quality_gates runs the repo's real gates before any
       // PR opens, and a hook failure here would kill the flow mid-loop.
-      const { committed } = await commitFixes(i.workdir, buildFixCommitMessage(phase, i.feature, messageCtx), {
-        skipHooks: true,
-      });
+      const { committed, shaBefore, shaAfter } = await commitFixes(
+        i.workdir,
+        buildFixCommitMessage(phase, i.feature, messageCtx),
+        { skipHooks: true },
+      );
       await appendRound(i, {
         ts: new Date().toISOString(),
         phase,
@@ -219,10 +232,15 @@ function commitFixNode(phase: FinishPhase) {
         findings: findingsOf(ctx, phase),
         ...(phase === "gate" ? { failing: gateOutputs(ctx).failing ?? [] } : {}),
       });
-      // `route` exists for `commit_gate`, whose successor depends on whether
-      // anything actually changed (see the edge list). The other phases route
-      // unconditionally and ignore it.
-      return { committed, route: committed ? "changed" : "unchanged" };
+      // Only `commit_gate` routes on this; the other phases have unconditional
+      // edges and ignore it.
+      const route =
+        phase === "gate"
+          ? await gateCommitRoute(i, committed, shaAfter, loadCtxOf(ctx).testFileRegex ?? [])
+          : committed
+            ? "changed"
+            : "unchanged";
+      return { committed, route, shaBefore, shaAfter };
     },
   };
 }
@@ -256,6 +274,7 @@ export default defineFlow({
           specPath: resolution.specPath,
           acceptanceStatus: resolution.acceptanceStatus,
           groups: resolution.groups,
+          testFileRegex: resolution.testFileRegex,
           commitsAhead: pf.commitsAhead,
           route: pf.route,
         };
@@ -277,7 +296,12 @@ export default defineFlow({
       profile: process.env.NAX_FINISH_SPEC_PROFILE || undefined,
       prompt(ctx) {
         const outs = loadCtxOf(ctx);
-        return buildReviewPrompt("spec", { base: outs.base ?? "origin/main", specPath: outs.specPath ?? "" });
+        return buildReviewPrompt("spec", {
+          base: outs.base ?? "origin/main",
+          specPath: outs.specPath ?? "",
+          since: incrementalSince(ctx, "spec"),
+          priorFindings: findingsOf(ctx, "spec"),
+        });
       },
       parse: parseVerdict,
     },
@@ -297,7 +321,12 @@ export default defineFlow({
       profile: process.env.NAX_FINISH_QUALITY_PROFILE || undefined,
       prompt(ctx) {
         const outs = loadCtxOf(ctx);
-        return buildReviewPrompt("quality", { base: outs.base ?? "origin/main", specPath: outs.specPath ?? "" });
+        return buildReviewPrompt("quality", {
+          base: outs.base ?? "origin/main",
+          specPath: outs.specPath ?? "",
+          since: incrementalSince(ctx, "quality"),
+          priorFindings: findingsOf(ctx, "quality"),
+        });
       },
       parse: parseVerdict,
     },
@@ -522,7 +551,10 @@ export default defineFlow({
     // turn to re-report what route_quality already called clean.
     {
       from: "commit_gate",
-      switch: { on: "$.route", cases: { changed: "review_quality", unchanged: "quality_gates" } },
+      switch: {
+        on: "$.route",
+        cases: { changed: "review_quality", "tests-only": "quality_gates", unchanged: "quality_gates" },
+      },
     },
   ],
 });

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -31,11 +31,19 @@
  *   the `acceptance` node last passed, and the repo-root `test` command does
  *   not cover per-feature acceptance tests — so without this a fix could break
  *   the contract the first gate proved and still ship.
+ * - `commit_gate` re-enters `review_quality` when it committed anything, so no
+ *   fix reaches the PR unreviewed — the gate loop was previously the one
+ *   editing loop whose output only ever faced mechanical checks.
+ * - Every `commit_*` node appends its round to the finish-audit trail. That is
+ *   the only place a round's findings and its commit are both in scope:
+ *   `ctx.outputs` holds one output per node, so the next round overwrites it.
  */
 import { defineFlow, extractJsonObject } from "acpx/flows";
+import { buildFixCommitMessage } from "./commit-message";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
 import {
   _contextDeps,
+  appendRound,
   buildEscalationComment,
   commitAndPush,
   commitFixes,
@@ -49,7 +57,7 @@ import {
   runQualityGates,
   writeResult,
 } from "./steps";
-import type { AcceptanceGroup, FinishInput, FinishResult, ReviewVerdict } from "./types";
+import type { AcceptanceGroup, Finding, FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
 
 const inputOf = (ctx: { input: unknown }) => ctx.input as FinishInput;
 
@@ -76,6 +84,18 @@ function fixAttemptCount(ctx: { state: { steps: { nodeId: string }[] } }, fixNod
 
 function loadCtxOf(ctx: { outputs: unknown }): LoadCtxOutput {
   return ((ctx.outputs as Record<string, LoadCtxOutput | undefined>).load_ctx ?? {}) as LoadCtxOutput;
+}
+
+function gateOutputs(ctx: { outputs: unknown }): { failing?: string[] } {
+  return ((ctx.outputs as Record<string, { failing?: string[] } | undefined>).quality_gates ?? {}) as {
+    failing?: string[];
+  };
+}
+
+/** The findings the `fix_<phase>` node was asked to resolve; empty for non-review phases. */
+function findingsOf(ctx: { outputs: unknown }, phase: FinishPhase): Finding[] {
+  if (phase !== "spec" && phase !== "quality") return [];
+  return (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`]?.findings ?? [];
 }
 
 /**
@@ -169,16 +189,40 @@ function routeReview(
  * One node per phase rather than a single shared one because each returns to a
  * different successor, and acpx routes on the node id — a shared node would
  * need a switch reconstructing which fix ran from the step history.
+ *
+ * Also the audit seam: this is the only point in the graph where a round's
+ * findings and its commit are both known. `ctx.outputs` keeps only the latest
+ * output per node, so a round not recorded here is a round no terminal node
+ * can reconstruct.
  */
-function commitFixNode(phase: "acceptance" | "spec" | "quality" | "gate") {
+function commitFixNode(phase: FinishPhase) {
   return {
     nodeType: "action" as const,
-    async run(ctx: { input: unknown }): Promise<{ committed: boolean }> {
+    async run(ctx: {
+      input: unknown;
+      outputs: unknown;
+      state: { steps: { nodeId: string }[] };
+    }): Promise<{ committed: boolean; route: string }> {
       const i = inputOf(ctx);
+      const messageCtx = { outputs: ctx.outputs as Record<string, unknown> };
       // skipHooks: an intermediate checkpoint must not be rejected by a repo's
       // pre-commit hook — quality_gates runs the repo's real gates before any
       // PR opens, and a hook failure here would kill the flow mid-loop.
-      return commitFixes(i.workdir, `fix(${i.feature}): nax-finish ${phase} fixes`, { skipHooks: true });
+      const { committed } = await commitFixes(i.workdir, buildFixCommitMessage(phase, i.feature, messageCtx), {
+        skipHooks: true,
+      });
+      await appendRound(i, {
+        ts: new Date().toISOString(),
+        phase,
+        attempt: fixAttemptCount(ctx, `fix_${phase}`),
+        committed,
+        findings: findingsOf(ctx, phase),
+        ...(phase === "gate" ? { failing: gateOutputs(ctx).failing ?? [] } : {}),
+      });
+      // `route` exists for `commit_gate`, whose successor depends on whether
+      // anything actually changed (see the edge list). The other phases route
+      // unconditionally and ignore it.
+      return { committed, route: committed ? "changed" : "unchanged" };
     },
   };
 }
@@ -350,7 +394,7 @@ export default defineFlow({
       async run(ctx) {
         const i = inputOf(ctx);
         if (loadCtxOf(ctx).route === "nothing-to-finish") {
-          await writeResult(i.workdir, { feature: i.feature, status: "nothing-to-finish" });
+          await writeResult(i, { feature: i.feature, status: "nothing-to-finish" });
           return { route: "done", status: "nothing-to-finish" };
         }
         // Every fix node edited the working tree; without this the PR would be
@@ -362,7 +406,7 @@ export default defineFlow({
           `nax-finish: ${i.feature}`,
           `Automated finish of \`${i.feature}\`.`,
         );
-        await writeResult(i.workdir, { feature: i.feature, status: r.status, url: r.url });
+        await writeResult(i, { feature: i.feature, status: r.status, url: r.url });
         return { route: "done", committed: sync.committed, ...r };
       },
     },
@@ -409,7 +453,7 @@ export default defineFlow({
           escalationReason: reason,
           findings: verdict?.findings ?? [],
         };
-        await writeResult(i.workdir, result);
+        await writeResult(i, result);
 
         const comment = buildEscalationComment(i.feature, reason, verdict?.findings ?? []) + syncNote;
         let url: string | undefined;
@@ -424,7 +468,7 @@ export default defineFlow({
         } catch (err) {
           deliveryError = String(err);
         }
-        await writeResult(i.workdir, { ...result, url, deliveryError });
+        await writeResult(i, { ...result, url, deliveryError });
 
         return { route: "done", url, channel, deliveryError, escalationReason: reason };
       },
@@ -464,6 +508,21 @@ export default defineFlow({
       switch: { on: "$.route", cases: { green: "open_pr", fix: "fix_gate", escalate: "escalate" } },
     },
     { from: "fix_gate", to: "commit_gate" },
-    { from: "commit_gate", to: "quality_gates" },
+    // A gate fix that changed code goes back through the quality reviewer, not
+    // straight to the gates. The gate loop is the last one to edit the tree and
+    // was the only one whose edits nothing reviewed: `quality_gates` proves the
+    // repo's commands are green, which a bad fix can satisfy. Observed on
+    // rs-stock/pipeline-run-outcome — the gate round repaired 8 tests by
+    // copy-pasting an identical 4-line stub into each, and it shipped, because
+    // no reviewer ran after it. Re-entry costs one review per gate round; both
+    // loops stay bounded by their own MAX_FIX_ATTEMPTS caps.
+    //
+    // `unchanged` skips it: with nothing committed there is no new diff to
+    // review, and re-running the reviewer on an identical tree would burn a
+    // turn to re-report what route_quality already called clean.
+    {
+      from: "commit_gate",
+      switch: { on: "$.route", cases: { changed: "review_quality", unchanged: "quality_gates" } },
+    },
   ],
 });

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -31,12 +31,15 @@
  *   the `acceptance` node last passed, and the repo-root `test` command does
  *   not cover per-feature acceptance tests — so without this a fix could break
  *   the contract the first gate proved and still ship.
- * - `commit_gate` re-enters `review_quality` when it committed anything, so no
- *   fix reaches the PR unreviewed — the gate loop was previously the one
- *   editing loop whose output only ever faced mechanical checks.
- * - Every `commit_*` node appends its round to the finish-audit trail. That is
- *   the only place a round's findings and its commit are both in scope:
- *   `ctx.outputs` holds one output per node, so the next round overwrites it.
+ * - `commit_gate` re-enters `review_quality` when its fix touched non-test code
+ *   — the gate loop was previously the one editing loop whose output only ever
+ *   faced mechanical checks. A test-only fix skips the re-review by explicit
+ *   cost tradeoff; see `gateCommitRoute` for why that is a known hole.
+ * - Every `commit_*` node appends its round to the finish-audit trail as it
+ *   happens, rather than a terminal node reconstructing them from
+ *   `ctx.state.steps`. Appending live is what makes the trail survive a flow
+ *   that is killed or times out — no terminal node runs on that path, and a
+ *   crashed finish is exactly when the record of what it changed matters most.
  */
 import { defineFlow, extractJsonObject } from "acpx/flows";
 import { buildFixCommitMessage } from "./commit-message";
@@ -187,7 +190,12 @@ async function gateCommitRoute(
   shaAfter: string | null,
   testFileRegex: string[],
 ): Promise<string> {
-  if (!committed || !shaAfter) return "unchanged";
+  if (!committed) return "unchanged";
+  // Committed, but HEAD did not resolve: the fix is real and unclassifiable, so
+  // it must be reviewed. Folding this into the `!committed` branch would skip
+  // the review for a change that actually landed — the one direction this
+  // function must never fail in.
+  if (!shaAfter) return "changed";
   const files = await filesInCommit(i.workdir, shaAfter);
   if (files.length === 0) return "changed";
   return partitionTestFiles(files, testFileRegex).nonTest.length > 0 ? "changed" : "tests-only";

--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -1,3 +1,5 @@
+import type { Finding } from "./types";
+
 export const SPEC_REVIEW_DIMENSIONS = `# Spec-relative review dimensions
 
 Reference for the post-impl-review **spec-relative** pass: Compliance, Drift,
@@ -310,12 +312,48 @@ const JSON_CONTRACT = [
   "}",
 ].join("\n");
 
-export function buildReviewPrompt(phase: "spec" | "quality", args: { base: string; specPath: string }): string {
+/**
+ * Build the reviewer prompt.
+ *
+ * With `since` set this is a **re-review**: the same reviewer already read the
+ * whole branch and raised `priorFindings`, a fix was applied and committed, and
+ * the only new material is `since..HEAD`. Re-reading the full branch diff every
+ * round made reviews 58% of the flow's wall clock, most of it re-reading code an
+ * earlier round had already cleared. The narrowed round still has the full repo
+ * available — it is told to open whatever the fix touches — it just is not asked
+ * to re-derive a verdict on unchanged code.
+ *
+ * `since` is only ever supplied when exactly one commit separates the two
+ * reviews (see `incrementalSince`), so `since..HEAD` provably contains every
+ * change made since the previous verdict.
+ */
+export function buildReviewPrompt(
+  phase: "spec" | "quality",
+  args: { base: string; specPath: string; since?: string | null; priorFindings?: Finding[] },
+): string {
   const dims = phase === "spec" ? SPEC_REVIEW_DIMENSIONS : QUALITY_REVIEW_DIMENSIONS;
+  if (!args.since) {
+    return [
+      `You are the ${phase.toUpperCase()} reviewer for a completed feature.`,
+      `The spec/requirements source is: ${args.specPath}. Read it in full.`,
+      `Fetch and review the diff: \`git diff ${args.base}...HEAD\` (also \`--name-only\` for the file list).`,
+      WORKER_PROTOCOL,
+      dims,
+      CLASSIFIER,
+      JSON_CONTRACT,
+    ].join("\n\n");
+  }
   return [
-    `You are the ${phase.toUpperCase()} reviewer for a completed feature.`,
-    `The spec/requirements source is: ${args.specPath}. Read it in full.`,
-    `Fetch and review the diff: \`git diff ${args.base}...HEAD\` (also \`--name-only\` for the file list).`,
+    `You are the ${phase.toUpperCase()} reviewer for a completed feature, continuing a review you already started.`,
+    `On your previous pass over \`git diff ${args.base}...HEAD\` you raised the findings below, and they have since been fixed and committed. Everything else in that diff you already judged acceptable — do not re-derive a verdict on it.`,
+    `Your findings from the previous pass:\n${JSON.stringify(args.priorFindings ?? [], null, 2)}`,
+    `The fix is \`git diff ${args.since}..HEAD\` — this is the only code that has changed since your last verdict. Review it, and only it, for two questions:`,
+    [
+      "1. **Resolved?** Does the fix actually resolve each finding above? A finding that was papered over (assertion weakened, test deleted, check disabled) is NOT resolved — re-raise it.",
+      "2. **Broken?** Did the fix introduce a new problem, in the changed lines or in the unchanged code they now call into?",
+      "",
+      `Read whatever files you need — the spec is at ${args.specPath} and the whole repo is available. Scope means *what you judge*, not *what you may read*.`,
+    ].join("\n"),
     WORKER_PROTOCOL,
     dims,
     CLASSIFIER,

--- a/flows/nax-finish/steps/context.ts
+++ b/flows/nax-finish/steps/context.ts
@@ -17,6 +17,13 @@ export interface FeatureResolution {
   specKind: "markdown" | "prd";
   acceptanceStatus: string;
   groups: AcceptanceGroup[];
+  /**
+   * Test-file classification regexes, as sources, from `nax features resolve`
+   * (the ADR-009 SSOT). Empty when the CLI is older than the field or could not
+   * resolve them — callers must treat empty as "cannot classify", never as
+   * "nothing is a test file".
+   */
+  testFileRegex: string[];
 }
 
 /**
@@ -30,6 +37,7 @@ export async function resolveFeature(feature: string, workdir: string): Promise<
   let parsed: {
     specSource?: { kind: "markdown" | "prd"; path: string };
     acceptance?: { status?: string; groups?: AcceptanceGroup[] };
+    testPatterns?: { regex?: string[] };
   };
   try {
     parsed = JSON.parse(res.stdout);
@@ -51,7 +59,37 @@ export async function resolveFeature(feature: string, workdir: string): Promise<
     specKind: parsed.specSource.kind,
     acceptanceStatus: parsed.acceptance?.status ?? "no-prd",
     groups: parsed.acceptance?.groups ?? [],
+    testFileRegex: parsed.testPatterns?.regex ?? [],
   };
+}
+
+/**
+ * Split paths into test and non-test, using the regexes `nax features resolve`
+ * reported.
+ *
+ * With no patterns (older nax, or a config the resolver choked on) every path is
+ * reported as non-test. That is the safe direction for the one caller: the gate
+ * loop skips its re-review only for a test-only change, so "cannot classify"
+ * must mean "review it", never "skip it".
+ *
+ * An unparseable regex source is skipped rather than thrown — a bad pattern in
+ * one config entry must not take the flow down mid-loop.
+ */
+export function partitionTestFiles(paths: string[], regexSources: string[]): { test: string[]; nonTest: string[] } {
+  const matchers: RegExp[] = [];
+  for (const src of regexSources) {
+    try {
+      matchers.push(new RegExp(src));
+    } catch {
+      // Skip — see the doc comment above.
+    }
+  }
+  const test: string[] = [];
+  const nonTest: string[] = [];
+  for (const p of paths) {
+    (matchers.some((re) => re.test(p)) ? test : nonTest).push(p);
+  }
+  return { test, nonTest };
 }
 
 export async function preflight(

--- a/flows/nax-finish/steps/git.ts
+++ b/flows/nax-finish/steps/git.ts
@@ -58,12 +58,35 @@ async function isDirty(repoRoot: string): Promise<boolean> {
  * A failing commit still throws: the fix is then unreviewable, and continuing
  * would silently reproduce the stale-diff bug this exists to fix.
  */
+/** Current HEAD sha, or null outside a repo / on an unborn branch. */
+async function headSha(repoRoot: string): Promise<string | null> {
+  const res = await _gitDeps.run(["git", "rev-parse", "HEAD"], { cwd: repoRoot });
+  return res.exitCode === 0 ? res.stdout.trim() || null : null;
+}
+
+/**
+ * Repo-root-relative paths touched by a commit.
+ *
+ * `--format=` suppresses the header so the output is just the file list.
+ * Failure yields `[]`, which the gate loop reads as "cannot tell what changed"
+ * and therefore reviews — see `partitionTestFiles`.
+ */
+export async function filesInCommit(repoRoot: string, sha: string): Promise<string[]> {
+  const res = await _gitDeps.run(["git", "show", "--name-only", "--format=", sha], { cwd: repoRoot });
+  if (res.exitCode !== 0) return [];
+  return res.stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
 export async function commitFixes(
   repoRoot: string,
   message: string,
   opts: { skipHooks?: boolean } = {},
-): Promise<{ committed: boolean }> {
-  if (!(await isDirty(repoRoot))) return { committed: false };
+): Promise<{ committed: boolean; shaBefore: string | null; shaAfter: string | null }> {
+  const shaBefore = await headSha(repoRoot);
+  if (!(await isDirty(repoRoot))) return { committed: false, shaBefore, shaAfter: shaBefore };
 
   const add = await _gitDeps.run(["git", "add", "-A"], { cwd: repoRoot });
   if (add.exitCode !== 0) {
@@ -82,7 +105,7 @@ export async function commitFixes(
       { stage: "finish-git", repoRoot },
     );
   }
-  return { committed: true };
+  return { committed: true, shaBefore, shaAfter: await headSha(repoRoot) };
 }
 
 /**

--- a/flows/nax-finish/steps/result.ts
+++ b/flows/nax-finish/steps/result.ts
@@ -1,23 +1,112 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
-import type { FinishResult } from "../types";
+/**
+ * Finish-audit artifacts.
+ *
+ * These live under nax's global per-project output directory —
+ * `~/.nax/<project>/finish-audit/<feature>/` — alongside `prompt-audit/` and
+ * `review-audit/`, not in the user's repo. Two reasons the repo was the wrong
+ * home: the artifact describes a *run*, not the source tree, so committing it
+ * and gitignoring it are both wrong answers; and a per-feature, per-run path
+ * makes the history queryable across runs, which a single overwritten
+ * `.nax/nax-finish-result.json` never was.
+ *
+ * The plugin supplies `auditDir` because it owns nax's path SSOT
+ * (`src/runtime/paths.ts`), which this module may not import — `flows/` is
+ * loaded by acpx, outside nax's own process. Absent, we fall back to a
+ * repo-local directory so a hand-run `acpx flow run` still records something.
+ *
+ * Two files per run:
+ * - `<runId>.jsonl`       — one line per fix round, appended as it happens
+ * - `<runId>.result.json` — the terminal result the plugin reads back
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { FinishInput, FinishResult, FinishRound } from "../types";
 
-export function resultPath(repoRoot: string): string {
-  return `${repoRoot}/.nax/nax-finish-result.json`;
+/** Used when the plugin supplied no run id (e.g. a hand-run `acpx flow run`). */
+const FALLBACK_RUN_ID = "run";
+
+type AuditTarget = Pick<FinishInput, "auditDir" | "workdir" | "feature" | "runId">;
+
+export function resolveAuditDir(input: AuditTarget): string {
+  return input.auditDir ?? join(input.workdir, ".nax", "finish-audit", input.feature);
 }
 
-export const _resultDeps: { writeText: (p: string, s: string) => Promise<void> } = {
+export function resultPath(input: AuditTarget): string {
+  return join(resolveAuditDir(input), `${input.runId || FALLBACK_RUN_ID}.result.json`);
+}
+
+export function roundsPath(input: AuditTarget): string {
+  return join(resolveAuditDir(input), `${input.runId || FALLBACK_RUN_ID}.jsonl`);
+}
+
+export const _resultDeps: {
+  writeText: (p: string, s: string) => Promise<void>;
+  appendText: (p: string, s: string) => Promise<void>;
+  readText: (p: string) => Promise<string | null>;
+} = {
   // node:fs, not Bun.write — this module runs inside acpx's Node process, where
   // the `Bun` global does not exist (see the header of `../exec.ts`). The mkdir
   // is not redundant: Bun.write creates missing parent directories implicitly,
-  // writeFile does not, and this is the one artifact the plugin needs on disk to
-  // report an outcome at all.
+  // writeFile does not, and the audit directory now lives under `~/.nax/`,
+  // where for a project's first run nothing on the path exists yet.
   writeText: async (p, s) => {
     await mkdir(dirname(p), { recursive: true });
     await writeFile(p, s, "utf8");
   },
+  appendText: async (p, s) => {
+    await mkdir(dirname(p), { recursive: true });
+    await writeFile(p, s, { encoding: "utf8", flag: "a" });
+  },
+  readText: async (p) => {
+    try {
+      return await readFile(p, "utf8");
+    } catch {
+      return null;
+    }
+  },
 };
 
-export async function writeResult(repoRoot: string, result: FinishResult): Promise<void> {
-  await _resultDeps.writeText(resultPath(repoRoot), `${JSON.stringify(result, null, 2)}\n`);
+/**
+ * Append one fix round to the run's audit trail.
+ *
+ * Best-effort: an unwritable audit directory must not take the flow down
+ * mid-loop. The round is a record of work already done — losing the record is
+ * bad, losing the run that did the work is worse.
+ */
+export async function appendRound(input: AuditTarget, round: FinishRound): Promise<void> {
+  try {
+    await _resultDeps.appendText(roundsPath(input), `${JSON.stringify(round)}\n`);
+  } catch {
+    // Intentionally swallowed — see the doc comment above.
+  }
+}
+
+/** Read back every round recorded for this run, so a terminal result can embed them. */
+export async function readRounds(input: AuditTarget): Promise<FinishRound[]> {
+  const raw = await _resultDeps.readText(roundsPath(input));
+  if (!raw) return [];
+  const rounds: FinishRound[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      rounds.push(JSON.parse(line) as FinishRound);
+    } catch {
+      // A torn final line (killed mid-write) must not lose the rounds before it.
+    }
+  }
+  return rounds;
+}
+
+/**
+ * Write the terminal result, embedding every round this run recorded.
+ *
+ * Rounds are attached on *every* status, not just `escalated`: a finish that
+ * succeeded after four rounds is precisely the case worth auditing — it says
+ * the run's own review gates missed four defects — and it was the one case
+ * that previously recorded nothing at all.
+ */
+export async function writeResult(input: AuditTarget, result: FinishResult): Promise<void> {
+  const rounds = await readRounds(input);
+  const withRounds: FinishResult = rounds.length > 0 ? { ...result, rounds } : result;
+  await _resultDeps.writeText(resultPath(input), `${JSON.stringify(withRounds, null, 2)}\n`);
 }

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -35,11 +35,12 @@ export type FinishPhase = "acceptance" | "spec" | "quality" | "gate";
 /**
  * One completed fix round, appended to the audit trail as it happens.
  *
- * Rounds are written incrementally rather than reconstructed at the end
- * because acpx's `ctx.outputs` keeps only the *latest* output per node — by the
- * time a terminal node runs, every earlier round's findings have been
- * overwritten by the round that superseded them. Appending at `commit_<phase>`
- * is the only point where a round's findings and its commit are both known.
+ * Rounds are appended at `commit_<phase>` as they happen rather than
+ * reconstructed by a terminal node from `ctx.state.steps` (which does retain
+ * every step's output). Appending live is what makes the trail survive a flow
+ * that is killed or times out: no terminal node runs on those paths, and a
+ * finish that died mid-loop is exactly when the record of what it already
+ * changed on the branch matters most.
  */
 export interface FinishRound {
   ts: string;

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -29,11 +29,45 @@ export interface FinishTimeouts {
   acceptanceMs?: number;
   gateMs?: number;
 }
+/** The four fix-and-reverify loops, in graph order. */
+export type FinishPhase = "acceptance" | "spec" | "quality" | "gate";
+
+/**
+ * One completed fix round, appended to the audit trail as it happens.
+ *
+ * Rounds are written incrementally rather than reconstructed at the end
+ * because acpx's `ctx.outputs` keeps only the *latest* output per node — by the
+ * time a terminal node runs, every earlier round's findings have been
+ * overwritten by the round that superseded them. Appending at `commit_<phase>`
+ * is the only point where a round's findings and its commit are both known.
+ */
+export interface FinishRound {
+  ts: string;
+  phase: FinishPhase;
+  /** 1-based; the Nth time this phase's fix node has run. */
+  attempt: number;
+  /** True when the fix produced a commit; false when it changed nothing. */
+  committed: boolean;
+  /** Reviewer findings this round set out to fix (spec/quality phases). */
+  findings: Finding[];
+  /** Gate commands that were red this round (gate phase). */
+  failing?: string[];
+}
+
 export interface FinishInput {
   feature: string;
   workdir: string;
   branch: string;
   prdPath: string;
+  /**
+   * Directory for this feature's finish-audit artifacts, e.g.
+   * `~/.nax/<project>/finish-audit/<feature>`. Supplied by the plugin, which
+   * owns nax's path SSOT (`src/runtime/paths.ts`) that this module may not
+   * import. Absent → the flow falls back to a repo-local directory.
+   */
+  auditDir?: string;
+  /** Run id, used to name this run's audit files. Absent → "run". */
+  runId?: string;
   /**
    * True only when Telegram escalation is both enabled *and* credentialed, as
    * determined by the plugin. When true the flow skips the PR/MR comment
@@ -62,6 +96,13 @@ export interface FinishResult {
    * rather than lost.
    */
   deliveryError?: string;
+  /**
+   * Every fix round the flow ran, on *all* terminal statuses — not just
+   * escalations. A successful finish that took four rounds to get there is the
+   * case worth auditing (it says the run's own review gates missed four
+   * defects), and it was previously the one case that recorded nothing.
+   */
+  rounds?: FinishRound[];
 }
 export interface RunResult {
   exitCode: number;

--- a/src/cli/features-resolve.ts
+++ b/src/cli/features-resolve.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
-import { findProjectDir } from "../config";
+import { findProjectDir, loadConfig } from "../config";
+import { resolveTestFilePatterns } from "../test-runners";
 import { validateFeatureName } from "../utils/feature-name";
 import { type AcceptanceResolution, resolveFeatureAcceptance } from "./features-acceptance";
 
@@ -13,15 +14,55 @@ export interface SpecSource {
   path: string; // repo-root-relative
 }
 
+/**
+ * Test-file classification patterns, in a JSON-portable form.
+ *
+ * `ResolvedTestPatterns.regex` is `RegExp[]`, which does not survive
+ * `JSON.stringify`, so the sources are emitted as strings for a consumer to
+ * rebuild with `new RegExp(src)`. Exists so out-of-process consumers — the
+ * nax-finish flow, which runs inside acpx and cannot import
+ * `resolveTestFilePatterns` — classify paths through the ADR-009 SSOT instead
+ * of reinventing `/\.test\.ts$/`.
+ *
+ * Root-level resolution only: a per-file answer in a polyglot monorepo would
+ * need `findPackageDir` per path. Consumers needing that precision must call
+ * the resolver directly.
+ */
+export interface TestPatternResolution {
+  /** Regex sources for path classification, e.g. ["\\.test\\.ts$"]. */
+  regex: string[];
+  /** Which tier resolved them: per-package | root-config | detected | fallback. */
+  resolution: string;
+}
+
 export interface ResolveResult {
   status: ResolveStatus;
   featureName?: string | null;
   specSource?: SpecSource | null;
   /** Acceptance test target(s) for the feature. Present only on an `ok` result with a known featureName. */
   acceptance?: AcceptanceResolution;
+  /** Repo-root test-file patterns. Present only on an `ok` result. */
+  testPatterns?: TestPatternResolution;
   candidates?: string[];
   checked?: string[];
   message: string;
+}
+
+/**
+ * Resolve the repo's test-file patterns for emission in `nax features resolve`.
+ *
+ * Never throws — this feeds a CLI whose primary job is spec resolution, so a
+ * broken/legacy config degrades to omitting the field rather than failing the
+ * whole command (the same rule `resolveFeatureAcceptance` follows).
+ */
+async function resolveTestPatterns(workdir: string): Promise<TestPatternResolution | undefined> {
+  try {
+    const config = await loadConfig(workdir);
+    const resolved = await resolveTestFilePatterns(config, workdir);
+    return { regex: resolved.regex.map((r) => r.source), resolution: resolved.resolution };
+  } catch {
+    return undefined;
+  }
 }
 
 /** Returns true if the file at absolutePath exists and has non-whitespace content. */
@@ -166,6 +207,7 @@ export async function resolveFeatureSpec(name: string | undefined, workdir: stri
         featureName: name,
         specSource: source,
         acceptance: await resolveFeatureAcceptance(name, workdir),
+        testPatterns: await resolveTestPatterns(workdir),
         message: `resolved spec: ${source.path}`,
       };
     }
@@ -220,6 +262,7 @@ export async function resolveFeatureSpec(name: string | undefined, workdir: stri
       featureName: onlyName,
       specSource: source,
       acceptance: await resolveFeatureAcceptance(onlyName, workdir),
+      testPatterns: await resolveTestPatterns(workdir),
       message: `resolved spec: ${source.path}`,
     };
   }

--- a/src/config/runtime-types-finish.ts
+++ b/src/config/runtime-types-finish.ts
@@ -20,6 +20,8 @@ export interface FinishAutoFlowConfig {
   flowPath: string;
   /** acpx `--default-agent` for nodes without a pinned profile */
   defaultAgent: string | null;
+  /** acpx `--model` — a run-wide fallback below `node.model` and `agent.model`; null passes no flag */
+  model: string | null;
   /** Per-phase reviewer acpx profiles */
   reviewers: { spec: string | null; quality: string | null };
   escalate: { telegram: boolean };

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -433,6 +433,18 @@ export const NaxConfigSchema = z
             enabled: z.boolean().default(false),
             flowPath: z.string().default("flows/nax-finish/nax-finish.flow.ts"),
             defaultAgent: z.string().nullable().default(null),
+            /**
+             * acpx `--model`, a run-wide *fallback*. acpx resolves a node's
+             * model as `node.model ?? agent.model ?? --model`, so this only
+             * reaches nodes whose agent entry pins no model of its own — i.e.
+             * the `fix_*` nodes, not the profile-pinned reviewers.
+             *
+             * Opt-in (null) because that precedence needs an acpx build that
+             * accepts a `model` on agent entries. On a build without it there is
+             * nothing above `--model` in the chain, so it would override the
+             * reviewers too.
+             */
+            model: z.string().min(1, "model must be non-empty").nullable().default(null),
             reviewers: z
               .object({
                 spec: z.string().nullable().default(null),
@@ -467,6 +479,7 @@ export const NaxConfigSchema = z
             enabled: false,
             flowPath: "flows/nax-finish/nax-finish.flow.ts",
             defaultAgent: null,
+            model: null,
             reviewers: { spec: null, quality: null },
             escalate: { telegram: true },
             notify: { mode: "escalation" },
@@ -478,6 +491,7 @@ export const NaxConfigSchema = z
           enabled: false,
           flowPath: "flows/nax-finish/nax-finish.flow.ts",
           defaultAgent: null,
+          model: null,
           reviewers: { spec: null, quality: null },
           escalate: { telegram: true },
           notify: { mode: "escalation" },

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -125,7 +125,9 @@ export const llmRoutingConfigSelector = pickSelector(
 // nax-finish autonomous flow — needs its own `finish` block plus `interaction`
 // (Telegram escalation credentials) and `quality` (the gate commands the flow
 // re-runs at the repo root).
-export const finishConfigSelector = pickSelector("finish", "finish", "interaction", "quality");
+// `agent` is in the slice so nax-finish can default the flow's agent to the one
+// the run itself used, instead of letting acpx fall back to its own default.
+export const finishConfigSelector = pickSelector("finish", "finish", "interaction", "quality", "agent");
 
 // Derived config-slice types — co-located with each selector so consumers
 // import the type instead of re-deriving `ReturnType<typeof xSelector.select>`

--- a/src/plugins/builtin/nax-finish/config.ts
+++ b/src/plugins/builtin/nax-finish/config.ts
@@ -9,13 +9,15 @@
  * than as an ad-hoc key list here.
  */
 
+import { resolveDefaultAgent } from "@/agents";
 import { finishConfigSelector } from "@/config";
 import type { NaxConfig } from "@/config/types";
 
 export interface FinishAutoFlowSettings {
   enabled: boolean;
   flowPath: string;
-  defaultAgent: string | null;
+  /** Never null — see resolveFlowAgent. */
+  defaultAgent: string;
   reviewers: { spec: string | null; quality: string | null };
   escalate: { telegram: boolean };
   notify: { mode: "escalation" | "always" | "off" };
@@ -27,10 +29,9 @@ export interface FinishAutoFlowSettings {
  * only when the plugin is handed a config carrying no `finish` block at all
  * (older configs, and tests that pass a partial object).
  */
-const DEFAULT_FINISH_AUTO_FLOW_CONFIG: FinishAutoFlowSettings = {
+const DEFAULT_FINISH_AUTO_FLOW_CONFIG: Omit<FinishAutoFlowSettings, "defaultAgent"> = {
   enabled: false,
   flowPath: "flows/nax-finish/nax-finish.flow.ts",
-  defaultAgent: null,
   reviewers: { spec: null, quality: null },
   escalate: { telegram: true },
   notify: { mode: "escalation" },
@@ -44,15 +45,30 @@ function selectFinish(config: unknown): { autoFlow?: Partial<FinishAutoFlowSetti
     | undefined;
 }
 
+/**
+ * The agent every non-review node in the flow runs on.
+ *
+ * `finish.autoFlow.defaultAgent` wins when set. Otherwise it is the agent the
+ * run itself used — NOT null. Passing null omits `--default-agent` from the
+ * `acpx flow run` argv, which silently hands the fix nodes to whatever agent
+ * acpx defaults to: a profile that configured only `reviewers` ran its
+ * reviewers on the intended models and every `fix_*` node on a different one.
+ * `resolveDefaultAgent` is the same accessor the run uses, so the two agree.
+ */
+function resolveFlowAgent(config: unknown, explicit: string | null | undefined): string {
+  if (typeof explicit === "string" && explicit.length > 0) return explicit;
+  return resolveDefaultAgent((config ?? {}) as Parameters<typeof resolveDefaultAgent>[0]);
+}
+
 /** Read the `finish.autoFlow` slice from `ctx.config`, applying schema defaults when absent. */
 export function getFinishAutoFlowConfig(ctx: { config?: unknown }): FinishAutoFlowSettings {
   const autoFlow = selectFinish(ctx.config)?.autoFlow;
-  if (!autoFlow) return DEFAULT_FINISH_AUTO_FLOW_CONFIG;
+  if (!autoFlow) return { ...DEFAULT_FINISH_AUTO_FLOW_CONFIG, defaultAgent: resolveFlowAgent(ctx.config, null) };
   const defaults = DEFAULT_FINISH_AUTO_FLOW_CONFIG;
   return {
     enabled: autoFlow.enabled === true,
     flowPath: autoFlow.flowPath ?? defaults.flowPath,
-    defaultAgent: autoFlow.defaultAgent ?? null,
+    defaultAgent: resolveFlowAgent(ctx.config, autoFlow.defaultAgent),
     reviewers: {
       spec: autoFlow.reviewers?.spec ?? null,
       quality: autoFlow.reviewers?.quality ?? null,

--- a/src/plugins/builtin/nax-finish/config.ts
+++ b/src/plugins/builtin/nax-finish/config.ts
@@ -18,6 +18,8 @@ export interface FinishAutoFlowSettings {
   flowPath: string;
   /** Never null — see resolveFlowAgent. */
   defaultAgent: string;
+  /** acpx `--model`; null passes no flag at all. Opt-in — see the schema. */
+  model: string | null;
   reviewers: { spec: string | null; quality: string | null };
   escalate: { telegram: boolean };
   notify: { mode: "escalation" | "always" | "off" };
@@ -32,6 +34,7 @@ export interface FinishAutoFlowSettings {
 const DEFAULT_FINISH_AUTO_FLOW_CONFIG: Omit<FinishAutoFlowSettings, "defaultAgent"> = {
   enabled: false,
   flowPath: "flows/nax-finish/nax-finish.flow.ts",
+  model: null,
   reviewers: { spec: null, quality: null },
   escalate: { telegram: true },
   notify: { mode: "escalation" },
@@ -69,6 +72,11 @@ export function getFinishAutoFlowConfig(ctx: { config?: unknown }): FinishAutoFl
     enabled: autoFlow.enabled === true,
     flowPath: autoFlow.flowPath ?? defaults.flowPath,
     defaultAgent: resolveFlowAgent(ctx.config, autoFlow.defaultAgent),
+    // Deliberately NOT defaulted to config.models: `--model` is opt-in because
+    // its "floor, not override" behaviour depends on acpx supporting a model on
+    // agent entries. Passing one unconditionally would override the pinned
+    // reviewers on a build without that support.
+    model: autoFlow.model ?? null,
     reviewers: {
       spec: autoFlow.reviewers?.spec ?? null,
       quality: autoFlow.reviewers?.quality ?? null,

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -212,30 +212,35 @@ export async function resolveFlowPath(
  * Build the `acpx flow run` argv.
  *
  * Flag placement is not interchangeable:
- * - `--approve-all` and `--timeout` are **top-level** flags and must precede
- *   `flow`. The flow declares `requireExplicitGrant`, so acpx rejects the run
- *   unless the grant is an explicit CLI flag (config alone does not satisfy it).
+ * - `--approve-all`, `--timeout` and `--model` are **top-level** flags and must
+ *   precede `flow`. The flow declares `requireExplicitGrant`, so acpx rejects
+ *   the run unless the grant is an explicit CLI flag (config alone does not
+ *   satisfy it).
  * - `--default-agent` is an option of the `flow run` **subcommand**, so it must
  *   come after the flow file; placing it before `flow` makes acpx exit with
  *   "unknown option '--default-agent'".
+ *
+ * `--model` is a *floor*, not an override: acpx resolves each node's model as
+ * `node.model ?? agent.model ?? --model`, so it reaches only nodes whose agent
+ * entry pins no model — the `fix_*` nodes, never a profile-pinned reviewer.
  */
 export function buildFlowArgv(
   flowPath: string,
   inputJson: string,
-  defaultAgent: string | null,
-  stepMs?: number | null,
+  opts: { defaultAgent?: string | null; stepMs?: number | null; model?: string | null } = {},
 ): string[] {
-  const stepTimeout = stepMs && stepMs > 0 ? ["--timeout", String(Math.ceil(stepMs / 1000))] : [];
+  const stepTimeout = opts.stepMs && opts.stepMs > 0 ? ["--timeout", String(Math.ceil(opts.stepMs / 1000))] : [];
   return [
     "acpx",
     "--approve-all",
     ...stepTimeout,
+    ...(opts.model ? ["--model", opts.model] : []),
     "flow",
     "run",
     flowPath,
     "--input-json",
     inputJson,
-    ...(defaultAgent ? ["--default-agent", defaultAgent] : []),
+    ...(opts.defaultAgent ? ["--default-agent", opts.defaultAgent] : []),
   ];
 }
 
@@ -300,7 +305,11 @@ async function executeFinishFlow(options: ExecuteFinishOptions): Promise<FinishT
     escalateTelegram,
     timeouts: { acceptanceMs: cfg.timeouts.acceptanceMs, gateMs: cfg.timeouts.gateMs },
   };
-  const cmd = buildFlowArgv(flowPath, JSON.stringify(input), cfg.defaultAgent, cfg.timeouts.stepMs);
+  const cmd = buildFlowArgv(flowPath, JSON.stringify(input), {
+    defaultAgent: cfg.defaultAgent,
+    stepMs: cfg.timeouts.stepMs,
+    model: cfg.model,
+  });
   const res = await _naxFinishDeps.run(cmd, {
     cwd: ctx.workdir,
     env: buildFlowEnv(cfg),

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -34,6 +34,8 @@ interface FinishResult {
   findings?: { severity: string; title: string }[];
   /** Set by the flow when it could not deliver the escalation to its channel. */
   deliveryError?: string;
+  /** Every fix round the flow ran — recorded on all terminal statuses, not just escalations. */
+  rounds?: { phase: string; attempt: number; committed: boolean }[];
 }
 
 type TelegramCreds = NonNullable<ReturnType<typeof telegramCreds>>;
@@ -94,16 +96,49 @@ async function defaultRun(
   }
 }
 
+/**
+ * Where this feature's finish-audit artifacts live.
+ *
+ * `<outputDir>/finish-audit/<feature>/`, i.e. `~/.nax/<project>/finish-audit/`
+ * — the same per-project, per-feature shape as `prompt-audit/` and
+ * `review-audit/`, resolved from the run's own `outputDir` so a configured
+ * `config.outputDir` override is honoured. The artifact records a *run*, not
+ * the source tree, so the repo was never the right home for it.
+ *
+ * `outputDir` is optional on `PostRunContext` for backward compatibility; a
+ * context without it falls back to the repo, which is where the artifact used
+ * to live. The flow applies the same fallback, so both sides agree.
+ */
+export function finishAuditDir(ctx: Pick<PostRunContext, "outputDir" | "workdir" | "feature">): string {
+  const root = ctx.outputDir ?? path.join(ctx.workdir, ".nax");
+  return path.join(root, "finish-audit", ctx.feature);
+}
+
+/** The terminal result file for one run, named the way prompt-audit names its runs. */
+export function finishResultPath(
+  ctx: Pick<PostRunContext, "outputDir" | "workdir" | "feature">,
+  runId: string,
+): string {
+  return path.join(finishAuditDir(ctx), `${runId}.result.json`);
+}
+
 /** Default result reader — reads the flow's terminal result off disk. */
-async function defaultReadResult(workdir: string): Promise<FinishResult | null> {
-  const f = Bun.file(path.join(workdir, ".nax", "nax-finish-result.json"));
+async function defaultReadResult(resultPath: string): Promise<FinishResult | null> {
+  const f = Bun.file(resultPath);
   if (!(await f.exists())) return null;
   return JSON.parse(await f.text()) as FinishResult;
 }
 
-/** Remove an earlier run's terminal artifact before starting a new flow. */
-async function defaultClearResult(workdir: string): Promise<void> {
-  const file = Bun.file(path.join(workdir, ".nax", "nax-finish-result.json"));
+/**
+ * Remove any terminal artifact left at this run's path before starting a flow.
+ *
+ * The path is run-scoped, so a stale file can only exist when the same run id
+ * is finished twice (a resume). Clearing keeps the "no result file" branch
+ * honest in that case — without it, a flow that died before writing would be
+ * reported using the previous attempt's outcome.
+ */
+async function defaultClearResult(resultPath: string): Promise<void> {
+  const file = Bun.file(resultPath);
   if (await file.exists()) await file.delete();
 }
 
@@ -115,8 +150,8 @@ async function defaultClearResult(workdir: string): Promise<void> {
  */
 export const _naxFinishDeps: {
   run: RunFn;
-  readResult: (workdir: string) => Promise<FinishResult | null>;
-  clearResult: (workdir: string) => Promise<void>;
+  readResult: (resultPath: string) => Promise<FinishResult | null>;
+  clearResult: (resultPath: string) => Promise<void>;
   /** Path-existence probe — used to resolve the flow module and the nax package root. */
   exists: (p: string) => Promise<boolean>;
   /** Directory this module was loaded from; overridable so package-root walking is testable. */
@@ -251,12 +286,17 @@ async function executeFinishFlow(options: ExecuteFinishOptions): Promise<FinishT
     };
   }
 
-  await _naxFinishDeps.clearResult(ctx.workdir);
+  const resultPath = finishResultPath(ctx, ctx.runId);
+  await _naxFinishDeps.clearResult(resultPath);
   const input = {
     feature: ctx.feature,
     workdir: ctx.workdir,
     branch: ctx.branch,
     prdPath: ctx.prdPath,
+    // The flow cannot import nax's path SSOT (`src/runtime/paths.ts`) — it runs
+    // inside acpx's process — so the audit location is resolved here and passed in.
+    auditDir: finishAuditDir(ctx),
+    runId: ctx.runId,
     escalateTelegram,
     timeouts: { acceptanceMs: cfg.timeouts.acceptanceMs, gateMs: cfg.timeouts.gateMs },
   };
@@ -266,7 +306,7 @@ async function executeFinishFlow(options: ExecuteFinishOptions): Promise<FinishT
     env: buildFlowEnv(cfg),
     timeoutMs: cfg.timeouts.flowMs,
   });
-  const result = await _naxFinishDeps.readResult(ctx.workdir);
+  const result = await _naxFinishDeps.readResult(resultPath);
   if (!result) return missingResultOutcome(ctx, res, escalateTelegram);
   return {
     actionResult: { success: true, message: `nax-finish: ${result.status}`, url: result.url },

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -54,5 +54,12 @@ export { buildLogsPayload, toLogRecord } from "./builtin/otel-reporter/logs";
 export type { LogRecord, LogsResourceInput } from "./builtin/otel-reporter/logs";
 
 // Built-in nax-finish post-run action (Task 8) — exposed for test injection (`_naxFinishDeps`)
-export { naxFinishPlugin, _naxFinishDeps, buildFlowArgv, resolveFlowPath } from "./builtin/nax-finish";
+export {
+  naxFinishPlugin,
+  _naxFinishDeps,
+  buildFlowArgv,
+  finishAuditDir,
+  finishResultPath,
+  resolveFlowPath,
+} from "./builtin/nax-finish";
 export { getFinishAutoFlowConfig, isTelegramConfigured, telegramCreds } from "./builtin/nax-finish/config";

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -23,4 +23,9 @@ export const NAX_GITIGNORE_ENTRIES = [
   "**/_nax_suggested_test.py",
   "**/.nax/features/*/",
   ".nax/prompt-audit/",
+  // Only reached when a run has no outputDir — nax-finish normally writes its
+  // audit under `~/.nax/<project>/finish-audit/`. It still must be ignored:
+  // the flow's `commit_*` nodes run `git add -A`, so an un-ignored artifact
+  // here lands in the feature branch's history.
+  ".nax/finish-audit/",
 ];

--- a/test/unit/cli/features-resolve.test.ts
+++ b/test/unit/cli/features-resolve.test.ts
@@ -362,3 +362,43 @@ function exitCodeFor(status: ResolveStatus): number {
   if (status === "not-a-nax-repo") return 1;
   return 2;
 }
+
+// Emitted so out-of-process consumers — the nax-finish flow, which runs inside
+// acpx and cannot import resolveTestFilePatterns — classify paths through the
+// ADR-009 SSOT instead of reinventing /\.test\.ts$/.
+describe("testPatterns", () => {
+  test("an ok result carries regex sources a JSON consumer can rebuild", async () => {
+    const naxDir = initNaxRepo();
+    createFeature(naxDir, "feat-x", { specMd: "# spec" });
+
+    const r = await resolveFeatureSpec("feat-x", tempDir);
+
+    expect(r.status).toBe("ok");
+    expect(r.testPatterns?.regex.length).toBeGreaterThan(0);
+    // Rebuildable, and actually classifying — a plain string list would pass a
+    // length assertion while being useless to the consumer.
+    const matchers = r.testPatterns!.regex.map((s) => new RegExp(s));
+    expect(matchers.some((re) => re.test("test/unit/a.test.ts"))).toBe(true);
+    expect(matchers.some((re) => re.test("src/scheduler.ts"))).toBe(false);
+  });
+
+  test("reports which tier resolved them", async () => {
+    const naxDir = initNaxRepo();
+    createFeature(naxDir, "feat-x", { specMd: "# spec" });
+    const r = await resolveFeatureSpec("feat-x", tempDir);
+    expect(["per-package", "root-config", "detected", "fallback"]).toContain(r.testPatterns?.resolution);
+  });
+
+  test("survives JSON round-trip, which is how the flow consumes it", async () => {
+    const naxDir = initNaxRepo();
+    createFeature(naxDir, "feat-x", { specMd: "# spec" });
+    const r = JSON.parse(JSON.stringify(await resolveFeatureSpec("feat-x", tempDir)));
+    expect(new RegExp(r.testPatterns.regex[0])).toBeInstanceOf(RegExp);
+  });
+
+  test("a non-nax dir resolves without testPatterns rather than throwing", async () => {
+    const r = await resolveFeatureSpec("feat-x", makeTempDir("nax-not-a-repo-"));
+    expect(r.status).toBe("not-a-nax-repo");
+    expect(r.testPatterns).toBeUndefined();
+  });
+});

--- a/test/unit/config/finish-autoflow-schema.test.ts
+++ b/test/unit/config/finish-autoflow-schema.test.ts
@@ -55,3 +55,21 @@ describe("finish.autoFlow schema", () => {
     ).toBe(false);
   });
 });
+
+describe("finish.autoFlow.model", () => {
+  // Opt-in, because it is only meaningful on an acpx build that supports a
+  // `model` on agent entries — without that, `--model` has nothing above it in
+  // the precedence chain and would override the pinned reviewers too.
+  test("defaults to null so no --model is passed at all", () => {
+    expect(NaxConfigSchema.parse({ version: 1 }).finish.autoFlow.model).toBeNull();
+  });
+
+  test("accepts a model id", () => {
+    const c = NaxConfigSchema.parse({ version: 1, finish: { autoFlow: { model: "sonnet" } } });
+    expect(c.finish.autoFlow.model).toBe("sonnet");
+  });
+
+  test("rejects an empty model id, which would produce a bare --model flag", () => {
+    expect(NaxConfigSchema.safeParse({ version: 1, finish: { autoFlow: { model: "" } } }).success).toBe(false);
+  });
+});

--- a/test/unit/flows/nax-finish/commit-message.test.ts
+++ b/test/unit/flows/nax-finish/commit-message.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { buildFixCommitMessage } from "@flows/nax-finish/commit-message";
+import type { Finding } from "@flows/nax-finish/types";
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  severity: "HIGH",
+  title: "Market gate skip branch is unreachable",
+  problem: "The `should_skip` branch is guarded by `row.gate is not None`, which is never set.",
+  fix: "Drop the extra guard.",
+  ...over,
+});
+
+const ctxOf = (outputs: Record<string, unknown>) => ({ outputs });
+
+describe("buildFixCommitMessage — subject line", () => {
+  test("a single review finding puts that finding's title in the subject", () => {
+    const msg = buildFixCommitMessage(
+      "spec",
+      "pipeline-run-outcome",
+      ctxOf({ review_spec: { findings: [finding()] } }),
+    );
+    const subject = msg.split("\n")[0];
+    expect(subject).toBe("fix(pipeline-run-outcome): market gate skip branch is unreachable");
+    // The generic phase label is what this replaces — it must not survive.
+    expect(subject).not.toContain("nax-finish spec fixes");
+  });
+
+  test("multiple findings summarise by count and worst severity", () => {
+    const msg = buildFixCommitMessage(
+      "quality",
+      "feat-x",
+      ctxOf({
+        review_quality: {
+          findings: [finding({ severity: "LOW" }), finding({ severity: "CRITICAL" }), finding({ severity: "MEDIUM" })],
+        },
+      }),
+    );
+    expect(msg.split("\n")[0]).toBe("fix(feat-x): address 3 quality review findings (worst: CRITICAL)");
+  });
+
+  test("the gate phase names the failing commands, not a finding", () => {
+    const msg = buildFixCommitMessage("gate", "feat-x", ctxOf({ quality_gates: { failing: ["lint", "test"] } }));
+    expect(msg.split("\n")[0]).toBe("fix(feat-x): repair failing lint and test gates");
+  });
+
+  test("the acceptance phase names the contract it is repairing", () => {
+    const msg = buildFixCommitMessage("acceptance", "feat-x", ctxOf({ acceptance: { output: "2 failed" } }));
+    expect(msg.split("\n")[0]).toBe("fix(feat-x): repair failing acceptance tests");
+  });
+
+  test("a subject too long for a git summary line is truncated, not wrapped", () => {
+    const long = "a".repeat(120);
+    const msg = buildFixCommitMessage("spec", "f", ctxOf({ review_spec: { findings: [finding({ title: long })] } }));
+    const subject = msg.split("\n")[0];
+    expect(subject.length).toBeLessThanOrEqual(72);
+    expect(subject.endsWith("...")).toBe(true);
+  });
+
+  test("falls back to the phase label when the reviewer produced no usable detail", () => {
+    expect(buildFixCommitMessage("spec", "f", ctxOf({})).split("\n")[0]).toBe("fix(f): apply spec review fixes");
+    expect(buildFixCommitMessage("gate", "f", ctxOf({ quality_gates: { failing: [] } })).split("\n")[0]).toBe(
+      "fix(f): repair failing quality gates",
+    );
+  });
+});
+
+describe("buildFixCommitMessage — body", () => {
+  test("lists every finding with severity, title and prescribed fix", () => {
+    const msg = buildFixCommitMessage(
+      "spec",
+      "f",
+      ctxOf({
+        review_spec: {
+          findings: [finding({ severity: "HIGH", title: "A", problem: "P-A", fix: "F-A" }), finding({ title: "B" })],
+        },
+      }),
+    );
+    expect(msg).toContain("- [HIGH] A\n  P-A\n  Fix: F-A");
+    expect(msg).toContain("- [HIGH] B");
+  });
+
+  test("attributes the commit to the flow phase so it is greppable in history", () => {
+    const msg = buildFixCommitMessage("quality", "f", ctxOf({ review_quality: { findings: [finding()] } }));
+    expect(msg).toContain("nax-finish: quality review fixes");
+  });
+
+  test("the gate body carries the gate output tail, not a finding list", () => {
+    const msg = buildFixCommitMessage(
+      "gate",
+      "f",
+      ctxOf({ quality_gates: { failing: ["test"], output: "FAIL src/a.test.ts\n1 failed" } }),
+    );
+    expect(msg).toContain("Failing: test");
+    expect(msg).toContain("1 failed");
+  });
+
+  test("a subject-only message still ends with a single trailing newline-free line", () => {
+    const msg = buildFixCommitMessage("spec", "f", ctxOf({}));
+    expect(msg.endsWith("\n")).toBe(false);
+  });
+
+  test("body lines are separated from the subject by exactly one blank line", () => {
+    const msg = buildFixCommitMessage("spec", "f", ctxOf({ review_spec: { findings: [finding()] } }));
+    expect(msg.split("\n")[1]).toBe("");
+    expect(msg.split("\n")[2]).not.toBe("");
+  });
+});

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -140,3 +140,127 @@ describe("gate fixes re-enter the quality review", () => {
     expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
   });
 });
+
+// Chosen tradeoff, not an oversight: the re-review is the flow's most expensive
+// node and a gate fix is usually a mechanical test repair. It is a real hole —
+// the defect that motivated the re-entry (rs-stock b6fb66dd) was itself
+// test-only — so these tests pin the boundary precisely.
+describe("gate re-entry is scoped to non-test changes", () => {
+  const originalRun = _gitDeps.run;
+  const originalAppend = _resultDeps.appendText;
+  afterEach(() => {
+    _gitDeps.run = originalRun;
+    _resultDeps.appendText = originalAppend;
+  });
+
+  const TS_TEST_REGEX = ["\\.test\\.ts$", "(^|/)test/"];
+
+  const runGateCommit = async (files: string[], regex: string[] = TS_TEST_REGEX) => {
+    _resultDeps.appendText = async () => {};
+    _gitDeps.run = async (cmd) => {
+      if (cmd.includes("--porcelain")) return { exitCode: 0, stdout: " M a\n", stderr: "" };
+      if (cmd.includes("rev-parse")) return { exitCode: 0, stdout: "sha1\n", stderr: "" };
+      if (cmd.includes("--name-only")) return { exitCode: 0, stdout: `${files.join("\n")}\n`, stderr: "" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    return nodeRun<{ route: string }>("commit_gate").run(ctxOf({ outputs: { load_ctx: { testFileRegex: regex } } }));
+  };
+
+  test("a fix touching production code routes into review_quality", async () => {
+    expect((await runGateCommit(["src/scheduler.ts", "test/unit/scheduler.test.ts"])).route).toBe("changed");
+  });
+
+  test("a fix touching only test files skips the re-review", async () => {
+    expect((await runGateCommit(["test/unit/a.test.ts", "test/unit/b.test.ts"])).route).toBe("tests-only");
+  });
+
+  // Fail-safe: an older nax whose `features resolve` predates testPatterns, or a
+  // config the resolver choked on, must review rather than skip.
+  test("with no patterns to classify by, it reviews rather than skipping", async () => {
+    expect((await runGateCommit(["test/unit/a.test.ts"], [])).route).toBe("changed");
+  });
+
+  test("an unparseable pattern is ignored without taking the flow down", async () => {
+    expect((await runGateCommit(["test/unit/a.test.ts"], ["\\.test\\.ts$", "([unclosed"])).route).toBe("tests-only");
+  });
+
+  test("an empty file list (git show failed) reviews rather than skipping", async () => {
+    expect((await runGateCommit([])).route).toBe("changed");
+  });
+});
+
+// `incrementalSince` decides how much a re-review re-reads. Under-scoping it
+// silently hides code from the reviewer, so every case that cannot prove
+// "exactly one commit since the last verdict" must fall back to a full review.
+describe("review nodes — incremental scoping window", () => {
+  const promptOf = (id: string, over: { outputs?: Record<string, unknown>; steps?: { nodeId: string }[] }) =>
+    (flow.nodes[id] as unknown as { prompt: (c: FlowNodeContext) => string }).prompt(ctxOf(over));
+
+  const LOAD = { load_ctx: { base: "origin/main", specPath: "s.md" } };
+
+  test("the first review of a phase reads the whole branch diff", () => {
+    expect(promptOf("review_spec", { outputs: LOAD, steps: [{ nodeId: "load_ctx" }] })).toContain(
+      "git diff origin/main...HEAD",
+    );
+  });
+
+  test("one commit since the last review scopes to that commit's parent tree", () => {
+    const p = promptOf("review_spec", {
+      outputs: { ...LOAD, commit_spec: { shaBefore: "sha-at-review-1" }, review_spec: { findings: [] } },
+      steps: [{ nodeId: "review_spec" }, { nodeId: "fix_spec" }, { nodeId: "commit_spec" }],
+    });
+    expect(p).toContain("git diff sha-at-review-1..HEAD");
+  });
+
+  // The acceptance loop can commit between a spec fix and its re-review. Only
+  // the latest output per node id survives, so the earliest shaBefore in the
+  // window may already be gone — guessing would hide the spec fix itself.
+  test("two commits since the last review fall back to a full review", () => {
+    const p = promptOf("review_spec", {
+      outputs: {
+        ...LOAD,
+        commit_spec: { shaBefore: "sha-a" },
+        commit_acceptance: { shaBefore: "sha-b" },
+        review_spec: { findings: [] },
+      },
+      steps: [
+        { nodeId: "review_spec" },
+        { nodeId: "commit_spec" },
+        { nodeId: "acceptance" },
+        { nodeId: "commit_acceptance" },
+      ],
+    });
+    expect(p).toContain("git diff origin/main...HEAD");
+    expect(p).not.toContain("sha-a..HEAD");
+  });
+
+  test("a commit that recorded no shaBefore falls back to a full review", () => {
+    const p = promptOf("review_quality", {
+      outputs: { ...LOAD, commit_quality: { shaBefore: null }, review_quality: { findings: [] } },
+      steps: [{ nodeId: "review_quality" }, { nodeId: "commit_quality" }],
+    });
+    expect(p).toContain("git diff origin/main...HEAD");
+  });
+
+  test("only commits AFTER the last review count — an earlier one does not scope it", () => {
+    const p = promptOf("review_quality", {
+      outputs: { ...LOAD, commit_quality: { shaBefore: "old" }, review_quality: { findings: [] } },
+      steps: [{ nodeId: "commit_quality" }, { nodeId: "review_quality" }],
+    });
+    expect(p).toContain("git diff origin/main...HEAD");
+  });
+
+  // The gate re-entry: quality_gates -> fix_gate -> commit_gate -> review_quality.
+  test("the gate re-entry scopes the quality re-review to the gate commit", () => {
+    const p = promptOf("review_quality", {
+      outputs: { ...LOAD, commit_gate: { shaBefore: "sha-at-clean-review" }, review_quality: { findings: [] } },
+      steps: [
+        { nodeId: "review_quality" },
+        { nodeId: "quality_gates" },
+        { nodeId: "fix_gate" },
+        { nodeId: "commit_gate" },
+      ],
+    });
+    expect(p).toContain("git diff sha-at-clean-review..HEAD");
+  });
+});

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -13,7 +13,10 @@ import type { FlowNodeContext } from "acpx/flows";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
-const ctxOf = (over: { outputs?: Record<string, unknown>; steps?: { nodeId: string }[] }): FlowNodeContext =>
+const ctxOf = (over: {
+  outputs?: Record<string, unknown>;
+  steps?: { nodeId: string; output?: unknown }[];
+}): FlowNodeContext =>
   ({
     input: INPUT,
     outputs: over.outputs ?? {},
@@ -155,11 +158,18 @@ describe("gate re-entry is scoped to non-test changes", () => {
 
   const TS_TEST_REGEX = ["\\.test\\.ts$", "(^|/)test/"];
 
-  const runGateCommit = async (files: string[], regex: string[] = TS_TEST_REGEX) => {
+  const runGateCommit = async (
+    files: string[],
+    regex: string[] = TS_TEST_REGEX,
+    opts: { revParseFails?: boolean } = {},
+  ) => {
     _resultDeps.appendText = async () => {};
     _gitDeps.run = async (cmd) => {
       if (cmd.includes("--porcelain")) return { exitCode: 0, stdout: " M a\n", stderr: "" };
-      if (cmd.includes("rev-parse")) return { exitCode: 0, stdout: "sha1\n", stderr: "" };
+      if (cmd.includes("rev-parse"))
+        return opts.revParseFails
+          ? { exitCode: 128, stdout: "", stderr: "fatal" }
+          : { exitCode: 0, stdout: "sha1\n", stderr: "" };
       if (cmd.includes("--name-only")) return { exitCode: 0, stdout: `${files.join("\n")}\n`, stderr: "" };
       return { exitCode: 0, stdout: "", stderr: "" };
     };
@@ -187,14 +197,25 @@ describe("gate re-entry is scoped to non-test changes", () => {
   test("an empty file list (git show failed) reviews rather than skipping", async () => {
     expect((await runGateCommit([])).route).toBe("changed");
   });
+
+  // A committed fix whose HEAD will not resolve is real and unclassifiable. It
+  // must not be folded in with "nothing committed" — that would skip the review
+  // for a change that actually landed on the branch.
+  test("a commit whose HEAD does not resolve reviews rather than skipping", async () => {
+    const out = await runGateCommit(["test/unit/a.test.ts"], TS_TEST_REGEX, { revParseFails: true });
+    expect(out.committed).toBe(true);
+    expect(out.route).toBe("changed");
+  });
 });
 
 // `incrementalSince` decides how much a re-review re-reads. Under-scoping it
 // silently hides code from the reviewer, so every case that cannot prove
 // "exactly one commit since the last verdict" must fall back to a full review.
 describe("review nodes — incremental scoping window", () => {
-  const promptOf = (id: string, over: { outputs?: Record<string, unknown>; steps?: { nodeId: string }[] }) =>
-    (flow.nodes[id] as unknown as { prompt: (c: FlowNodeContext) => string }).prompt(ctxOf(over));
+  const promptOf = (
+    id: string,
+    over: { outputs?: Record<string, unknown>; steps?: { nodeId: string; output?: unknown }[] },
+  ) => (flow.nodes[id] as unknown as { prompt: (c: FlowNodeContext) => string }).prompt(ctxOf(over));
 
   const LOAD = { load_ctx: { base: "origin/main", specPath: "s.md" } };
 
@@ -206,46 +227,45 @@ describe("review nodes — incremental scoping window", () => {
 
   test("one commit since the last review scopes to that commit's parent tree", () => {
     const p = promptOf("review_spec", {
-      outputs: { ...LOAD, commit_spec: { shaBefore: "sha-at-review-1" }, review_spec: { findings: [] } },
-      steps: [{ nodeId: "review_spec" }, { nodeId: "fix_spec" }, { nodeId: "commit_spec" }],
+      outputs: { ...LOAD, review_spec: { findings: [] } },
+      steps: [
+        { nodeId: "review_spec" },
+        { nodeId: "fix_spec" },
+        { nodeId: "commit_spec", output: { shaBefore: "sha-at-review-1" } },
+      ],
     });
     expect(p).toContain("git diff sha-at-review-1..HEAD");
   });
 
-  // The acceptance loop can commit between a spec fix and its re-review. Only
-  // the latest output per node id survives, so the earliest shaBefore in the
-  // window may already be gone — guessing would hide the spec fix itself.
-  test("two commits since the last review fall back to a full review", () => {
+  // The acceptance loop can commit between a spec fix and its re-review. The
+  // window must span BOTH commits, so it anchors on the first one after the
+  // review — anchoring on the last would hide the spec fix from the reviewer.
+  test("two commits since the last review scope from the FIRST, spanning both", () => {
     const p = promptOf("review_spec", {
-      outputs: {
-        ...LOAD,
-        commit_spec: { shaBefore: "sha-a" },
-        commit_acceptance: { shaBefore: "sha-b" },
-        review_spec: { findings: [] },
-      },
+      outputs: { ...LOAD, review_spec: { findings: [] } },
       steps: [
         { nodeId: "review_spec" },
-        { nodeId: "commit_spec" },
+        { nodeId: "commit_spec", output: { shaBefore: "sha-at-review-1" } },
         { nodeId: "acceptance" },
-        { nodeId: "commit_acceptance" },
+        { nodeId: "commit_acceptance", output: { shaBefore: "sha-after-spec-fix" } },
       ],
     });
-    expect(p).toContain("git diff origin/main...HEAD");
-    expect(p).not.toContain("sha-a..HEAD");
+    expect(p).toContain("git diff sha-at-review-1..HEAD");
+    expect(p).not.toContain("sha-after-spec-fix..HEAD");
   });
 
   test("a commit that recorded no shaBefore falls back to a full review", () => {
     const p = promptOf("review_quality", {
-      outputs: { ...LOAD, commit_quality: { shaBefore: null }, review_quality: { findings: [] } },
-      steps: [{ nodeId: "review_quality" }, { nodeId: "commit_quality" }],
+      outputs: { ...LOAD, review_quality: { findings: [] } },
+      steps: [{ nodeId: "review_quality" }, { nodeId: "commit_quality", output: { shaBefore: null } }],
     });
     expect(p).toContain("git diff origin/main...HEAD");
   });
 
   test("only commits AFTER the last review count — an earlier one does not scope it", () => {
     const p = promptOf("review_quality", {
-      outputs: { ...LOAD, commit_quality: { shaBefore: "old" }, review_quality: { findings: [] } },
-      steps: [{ nodeId: "commit_quality" }, { nodeId: "review_quality" }],
+      outputs: { ...LOAD, review_quality: { findings: [] } },
+      steps: [{ nodeId: "commit_quality", output: { shaBefore: "old" } }, { nodeId: "review_quality" }],
     });
     expect(p).toContain("git diff origin/main...HEAD");
   });
@@ -253,12 +273,12 @@ describe("review nodes — incremental scoping window", () => {
   // The gate re-entry: quality_gates -> fix_gate -> commit_gate -> review_quality.
   test("the gate re-entry scopes the quality re-review to the gate commit", () => {
     const p = promptOf("review_quality", {
-      outputs: { ...LOAD, commit_gate: { shaBefore: "sha-at-clean-review" }, review_quality: { findings: [] } },
+      outputs: { ...LOAD, review_quality: { findings: [] } },
       steps: [
         { nodeId: "review_quality" },
         { nodeId: "quality_gates" },
         { nodeId: "fix_gate" },
-        { nodeId: "commit_gate" },
+        { nodeId: "commit_gate", output: { shaBefore: "sha-at-clean-review" } },
       ],
     });
     expect(p).toContain("git diff sha-at-clean-review..HEAD");

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `commit_<phase>` node behaviour: the message it writes, the round it records,
+ * and the gate loop's re-entry into the quality review.
+ *
+ * Split out of `flow-graph.test.ts` (800-line test cap) — that file covers the
+ * graph's shape and the other nodes' routing.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import flow from "@flows/nax-finish/nax-finish.flow";
+import { _gitDeps } from "@flows/nax-finish/steps/git";
+import { _resultDeps } from "@flows/nax-finish/steps/result";
+import type { FlowNodeContext } from "acpx/flows";
+
+const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
+
+const ctxOf = (over: { outputs?: Record<string, unknown>; steps?: { nodeId: string }[] }): FlowNodeContext =>
+  ({
+    input: INPUT,
+    outputs: over.outputs ?? {},
+    results: {},
+    state: { steps: over.steps ?? [] } as never,
+    services: {},
+  }) as FlowNodeContext;
+
+type NodeRun<T> = { run: (ctx: FlowNodeContext) => Promise<T> | T };
+const nodeRun = <T>(id: string) => flow.nodes[id] as unknown as NodeRun<T>;
+const switchOf = (from: string) => {
+  const edge = flow.edges.find((e) => e.from === from && "switch" in e);
+  if (!edge || !("switch" in edge)) throw new Error(`no switch edge from ${from}`);
+  return edge.switch;
+};
+
+describe("commit_* nodes", () => {
+  const originalRun = _gitDeps.run;
+  const originalAppend = _resultDeps.appendText;
+  afterEach(() => {
+    _gitDeps.run = originalRun;
+    _resultDeps.appendText = originalAppend;
+  });
+
+  const runCommitNode = async (id: string, porcelain: string, outputs: Record<string, unknown> = {}) => {
+    const calls: string[][] = [];
+    const rounds: unknown[] = [];
+    _gitDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--porcelain")
+        ? { exitCode: 0, stdout: porcelain, stderr: "" }
+        : { exitCode: 0, stdout: "", stderr: "" };
+    };
+    _resultDeps.appendText = async (_p, s) => {
+      rounds.push(JSON.parse(s));
+    };
+    const out = await nodeRun<{ committed: boolean; route: string }>(id).run(ctxOf({ outputs }));
+    // The commit message is the last `-m` argument; asserting on it directly
+    // keeps these tests readable now that it spans multiple lines.
+    const commit = calls.find((c) => c[1] === "commit");
+    return { out, argv: calls.map((c) => c.join(" ")), message: commit?.[3] ?? "", rounds };
+  };
+
+  test("commits the fix under a subject naming what was fixed, and does not push", async () => {
+    const { out, message, argv } = await runCommitNode("commit_spec", " M apps/api/_calendar.py\n", {
+      review_spec: {
+        findings: [{ severity: "HIGH", title: "Market gate skip branch is unreachable", problem: "P", fix: "F" }],
+      },
+    });
+    expect(out.committed).toBe(true);
+    expect(message.split("\n")[0]).toBe("fix(x): market gate skip branch is unreachable");
+    // The finding's detail belongs in the body — a PR reviewer reads it there.
+    expect(message).toContain("- [HIGH] Market gate skip branch is unreachable");
+    // --no-verify: a pre-commit hook rejecting an intermediate state would
+    // otherwise kill the flow before the gate loop could fix it
+    expect(argv.some((c) => c.endsWith("--no-verify"))).toBe(true);
+    // the push belongs to the terminal nodes; a mid-loop push would publish
+    // half-fixed states to the forge on every round
+    expect(argv.some((c) => c.startsWith("git push"))).toBe(false);
+  });
+
+  // Regression: all six nax-finish commits on rs-stock/pipeline-run-outcome read
+  // `fix(f): nax-finish <phase> fixes` with an empty body, so a PR reviewer could
+  // not tell which one re-enabled a disabled market gate.
+  test("no phase falls back to the old opaque 'nax-finish <phase> fixes' subject", async () => {
+    for (const phase of ["acceptance", "spec", "quality", "gate"]) {
+      const { message } = await runCommitNode(`commit_${phase}`, " M a.ts\n");
+      expect(message.split("\n")[0]).not.toBe(`fix(x): nax-finish ${phase} fixes`);
+      expect(message.split("\n")[0].startsWith("fix(x): ")).toBe(true);
+    }
+  });
+
+  test("the gate phase names the failing commands in its subject", async () => {
+    const { message } = await runCommitNode("commit_gate", " M a.ts\n", {
+      quality_gates: { failing: ["lint", "test"], output: "1 failed" },
+    });
+    expect(message.split("\n")[0]).toBe("fix(x): repair failing lint and test gates");
+  });
+
+  test("a fix node that changed nothing produces no commit", async () => {
+    const { out, argv } = await runCommitNode("commit_gate", "");
+    expect(out.committed).toBe(false);
+    expect(argv.some((c) => c.startsWith("git commit"))).toBe(false);
+  });
+
+  // ctx.outputs holds only the latest output per node, so a round not recorded
+  // here is a round no terminal node can reconstruct.
+  test("records the round to the audit trail, findings included", async () => {
+    const { rounds } = await runCommitNode("commit_quality", " M a.ts\n", {
+      review_quality: { findings: [{ severity: "CRITICAL", title: "T", problem: "P", fix: "F" }] },
+    });
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0]).toMatchObject({
+      phase: "quality",
+      committed: true,
+      findings: [{ severity: "CRITICAL", title: "T" }],
+    });
+  });
+
+  test("records a round even when the fix committed nothing, so the dead round is visible", async () => {
+    const { rounds } = await runCommitNode("commit_gate", "", { quality_gates: { failing: ["test"] } });
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0]).toMatchObject({ phase: "gate", committed: false, failing: ["test"] });
+  });
+});
+
+// Regression: the gate loop was the last loop to edit the tree and the only one
+// whose edits nothing reviewed — `quality_gates` proves the repo's commands are
+// green, which a bad fix can satisfy. rs-stock/pipeline-run-outcome shipped 8
+// copy-pasted test stubs through this hole.
+describe("gate fixes re-enter the quality review", () => {
+  const gateSwitch = () => switchOf("commit_gate");
+
+  test("a gate fix that committed goes back through review_quality", () => {
+    expect(gateSwitch().cases.changed).toBe("review_quality");
+  });
+
+  test("a gate fix that changed nothing skips the re-review", () => {
+    expect(gateSwitch().cases.unchanged).toBe("quality_gates");
+  });
+
+  test("the re-entry still terminates: review_quality's own fix loop keeps its escalate exit", () => {
+    expect(switchOf("route_quality").cases.escalate).toBe("escalate");
+    expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
+  });
+});

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -101,7 +101,10 @@ describe("nax-finish flow graph", () => {
     // quality fixes are re-reviewed by the same lens
     expect(toOf("commit_quality")).toBe("review_quality");
     expect(toOf("commit_acceptance")).toBe("acceptance");
-    expect(toOf("commit_gate")).toBe("quality_gates");
+    // commit_gate is the exception — it switches on whether it committed, so
+    // that a real gate fix is re-reviewed. See "gate fixes re-enter the quality
+    // review" below.
+    expect(switchOf("commit_gate").cases.unchanged).toBe("quality_gates");
   });
 
   // Regression: #1397 — reviewers read `git diff base...HEAD`, so an uncommitted
@@ -113,49 +116,6 @@ describe("nax-finish flow graph", () => {
       expect(flow.nodes[`commit_${phase}`].nodeType).toBe("action");
       expect(toOf(`fix_${phase}`)).toBe(`commit_${phase}`);
     }
-  });
-});
-
-describe("commit_* nodes", () => {
-  const originalRun = _gitDeps.run;
-  afterEach(() => {
-    _gitDeps.run = originalRun;
-  });
-
-  const runCommitNode = async (id: string, porcelain: string) => {
-    const calls: string[][] = [];
-    _gitDeps.run = async (cmd) => {
-      calls.push(cmd);
-      return cmd.includes("--porcelain")
-        ? { exitCode: 0, stdout: porcelain, stderr: "" }
-        : { exitCode: 0, stdout: "", stderr: "" };
-    };
-    const out = await nodeRun<{ committed: boolean }>(id).run(ctxOf({}));
-    return { out, argv: calls.map((c) => c.join(" ")) };
-  };
-
-  test("commits the fix with a conventional, phase-named message and no push", async () => {
-    const { out, argv } = await runCommitNode("commit_spec", " M apps/api/_calendar.py\n");
-    expect(out.committed).toBe(true);
-    // --no-verify: a pre-commit hook rejecting an intermediate state would
-    // otherwise kill the flow before the gate loop could fix it
-    expect(argv).toContain("git commit -m fix(x): nax-finish spec fixes --no-verify");
-    // the push belongs to the terminal nodes; a mid-loop push would publish
-    // half-fixed states to the forge on every round
-    expect(argv.some((c) => c.startsWith("git push"))).toBe(false);
-  });
-
-  test("each phase commits under its own message", async () => {
-    for (const phase of ["acceptance", "quality", "gate"]) {
-      const { argv } = await runCommitNode(`commit_${phase}`, " M a.ts\n");
-      expect(argv).toContain(`git commit -m fix(x): nax-finish ${phase} fixes --no-verify`);
-    }
-  });
-
-  test("a fix node that changed nothing produces no commit", async () => {
-    const { out, argv } = await runCommitNode("commit_gate", "");
-    expect(out.committed).toBe(false);
-    expect(argv.some((c) => c.startsWith("git commit"))).toBe(false);
   });
 });
 
@@ -572,8 +532,7 @@ describe("escalate node", () => {
     _escalateDeps.run = async (cmd) => {
       calls.push(cmd);
       if (cmd.join(" ").includes("remote get-url")) return { exitCode: 0, stdout: "git@github.com:o/r", stderr: "" };
-      if (cmd.includes("view"))
-        return { exitCode: 0, stdout: JSON.stringify({ url: "https://gh/pr/9" }), stderr: "" };
+      if (cmd.includes("view")) return { exitCode: 0, stdout: JSON.stringify({ url: "https://gh/pr/9" }), stderr: "" };
       return { exitCode: 0, stdout: "", stderr: "" };
     };
   };

--- a/test/unit/flows/nax-finish/review-prompts.test.ts
+++ b/test/unit/flows/nax-finish/review-prompts.test.ts
@@ -51,3 +51,59 @@ describe("fixPrompt", () => {
     expect(p).toContain('"severity":"LOW"');
   });
 });
+
+// Reviews were 58% of the flow's wall clock on rs-stock/pipeline-run-outcome
+// (7 calls, 1306s of 2232s), most of it re-reading code an earlier round had
+// already cleared.
+describe("buildReviewPrompt — incremental re-review", () => {
+  const PRIOR = [{ severity: "HIGH" as const, title: "T", problem: "P", fix: "F" }];
+
+  test("round 1 (no since) reviews the whole branch diff", () => {
+    const p = buildReviewPrompt("spec", { base: "origin/main", specPath: "s.md" });
+    expect(p).toContain("git diff origin/main...HEAD");
+    expect(p).not.toContain("continuing a review you already started");
+  });
+
+  test("a re-review scopes the verdict to the fix diff", () => {
+    const p = buildReviewPrompt("spec", {
+      base: "origin/main",
+      specPath: "s.md",
+      since: "abc123",
+      priorFindings: PRIOR,
+    });
+    expect(p).toContain("git diff abc123..HEAD");
+    expect(p).toContain("continuing a review you already started");
+    expect(p).toContain("do not re-derive a verdict on it");
+  });
+
+  test("a re-review carries the prior findings forward, so the fix can be checked against them", () => {
+    const p = buildReviewPrompt("quality", {
+      base: "origin/main",
+      specPath: "s.md",
+      since: "abc123",
+      priorFindings: PRIOR,
+    });
+    expect(p).toContain('"title": "T"');
+  });
+
+  // The saving must come from narrowing what is *judged*, never from blinding
+  // the reviewer — a fix's real damage is often in the unchanged code it calls.
+  test("a re-review may still read anything, and is told so explicitly", () => {
+    const p = buildReviewPrompt("spec", { base: "origin/main", specPath: "s.md", since: "abc", priorFindings: PRIOR });
+    expect(p).toContain("the whole repo is available");
+    expect(p).toContain("Scope means *what you judge*, not *what you may read*");
+  });
+
+  test("a re-review refuses papered-over fixes rather than accepting a green gate", () => {
+    const p = buildReviewPrompt("spec", { base: "origin/main", specPath: "s.md", since: "abc", priorFindings: PRIOR });
+    expect(p).toContain("assertion weakened, test deleted, check disabled");
+  });
+
+  test("both rounds keep the full dimensions and the JSON contract", () => {
+    for (const since of [null, "abc123"]) {
+      const p = buildReviewPrompt("quality", { base: "origin/main", specPath: "s.md", since, priorFindings: PRIOR });
+      expect(p).toContain("Confidence threshold");
+      expect(p).toContain('"route"');
+    }
+  });
+});

--- a/test/unit/flows/nax-finish/steps/context.test.ts
+++ b/test/unit/flows/nax-finish/steps/context.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { _contextDeps, detectBaseBranch, preflight, resolveFeature } from "@flows/nax-finish/steps/context";
+import {
+  _contextDeps,
+  detectBaseBranch,
+  partitionTestFiles,
+  preflight,
+  resolveFeature,
+} from "@flows/nax-finish/steps/context";
 import type { RunResult } from "@flows/nax-finish/types";
 
 const ok = (stdout: string): RunResult => ({ exitCode: 0, stdout, stderr: "" });
@@ -83,5 +89,37 @@ describe("context steps", () => {
   test("preflight routes proceed when ahead", async () => {
     _contextDeps.run = async () => ok("3\n");
     expect(await preflight("/w", "origin/main")).toEqual({ commitsAhead: 3, route: "proceed" });
+  });
+});
+
+describe("partitionTestFiles", () => {
+  const TS = ["\\.test\\.ts$", "(^|/)test/"];
+
+  test("splits by the resolver's patterns", () => {
+    const r = partitionTestFiles(["src/a.ts", "test/unit/a.test.ts", "apps/api/tests/b.py"], TS);
+    expect(r.test).toEqual(["test/unit/a.test.ts"]);
+    expect(r.nonTest).toEqual(["src/a.ts", "apps/api/tests/b.py"]);
+  });
+
+  // The one caller skips its re-review only on a test-only change, so
+  // "cannot classify" must mean "review it", never "skip it".
+  test("no patterns means nothing is classified as a test", () => {
+    const r = partitionTestFiles(["test/unit/a.test.ts"], []);
+    expect(r.test).toEqual([]);
+    expect(r.nonTest).toEqual(["test/unit/a.test.ts"]);
+  });
+
+  test("an unparseable pattern is skipped, the valid ones still apply", () => {
+    const r = partitionTestFiles(["test/unit/a.test.ts", "src/a.ts"], ["([unclosed", "\\.test\\.ts$"]);
+    expect(r.test).toEqual(["test/unit/a.test.ts"]);
+    expect(r.nonTest).toEqual(["src/a.ts"]);
+  });
+
+  test("an all-bad pattern list degrades to non-test, not to a throw", () => {
+    expect(partitionTestFiles(["test/a.test.ts"], ["([unclosed"]).nonTest).toEqual(["test/a.test.ts"]);
+  });
+
+  test("an empty path list yields two empty buckets", () => {
+    expect(partitionTestFiles([], TS)).toEqual({ test: [], nonTest: [] });
   });
 });

--- a/test/unit/flows/nax-finish/steps/git.test.ts
+++ b/test/unit/flows/nax-finish/steps/git.test.ts
@@ -69,7 +69,7 @@ describe("commitFixes", () => {
       return cmd.includes("--porcelain") ? ok(" M apps/api/_calendar.py\n?? apps/api/tests/test_new.py\n") : ok();
     };
     const r = await commitFixes("/repo", "fix(x): nax-finish spec fixes");
-    expect(r).toEqual({ committed: true });
+    expect(r).toMatchObject({ committed: true });
     const argv = argvOf(calls);
     // -A, not -u: a fix that adds a new test file must be committed too, or the
     // reviewer's `git diff base...HEAD` still cannot see it.
@@ -94,7 +94,7 @@ describe("commitFixes", () => {
       return ok("");
     };
     const r = await commitFixes("/repo", "msg");
-    expect(r).toEqual({ committed: false });
+    expect(r).toMatchObject({ committed: false });
     expect(argvOf(calls).some((c) => c.startsWith("git commit"))).toBe(false);
   });
 

--- a/test/unit/flows/nax-finish/steps/result.test.ts
+++ b/test/unit/flows/nax-finish/steps/result.test.ts
@@ -1,19 +1,146 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { _resultDeps, resultPath, writeResult } from "@flows/nax-finish/steps/result";
+import {
+  _resultDeps,
+  appendRound,
+  readRounds,
+  resolveAuditDir,
+  resultPath,
+  roundsPath,
+  writeResult,
+} from "@flows/nax-finish/steps/result";
+import type { FinishRound } from "@flows/nax-finish/types";
 
 const originalWriteText = _resultDeps.writeText;
+const originalAppendText = _resultDeps.appendText;
+const originalReadText = _resultDeps.readText;
+
 afterEach(() => {
   _resultDeps.writeText = originalWriteText;
+  _resultDeps.appendText = originalAppendText;
+  _resultDeps.readText = originalReadText;
+});
+
+const TARGET = {
+  auditDir: "/home/u/.nax/proj/finish-audit/feat-x",
+  workdir: "/repo",
+  feature: "feat-x",
+  runId: "run-2026-08-01T03-30-25-572Z",
+};
+
+const round = (over: Partial<FinishRound> = {}): FinishRound => ({
+  ts: "2026-08-01T05:00:00.000Z",
+  phase: "quality",
+  attempt: 1,
+  committed: true,
+  findings: [],
+  ...over,
+});
+
+/** Stub readText to return `raw`, and capture what writeResult/appendRound emit. */
+function captureWrites(raw: string | null = null) {
+  const wrote: { p: string; s: string }[] = [];
+  const appended: { p: string; s: string }[] = [];
+  _resultDeps.readText = async () => raw;
+  _resultDeps.writeText = async (p, s) => {
+    wrote.push({ p, s });
+  };
+  _resultDeps.appendText = async (p, s) => {
+    appended.push({ p, s });
+  };
+  return { wrote, appended };
+}
+
+describe("audit paths", () => {
+  test("live under the plugin-supplied global audit dir, not the repo", () => {
+    expect(resolveAuditDir(TARGET)).toBe("/home/u/.nax/proj/finish-audit/feat-x");
+    expect(resultPath(TARGET)).toBe(`/home/u/.nax/proj/finish-audit/feat-x/${TARGET.runId}.result.json`);
+    expect(roundsPath(TARGET)).toBe(`/home/u/.nax/proj/finish-audit/feat-x/${TARGET.runId}.jsonl`);
+  });
+
+  test("are per-run, so a second finish of the same feature cannot overwrite the first", () => {
+    const a = resultPath({ ...TARGET, runId: "run-a" });
+    const b = resultPath({ ...TARGET, runId: "run-b" });
+    expect(a).not.toBe(b);
+  });
+
+  test("fall back to a repo-local dir when the caller supplied no auditDir", () => {
+    const { auditDir: _drop, ...noAuditDir } = TARGET;
+    expect(resolveAuditDir(noAuditDir)).toBe("/repo/.nax/finish-audit/feat-x");
+  });
+
+  test("fall back to a fixed run id when the caller supplied none, rather than producing an undefined path", () => {
+    const { runId: _drop, ...noRunId } = TARGET;
+    expect(resultPath(noRunId)).toBe("/home/u/.nax/proj/finish-audit/feat-x/run.result.json");
+  });
+});
+
+describe("appendRound", () => {
+  test("appends one JSON line per round to the run's jsonl", async () => {
+    const { appended } = captureWrites();
+    await appendRound(TARGET, round({ attempt: 2 }));
+    expect(appended).toHaveLength(1);
+    expect(appended[0].p).toBe(roundsPath(TARGET));
+    expect(appended[0].s.endsWith("\n")).toBe(true);
+    expect(JSON.parse(appended[0].s)).toMatchObject({ phase: "quality", attempt: 2, committed: true });
+  });
+
+  // A round is a record of work already done; an unwritable ~/.nax must not
+  // take down the flow mid-loop and lose the work itself.
+  test("an unwritable audit dir does not propagate out of the fix loop", async () => {
+    _resultDeps.appendText = async () => {
+      throw new Error("EACCES");
+    };
+    expect(await appendRound(TARGET, round())).toBeUndefined();
+  });
+});
+
+describe("readRounds", () => {
+  test("parses every line back", async () => {
+    captureWrites(`${JSON.stringify(round({ attempt: 1 }))}\n${JSON.stringify(round({ attempt: 2 }))}\n`);
+    expect(await readRounds(TARGET)).toHaveLength(2);
+  });
+
+  test("a torn final line does not lose the rounds before it", async () => {
+    captureWrites(`${JSON.stringify(round({ attempt: 1 }))}\n{"phase":"qual`);
+    const rounds = await readRounds(TARGET);
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0].attempt).toBe(1);
+  });
+
+  test("no trail yet reads as no rounds, not an error", async () => {
+    captureWrites(null);
+    expect(await readRounds(TARGET)).toEqual([]);
+  });
 });
 
 describe("writeResult", () => {
-  test("writes the result JSON to .nax/nax-finish-result.json", async () => {
-    let wrote: { p: string; s: string } | null = null;
-    _resultDeps.writeText = async (p, s) => {
-      wrote = { p, s };
-    };
-    await writeResult("/repo", { feature: "x", status: "escalated", escalationReason: "design call" });
-    expect(wrote!.p).toBe(resultPath("/repo"));
-    expect(JSON.parse(wrote!.s)).toMatchObject({ feature: "x", status: "escalated", escalationReason: "design call" });
+  test("writes the terminal result to the run-scoped audit path", async () => {
+    const { wrote } = captureWrites();
+    await writeResult(TARGET, { feature: "feat-x", status: "escalated", escalationReason: "design call" });
+    expect(wrote[0].p).toBe(resultPath(TARGET));
+    expect(JSON.parse(wrote[0].s)).toMatchObject({
+      feature: "feat-x",
+      status: "escalated",
+      escalationReason: "design call",
+    });
+  });
+
+  // The regression this exists for: a successful finish that took rounds to get
+  // there recorded nothing, so the fixes it made were invisible after the fact.
+  test("embeds the recorded rounds on a SUCCESS status, not only on escalations", async () => {
+    const { wrote } = captureWrites(
+      `${JSON.stringify(round({ phase: "gate", attempt: 1 }))}\n${JSON.stringify(round({ phase: "quality", attempt: 1 }))}\n`,
+    );
+    await writeResult(TARGET, { feature: "feat-x", status: "promoted", url: "https://forge/pr/1" });
+    const parsed = JSON.parse(wrote[0].s);
+    expect(parsed.status).toBe("promoted");
+    expect(parsed.rounds).toHaveLength(2);
+    expect(parsed.rounds[0]).toMatchObject({ phase: "gate", attempt: 1 });
+  });
+
+  test("omits the rounds key entirely when no round ran", async () => {
+    const { wrote } = captureWrites(null);
+    await writeResult(TARGET, { feature: "feat-x", status: "promoted" });
+    expect(JSON.parse(wrote[0].s)).not.toHaveProperty("rounds");
   });
 });

--- a/test/unit/plugins/builtin/nax-finish/config.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/config.test.ts
@@ -37,6 +37,24 @@ describe("getFinishAutoFlowConfig — defaultAgent", () => {
   });
 });
 
+describe("getFinishAutoFlowConfig — model", () => {
+  // Opt-in on purpose. acpx resolves a node's model as
+  // `node.model ?? agent.model ?? --model`, so --model is a floor that cannot
+  // override a profile-pinned reviewer — but only on an acpx build that reads a
+  // `model` from agent entries. Defaulting it from config.models would break
+  // that guarantee on builds without the support.
+  test("is null unless explicitly configured, and is never derived from config.models", () => {
+    const cfg = getFinishAutoFlowConfig(
+      withAutoFlow({ enabled: true }, { agent: { default: "claude" }, models: { claude: { balanced: "sonnet" } } }),
+    );
+    expect(cfg.model).toBeNull();
+  });
+
+  test("passes an explicitly configured model through", () => {
+    expect(getFinishAutoFlowConfig(withAutoFlow({ enabled: true, model: "sonnet" })).model).toBe("sonnet");
+  });
+});
+
 describe("getFinishAutoFlowConfig — unrelated defaults are unchanged", () => {
   test("a context with no finish block at all still reports disabled", () => {
     expect(getFinishAutoFlowConfig({ config: {} }).enabled).toBe(false);

--- a/test/unit/plugins/builtin/nax-finish/config.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/config.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { getFinishAutoFlowConfig } from "@/plugins";
+
+const withAutoFlow = (autoFlow: Record<string, unknown>, rest: Record<string, unknown> = {}) => ({
+  config: { finish: { autoFlow }, ...rest },
+});
+
+describe("getFinishAutoFlowConfig — defaultAgent", () => {
+  // Regression: a profile that set only `reviewers` left defaultAgent null, so
+  // the plugin passed no `--default-agent` and every non-review node (fix_spec,
+  // fix_quality, fix_gate) silently ran on acpx's own default agent — not the
+  // one the run had been using.
+  test("falls back to the run's own agent when finish.autoFlow.defaultAgent is unset", () => {
+    const cfg = getFinishAutoFlowConfig(
+      withAutoFlow({ enabled: true, reviewers: { spec: "s", quality: "q" } }, { agent: { default: "claude" } }),
+    );
+    expect(cfg.defaultAgent).toBe("claude");
+  });
+
+  test("an explicit finish.autoFlow.defaultAgent still wins over the run's agent", () => {
+    const cfg = getFinishAutoFlowConfig(
+      withAutoFlow({ enabled: true, defaultAgent: "codex" }, { agent: { default: "claude" } }),
+    );
+    expect(cfg.defaultAgent).toBe("codex");
+  });
+
+  // resolveDefaultAgent's own fallback — a config with no agent block at all
+  // still names an agent rather than deferring to whatever acpx defaults to.
+  test("a config with no agent block resolves to nax's fallback agent, never null", () => {
+    const cfg = getFinishAutoFlowConfig(withAutoFlow({ enabled: true }));
+    expect(cfg.defaultAgent).toBe("claude");
+  });
+
+  test("reviewers still default to null, so acpx uses --default-agent for them", () => {
+    const cfg = getFinishAutoFlowConfig(withAutoFlow({ enabled: true }));
+    expect(cfg.reviewers).toEqual({ spec: null, quality: null });
+  });
+});
+
+describe("getFinishAutoFlowConfig — unrelated defaults are unchanged", () => {
+  test("a context with no finish block at all still reports disabled", () => {
+    expect(getFinishAutoFlowConfig({ config: {} }).enabled).toBe(false);
+  });
+
+  test("timeouts fall back to the schema defaults", () => {
+    const cfg = getFinishAutoFlowConfig(withAutoFlow({ enabled: true, timeouts: { gateMs: 1234 } }));
+    expect(cfg.timeouts.gateMs).toBe(1234);
+    expect(cfg.timeouts.acceptanceMs).toBe(600_000);
+  });
+});

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -562,7 +562,7 @@ describe("nax-finish post-run action", () => {
 
 describe("buildFlowArgv", () => {
   test("puts --default-agent AFTER the flow file — acpx defines it on `flow run`, not the root", () => {
-    const argv = buildFlowArgv("/pkg/flows/nax-finish/nax-finish.flow.ts", "{}", "claude");
+    const argv = buildFlowArgv("/pkg/flows/nax-finish/nax-finish.flow.ts", "{}", { defaultAgent: "claude" });
     expect(argv).toEqual([
       "acpx",
       "--approve-all",
@@ -580,18 +580,39 @@ describe("buildFlowArgv", () => {
   });
 
   test("omits --default-agent entirely when unset", () => {
-    expect(buildFlowArgv("/f.ts", "{}", null)).not.toContain("--default-agent");
+    expect(buildFlowArgv("/f.ts", "{}", {})).not.toContain("--default-agent");
   });
 
   test("puts --timeout (seconds) BEFORE `flow` — it is a top-level flag", () => {
-    const argv = buildFlowArgv("/f.ts", "{}", null, 1_800_000);
+    const argv = buildFlowArgv("/f.ts", "{}", { stepMs: 1_800_000 });
     expect(argv.slice(0, 4)).toEqual(["acpx", "--approve-all", "--timeout", "1800"]);
     expect(argv.indexOf("--timeout")).toBeLessThan(argv.indexOf("flow"));
   });
 
   test("omits --timeout when stepMs is unset, leaving acpx's own default", () => {
-    expect(buildFlowArgv("/f.ts", "{}", null, null)).not.toContain("--timeout");
-    expect(buildFlowArgv("/f.ts", "{}", null)).not.toContain("--timeout");
+    expect(buildFlowArgv("/f.ts", "{}", { stepMs: null })).not.toContain("--timeout");
+    expect(buildFlowArgv("/f.ts", "{}", {})).not.toContain("--timeout");
+  });
+
+  // acpx resolves a node's model as `node.model ?? agent.model ?? --model`, so
+  // this flag is the run-wide floor: it reaches the fix_* nodes and cannot
+  // override a reviewer whose agent entry pins its own model.
+  test("puts --model BEFORE `flow` — it is a top-level flag, not a `flow run` option", () => {
+    const argv = buildFlowArgv("/f.ts", "{}", { model: "sonnet" });
+    expect(argv.slice(0, 4)).toEqual(["acpx", "--approve-all", "--model", "sonnet"]);
+    expect(argv.indexOf("--model")).toBeLessThan(argv.indexOf("flow"));
+  });
+
+  test("omits --model when unset, so nothing changes for a repo that did not opt in", () => {
+    expect(buildFlowArgv("/f.ts", "{}", {})).not.toContain("--model");
+    expect(buildFlowArgv("/f.ts", "{}", { model: null })).not.toContain("--model");
+  });
+
+  test("--model and --timeout coexist, both ahead of `flow`", () => {
+    const argv = buildFlowArgv("/f.ts", "{}", { defaultAgent: "claude", stepMs: 60_000, model: "sonnet" });
+    expect(argv.indexOf("--model")).toBeLessThan(argv.indexOf("flow"));
+    expect(argv.indexOf("--timeout")).toBeLessThan(argv.indexOf("flow"));
+    expect(argv.indexOf("--default-agent")).toBeGreaterThan(argv.indexOf("run"));
   });
 });
 
@@ -685,5 +706,33 @@ describe("telegramCreds / isTelegramConfigured", () => {
     const config = {};
     expect(telegramCreds(config)).toBeNull();
     expect(isTelegramConfigured(config)).toBe(false);
+  });
+});
+
+describe("model reaches the spawned acpx argv", () => {
+  const spawnedArgv = async (autoFlow: Record<string, unknown>): Promise<string[]> => {
+    let argv: string[] = [];
+    _naxFinishDeps.run = async (cmd) => {
+      argv = cmd;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    _naxFinishDeps.clearResult = async () => {};
+    _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
+    _naxFinishDeps.exists = async () => true;
+    await action.execute(baseCtx({ config: { finish: { autoFlow: { enabled: true, ...autoFlow } } } } as never));
+    return argv;
+  };
+
+  test("a configured model is spawned as a top-level --model", async () => {
+    const argv = await spawnedArgv({ model: "sonnet" });
+    expect(argv.join(" ")).toContain("--model sonnet");
+    expect(argv.indexOf("--model")).toBeLessThan(argv.indexOf("flow"));
+  });
+
+  // The default path must be byte-identical to before this feature existed —
+  // an unconditional --model would override profile-pinned reviewers on an acpx
+  // build that does not support a model on agent entries.
+  test("no --model is spawned when the repo did not opt in", async () => {
+    expect(await spawnedArgv({})).not.toContain("--model");
   });
 });

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   _naxFinishDeps,
   buildFlowArgv,
+  finishAuditDir,
+  finishResultPath,
   isTelegramConfigured,
   naxFinishPlugin,
   resolveFlowPath,
@@ -37,6 +39,54 @@ const baseCtx = (over: Partial<PostRunContext> = {}): PostRunContext =>
     },
     ...over,
   }) as unknown as PostRunContext;
+
+describe("finish-audit location", () => {
+  // The artifact records a run, not the source tree, so it belongs beside
+  // prompt-audit/ and review-audit/ under the project's output dir — not in the
+  // user's repo, where it was neither committable nor gitignorable.
+  test("resolves under <outputDir>/finish-audit/<feature>, like prompt-audit and review-audit", () => {
+    const ctx = baseCtx({ outputDir: "/home/u/.nax/proj" });
+    expect(finishAuditDir(ctx)).toBe("/home/u/.nax/proj/finish-audit/x");
+  });
+
+  test("names the result file by run id, so two finishes of one feature do not collide", () => {
+    const ctx = baseCtx({ outputDir: "/home/u/.nax/proj" });
+    expect(finishResultPath(ctx, "run-a")).toBe("/home/u/.nax/proj/finish-audit/x/run-a.result.json");
+    expect(finishResultPath(ctx, "run-b")).not.toBe(finishResultPath(ctx, "run-a"));
+  });
+
+  // outputDir is optional on PostRunContext for backward compatibility; the
+  // flow applies the same repo-local fallback, so both sides agree on the path.
+  test("falls back to the repo when the context carries no outputDir", () => {
+    expect(finishAuditDir(baseCtx())).toBe("/repo/.nax/finish-audit/x");
+  });
+
+  test("passes the resolved audit dir and run id to the flow, and reads back the same path", async () => {
+    let flowInput: Record<string, unknown> = {};
+    let readFrom = "";
+    let clearedFrom = "";
+    _naxFinishDeps.run = async (cmd) => {
+      flowInput = JSON.parse(cmd[cmd.indexOf("--input-json") + 1]);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    _naxFinishDeps.clearResult = async (p) => {
+      clearedFrom = p;
+    };
+    _naxFinishDeps.readResult = async (p) => {
+      readFrom = p;
+      return { feature: "x", status: "opened" };
+    };
+    _naxFinishDeps.exists = async () => true;
+    const ctx = baseCtx({ outputDir: "/home/u/.nax/proj", runId: "run-42" });
+    await action.execute(ctx);
+
+    expect(flowInput.auditDir).toBe("/home/u/.nax/proj/finish-audit/x");
+    expect(flowInput.runId).toBe("run-42");
+    // The plugin must read back exactly where it told the flow to write.
+    expect(readFrom).toBe("/home/u/.nax/proj/finish-audit/x/run-42.result.json");
+    expect(clearedFrom).toBe(readFrom);
+  });
+});
 
 describe("nax-finish post-run action", () => {
   test("shouldRun=false when disabled", async () => {
@@ -555,10 +605,7 @@ describe("resolveFlowPath", () => {
     const resolved = await resolveFlowPath(
       "/user/repo",
       "flows/nax-finish/nax-finish.flow.ts",
-      deps(
-        ["/nax/package.json", "/nax/flows/nax-finish/nax-finish.flow.ts"],
-        "/nax/src/plugins/builtin/nax-finish",
-      ),
+      deps(["/nax/package.json", "/nax/flows/nax-finish/nax-finish.flow.ts"], "/nax/src/plugins/builtin/nax-finish"),
     );
     expect(resolved).toBe("/nax/flows/nax-finish/nax-finish.flow.ts");
   });
@@ -590,7 +637,11 @@ describe("resolveFlowPath", () => {
 
   test("returns null when the flow exists nowhere", async () => {
     expect(
-      await resolveFlowPath("/user/repo", "flows/nax-finish/nax-finish.flow.ts", deps(["/nax/package.json"], "/nax/dist")),
+      await resolveFlowPath(
+        "/user/repo",
+        "flows/nax-finish/nax-finish.flow.ts",
+        deps(["/nax/package.json"], "/nax/dist"),
+      ),
     ).toBeNull();
   });
 });


### PR DESCRIPTION
Reviewing what `nax-finish-flow` actually shipped on `rs-stock/pipeline-run-outcome` turned up three gaps. It caught six real defects the run's own review gates had passed — including production code that had been contorted to make tests pass — and then shipped its own unreviewed duplication through a hole in the graph.

## 1. Gate fixes are reviewed (when they touch production code)

`commit_gate` routed straight back to `quality_gates`, so the gate loop — the last loop to edit the tree — was the only editing loop whose output nothing reviewed. `quality_gates` proves the repo's commands are green, which a bad fix can satisfy: that round repaired 8 tests by copy-pasting an identical 4-line stub into each, and it shipped.

`commit_gate` now switches three ways:

| route | when | goes to |
|:--|:--|:--|
| `changed` | touched non-test files, **or** the paths could not be classified | `review_quality` |
| `tests-only` | every touched path matched the repo's test-file patterns | `quality_gates` |
| `unchanged` | nothing committed | `quality_gates` |

Classification comes from `nax features resolve --json`, which now emits `testPatterns` — regex sources from the ADR-009 resolver — so it is correct for Go/Python/Rust packages, not just `*.test.ts`. Verified against rs-stock's real layout: `apps/api/tests/*.py` → test, `apps/api/src/**` → non-test.

> **Known gap, deliberately accepted.** The defect that motivated this re-entry was *itself* test-only, so `tests-only` would not have caught it. The re-review is the flow's most expensive node and a gate fix is usually a mechanical test repair; this is a cost tradeoff, documented in the guide with the pointer to widen it (`gateCommitRoute`) if test-quality regressions start reaching PRs.

## 2. Re-reviews are narrowed

Reviews were **58% of the flow's wall clock** on the measured run — 7 calls, 1306s of 2232s — because every round re-read the spec in full and the whole `git diff base...HEAD`, re-deriving a verdict on code earlier rounds had already cleared.

A re-review now gets its prior findings plus `git diff <shaAtLastReview>..HEAD` and is asked two questions: are those findings actually resolved (a weakened assertion, deleted test or disabled check is **not**), and did the fix break anything, including in unchanged code it now calls into.

Scope means *what is judged*, not *what may be read* — the spec and the whole repo stay available and the prompt says so explicitly.

The window anchors on the **first** commit step after the last review, read from `ctx.state.steps[].output`, so it spans every commit in the window (the acceptance loop can commit between a spec fix and its re-review). Anchoring on the last would hide the spec fix from the reviewer; a test pins that.

## 3. Audit trail moved to `~/.nax/` and grew a history

`.nax/nax-finish-result.json` was a single overwritten file describing a *run*, not the source tree — neither committable nor, as it turned out, gitignored by `nax init`. It now lives beside `prompt-audit/` and `review-audit/`:

```
~/.nax/<project>/finish-audit/<feature>/<runId>.jsonl        one line per fix round
~/.nax/<project>/finish-audit/<feature>/<runId>.result.json  terminal state
```

Rounds are appended at each `commit_*` as they happen, which is what makes the trail survive a flow that is killed or times out. `findings` now lands on **every** terminal status, not just `escalated` — a finish that succeeded after four rounds is precisely the case worth auditing, and it was the one case that previously recorded nothing.

## 4. Commit messages describe the fix

All six commits on that branch read `fix(f): nax-finish <phase> fixes` with an empty body, so a reviewer could not tell which one re-enabled a disabled market gate. Subjects now name the finding (or the failing gates); bodies list severity / problem / fix. The reviewer already produced that material — it was discarded at the one moment it could be recorded.

## 5. Agent and model resolution

Two separate bugs found while testing against a real profile:

- **`defaultAgent` defaulted to `null`**, which omits `--default-agent` from the acpx argv entirely. A profile configuring only `reviewers` ran its reviewers on the named models and every `fix_*` node — the nodes that edit code — on acpx's own default. Now falls back to `agent.default` via `resolveDefaultAgent`, the same accessor a run uses.
- **New `finish.autoFlow.model`** → acpx `--model`. acpx resolves a node's model as `node.model ?? agent.model ?? --model`, verified in `src/flows/runtime.ts`, so this is a *floor*, not an override: it reaches the `fix_*` nodes and cannot override a profile-pinned reviewer whose agent entry names its own model.

`model` is opt-in (`null`) and never derived from `config.models`. The floor guarantee needs an acpx build that reads `model` from agent entries; without that, `--model` becomes the only model signal and *would* override the reviewers. Unset, the spawned argv is byte-identical to before — pinned by a test.

## Test plan

- [x] `bun run test` — full suite green (unit + integration + ui)
- [x] `bun run lint` — including `check:flows-no-bun`, `check:file-sizes`, `check:no-real-global-nax`
- [x] `bun run typecheck`
- [x] Negative controls for every behavioural change — each fails exactly the tests pinning it, no decorative assertions:
  - gate edge reverted to `to: quality_gates` → 5 failures
  - `incrementalSince` forced to `null` → 2 failures
  - `defaultAgent` forced to `null` → 2 failures
  - `--model` spread removed → 2 failures
  - `gateCommitRoute` fail-safe re-folded → 1 failure
- [x] acpx model precedence verified against the acpx source, not inferred from `--help`
- [x] Test-file classification verified against rs-stock's real polyglot layout
- [ ] End-to-end: next real `nax-finish` run on a feature branch (the 58% figure is pre-change; the post-change trace at `~/.acpx/flows/runs/` is what confirms the saving)

## Reviewer notes

- The last commit is a **self-review** of the first three. It fixes a real correctness bug (`gateCommitRoute` skipped the re-review for a committed-but-unresolvable fix) and corrects three doc blocks that stated a false premise about acpx retaining only the latest output per node — true of `ctx.outputs`, not of `ctx.state.steps`.
- Recorded but not changed: `clearResult` removes `<runId>.result.json` but not `<runId>.jsonl`, so re-finishing the same run id accumulates rounds across attempts. Both sets are real branch changes and `ts` disambiguates, so this may be correct as-is.
- `flow-ctx.ts` and `flow-commits.test.ts` are splits forced by the 600-line source / 800-line test caps, not new concepts.
