### PR TITLE
perf(test): cut the unit suite 36s -> 18s by removing wall-clock waits

### DIFF
--- a/.claude/rules/forbidden-patterns.md
+++ b/.claude/rules/forbidden-patterns.md
@@ -94,7 +94,8 @@ const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt(...);
 
 | ❌ Forbidden | ✅ Use Instead | Why |
 |:---|:---|:---|
-| Test files in `test/` root | `test/unit/`, `test/integration/`, `test/ui/`, or `test/e2e/` (sanctioned independent suite, run via `bun run test:e2e`) | Orphaned files with no clear ownership |
+| Test files anywhere outside `test/unit/`, `test/integration/`, `test/ui/` (or `test/e2e/`, run separately via `bun run test:e2e`) | Move under the matching sanctioned directory | Orphaned files with no clear ownership — **and they silently never run.** `bun run test` walks exactly those three directories (see `scripts/run-tests.ts` PHASES), so a `.test.ts` outside them looks like coverage and is not. |
+| Fixed-duration sleeps in tests — **both** `Bun.sleep(n)` and `await new Promise(r => setTimeout(r, n))` | Waiting on a side effect → `waitForCondition` / `waitForFile`. Timer-driven code → inject `_deps` timers and drive `makeFakeClock()`. Asserting a handle is cleared → `withTimerSpy`. | Flaky under load, and additive on the suite wall clock since Bun runs files serially. Naming only `Bun.sleep` left the `new Promise` spelling to accumulate. Carve-out: a bounded poll interval *inside* a `test/helpers/` helper. See `docs/guides/testing-rules.md` §3. |
 | Standalone bug-fix test files (`*-bug026.test.ts`) | Add to existing relevant test file | Fragments test coverage, creates ownership confusion |
 | `TEST_COVERAGE_*.md` in test/ | `docs/` directory | Test dir is for test code only |
 | `rm -rf` in test cleanup | `test/helpers/temp.ts` helpers (`makeTempDir()` / `cleanupTempDir()` / `withTempDir()`) | Accidental deletion risk; temp-dir handling is centralized and portable |

--- a/.claude/rules/test-helpers.md
+++ b/.claude/rules/test-helpers.md
@@ -20,6 +20,8 @@ Import from the barrel: `import { ... } from "../../helpers"` (adjust depth).
 | `makeLogger()` | Logger with captured calls for assertions | `test/helpers/mock-logger.ts` |
 | `makeSessionManager(overrides?)` | `ISessionManager` mock (covers `openSession` / `sendPrompt` / `closeSession` / `runInSession` / `nameFor` / `handoff`) | `test/helpers/mock-session-manager.ts` |
 | `makeTestRuntime(opts?)` | `NaxRuntime` for tests that need the container (calls `createRuntime` with `DEFAULT_CONFIG` + `/tmp/test` defaults) | `test/helpers/runtime.ts` |
+| `makeFakeClock()` | Virtual clock for timer-driven code. Inject into the module's `_deps` and step with `advance(ms)` instead of sleeping. `pending()` asserts nothing was left armed. | `test/helpers/fake-clock.ts` |
+| `withTimerSpy(fn)` | Records timers armed/cleared during `fn` on the **real** clock — for asserting a handle reaches `clearTimeout`, which a fake clock would substitute away. | `test/helpers/timer-spy.ts` |
 
 ## Rule
 

--- a/docs/guides/testing-rules.md
+++ b/docs/guides/testing-rules.md
@@ -99,9 +99,27 @@ await mkdir(dir, { recursive: true });
 
 ## 3. Timing Rules
 
-### Never use `Bun.sleep()` in tests
+### Never sleep for a fixed duration in tests
 
-Fixed-duration waits are timing-sensitive and flaky under CI load. Use polling or make the operation awaitable.
+This covers **both** spellings — `await Bun.sleep(n)` and `await new Promise(r => setTimeout(r, n))`.
+They are the same rule. The second form is the one that actually accumulates,
+because it does not read as a "sleep" at a glance.
+
+Fixed-duration waits are timing-sensitive and flaky under CI load, and because
+Bun runs test files serially in one process, every one of them is additive on
+the suite's wall clock.
+
+The right replacement depends on **what you are waiting for**:
+
+| What you're waiting for | Use |
+|:---|:---|
+| An async side effect to land (file written, event handled) | Poll with a cap — `waitForFile`, `waitForCondition` |
+| Code under test that is **driven by a timer** (heartbeat, watchdog, poll loop, backoff) | Inject the clock via `_deps` and drive `makeFakeClock()` — see below |
+| That a timer handle actually reaches `clearTimeout` | `withTimerSpy`, which deliberately uses real timers |
+
+Only the *first* row is a polling problem. Reaching for polling in the second
+case still burns real wall-clock and still races — the fix there is to stop
+using the real clock at all.
 
 ```typescript
 // ❌ WRONG — may not be enough time under load
@@ -116,6 +134,11 @@ await waitForFile(metaFile, 500);
 const meta = JSON.parse(await readFile(metaFile, "utf8"));
 ```
 
+**Carve-out:** a bounded poll *inside a helper in `test/helpers/`* may use
+`new Promise(r => setTimeout(r, …))` as its own polling interval — that is the
+sanctioned place for it. `waitForFile` below is exactly that. Test files
+themselves should call the helper, never re-implement the wait inline.
+
 `waitForFile` lives in `test/helpers/fs.ts`:
 
 ```typescript
@@ -128,6 +151,54 @@ export async function waitForFile(path: string, timeoutMs = 500): Promise<void> 
   throw new Error(`waitForFile: ${path} not created within ${timeoutMs}ms`);
 }
 ```
+
+### Timer-driven code: inject the clock, never sleep past the threshold
+
+When the subject under test *is* a timer — a heartbeat, an idle watchdog, a poll
+loop, a retry backoff — there is no duration you can sleep that is both fast and
+safe. Shortening it shrinks the margin; lengthening it slows every run. Both are
+bets on the scheduler.
+
+Expose the timer pair (and `now()`, if the code compares elapsed time) on the
+module's `_deps` object and drive it from `makeFakeClock()` in `test/helpers/`.
+Time then moves only when the test says so.
+
+```typescript
+// ✅ Source — timers reach the module through _deps
+export const _heartbeatDeps = {
+  setTimeout: ((fn: () => void, ms: number) => setTimeout(fn, ms)) as (fn: () => void, ms: number) => unknown,
+  clearTimeout: ((id: unknown) => clearTimeout(id as ReturnType<typeof setTimeout>)) as (id: unknown) => void,
+  now: (): number => Date.now(),
+};
+
+// ✅ Test — exact, instant, and independent of machine load
+const clock = makeFakeClock();
+_heartbeatDeps.setTimeout = clock.setTimeout as typeof _heartbeatDeps.setTimeout;
+_heartbeatDeps.clearTimeout = clock.clearTimeout as typeof _heartbeatDeps.clearTimeout;
+
+startHeartbeat({ intervalMs: 100, ... });
+await clock.advance(300);
+expect(ticks).toHaveLength(3);   // exact count, not "at least one"
+expect(clock.pending()).toBe(0); // and nothing was left armed
+```
+
+Always save and restore the `_deps` fields in `beforeEach`/`afterEach` — they are
+module state and leak into every later test file in the same process otherwise.
+
+Inject **per module, never globally**. Patching `globalThis.setTimeout` would
+also freeze the logger's and the test runner's own timers.
+
+Two consequences worth planning for:
+
+- **State the exact number.** Virtual time makes `toHaveLength(3)` reachable where
+  the old sleep could only justify `toBeGreaterThanOrEqual(1)`. Assert the exact
+  count — a lower bound cannot catch a timer that fires twice as often as configured.
+- **Confirm the test can still fail.** A fake clock makes it easy to write a test
+  that passes because the timer never fired at all. After converting, break the
+  behaviour on purpose and check the test goes red. When this rule was introduced,
+  that step caught two tests that had stopped discriminating — one because a
+  downstream re-check masked the flag under test, one because the window never
+  reached the threshold it named.
 
 ### Never bump timeouts to fix flaky tests
 

--- a/src/interaction/plugins/telegram.ts
+++ b/src/interaction/plugins/telegram.ts
@@ -17,6 +17,12 @@ import { MAX_MESSAGE_CHARS, buildBody, buildHeader, buildKeyboard, splitText } f
  */
 export const _telegramPluginDeps = {
   fetch: globalThis.fetch.bind(globalThis) as typeof fetch,
+  /**
+   * Base interval between getUpdates polls, and the value the exponential
+   * backoff resets to on success. Injectable so poll-loop tests can exercise
+   * multi-poll behaviour without burning seconds of wall-clock per test.
+   */
+  basePollBackoffMs: 1000,
 };
 
 const CALLBACK_API_TIMEOUT_MS = 4000;
@@ -80,7 +86,8 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   // requestId -> { type of the request (gates which update kinds count as an answer), sent message ids }
   private pendingMessages = new Map<string, { type: InteractionRequest["type"]; ids: number[] }>();
   private lastUpdateId = 0;
-  private backoffMs = 1000; // Exponential backoff for getUpdates (starts at 1s)
+  // Exponential backoff for getUpdates (starts at the injectable base, 1s in production)
+  private backoffMs = _telegramPluginDeps.basePollBackoffMs;
   private readonly maxBackoffMs = 30000; // Max 30 seconds between retries
 
   /** Bound on how many getUpdates() pages drainBacklog() will consume before giving up. */
@@ -253,7 +260,7 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
           // Clean up tracking entry before returning to avoid accumulating stale entries
           this.pendingMessages.delete(requestId);
           // Reset backoff on successful response
-          this.backoffMs = 1000;
+          this.backoffMs = _telegramPluginDeps.basePollBackoffMs;
           return response;
         }
 
@@ -356,7 +363,7 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
       }
 
       // Reset backoff on success
-      this.backoffMs = 1000;
+      this.backoffMs = _telegramPluginDeps.basePollBackoffMs;
       return { ok: true, updates, rawCount: raw.length };
     } catch (err) {
       // Apply exponential backoff on network error

--- a/src/plugins/builtin/otel-reporter/heartbeat.ts
+++ b/src/plugins/builtin/otel-reporter/heartbeat.ts
@@ -3,6 +3,18 @@ import { type KeyValue, attr, buildResourceAttributes } from "./otlp";
 
 const STAGE = "otel-reporter-heartbeat";
 
+/**
+ * Injectable timer pair — allows tests to drive the heartbeat off a virtual
+ * clock instead of sleeping for real, which is both faster and removes the
+ * scheduling races that loose "at least one tick fired" bounds paper over.
+ *
+ * @internal
+ */
+export const _heartbeatDeps = {
+  setTimeout: ((fn: () => void, ms: number) => setTimeout(fn, ms)) as (fn: () => void, ms: number) => unknown,
+  clearTimeout: ((id: unknown) => clearTimeout(id as ReturnType<typeof setTimeout>)) as (id: unknown) => void,
+};
+
 /** Attributes carried by every heartbeat gauge (US-008). */
 export interface HeartbeatAttributes {
   runId: string;
@@ -48,10 +60,10 @@ export function startHeartbeat(opts: HeartbeatOptions): Heartbeat {
   if (intervalMs <= 0) return { stop() {} };
 
   let stopped = false;
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timer: unknown;
 
   const armTimer = (): void => {
-    timer = setTimeout(() => {
+    timer = _heartbeatDeps.setTimeout(() => {
       // Never let a telemetry tick escalate into a fatal unhandled
       // rejection/exception (src/execution/crash-signals.ts aborts the run
       // on either) — mirrors batch-queue.ts's own defensive try/catch.
@@ -74,7 +86,7 @@ export function startHeartbeat(opts: HeartbeatOptions): Heartbeat {
   return {
     stop(): void {
       stopped = true;
-      if (timer !== undefined) clearTimeout(timer);
+      if (timer !== undefined) _heartbeatDeps.clearTimeout(timer);
     },
   };
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -60,7 +60,7 @@ export type {
   AgentStreamListener,
 } from "./agent-stream-events";
 export { AgentStreamEventBus } from "./agent-stream-events";
-export { attachAgentIdleWatchdog, attachAgentStreamLogging } from "./middleware";
+export { attachAgentIdleWatchdog, attachAgentStreamLogging, _idleWatchdogDeps } from "./middleware";
 export type { WatchdogState } from "./middleware";
 export { formatSessionName } from "./session-name";
 export { KNOWN_SESSION_ROLES, isSessionRole } from "./session-role";

--- a/src/runtime/middleware/idle-watchdog.ts
+++ b/src/runtime/middleware/idle-watchdog.ts
@@ -20,22 +20,36 @@ export interface WatchdogState {
 
 type IdleTimeoutReason = "idle_timeout_exceeded" | "tool_call_only_idle_timeout_exceeded";
 
+/**
+ * Injectable clock — the tick timer, the grace timer, and every elapsed-time
+ * comparison read through this.
+ *
+ * The watchdog is defined entirely in terms of "has enough time passed", so
+ * testing it against the real clock means sleeping through each threshold and
+ * asserting on a margin. That is slow and it is what made this suite flaky
+ * twice before (#1002, #1008). Injecting the clock lets tests step time
+ * exactly, so the assertions become deterministic instead of probabilistic.
+ *
+ * @internal
+ */
+export const _idleWatchdogDeps = {
+  setTimeout: ((fn: () => void, ms: number) => setTimeout(fn, ms)) as (fn: () => void, ms: number) => unknown,
+  clearTimeout: ((id: unknown) => clearTimeout(id as ReturnType<typeof setTimeout>)) as (id: unknown) => void,
+  now: (): number => Date.now(),
+};
+
 interface WatchdogStateInternal extends WatchdogState {
   cancelAttempts: number;
-  graceTimer?: ReturnType<typeof setTimeout>;
+  graceTimer?: unknown;
   inGracePeriod: boolean;
   warnedForCurrentIdlePeriod: boolean;
   graceReason?: IdleTimeoutReason;
 }
 
 // setTimeout is permitted here for the recurring tick and grace period cancellation via clearTimeout
-function scheduleTickIfNeeded(
-  tickRef: { handle: ReturnType<typeof setTimeout> | null },
-  tick: () => void,
-  intervalMs: number,
-): void {
+function scheduleTickIfNeeded(tickRef: { handle: unknown }, tick: () => void, intervalMs: number): void {
   if (tickRef.handle !== null) return;
-  tickRef.handle = setTimeout(tick, intervalMs);
+  tickRef.handle = _idleWatchdogDeps.setTimeout(tick, intervalMs);
 }
 
 function handleObserveTimeout(
@@ -82,7 +96,7 @@ async function handleCancelTimeout(
   }
   state.cancelAttempts++;
   // Reset synchronously to prevent double-trigger in next tick
-  state.lastActivityAt = Date.now();
+  state.lastActivityAt = _idleWatchdogDeps.now();
   getSafeLogger()?.warn(
     "idle-watchdog",
     reason === "tool_call_only_idle_timeout_exceeded" ? "Canceling tool-call-only idle call" : "Canceling idle call",
@@ -136,15 +150,15 @@ function handleWarnThenCancelTimeout(
   state.inGracePeriod = true;
   state.graceReason = reason;
   // setTimeout permitted here for grace period cancellation via clearTimeout
-  state.graceTimer = setTimeout(async () => {
+  state.graceTimer = _idleWatchdogDeps.setTimeout(async () => {
     if (!activeStates.has(state.callId)) return;
     state.inGracePeriod = false;
     state.graceTimer = undefined;
     state.graceReason = undefined;
-    const currentReason = getTimeoutReason(state, Date.now(), idleTimeoutMs, toolCallOnlyTimeoutMs);
+    const currentReason = getTimeoutReason(state, _idleWatchdogDeps.now(), idleTimeoutMs, toolCallOnlyTimeoutMs);
     if (currentReason !== reason) return;
     state.cancelAttempts++;
-    state.lastActivityAt = Date.now();
+    state.lastActivityAt = _idleWatchdogDeps.now();
     const cancel = controllerRegistry.get(state.callId);
     if (cancel) await cancel().catch(() => {});
   }, graceMs);
@@ -152,7 +166,7 @@ function handleWarnThenCancelTimeout(
 
 function clearGrace(state: WatchdogStateInternal): void {
   if (state.inGracePeriod && state.graceTimer !== undefined) {
-    clearTimeout(state.graceTimer);
+    _idleWatchdogDeps.clearTimeout(state.graceTimer);
     state.graceTimer = undefined;
     state.inGracePeriod = false;
     state.graceReason = undefined;
@@ -205,7 +219,7 @@ export function attachAgentIdleWatchdog(
 
   function tick(): void {
     tickRef.handle = null;
-    const now = Date.now();
+    const now = _idleWatchdogDeps.now();
     for (const [, state] of activeStates) {
       if (state.inGracePeriod) continue;
       const idleDurationMs = now - state.lastActivityAt;
@@ -234,7 +248,7 @@ export function attachAgentIdleWatchdog(
   const unsubscribe = agentStreamEvents.onAgentStream((event: AgentStreamEvent) => {
     switch (event.kind) {
       case "agent.call_started": {
-        const now = Date.now();
+        const now = _idleWatchdogDeps.now();
         activeStates.set(event.callId, {
           callId: event.callId,
           agentName: event.agentName,
@@ -306,11 +320,11 @@ export function attachAgentIdleWatchdog(
       case "agent.call_ended": {
         const state = activeStates.get(event.callId);
         if (state) {
-          if (state.graceTimer !== undefined) clearTimeout(state.graceTimer);
+          if (state.graceTimer !== undefined) _idleWatchdogDeps.clearTimeout(state.graceTimer);
           activeStates.delete(event.callId);
         }
         if (activeStates.size === 0 && tickRef.handle !== null) {
-          clearTimeout(tickRef.handle);
+          _idleWatchdogDeps.clearTimeout(tickRef.handle);
           tickRef.handle = null;
         }
         break;
@@ -321,11 +335,11 @@ export function attachAgentIdleWatchdog(
   return () => {
     unsubscribe();
     for (const state of activeStates.values()) {
-      if (state.graceTimer !== undefined) clearTimeout(state.graceTimer);
+      if (state.graceTimer !== undefined) _idleWatchdogDeps.clearTimeout(state.graceTimer);
     }
     activeStates.clear();
     if (tickRef.handle !== null) {
-      clearTimeout(tickRef.handle);
+      _idleWatchdogDeps.clearTimeout(tickRef.handle);
       tickRef.handle = null;
     }
   };

--- a/src/runtime/middleware/index.ts
+++ b/src/runtime/middleware/index.ts
@@ -4,4 +4,4 @@ export { attachAgentStreamLogging } from "./agent-stream-logging";
 export { attachCostSubscriber } from "./cost";
 export { attachAuditSubscriber } from "./audit";
 export { attachReviewAuditSubscriber } from "./review-audit";
-export { attachAgentIdleWatchdog, type WatchdogState } from "./idle-watchdog";
+export { attachAgentIdleWatchdog, _idleWatchdogDeps, type WatchdogState } from "./idle-watchdog";

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -6,14 +6,6 @@ import { getSafeLogger } from "../logger";
 import { spawn } from "./bun-deps";
 
 /**
- * Injectable dependencies for git subprocess calls — allows tests to intercept
- * Bun.spawn without mock.module().
- *
- * @internal
- */
-export const _gitDeps = { spawn, getSafeLogger };
-
-/**
  * Default timeout for git subprocess calls.
  * Prevents git from hanging indefinitely on locked repos or network mounts.
  */
@@ -26,6 +18,21 @@ const GIT_TIMEOUT_MS = 10_000;
  * etc.) — a hung git here must not stall the already-timed-out agent turn.
  */
 const TIMEOUT_RETRY_GIT_TIMEOUT_MS = 3_000;
+
+/**
+ * Injectable dependencies for git subprocess calls — allows tests to intercept
+ * Bun.spawn without mock.module().
+ *
+ * `timeoutRetryGitTimeoutMs` is injectable so the hang-path tests can assert the
+ * SIGKILL contract without burning the full production timeout in wall-clock.
+ *
+ * @internal
+ */
+export const _gitDeps = {
+  spawn,
+  getSafeLogger,
+  timeoutRetryGitTimeoutMs: TIMEOUT_RETRY_GIT_TIMEOUT_MS,
+};
 
 /**
  * Return the absolute path of the git repository root for the given workdir.
@@ -346,7 +353,7 @@ export async function captureWorkingTreeChanges(
 
   const runDiff = async (args: string[]): Promise<string[]> => {
     const fullArgs = scopePrefix ? [...args, "--", `${scopePrefix}/`] : args;
-    const { stdout, exitCode } = await gitWithTimeout(fullArgs, workdir, TIMEOUT_RETRY_GIT_TIMEOUT_MS);
+    const { stdout, exitCode } = await gitWithTimeout(fullArgs, workdir, _gitDeps.timeoutRetryGitTimeoutMs);
     if (exitCode !== 0) return [];
     return stdout.trim().split("\n").filter(Boolean);
   };

--- a/test/helpers/fake-clock.ts
+++ b/test/helpers/fake-clock.ts
@@ -1,0 +1,139 @@
+/**
+ * Deterministic virtual clock for timer-driven code.
+ *
+ * Tests that assert on timer behaviour normally sleep for real and then assert
+ * a loose bound ("at least one tick fired"). That is slow — the sleeps are
+ * additive across a serially-executed suite — and flaky, because the margin
+ * between "long enough" and "too long" shrinks whenever CI stalls.
+ *
+ * A FakeClock removes both problems: time only moves when the test says so, so
+ * assertions become exact ("exactly three ticks") and cost no wall-clock.
+ *
+ * Inject it into the module under test via that module's `_deps` object:
+ *
+ * ```ts
+ * const clock = makeFakeClock();
+ * _heartbeatDeps.setTimeout = clock.setTimeout;
+ * _heartbeatDeps.clearTimeout = clock.clearTimeout;
+ *
+ * startHeartbeat({ intervalMs: 100, ... });
+ * await clock.advance(250);
+ * expect(ticks).toHaveLength(2);
+ * ```
+ */
+
+/** A timer scheduled on the virtual timeline. */
+interface ScheduledTimer {
+  id: number;
+  /** Virtual timestamp at which this timer is due. */
+  dueAt: number;
+  callback: () => void;
+  /** Insertion order — breaks ties so same-deadline timers fire FIFO, as real timers do. */
+  seq: number;
+}
+
+export interface FakeClock {
+  /** Current virtual time in ms. Starts at an arbitrary non-zero epoch. */
+  now(): number;
+  /** Drop-in for `globalThis.setTimeout`. Returns an opaque numeric handle. */
+  setTimeout(callback: () => void, delayMs?: number): number;
+  /** Drop-in for `globalThis.clearTimeout`. Unknown/undefined ids are ignored. */
+  clearTimeout(id?: number): void;
+  /**
+   * Move virtual time forward by `ms`, firing every timer that comes due — in
+   * deadline order — and draining microtasks after each one so `async` callbacks
+   * settle before the next fires. Timers armed *during* the advance are honoured
+   * if they fall inside the same window, which is what makes self-re-arming
+   * loops (heartbeats, poll loops) work.
+   */
+  advance(ms: number): Promise<void>;
+  /** Number of timers currently armed. Use to assert nothing was leaked. */
+  pending(): number;
+}
+
+/**
+ * Ceiling on timers fired within a single `advance()` call. Guards against a
+ * callback that re-arms itself at 0ms, which would otherwise spin forever
+ * inside the loop and hang the test with no useful diagnostic.
+ */
+const MAX_TIMERS_PER_ADVANCE = 10_000;
+
+/** Arbitrary non-zero start so tests can't accidentally pass by treating 0 as "unset". */
+const EPOCH_MS = 1_700_000_000_000;
+
+/**
+ * Let already-queued promise callbacks run. Pure microtask draining — no real
+ * timer is involved, so this stays deterministic and costs no wall-clock.
+ * Several turns, because an `async` callback that awaits chains microtasks.
+ */
+const MICROTASK_DRAIN_TURNS = 8;
+
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < MICROTASK_DRAIN_TURNS; i++) {
+    await Promise.resolve();
+  }
+}
+
+export function makeFakeClock(): FakeClock {
+  let currentMs = EPOCH_MS;
+  let nextId = 1;
+  let nextSeq = 0;
+  const timers = new Map<number, ScheduledTimer>();
+
+  /** The armed timer with the earliest deadline, or undefined when none is armed. */
+  function earliest(): ScheduledTimer | undefined {
+    let best: ScheduledTimer | undefined;
+    for (const timer of timers.values()) {
+      if (!best || timer.dueAt < best.dueAt || (timer.dueAt === best.dueAt && timer.seq < best.seq)) {
+        best = timer;
+      }
+    }
+    return best;
+  }
+
+  return {
+    now: () => currentMs,
+
+    setTimeout(callback: () => void, delayMs = 0): number {
+      const id = nextId++;
+      // Real setTimeout floors negative/NaN delays at 0; match that so code
+      // under test behaves identically on either clock.
+      const delay = Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0;
+      timers.set(id, { id, dueAt: currentMs + delay, callback, seq: nextSeq++ });
+      return id;
+    },
+
+    clearTimeout(id?: number): void {
+      if (id !== undefined) timers.delete(id);
+    },
+
+    async advance(ms: number): Promise<void> {
+      const target = currentMs + ms;
+      let fired = 0;
+
+      for (;;) {
+        const next = earliest();
+        if (!next || next.dueAt > target) break;
+
+        if (++fired > MAX_TIMERS_PER_ADVANCE) {
+          throw new Error(
+            `FakeClock.advance(${ms}) fired ${MAX_TIMERS_PER_ADVANCE} timers without reaching the target — ` +
+              `a callback is almost certainly re-arming itself with a zero/near-zero delay.`,
+          );
+        }
+
+        // Jump to this timer's deadline before invoking it, so a callback that
+        // reads now() sees the time it was scheduled for, not the window's end.
+        currentMs = next.dueAt;
+        timers.delete(next.id);
+        next.callback();
+        await drainMicrotasks();
+      }
+
+      currentMs = target;
+      await drainMicrotasks();
+    },
+
+    pending: () => timers.size,
+  };
+}

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -36,6 +36,8 @@ export { makeMockPlanInputs } from "./plan-inputs";
 export { withWarnSpy, withInfoSpy } from "./warn-spy";
 export { withTimerSpy } from "./timer-spy";
 export type { TimerSpyResult } from "./timer-spy";
+export { makeFakeClock } from "./fake-clock";
+export type { FakeClock } from "./fake-clock";
 export { makeScriptedAgent, runOrchestratorE2E } from "./e2e";
 export type { ScriptedAgentSpec, ScriptedTurn, E2EOptions, E2EResult, E2EGates } from "./e2e";
 export { DEFAULT_TEST_ROUTING, makeTestContext, makeTestPRD, makeTestStory } from "./pipeline-context";

--- a/test/unit/execution/helpers.test.ts
+++ b/test/unit/execution/helpers.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "bun";
-import { acquireLock, formatProgress, releaseLock } from "../../src/execution/helpers";
-import type { StoryCounts } from "../../src/execution/helpers";
+import { acquireLock, formatProgress, releaseLock } from "@/execution";
+import type { StoryCounts } from "@/execution";
 
 describe("formatProgress", () => {
   test("formats progress with all stories pending", () => {

--- a/test/unit/helpers/fake-clock.test.ts
+++ b/test/unit/helpers/fake-clock.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the FakeClock test helper.
+ *
+ * The helper is what the timer-driven suites (heartbeat, idle-watchdog) assert
+ * against, so a silent bug here would weaken every one of those tests without
+ * failing anything. Placed under test/unit/ rather than beside the helper
+ * because `bun run test` only executes test/unit, test/integration and test/ui.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { makeFakeClock } from "@test/helpers";
+
+describe("makeFakeClock", () => {
+  test("does not fire a timer before its deadline", async () => {
+    const clock = makeFakeClock();
+    const fired: string[] = [];
+    clock.setTimeout(() => fired.push("t"), 100);
+
+    await clock.advance(99);
+
+    expect(fired).toEqual([]);
+  });
+
+  test("fires a timer exactly at its deadline", async () => {
+    const clock = makeFakeClock();
+    const fired: string[] = [];
+    clock.setTimeout(() => fired.push("t"), 100);
+
+    await clock.advance(100);
+
+    expect(fired).toEqual(["t"]);
+  });
+
+  test("fires timers in deadline order, not insertion order", async () => {
+    const clock = makeFakeClock();
+    const fired: string[] = [];
+    clock.setTimeout(() => fired.push("late"), 200);
+    clock.setTimeout(() => fired.push("early"), 50);
+
+    await clock.advance(500);
+
+    expect(fired).toEqual(["early", "late"]);
+  });
+
+  test("breaks deadline ties in insertion order, as real timers do", async () => {
+    const clock = makeFakeClock();
+    const fired: string[] = [];
+    clock.setTimeout(() => fired.push("first"), 10);
+    clock.setTimeout(() => fired.push("second"), 10);
+
+    await clock.advance(10);
+
+    expect(fired).toEqual(["first", "second"]);
+  });
+
+  test("advances now() to the target even when no timer fires", async () => {
+    const clock = makeFakeClock();
+    const start = clock.now();
+
+    await clock.advance(1234);
+
+    expect(clock.now() - start).toBe(1234);
+  });
+
+  test("a callback observes now() at its own deadline, not the window's end", async () => {
+    const clock = makeFakeClock();
+    const start = clock.now();
+    let observed = -1;
+    clock.setTimeout(() => {
+      observed = clock.now();
+    }, 30);
+
+    await clock.advance(500);
+
+    expect(observed - start).toBe(30);
+  });
+
+  test("runs a self-re-arming timer once per interval in the window", async () => {
+    const clock = makeFakeClock();
+    let ticks = 0;
+    const arm = () => {
+      clock.setTimeout(() => {
+        ticks++;
+        arm();
+      }, 100);
+    };
+    arm();
+
+    await clock.advance(350);
+
+    expect(ticks).toBe(3);
+  });
+
+  test("clearTimeout stops a pending timer", async () => {
+    const clock = makeFakeClock();
+    const fired: string[] = [];
+    const id = clock.setTimeout(() => fired.push("t"), 100);
+
+    clock.clearTimeout(id);
+    await clock.advance(500);
+
+    expect(fired).toEqual([]);
+    expect(clock.pending()).toBe(0);
+  });
+
+  test("clearTimeout tolerates undefined and unknown ids", () => {
+    const clock = makeFakeClock();
+
+    expect(() => clock.clearTimeout(undefined)).not.toThrow();
+    expect(() => clock.clearTimeout(9999)).not.toThrow();
+  });
+
+  test("pending() reports armed timers so tests can assert no leak", async () => {
+    const clock = makeFakeClock();
+    clock.setTimeout(() => {}, 100);
+    clock.setTimeout(() => {}, 200);
+    expect(clock.pending()).toBe(2);
+
+    await clock.advance(150);
+
+    expect(clock.pending()).toBe(1);
+  });
+
+  test("settles an async callback before firing the next timer", async () => {
+    const clock = makeFakeClock();
+    const order: string[] = [];
+    clock.setTimeout(async () => {
+      order.push("a:start");
+      await Promise.resolve();
+      order.push("a:end");
+    }, 10);
+    clock.setTimeout(() => order.push("b"), 20);
+
+    await clock.advance(50);
+
+    expect(order).toEqual(["a:start", "a:end", "b"]);
+  });
+
+  test("a zero-delay timer fires on the next advance", async () => {
+    const clock = makeFakeClock();
+    const fired: string[] = [];
+    clock.setTimeout(() => fired.push("t"), 0);
+
+    await clock.advance(0);
+
+    expect(fired).toEqual(["t"]);
+  });
+
+  test("throws a diagnostic rather than hanging on a zero-delay re-arm loop", async () => {
+    const clock = makeFakeClock();
+    const arm = () => {
+      clock.setTimeout(() => arm(), 0);
+    };
+    arm();
+
+    await expect(clock.advance(10)).rejects.toThrow(/re-arming itself/);
+  });
+});

--- a/test/unit/helpers/runtime.test.ts
+++ b/test/unit/helpers/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { makeMockRuntime, makeTestRuntime } from "./runtime";
+import { makeMockRuntime, makeTestRuntime } from "@test/helpers";
 
 const autoCleanupCloseCalls: string[] = [];
 const manualCloseCalls: string[] = [];

--- a/test/unit/interaction/plugins/telegram-authorization.test.ts
+++ b/test/unit/interaction/plugins/telegram-authorization.test.ts
@@ -4,9 +4,24 @@
  * Split out of telegram.test.ts, which was at the 800-line limit.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { InteractionRequest } from "@/interaction";
 import { TelegramInteractionPlugin, _telegramPluginDeps, normalizeChatId } from "@/interaction";
+
+// The poll loop sleeps `basePollBackoffMs` between getUpdates calls, so with the
+// production 1s base every multi-poll test costs seconds of wall-clock. The
+// behaviour under test is ordering and filtering, not the production cadence —
+// shrink the base and scale the receive() timeouts to match.
+const POLL_BACKOFF_MS = 20;
+const originalBackoffMs = _telegramPluginDeps.basePollBackoffMs;
+
+beforeEach(() => {
+  _telegramPluginDeps.basePollBackoffMs = POLL_BACKOFF_MS;
+});
+
+afterEach(() => {
+  _telegramPluginDeps.basePollBackoffMs = originalBackoffMs;
+});
 
 // ---------------------------------------------------------------------------
 // Inbound chat authorization (closes #1365)
@@ -103,7 +118,7 @@ describe("TelegramInteractionPlugin - inbound chat authorization", () => {
     await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
     await plugin.send(makeConfirmRequest("auth-1"));
 
-    const response = await plugin.receive("auth-1", 300);
+    const response = await plugin.receive("auth-1", 60);
 
     expect(response.respondedBy).toBe("timeout");
     expect(response.action).not.toBe("approve");
@@ -124,7 +139,7 @@ describe("TelegramInteractionPlugin - inbound chat authorization", () => {
     const plugin = new TelegramInteractionPlugin();
     await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
     await plugin.send(makeConfirmRequest("auth-2"));
-    await plugin.receive("auth-2", 300);
+    await plugin.receive("auth-2", 60);
 
     expect(acked).not.toContain("cq-foreign");
   });
@@ -149,7 +164,7 @@ describe("TelegramInteractionPlugin - inbound chat authorization", () => {
       createdAt: Date.now(),
     } as InteractionRequest);
 
-    const response = await plugin.receive("auth-3", 300);
+    const response = await plugin.receive("auth-3", 60);
 
     expect(response.respondedBy).toBe("timeout");
     expect(response.value).toBeUndefined();
@@ -166,9 +181,9 @@ describe("TelegramInteractionPlugin - inbound chat authorization", () => {
     const plugin = new TelegramInteractionPlugin();
     await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
     await plugin.send(makeConfirmRequest("auth-4"));
-    // 2500ms, not 300ms: the poll loop backs off 1000ms between attempts, so a
-    // short timeout yields a single poll and never demonstrates the offset moving.
-    await plugin.receive("auth-4", 2500);
+    // Must span several backoff cycles: a timeout shorter than one POLL_BACKOFF_MS
+    // yields a single poll and never demonstrates the offset moving.
+    await plugin.receive("auth-4", POLL_BACKOFF_MS * 8);
 
     // Reaching offset 8 is the discriminating assertion. If the filter ran
     // before lastUpdateId advanced, the offset would stay parked at 1 forever
@@ -193,7 +208,7 @@ describe("TelegramInteractionPlugin - inbound chat authorization", () => {
     await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
     await plugin.send(makeConfirmRequest("auth-5"));
 
-    const response = await plugin.receive("auth-5", 5000);
+    const response = await plugin.receive("auth-5", 1000);
 
     expect(response.action).toBe("approve");
     expect(response.respondedBy).toBe("telegram");
@@ -219,7 +234,7 @@ describe("TelegramInteractionPlugin - inbound chat authorization", () => {
       createdAt: Date.now(),
     } as InteractionRequest);
 
-    const response = await plugin.receive("auth-6", 5000);
+    const response = await plugin.receive("auth-6", 1000);
 
     expect(response.action).toBe("input");
     expect(response.value).toBe("ship it");
@@ -302,7 +317,7 @@ describe("TelegramInteractionPlugin - backlog drain with foreign traffic", () =>
       createdAt: Date.now(),
     } as InteractionRequest);
 
-    const response = await plugin.receive("drain-1", 300);
+    const response = await plugin.receive("drain-1", 60);
 
     // "yes do it" was sitting in the queue BEFORE the prompt was posted, so it
     // cannot be the answer to it. If the drain stopped at update 1 -- the first
@@ -413,7 +428,7 @@ describe("TelegramInteractionPlugin - configured chat id normalization", () => {
       createdAt: Date.now(),
     } as InteractionRequest);
 
-    const response = await plugin.receive("norm-1", 5000);
+    const response = await plugin.receive("norm-1", 60);
 
     expect(response.action).toBe("approve");
     expect(response.respondedBy).toBe("telegram");

--- a/test/unit/plugins/builtin/otel-heartbeat.test.ts
+++ b/test/unit/plugins/builtin/otel-heartbeat.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { withTimerSpy } from "@test/helpers";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type FakeClock, makeFakeClock, withTimerSpy } from "@test/helpers";
 import {
   type Heartbeat,
   type HeartbeatSnapshot,
+  _heartbeatDeps,
   buildHeartbeatMetricsPayload,
   startHeartbeat,
 } from "../../../../src/plugins/builtin/otel-reporter/heartbeat";
@@ -32,8 +33,27 @@ function track(hb: Heartbeat): Heartbeat {
   return hb;
 }
 
+// Every timer assertion below runs on a virtual clock: time moves only when the
+// test advances it. That makes the tick counts exact rather than "at least N"
+// — a heartbeat that fires twice as often as configured is now a failure, which
+// a wall-clock sleep with a loose lower bound could never catch — and it costs
+// no real time, so nothing here can flake when the machine stalls.
+let clock: FakeClock;
+let origSetTimeout: typeof _heartbeatDeps.setTimeout;
+let origClearTimeout: typeof _heartbeatDeps.clearTimeout;
+
+beforeEach(() => {
+  clock = makeFakeClock();
+  origSetTimeout = _heartbeatDeps.setTimeout;
+  origClearTimeout = _heartbeatDeps.clearTimeout;
+  _heartbeatDeps.setTimeout = clock.setTimeout as typeof _heartbeatDeps.setTimeout;
+  _heartbeatDeps.clearTimeout = clock.clearTimeout as typeof _heartbeatDeps.clearTimeout;
+});
+
 afterEach(() => {
   for (const hb of liveHeartbeats.splice(0)) hb.stop();
+  _heartbeatDeps.setTimeout = origSetTimeout;
+  _heartbeatDeps.clearTimeout = origClearTimeout;
 });
 
 describe("startHeartbeat", () => {
@@ -41,15 +61,23 @@ describe("startHeartbeat", () => {
     const ticks: HeartbeatSnapshot[] = [];
     track(startHeartbeat({ intervalMs: 40, getSnapshot: () => snapshot(), onTick: (s) => ticks.push(s) }));
 
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(ticks.length).toBeGreaterThanOrEqual(1);
+    await clock.advance(40);
+    expect(ticks).toHaveLength(1);
+  });
+
+  test("AC1: keeps ticking once per interval", async () => {
+    const ticks: HeartbeatSnapshot[] = [];
+    track(startHeartbeat({ intervalMs: 40, getSnapshot: () => snapshot(), onTick: (s) => ticks.push(s) }));
+
+    await clock.advance(160);
+    expect(ticks).toHaveLength(4);
   });
 
   test("AC1 boundary: issues no tick before intervalMs has elapsed", async () => {
     const ticks: HeartbeatSnapshot[] = [];
     track(startHeartbeat({ intervalMs: 200, getSnapshot: () => snapshot(), onTick: (s) => ticks.push(s) }));
 
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await clock.advance(199);
     expect(ticks).toHaveLength(0);
   });
 
@@ -57,23 +85,56 @@ describe("startHeartbeat", () => {
     const ticks: HeartbeatSnapshot[] = [];
     track(startHeartbeat({ intervalMs: 0, getSnapshot: () => snapshot(), onTick: (s) => ticks.push(s) }));
 
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await clock.advance(10_000);
     expect(ticks).toHaveLength(0);
+    // No timer was ever armed, not merely one that failed to fire.
+    expect(clock.pending()).toBe(0);
   });
 
   test("AC7: stop() prevents further ticks", async () => {
     const ticks: HeartbeatSnapshot[] = [];
     const hb = startHeartbeat({ intervalMs: 30, getSnapshot: () => snapshot(), onTick: (s) => ticks.push(s) });
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    hb.stop();
-    const countAtStop = ticks.length;
+    await clock.advance(90);
+    expect(ticks).toHaveLength(3);
 
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    expect(ticks.length).toBe(countAtStop);
+    hb.stop();
+    await clock.advance(10_000);
+
+    expect(ticks).toHaveLength(3);
+    expect(clock.pending()).toBe(0);
   });
 
+  // Isolates the `stopped` flag from the clearTimeout in stop(). Called from
+  // outside a tick, clearTimeout alone is enough to halt the loop — so only a
+  // stop() issued from *inside* onTick, while the callback that will re-arm is
+  // still on the stack, can prove the flag is checked before re-arming.
+  test("AC7: stop() called from inside a tick prevents the loop re-arming", async () => {
+    let ticks = 0;
+    let hb: Heartbeat | undefined;
+    hb = track(
+      startHeartbeat({
+        intervalMs: 30,
+        getSnapshot: () => snapshot(),
+        onTick: () => {
+          ticks++;
+          hb?.stop();
+        },
+      }),
+    );
+
+    await clock.advance(300);
+
+    expect(ticks).toBe(1);
+    expect(clock.pending()).toBe(0);
+  });
+
+  // Runs against the REAL timers: this asserts that the handle reaches
+  // clearTimeout, which is precisely what the fake clock would substitute away.
   test("AC7: stop() clears the underlying timer (no leaked handle)", async () => {
+    _heartbeatDeps.setTimeout = origSetTimeout;
+    _heartbeatDeps.clearTimeout = origClearTimeout;
+
     const { leaked } = await withTimerSpy(async () => {
       const hb = startHeartbeat({ intervalMs: 30, getSnapshot: () => snapshot(), onTick: () => {} });
       hb.stop();
@@ -93,7 +154,7 @@ describe("startHeartbeat", () => {
       }),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await clock.advance(30);
     expect(ticks[0]?.phaseElapsedMs).toBe(42);
     expect(ticks[0]?.costUsd).toBe(1.23);
   });
@@ -111,8 +172,9 @@ describe("startHeartbeat", () => {
       }),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(calls).toBeGreaterThanOrEqual(2);
+    await clock.advance(90);
+    // Exact, not a lower bound: a throw must cost the heartbeat no ticks at all.
+    expect(calls).toBe(3);
   });
 
   test("an onTick that returns a rejected promise does not stop subsequent ticks", async () => {
@@ -128,8 +190,9 @@ describe("startHeartbeat", () => {
       }),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(calls).toBeGreaterThanOrEqual(2);
+    await clock.advance(90);
+    // Exact, not a lower bound: a throw must cost the heartbeat no ticks at all.
+    expect(calls).toBe(3);
   });
 });
 

--- a/test/unit/routing/llm-batch-route.test.ts
+++ b/test/unit/routing/llm-batch-route.test.ts
@@ -1,12 +1,24 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { UserStory } from "../../../src/prd/types";
+import { _callOpDeps } from "../../../src/operations";
 import { tryLlmBatchRoute } from "../../../src/routing/router";
 import { makeNaxConfig, makeStory } from "../../helpers";
 import { makeMockRuntime } from "../../helpers/runtime";
 import type { NaxRuntime } from "../../../src/runtime";
 
+// The mock runtime makes the routing LLM call fail, which the classify-route op
+// retries behind a 1s base backoff. The retry cadence is classify-route's
+// contract, not this file's — stub the sleep out so the swallow-the-failure
+// assertions don't pay it in wall-clock.
+let origSleep: typeof _callOpDeps.sleep;
+
 const createdRuntimes: NaxRuntime[] = [];
+beforeEach(() => {
+  origSleep = _callOpDeps.sleep;
+  _callOpDeps.sleep = async () => {};
+});
 afterEach(async () => {
+  _callOpDeps.sleep = origSleep;
   await Promise.allSettled(createdRuntimes.map((r) => r.close()));
   createdRuntimes.length = 0;
 });

--- a/test/unit/runtime/middleware/_idle-watchdog-harness.ts
+++ b/test/unit/runtime/middleware/_idle-watchdog-harness.ts
@@ -1,0 +1,180 @@
+/**
+ * Shared harness for the idle-watchdog suites.
+ *
+ * The watchdog runs entirely on a virtual clock in tests — its tick timer,
+ * grace timer, and every elapsed-time comparison are injected via
+ * `_idleWatchdogDeps`.
+ *
+ * That matters for more than speed. These suites were stabilized twice for
+ * timing races (#1002, #1008) because the old approach — sleep past a
+ * threshold, then assert — is a bet that the machine schedules the test
+ * promptly. Stepping the clock removes the bet: `advance(IDLE_TIMEOUT_MS)`
+ * lands on the threshold exactly, every run, so thresholds can be stated in
+ * readable whole seconds instead of being shaved down to keep the suite fast.
+ *
+ * The injection is module-scoped, not global: the logger's own timers keep
+ * using the real clock, so `flush()` still behaves normally.
+ *
+ * Naming follows test/integration/tdd/_tdd-test-helpers.ts — the leading
+ * underscore marks a local, non-collected helper module.
+ */
+
+import type { AgentCallEndedEvent, AgentProcessUpdateEvent, AgentStreamEvent } from "@/runtime";
+import { _idleWatchdogDeps } from "@/runtime";
+import { type FakeClock, makeFakeClock } from "@test/helpers";
+
+/** Watchdog thresholds. Virtual time is free, so these are round and readable. */
+export const IDLE_TIMEOUT_SECONDS = 1;
+export const IDLE_TIMEOUT_MS = IDLE_TIMEOUT_SECONDS * 1000;
+export const GRACE_SECONDS = 0.5;
+export const GRACE_MS = GRACE_SECONDS * 1000;
+/** The watchdog polls at a quarter of the idle timeout. */
+export const TICK_MS = IDLE_TIMEOUT_MS / 4;
+/**
+ * A threshold far beyond anything these tests step to. Used by cases whose
+ * subject is "the event was accepted", not "the timeout fired" — the watchdog
+ * must stay quiet for the whole test.
+ */
+export const NEVER_FIRES_SECONDS = 10;
+
+/**
+ * The clock the event factories below stamp their timestamps from. Reassigned
+ * by installFakeWatchdogClock() so each test gets a fresh timeline.
+ */
+let activeClock: FakeClock = makeFakeClock();
+
+interface SavedDeps {
+  setTimeout: typeof _idleWatchdogDeps.setTimeout;
+  clearTimeout: typeof _idleWatchdogDeps.clearTimeout;
+  now: typeof _idleWatchdogDeps.now;
+}
+let saved: SavedDeps | undefined;
+
+/**
+ * Point the watchdog at a fresh virtual clock. Call from `beforeEach`; the
+ * returned clock is what the test steps with `advance()`. Always pair with
+ * restoreWatchdogClock() in `afterEach` — the deps object is module state and
+ * would otherwise leak into every later test file in the same process.
+ */
+export function installFakeWatchdogClock(): FakeClock {
+  activeClock = makeFakeClock();
+  saved = {
+    setTimeout: _idleWatchdogDeps.setTimeout,
+    clearTimeout: _idleWatchdogDeps.clearTimeout,
+    now: _idleWatchdogDeps.now,
+  };
+  _idleWatchdogDeps.setTimeout = activeClock.setTimeout as typeof _idleWatchdogDeps.setTimeout;
+  _idleWatchdogDeps.clearTimeout = activeClock.clearTimeout as typeof _idleWatchdogDeps.clearTimeout;
+  _idleWatchdogDeps.now = activeClock.now;
+  return activeClock;
+}
+
+/** Restore the real timers and clock. Idempotent. */
+export function restoreWatchdogClock(): void {
+  if (!saved) return;
+  _idleWatchdogDeps.setTimeout = saved.setTimeout;
+  _idleWatchdogDeps.clearTimeout = saved.clearTimeout;
+  _idleWatchdogDeps.now = saved.now;
+  saved = undefined;
+}
+
+export type ActivityKind = "message_update" | "thinking_update" | "usage_update";
+
+export function makeIdleWatchdogConfig(
+  overrides: {
+    enabled?: boolean;
+    mode?: "off" | "observe" | "cancel" | "warn-then-cancel";
+    idleTimeoutSeconds?: number;
+    activityKinds?: ActivityKind[];
+    cancelGraceSeconds?: number;
+    maxRetryAttempts?: number;
+  } = {},
+) {
+  return {
+    enabled: true,
+    mode: "cancel" as const,
+    idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
+    activityKinds: ["message_update", "thinking_update", "usage_update"] as ActivityKind[],
+    cancelGraceSeconds: GRACE_SECONDS,
+    maxRetryAttempts: 3,
+    ...overrides,
+  };
+}
+
+/** Fields every agent stream event carries. Timestamped from the virtual clock. */
+function baseEvent(callId: string) {
+  return {
+    callId,
+    runId: "run-001",
+    agentName: "claude",
+    sessionName: "nax-abc-feat-s1-main",
+    storyId: "s-42",
+    stage: "run",
+    pid: 1234,
+    timestamp: activeClock.now(),
+  };
+}
+
+export function makeCallStartedEvent(overrides: { callId?: string; pid?: number } = {}): AgentStreamEvent {
+  return {
+    kind: "agent.call_started",
+    ...baseEvent(overrides.callId ?? "call-123"),
+    pid: overrides.pid ?? 1234,
+    model: "claude-opus-4-5",
+    timeoutSeconds: 60,
+  } as AgentStreamEvent;
+}
+
+export function makeMessageUpdateEvent(overrides: { callId?: string } = {}): AgentStreamEvent {
+  return {
+    kind: "agent.message_update",
+    ...baseEvent(overrides.callId ?? "call-123"),
+    deltaBytes: 100,
+  } as AgentStreamEvent;
+}
+
+export function makeThinkingUpdateEvent(overrides: { callId?: string } = {}): AgentStreamEvent {
+  return {
+    kind: "agent.thinking_update",
+    ...baseEvent(overrides.callId ?? "call-123"),
+    deltaBytes: 50,
+  } as AgentStreamEvent;
+}
+
+export function makeUsageUpdateEvent(overrides: { callId?: string } = {}): AgentStreamEvent {
+  return {
+    kind: "agent.usage_update",
+    ...baseEvent(overrides.callId ?? "call-123"),
+    inputTokens: 100,
+    outputTokens: 200,
+    costUsd: 0.01,
+  } as AgentStreamEvent;
+}
+
+export function makeToolCallUpdateEvent(overrides: { callId?: string } = {}): AgentStreamEvent {
+  return {
+    kind: "agent.tool_call_update",
+    ...baseEvent(overrides.callId ?? "call-123"),
+    toolName: "bash",
+  } as AgentStreamEvent;
+}
+
+export function makeProcessUpdateEvent(
+  overrides: { callId?: string; status?: AgentProcessUpdateEvent["status"] } = {},
+): AgentStreamEvent {
+  return {
+    kind: "agent.process_update",
+    ...baseEvent(overrides.callId ?? "call-123"),
+    status: overrides.status ?? "spawned",
+  } as AgentStreamEvent;
+}
+
+export function makeCallEndedEvent(
+  overrides: { callId?: string; status?: AgentCallEndedEvent["status"] } = {},
+): AgentStreamEvent {
+  return {
+    kind: "agent.call_ended",
+    ...baseEvent(overrides.callId ?? "call-123"),
+    status: overrides.status ?? "success",
+  } as AgentStreamEvent;
+}

--- a/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
+++ b/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
@@ -2,22 +2,37 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { getLogger, initLogger, resetLogger } from "@/logger";
 import type { LogEntry } from "@/logger/types";
-import { AgentStreamEventBus, attachAgentIdleWatchdog, type AgentStreamEvent } from "@/runtime";
-import { cleanupTempDir, makeTempDir, makeNaxConfig, waitForCondition } from "@test/helpers";
+import { AgentStreamEventBus, attachAgentIdleWatchdog } from "@/runtime";
+import type { FakeClock } from "@test/helpers";
+import { cleanupTempDir, makeNaxConfig, makeTempDir } from "@test/helpers";
+import {
+  installFakeWatchdogClock,
+  makeCallStartedEvent,
+  makeThinkingUpdateEvent,
+  makeToolCallUpdateEvent,
+  restoreWatchdogClock,
+} from "./_idle-watchdog-harness";
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+// Virtual clock — see _idle-watchdog-harness.ts. These cases turn on how
+// tool-call activity interacts with two different timeouts, so the exact
+// interleaving of events and ticks is the thing under test; stepping the clock
+// makes that interleaving reproducible instead of scheduler-dependent.
+let clock: FakeClock;
 
+/**
+ * Emit a tool_call_update every `intervalMs` of virtual time for `durationMs`,
+ * then one more so the final activity timestamp is fresh for the assertions
+ * that run immediately after.
+ */
 async function emitToolCallUpdatesForDuration(
   eventBus: AgentStreamEventBus,
   durationMs: number,
   intervalMs = 25,
 ): Promise<void> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < durationMs) {
+  for (let elapsed = 0; elapsed < durationMs; elapsed += intervalMs) {
     eventBus.emitAgentStream(makeToolCallUpdateEvent());
-    await sleep(intervalMs);
+    await clock.advance(intervalMs);
   }
-  // Keep the final activity timestamp fresh for immediate post-loop assertions.
   eventBus.emitAgentStream(makeToolCallUpdateEvent());
 }
 
@@ -45,42 +60,18 @@ function makeWatchdogConfig(overrides: {
   });
 }
 
-function makeBaseEvent(timestamp = Date.now()) {
-  return {
-    callId: "call-123",
-    runId: "run-001",
-    agentName: "claude",
-    sessionName: "test-session",
-    storyId: "story-42",
-    stage: "run" as const,
-    pid: 1234,
-    timestamp,
-  };
-}
-
-function makeCallStartedEvent(timestamp = Date.now()): AgentStreamEvent {
-  return {
-    ...makeBaseEvent(timestamp),
-    kind: "agent.call_started",
-    model: "claude-sonnet-4-5",
-    timeoutSeconds: 60,
-  };
-}
-
-function makeThinkingUpdateEvent(timestamp = Date.now()): AgentStreamEvent {
-  return {
-    ...makeBaseEvent(timestamp),
-    kind: "agent.thinking_update",
-    deltaBytes: 12,
-  };
-}
-
-function makeToolCallUpdateEvent(timestamp = Date.now()): AgentStreamEvent {
-  return {
-    ...makeBaseEvent(timestamp),
-    kind: "agent.tool_call_update",
-    toolName: "bash",
-  };
+/** Registry with a single counting cancel callback for "call-123". */
+function makeCountingRegistry(): { registry: Map<string, () => Promise<void>>; count: () => number } {
+  let cancelCount = 0;
+  const registry = new Map<string, () => Promise<void>>([
+    [
+      "call-123",
+      async () => {
+        cancelCount++;
+      },
+    ],
+  ]);
+  return { registry, count: () => cancelCount };
 }
 
 async function parseAllEntries(logFile: string): Promise<LogEntry[]> {
@@ -97,12 +88,14 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
   let logFile: string;
 
   beforeEach(() => {
+    clock = installFakeWatchdogClock();
     tmpDir = makeTempDir("nax-test-idle-watchdog-tool-");
     logFile = join(tmpDir, `idle-watchdog-tool-${Date.now()}.jsonl`);
     initLogger({ level: "silent", filePath: logFile });
   });
 
   afterEach(async () => {
+    restoreWatchdogClock();
     await getLogger().flush();
     resetLogger();
     cleanupTempDir(tmpDir);
@@ -110,15 +103,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
   test("tool-call updates keep the primary idle timeout alive until the secondary cap is reached", async () => {
     const eventBus = new AgentStreamEventBus();
-    let cancelCount = 0;
-    const registry = new Map<string, () => Promise<void>>([
-      [
-        "call-123",
-        async () => {
-          cancelCount++;
-        },
-      ],
-    ]);
+    const { registry, count } = makeCountingRegistry();
     const detach = attachAgentIdleWatchdog(
       eventBus,
       registry,
@@ -129,7 +114,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
       eventBus.emitAgentStream(makeCallStartedEvent());
       await emitToolCallUpdatesForDuration(eventBus, 220, 30);
 
-      expect(cancelCount).toBe(0);
+      expect(count()).toBe(0);
       await getLogger().flush();
       const entries = await parseAllEntries(logFile);
       expect(entries.some((entry) => entry.data?.key === "idle_timeout_exceeded")).toBe(false);
@@ -140,23 +125,16 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
   test("tool-call-only activity hits the secondary timeout with a distinct log key", async () => {
     const eventBus = new AgentStreamEventBus();
-    let cancelCount = 0;
-    const registry = new Map<string, () => Promise<void>>([
-      [
-        "call-123",
-        async () => {
-          cancelCount++;
-        },
-      ],
-    ]);
+    const { registry, count } = makeCountingRegistry();
     const detach = attachAgentIdleWatchdog(eventBus, registry, makeWatchdogConfig());
 
     try {
       eventBus.emitAgentStream(makeCallStartedEvent());
       await emitToolCallUpdatesForDuration(eventBus, 220, 25);
-      await waitForCondition(() => cancelCount === 1, 1_000, 10);
 
-      expect(cancelCount).toBe(1);
+      // No polling needed: the cancel runs inside advance(), and the fake clock
+      // drains microtasks before returning.
+      expect(count()).toBe(1);
       await getLogger().flush();
       const entries = await parseAllEntries(logFile);
       expect(entries.some((entry) => entry.data?.key === "tool_call_only_idle_timeout_exceeded")).toBe(true);
@@ -168,15 +146,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
   test("non-tool activity resets the secondary timer", async () => {
     const eventBus = new AgentStreamEventBus();
-    let cancelCount = 0;
-    const registry = new Map<string, () => Promise<void>>([
-      [
-        "call-123",
-        async () => {
-          cancelCount++;
-        },
-      ],
-    ]);
+    const { registry, count } = makeCountingRegistry();
     const detach = attachAgentIdleWatchdog(
       eventBus,
       registry,
@@ -194,7 +164,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
       await emitToolCallUpdatesForDuration(eventBus, 220, 30);
 
-      expect(cancelCount).toBe(0);
+      expect(count()).toBe(0);
     } finally {
       detach();
     }
@@ -202,15 +172,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
   test("excluding tool_call_update from activityKinds preserves the legacy primary timeout behavior", async () => {
     const eventBus = new AgentStreamEventBus();
-    let cancelCount = 0;
-    const registry = new Map<string, () => Promise<void>>([
-      [
-        "call-123",
-        async () => {
-          cancelCount++;
-        },
-      ],
-    ]);
+    const { registry, count } = makeCountingRegistry();
     const detach = attachAgentIdleWatchdog(
       eventBus,
       registry,
@@ -220,9 +182,8 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
     try {
       eventBus.emitAgentStream(makeCallStartedEvent());
       await emitToolCallUpdatesForDuration(eventBus, 220, 30);
-      await waitForCondition(() => cancelCount === 1, 1_000, 10);
 
-      expect(cancelCount).toBe(1);
+      expect(count()).toBe(1);
       await getLogger().flush();
       const entries = await parseAllEntries(logFile);
       expect(entries.some((entry) => entry.data?.key === "idle_timeout_exceeded")).toBe(true);
@@ -233,15 +194,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
   test("toolCallOnlyIdleTimeoutSeconds=0 disables the secondary cap", async () => {
     const eventBus = new AgentStreamEventBus();
-    let cancelCount = 0;
-    const registry = new Map<string, () => Promise<void>>([
-      [
-        "call-123",
-        async () => {
-          cancelCount++;
-        },
-      ],
-    ]);
+    const { registry, count } = makeCountingRegistry();
     const detach = attachAgentIdleWatchdog(
       eventBus,
       registry,
@@ -252,7 +205,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
       eventBus.emitAgentStream(makeCallStartedEvent());
       await emitToolCallUpdatesForDuration(eventBus, 260, 30);
 
-      expect(cancelCount).toBe(0);
+      expect(count()).toBe(0);
       await getLogger().flush();
       const entries = await parseAllEntries(logFile);
       expect(entries.some((entry) => entry.data?.key === "tool_call_only_idle_timeout_exceeded")).toBe(false);
@@ -263,15 +216,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
   test("toolCallOnlyIdleTimeoutSeconds less than or equal to the primary timeout does not create an earlier cancel path", async () => {
     const eventBus = new AgentStreamEventBus();
-    let cancelCount = 0;
-    const registry = new Map<string, () => Promise<void>>([
-      [
-        "call-123",
-        async () => {
-          cancelCount++;
-        },
-      ],
-    ]);
+    const { registry, count } = makeCountingRegistry();
     const detach = attachAgentIdleWatchdog(
       eventBus,
       registry,
@@ -283,9 +228,14 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
 
     try {
       eventBus.emitAgentStream(makeCallStartedEvent());
-      await emitToolCallUpdatesForDuration(eventBus, 180, 30);
+      // Must run PAST the secondary value (200ms), or the test proves nothing:
+      // if it stops short, no tick ever evaluates the secondary condition and
+      // the assertion holds even when the "> primary" guard is removed.
+      // Tool-call activity keeps refreshing the primary clock, so the 300ms
+      // primary timeout is never reached within this window.
+      await emitToolCallUpdatesForDuration(eventBus, 280, 30);
 
-      expect(cancelCount).toBe(0);
+      expect(count()).toBe(0);
       await getLogger().flush();
       const entries = await parseAllEntries(logFile);
       expect(entries.some((entry) => entry.data?.key === "tool_call_only_idle_timeout_exceeded")).toBe(false);

--- a/test/unit/runtime/middleware/idle-watchdog.test.ts
+++ b/test/unit/runtime/middleware/idle-watchdog.test.ts
@@ -26,9 +26,9 @@ function makeIdleWatchdogConfig(overrides: {
   return {
     enabled: true,
     mode: "cancel" as const,
-    idleTimeoutSeconds: 1,
+    idleTimeoutSeconds: 0.333,
     activityKinds: ["message_update", "thinking_update", "usage_update"] as ("message_update" | "thinking_update" | "usage_update")[],
-    cancelGraceSeconds: 0.5,
+    cancelGraceSeconds: 0.167,
     maxRetryAttempts: 3,
     ...overrides,
   };
@@ -181,7 +181,7 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-1" }));
 
     // Wait a tiny bit, then emit message_update
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 17));
     eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-1" }));
     await getLogger().flush();
 
@@ -204,7 +204,7 @@ describe("attachAgentIdleWatchdog", () => {
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-2" }));
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 17));
     eventBus.emitAgentStream(makeThinkingUpdateEvent({ callId: "call-2" }));
     await getLogger().flush();
 
@@ -226,7 +226,7 @@ describe("attachAgentIdleWatchdog", () => {
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-3" }));
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 17));
     eventBus.emitAgentStream(makeUsageUpdateEvent({ callId: "call-3" }));
     await getLogger().flush();
 
@@ -239,7 +239,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "observe",
-          idleTimeoutSeconds: 0.2, // Short timeout so the timer fires quickly
+          idleTimeoutSeconds: 0.067, // Short timeout so the timer fires quickly
           activityKinds: ["message_update", "thinking_update", "usage_update"],
         }),
       },
@@ -250,11 +250,11 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-4" }));
 
     // Emit process_update well before the timeout — must NOT reset the idle clock
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 17));
     eventBus.emitAgentStream(makeProcessUpdateEvent({ callId: "call-4", status: "spawned" }));
 
     // Wait past the idle timeout — the timer must fire because process_update did not count as activity
-    await new Promise((r) => setTimeout(r, 250));
+    await new Promise((r) => setTimeout(r, 83));
     await getLogger().flush();
 
     const entries = await parseAllEntries(logFile);
@@ -278,7 +278,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "observe",
-          idleTimeoutSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
           activityKinds: ["message_update"],
         }),
       },
@@ -289,7 +289,7 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-5" }));
 
     // Wait for timeout to be exceeded
-    await new Promise((r) => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 100));
     await getLogger().flush();
 
     const entries = await parseAllEntries(logFile);
@@ -313,8 +313,8 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "warn-then-cancel",
-          idleTimeoutSeconds: 0.2,
-          cancelGraceSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
+          cancelGraceSeconds: 0.067,
           activityKinds: ["message_update"],
         }),
       },
@@ -325,7 +325,7 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-6" }));
 
     // Wait for timeout + grace period
-    await new Promise((r) => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 167));
     await getLogger().flush();
 
     // Should have logged warning and then canceled
@@ -350,8 +350,8 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "warn-then-cancel",
-          idleTimeoutSeconds: 0.2,
-          cancelGraceSeconds: 0.3,
+          idleTimeoutSeconds: 0.067,
+          cancelGraceSeconds: 0.1,
           activityKinds: ["message_update"],
         }),
       },
@@ -362,13 +362,13 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-6b" }));
 
     // Wait for timeout to be exceeded
-    await new Promise((r) => setTimeout(r, 250));
+    await new Promise((r) => setTimeout(r, 83));
 
     // Activity arrives during grace period
     eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-6b" }));
 
     // Wait a bit more to see if cancel is called
-    await new Promise((r) => setTimeout(r, 200));
+    await new Promise((r) => setTimeout(r, 67));
     await getLogger().flush();
 
     // Cancel should NOT have been called because activity reset the timer
@@ -392,7 +392,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
           cancelGraceSeconds: 0, // ignored in cancel mode
           activityKinds: ["message_update"],
         }),
@@ -404,13 +404,13 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-7" }));
 
     // Wait for timeout
-    await new Promise((r) => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 100));
     await getLogger().flush();
 
     expect(cancelWasCalled).toBe(true);
     // Verify it was called around the timeout, not much later
     const elapsedMs = cancelTime - startTime;
-    expect(elapsedMs).toBeLessThan(500); // Should be around 200-300ms
+    expect(elapsedMs).toBeLessThan(167); // Should be around 67-100ms
 
     currentUnsubscribe();
   });
@@ -421,7 +421,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.5,
+          idleTimeoutSeconds: 0.167,
           activityKinds: ["message_update"],
         }),
       },
@@ -432,11 +432,11 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-8" }));
 
     // Emit call_ended
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 17));
     eventBus.emitAgentStream(makeCallEndedEvent({ callId: "call-8", status: "success" }));
 
     // Wait to see if any timeout fires after call_ended
-    await new Promise((r) => setTimeout(r, 700));
+    await new Promise((r) => setTimeout(r, 233));
     await getLogger().flush();
 
     // Should not have any cancellation or excessive warnings
@@ -454,7 +454,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
           maxRetryAttempts: 2,
           activityKinds: ["message_update"],
         }),
@@ -466,7 +466,7 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-9" }));
 
     // Wait for multiple timeout/cancel cycles
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, 333));
     await getLogger().flush();
 
     const entries = await parseAllEntries(logFile);
@@ -507,7 +507,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
           activityKinds: ["message_update"],
         }),
       },
@@ -518,11 +518,11 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-unsub" }));
 
     // Unsubscribe before timeout
-    await new Promise((r) => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 33));
     currentUnsubscribe();
 
     // Wait for what would have been the timeout
-    await new Promise((r) => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 100));
     await getLogger().flush();
 
     // Should not have canceled because we unsubscribed
@@ -535,7 +535,7 @@ describe("attachAgentIdleWatchdog", () => {
         idleWatchdog: makeIdleWatchdogConfig({
           enabled: false,
           mode: "cancel",
-          idleTimeoutSeconds: 0.1,
+          idleTimeoutSeconds: 0.033,
         }),
       },
     });
@@ -544,7 +544,7 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-disabled" }));
 
-    await new Promise((r) => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 100));
     await getLogger().flush();
 
     // No timers should be active when disabled
@@ -564,7 +564,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
           activityKinds: ["message_update"],
         }),
       },
@@ -578,14 +578,14 @@ describe("attachAgentIdleWatchdog", () => {
 
     // Keep call-10a alive: emit messages every ~100ms so it never reaches the 200ms idle threshold.
     // call-10b receives no activity and will time out at t≈200ms.
-    await new Promise((r) => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 33));
     eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-10a" })); // t=100ms
 
-    await new Promise((r) => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 33));
     eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-10a" })); // t=200ms
 
     // call-10b has been idle 200ms — confirm it timed out; call-10a is still fresh (lastActivity=200ms)
-    await new Promise((r) => setTimeout(r, 150));
+    await new Promise((r) => setTimeout(r, 50));
     await getLogger().flush();
 
     // call-10b should have been canceled, call-10a should still be active
@@ -617,7 +617,7 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-mode-off" }));
 
     // Wait longer than idle timeout
-    await new Promise((r) => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 100));
     await getLogger().flush();
 
     // No cancellation should occur when mode is 'off'
@@ -637,7 +637,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "warn-then-cancel",
-          idleTimeoutSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
           cancelGraceSeconds: 0, // Zero grace period
           activityKinds: ["message_update"],
         }),
@@ -649,7 +649,7 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-zero-grace" }));
 
     // Wait for timeout + negligible grace period
-    await new Promise((r) => setTimeout(r, 400));
+    await new Promise((r) => setTimeout(r, 133));
     await getLogger().flush();
 
     // Cancellation should have been called (like cancel mode)
@@ -680,7 +680,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.2,
+          idleTimeoutSeconds: 0.067,
           activityKinds: ["message_update"],
         }),
       },
@@ -690,11 +690,11 @@ describe("attachAgentIdleWatchdog", () => {
 
     // Start two calls
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-throwing" }));
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 17));
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-normal" }));
 
     // Wait for timeouts
-    await new Promise((r) => setTimeout(r, 400));
+    await new Promise((r) => setTimeout(r, 133));
     await getLogger().flush();
 
     // Both should have been attempted to cancel
@@ -724,7 +724,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.15,
+          idleTimeoutSeconds: 0.05,
           maxRetryAttempts: 3,
           activityKinds: ["message_update"],
         }),
@@ -734,11 +734,11 @@ describe("attachAgentIdleWatchdog", () => {
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-retry-a" }));
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 17));
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-retry-b" }));
 
     // Wait for multiple timeout cycles
-    await new Promise((r) => setTimeout(r, 800));
+    await new Promise((r) => setTimeout(r, 267));
     await getLogger().flush();
 
     // Each call should have been retried independently

--- a/test/unit/runtime/middleware/idle-watchdog.test.ts
+++ b/test/unit/runtime/middleware/idle-watchdog.test.ts
@@ -2,130 +2,34 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { initLogger, getLogger, resetLogger } from "../../../../src/logger";
 import type { LogEntry } from "../../../../src/logger/types";
-import {
-  AgentStreamEventBus,
-  type AgentProcessUpdateEvent,
-  type AgentCallEndedEvent,
-  type AgentStreamEvent,
-  type IAgentStreamEventBus,
-} from "../../../../src/runtime/agent-stream-events";
+import { AgentStreamEventBus, type IAgentStreamEventBus } from "../../../../src/runtime/agent-stream-events";
 import { attachAgentIdleWatchdog } from "../../../../src/runtime/middleware/idle-watchdog";
+import type { FakeClock } from "../../../helpers";
 import { makeNaxConfig } from "../../../helpers";
 import { cleanupTempDir, makeTempDir } from "../../../helpers";
+import {
+  GRACE_MS,
+  GRACE_SECONDS,
+  IDLE_TIMEOUT_MS,
+  IDLE_TIMEOUT_SECONDS,
+  NEVER_FIRES_SECONDS,
+  TICK_MS,
+  installFakeWatchdogClock,
+  makeCallEndedEvent,
+  makeCallStartedEvent,
+  makeIdleWatchdogConfig,
+  makeMessageUpdateEvent,
+  makeProcessUpdateEvent,
+  makeThinkingUpdateEvent,
+  makeUsageUpdateEvent,
+  restoreWatchdogClock,
+} from "./_idle-watchdog-harness";
 
 type CancelCallback = () => Promise<void>;
 
-function makeIdleWatchdogConfig(overrides: {
-  enabled?: boolean;
-  mode?: "off" | "observe" | "cancel" | "warn-then-cancel";
-  idleTimeoutSeconds?: number;
-  activityKinds?: ("message_update" | "thinking_update" | "usage_update")[];
-  cancelGraceSeconds?: number;
-  maxRetryAttempts?: number;
-} = {}) {
-  return {
-    enabled: true,
-    mode: "cancel" as const,
-    idleTimeoutSeconds: 0.333,
-    activityKinds: ["message_update", "thinking_update", "usage_update"] as ("message_update" | "thinking_update" | "usage_update")[],
-    cancelGraceSeconds: 0.167,
-    maxRetryAttempts: 3,
-    ...overrides,
-  };
-}
-
-function makeCallStartedEvent(overrides: { callId?: string; pid?: number } = {}): AgentStreamEvent {
-  return {
-    kind: "agent.call_started",
-    callId: overrides.callId ?? "call-123",
-    runId: "run-001",
-    agentName: "claude",
-    sessionName: "nax-abc-feat-s1-main",
-    storyId: "s-42",
-    stage: "run",
-    pid: overrides.pid ?? 1234,
-    timestamp: Date.now(),
-    model: "claude-opus-4-5",
-    timeoutSeconds: 60,
-  } as AgentStreamEvent;
-}
-
-function makeMessageUpdateEvent(overrides: { callId?: string } = {}): AgentStreamEvent {
-  return {
-    kind: "agent.message_update",
-    callId: overrides.callId ?? "call-123",
-    runId: "run-001",
-    agentName: "claude",
-    sessionName: "nax-abc-feat-s1-main",
-    storyId: "s-42",
-    stage: "run",
-    pid: 1234,
-    timestamp: Date.now(),
-    deltaBytes: 100,
-  } as AgentStreamEvent;
-}
-
-function makeThinkingUpdateEvent(overrides: { callId?: string } = {}): AgentStreamEvent {
-  return {
-    kind: "agent.thinking_update",
-    callId: overrides.callId ?? "call-123",
-    runId: "run-001",
-    agentName: "claude",
-    sessionName: "nax-abc-feat-s1-main",
-    storyId: "s-42",
-    stage: "run",
-    pid: 1234,
-    timestamp: Date.now(),
-    deltaBytes: 50,
-  } as AgentStreamEvent;
-}
-
-function makeUsageUpdateEvent(overrides: { callId?: string } = {}): AgentStreamEvent {
-  return {
-    kind: "agent.usage_update",
-    callId: overrides.callId ?? "call-123",
-    runId: "run-001",
-    agentName: "claude",
-    sessionName: "nax-abc-feat-s1-main",
-    storyId: "s-42",
-    stage: "run",
-    pid: 1234,
-    timestamp: Date.now(),
-    inputTokens: 100,
-    outputTokens: 200,
-    costUsd: 0.01,
-  } as AgentStreamEvent;
-}
-
-function makeProcessUpdateEvent(overrides: { callId?: string; status?: AgentProcessUpdateEvent["status"] } = {}): AgentStreamEvent {
-  return {
-    kind: "agent.process_update",
-    callId: overrides.callId ?? "call-123",
-    runId: "run-001",
-    agentName: "claude",
-    sessionName: "nax-abc-feat-s1-main",
-    storyId: "s-42",
-    stage: "run",
-    pid: 1234,
-    timestamp: Date.now(),
-    status: overrides.status ?? "spawned",
-  } as AgentStreamEvent;
-}
-
-function makeCallEndedEvent(overrides: { callId?: string; status?: AgentCallEndedEvent["status"] } = {}): AgentStreamEvent {
-  return {
-    kind: "agent.call_ended",
-    callId: overrides.callId ?? "call-123",
-    runId: "run-001",
-    agentName: "claude",
-    sessionName: "nax-abc-feat-s1-main",
-    storyId: "s-42",
-    stage: "run",
-    pid: 1234,
-    timestamp: Date.now(),
-    status: overrides.status ?? "success",
-  } as AgentStreamEvent;
-}
+// Virtual clock — see _idle-watchdog-harness.ts for why these suites do not
+// sleep. Assigned in beforeEach; every test steps it with clock.advance().
+let clock: FakeClock;
 
 async function parseAllEntries(logFile: string): Promise<LogEntry[]> {
   const content = await Bun.file(logFile).text();
@@ -141,6 +45,8 @@ describe("attachAgentIdleWatchdog", () => {
   let currentUnsubscribe: (() => void) | undefined;
 
   beforeEach(() => {
+    clock = installFakeWatchdogClock();
+
     tmpDir = makeTempDir("nax-test-idle-watchdog-");
     logFile = join(tmpDir, `test-idle-watchdog-${Date.now()}.jsonl`);
     initLogger({ level: "silent", filePath: logFile });
@@ -156,6 +62,7 @@ describe("attachAgentIdleWatchdog", () => {
       /* best-effort — unsubscribe itself threw */
     }
     currentUnsubscribe = undefined;
+    restoreWatchdogClock();
     try {
       await getLogger().flush();
       resetLogger();
@@ -170,7 +77,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "observe",
-          idleTimeoutSeconds: 10,
+          idleTimeoutSeconds: NEVER_FIRES_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -181,7 +88,7 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-1" }));
 
     // Wait a tiny bit, then emit message_update
-    await new Promise((r) => setTimeout(r, 17));
+    await clock.advance(TICK_MS);
     eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-1" }));
     await getLogger().flush();
 
@@ -195,7 +102,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "observe",
-          idleTimeoutSeconds: 10,
+          idleTimeoutSeconds: NEVER_FIRES_SECONDS,
           activityKinds: ["thinking_update"],
         }),
       },
@@ -204,7 +111,7 @@ describe("attachAgentIdleWatchdog", () => {
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-2" }));
-    await new Promise((r) => setTimeout(r, 17));
+    await clock.advance(TICK_MS);
     eventBus.emitAgentStream(makeThinkingUpdateEvent({ callId: "call-2" }));
     await getLogger().flush();
 
@@ -217,7 +124,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "observe",
-          idleTimeoutSeconds: 10,
+          idleTimeoutSeconds: NEVER_FIRES_SECONDS,
           activityKinds: ["usage_update"],
         }),
       },
@@ -226,7 +133,7 @@ describe("attachAgentIdleWatchdog", () => {
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-3" }));
-    await new Promise((r) => setTimeout(r, 17));
+    await clock.advance(TICK_MS);
     eventBus.emitAgentStream(makeUsageUpdateEvent({ callId: "call-3" }));
     await getLogger().flush();
 
@@ -239,7 +146,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "observe",
-          idleTimeoutSeconds: 0.067, // Short timeout so the timer fires quickly
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           activityKinds: ["message_update", "thinking_update", "usage_update"],
         }),
       },
@@ -250,11 +157,12 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-4" }));
 
     // Emit process_update well before the timeout — must NOT reset the idle clock
-    await new Promise((r) => setTimeout(r, 17));
+    await clock.advance(TICK_MS);
     eventBus.emitAgentStream(makeProcessUpdateEvent({ callId: "call-4", status: "spawned" }));
 
-    // Wait past the idle timeout — the timer must fire because process_update did not count as activity
-    await new Promise((r) => setTimeout(r, 83));
+    // Step to exactly the idle threshold measured from call_started. It can only
+    // be reached if process_update left lastActivityAt alone.
+    await clock.advance(IDLE_TIMEOUT_MS - TICK_MS);
     await getLogger().flush();
 
     const entries = await parseAllEntries(logFile);
@@ -278,7 +186,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "observe",
-          idleTimeoutSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -288,8 +196,7 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-5" }));
 
-    // Wait for timeout to be exceeded
-    await new Promise((r) => setTimeout(r, 100));
+    await clock.advance(IDLE_TIMEOUT_MS);
     await getLogger().flush();
 
     const entries = await parseAllEntries(logFile);
@@ -313,8 +220,8 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "warn-then-cancel",
-          idleTimeoutSeconds: 0.067,
-          cancelGraceSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
+          cancelGraceSeconds: GRACE_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -324,8 +231,10 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-6" }));
 
-    // Wait for timeout + grace period
-    await new Promise((r) => setTimeout(r, 167));
+    // Idle threshold arms the grace timer; the grace period then elapses.
+    await clock.advance(IDLE_TIMEOUT_MS);
+    expect(cancelWasCalled).toBe(false); // still inside the grace window
+    await clock.advance(GRACE_MS);
     await getLogger().flush();
 
     // Should have logged warning and then canceled
@@ -350,8 +259,16 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "warn-then-cancel",
-          idleTimeoutSeconds: 0.067,
-          cancelGraceSeconds: 0.1,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
+          // Deliberately LONGER than the idle timeout, which is what makes this
+          // test discriminating. When the grace timer fires it re-checks whether
+          // the call is still idle; with a short grace the activity below is
+          // recent enough that the re-check alone suppresses the cancel, and the
+          // test passes even if clearGrace() is broken. A grace longer than the
+          // idle period means the call is idle *again* by the time grace expires,
+          // so the only thing that can prevent the cancel is the timer having
+          // been cleared when the activity arrived.
+          cancelGraceSeconds: IDLE_TIMEOUT_SECONDS * 2,
           activityKinds: ["message_update"],
         }),
       },
@@ -361,17 +278,17 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-6b" }));
 
-    // Wait for timeout to be exceeded
-    await new Promise((r) => setTimeout(r, 83));
+    // Reach the idle threshold, which opens the grace window.
+    await clock.advance(IDLE_TIMEOUT_MS);
 
-    // Activity arrives during grace period
+    // Activity arrives mid-grace and must abort the pending cancel.
     eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-6b" }));
 
-    // Wait a bit more to see if cancel is called
-    await new Promise((r) => setTimeout(r, 67));
+    // Step past where the grace timer would have fired had it survived.
+    await clock.advance(IDLE_TIMEOUT_MS * 2);
     await getLogger().flush();
 
-    // Cancel should NOT have been called because activity reset the timer
+    // Cancel should NOT have been called because activity cleared the grace timer
     expect(cancelWasCalled).toBe(false);
 
     currentUnsubscribe();
@@ -383,16 +300,16 @@ describe("attachAgentIdleWatchdog", () => {
     let cancelTime = 0;
     controllerRegistry.set("call-7", async () => {
       cancelWasCalled = true;
-      cancelTime = Date.now();
+      cancelTime = clock.now();
     });
 
-    const startTime = Date.now();
+    const startTime = clock.now();
 
     const config = makeNaxConfig({
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           cancelGraceSeconds: 0, // ignored in cancel mode
           activityKinds: ["message_update"],
         }),
@@ -403,14 +320,13 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-7" }));
 
-    // Wait for timeout
-    await new Promise((r) => setTimeout(r, 100));
+    await clock.advance(IDLE_TIMEOUT_MS);
     await getLogger().flush();
 
     expect(cancelWasCalled).toBe(true);
-    // Verify it was called around the timeout, not much later
-    const elapsedMs = cancelTime - startTime;
-    expect(elapsedMs).toBeLessThan(167); // Should be around 67-100ms
+    // Exact, not a bound: cancel mode skips the grace period, so the cancel
+    // lands on the very tick that detects the threshold.
+    expect(cancelTime - startTime).toBe(IDLE_TIMEOUT_MS);
 
     currentUnsubscribe();
   });
@@ -421,7 +337,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.167,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -431,15 +347,17 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-8" }));
 
-    // Emit call_ended
-    await new Promise((r) => setTimeout(r, 17));
+    // Emit call_ended before the threshold is reached.
+    await clock.advance(TICK_MS);
     eventBus.emitAgentStream(makeCallEndedEvent({ callId: "call-8", status: "success" }));
 
-    // Wait to see if any timeout fires after call_ended
-    await new Promise((r) => setTimeout(r, 233));
+    // The tick timer must be disarmed, not merely inert.
+    expect(clock.pending()).toBe(0);
+
+    // Far past where the timeout would have fired had the state survived.
+    await clock.advance(IDLE_TIMEOUT_MS * 10);
     await getLogger().flush();
 
-    // Should not have any cancellation or excessive warnings
     const entries = await parseAllEntries(logFile);
     const cancelEntries = entries.filter((e) => e.data?.action === "cancel");
     // After call_ended, there should be no cancellation attempts
@@ -454,7 +372,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           maxRetryAttempts: 2,
           activityKinds: ["message_update"],
         }),
@@ -465,8 +383,9 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-9" }));
 
-    // Wait for multiple timeout/cancel cycles
-    await new Promise((r) => setTimeout(r, 333));
+    // Each cancel resets the idle clock, so N attempts take N idle periods;
+    // step past the 2-attempt cap to reach the terminal failure.
+    await clock.advance(IDLE_TIMEOUT_MS * 4);
     await getLogger().flush();
 
     const entries = await parseAllEntries(logFile);
@@ -507,7 +426,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -518,11 +437,14 @@ describe("attachAgentIdleWatchdog", () => {
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-unsub" }));
 
     // Unsubscribe before timeout
-    await new Promise((r) => setTimeout(r, 33));
+    await clock.advance(TICK_MS);
     currentUnsubscribe();
 
-    // Wait for what would have been the timeout
-    await new Promise((r) => setTimeout(r, 100));
+    // Teardown must disarm the tick timer, not leave it running.
+    expect(clock.pending()).toBe(0);
+
+    // Well past what would have been the timeout.
+    await clock.advance(IDLE_TIMEOUT_MS * 10);
     await getLogger().flush();
 
     // Should not have canceled because we unsubscribed
@@ -535,7 +457,7 @@ describe("attachAgentIdleWatchdog", () => {
         idleWatchdog: makeIdleWatchdogConfig({
           enabled: false,
           mode: "cancel",
-          idleTimeoutSeconds: 0.033,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
         }),
       },
     });
@@ -544,10 +466,11 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-disabled" }));
 
-    await new Promise((r) => setTimeout(r, 100));
+    await clock.advance(IDLE_TIMEOUT_MS * 10);
     await getLogger().flush();
 
-    // No timers should be active when disabled
+    // Directly observable now: a disabled watchdog arms no timer whatsoever.
+    expect(clock.pending()).toBe(0);
     expect(controllerRegistry.size).toBe(0);
   });
 
@@ -564,7 +487,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -572,20 +495,17 @@ describe("attachAgentIdleWatchdog", () => {
 
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
-    // Start two calls
+    // Start two calls at t=0.
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-10a" }));
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-10b" }));
 
-    // Keep call-10a alive: emit messages every ~100ms so it never reaches the 200ms idle threshold.
-    // call-10b receives no activity and will time out at t≈200ms.
-    await new Promise((r) => setTimeout(r, 33));
-    eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-10a" })); // t=100ms
+    // Keep call-10a alive with activity at the halfway mark; call-10b gets none.
+    await clock.advance(IDLE_TIMEOUT_MS / 2);
+    eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-10a" }));
 
-    await new Promise((r) => setTimeout(r, 33));
-    eventBus.emitAgentStream(makeMessageUpdateEvent({ callId: "call-10a" })); // t=200ms
-
-    // call-10b has been idle 200ms — confirm it timed out; call-10a is still fresh (lastActivity=200ms)
-    await new Promise((r) => setTimeout(r, 50));
+    // t = IDLE_TIMEOUT_MS: call-10b has been idle the full period and is cancelled.
+    // call-10a's clock restarted at the halfway mark, so it is only half-idle.
+    await clock.advance(IDLE_TIMEOUT_MS / 2);
     await getLogger().flush();
 
     // call-10b should have been canceled, call-10a should still be active
@@ -606,7 +526,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "off",
-          idleTimeoutSeconds: 10,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -616,11 +536,12 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-mode-off" }));
 
-    // Wait longer than idle timeout
-    await new Promise((r) => setTimeout(r, 100));
+    // Far longer than the idle timeout.
+    await clock.advance(IDLE_TIMEOUT_MS * 10);
     await getLogger().flush();
 
-    // No cancellation should occur when mode is 'off'
+    // Directly observable now: mode "off" arms no timer at all.
+    expect(clock.pending()).toBe(0);
     expect(cancelWasCalled).toBe(false);
 
     currentUnsubscribe();
@@ -637,7 +558,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "warn-then-cancel",
-          idleTimeoutSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           cancelGraceSeconds: 0, // Zero grace period
           activityKinds: ["message_update"],
         }),
@@ -648,8 +569,8 @@ describe("attachAgentIdleWatchdog", () => {
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-zero-grace" }));
 
-    // Wait for timeout + negligible grace period
-    await new Promise((r) => setTimeout(r, 133));
+    // A zero-length grace window closes on the same tick that opened it.
+    await clock.advance(IDLE_TIMEOUT_MS);
     await getLogger().flush();
 
     // Cancellation should have been called (like cancel mode)
@@ -680,7 +601,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.067,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           activityKinds: ["message_update"],
         }),
       },
@@ -688,13 +609,13 @@ describe("attachAgentIdleWatchdog", () => {
 
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
-    // Start two calls
+    // Start two calls, staggered, so they reach their thresholds on different ticks.
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-throwing" }));
-    await new Promise((r) => setTimeout(r, 17));
+    await clock.advance(TICK_MS);
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-normal" }));
 
-    // Wait for timeouts
-    await new Promise((r) => setTimeout(r, 133));
+    // Past both thresholds: call-throwing at +1000, call-normal at +1250.
+    await clock.advance(IDLE_TIMEOUT_MS * 2);
     await getLogger().flush();
 
     // Both should have been attempted to cancel
@@ -724,7 +645,7 @@ describe("attachAgentIdleWatchdog", () => {
       agent: {
         idleWatchdog: makeIdleWatchdogConfig({
           mode: "cancel",
-          idleTimeoutSeconds: 0.05,
+          idleTimeoutSeconds: IDLE_TIMEOUT_SECONDS,
           maxRetryAttempts: 3,
           activityKinds: ["message_update"],
         }),
@@ -734,16 +655,18 @@ describe("attachAgentIdleWatchdog", () => {
     currentUnsubscribe = attachAgentIdleWatchdog(eventBus, controllerRegistry, config);
 
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-retry-a" }));
-    await new Promise((r) => setTimeout(r, 17));
+    await clock.advance(TICK_MS);
     eventBus.emitAgentStream(makeCallStartedEvent({ callId: "call-retry-b" }));
 
-    // Wait for multiple timeout cycles
-    await new Promise((r) => setTimeout(r, 267));
+    // Each cancel resets that call's idle clock, so three attempts take three
+    // idle periods. Step past all of them for both calls.
+    await clock.advance(IDLE_TIMEOUT_MS * 4);
     await getLogger().flush();
 
-    // Each call should have been retried independently
-    expect(cancelAttempts["call-retry-a"]).toBeGreaterThan(0);
-    expect(cancelAttempts["call-retry-b"]).toBeGreaterThan(0);
+    // Exact, not a lower bound: each call must spend its own maxRetryAttempts
+    // budget, so a shared counter (the cross-contamination this guards) now fails.
+    expect(cancelAttempts["call-retry-a"]).toBe(3);
+    expect(cancelAttempts["call-retry-b"]).toBe(3);
 
     currentUnsubscribe();
   });

--- a/test/unit/utils/git.test.ts
+++ b/test/unit/utils/git.test.ts
@@ -53,13 +53,16 @@ function mockSpawnOutput(output: string, exitCode = 0) {
 }
 
 let origSpawn: typeof _gitDeps.spawn;
+let origRetryTimeoutMs: number;
 
 beforeEach(() => {
   origSpawn = _gitDeps.spawn;
+  origRetryTimeoutMs = _gitDeps.timeoutRetryGitTimeoutMs;
 });
 
 afterEach(() => {
   _gitDeps.spawn = origSpawn;
+  _gitDeps.timeoutRetryGitTimeoutMs = origRetryTimeoutMs;
   mock.restore();
 });
 
@@ -217,12 +220,17 @@ describe("captureWorkingTreeChanges", () => {
 
   test("does not stall when git subprocess hangs (SIGKILL after timeout)", async () => {
     // Adversarial review: a hung git must not stall timeout-retry recovery.
-    // captureWorkingTreeChanges passes TIMEOUT_RETRY_GIT_TIMEOUT_MS (3s) to
-    // gitWithTimeout, scoped separately from the general-purpose GIT_TIMEOUT_MS
-    // (10s) so a slow retry-recovery capture can't shrink the timeout for other
-    // gitWithTimeout callers. The mock simulates real Bun.spawn behaviour:
-    // proc.kill() resolves the exited promise so the await unblocks and the
-    // function returns the empty-on-failure contract.
+    // captureWorkingTreeChanges passes _gitDeps.timeoutRetryGitTimeoutMs (3s in
+    // production) to gitWithTimeout, scoped separately from the general-purpose
+    // GIT_TIMEOUT_MS (10s) so a slow retry-recovery capture can't shrink the
+    // timeout for other gitWithTimeout callers. The mock simulates real
+    // Bun.spawn behaviour: proc.kill() resolves the exited promise so the await
+    // unblocks and the function returns the empty-on-failure contract.
+    //
+    // The timeout is injected down to 50ms — the contract under test is
+    // "arms a timer, SIGKILLs on expiry, degrades to []", not the production
+    // duration. Waiting the real 3s made this the slowest test in the suite.
+    _gitDeps.timeoutRetryGitTimeoutMs = 50;
     let killCount = 0;
     _gitDeps.spawn = mock((_args: unknown[], _opts: unknown) => {
       let resolveExited: (code: number) => void = () => {};
@@ -243,8 +251,8 @@ describe("captureWorkingTreeChanges", () => {
     const start = Date.now();
     const result = await captureWorkingTreeChanges("/tmp/repo", "abc123");
     const elapsed = Date.now() - start;
-    // Allow generous slack for CI; the scoped TIMEOUT_RETRY_GIT_TIMEOUT_MS is 3s.
-    expect(elapsed).toBeLessThan(15_000);
+    // Allow generous slack for CI; the injected timeout above is 50ms.
+    expect(elapsed).toBeLessThan(5_000);
     // All three git subprocesses must be killed on timeout (one per diff call).
     expect(killCount).toBe(3);
     // Best-effort contract: hangs degrade to empty array.

--- a/test/unit/verification/executor.test.ts
+++ b/test/unit/verification/executor.test.ts
@@ -29,8 +29,10 @@ describe("normalizeEnvironment", () => {
 });
 
 describe("executeWithTimeout", () => {
+  // 0.1s, not 1s: `timeoutSeconds` is only ever multiplied out to ms, and what is
+  // under test is the timeout->kill transition, not how long the wait was.
   test("returns a timeout result and reports the process killed", async () => {
-    const result = await executeWithTimeout("sleep 30", 1, undefined, { gracePeriodMs: 200 });
+    const result = await executeWithTimeout("sleep 30", 0.1, undefined, { gracePeriodMs: 200 });
 
     expect(result.timeout).toBe(true);
     expect(result.killed).toBe(true);
@@ -58,7 +60,7 @@ describe("executeWithTimeout", () => {
       // never passed to clearTimeout), not durational, so the assertion does not
       // need a long window — and CI cannot be relied on to make SIGTERM reap the
       // child, which would otherwise stall the test for the full grace period.
-      executeWithTimeout("sleep 30", 1, undefined, { gracePeriodMs: 200, drainTimeoutMs: 500 }),
+      executeWithTimeout("sleep 30", 0.1, undefined, { gracePeriodMs: 200, drainTimeoutMs: 500 }),
     );
 
     expect(result.timeout).toBe(true);


### PR DESCRIPTION
## Why

`bun run test` had roughly doubled since May. Measured against `c5da2b8d` (2026-05-30), same Bun, same `node_modules`:

| | unit files | tests | unit time |
|---|---|---|---|
| 2026-05-30 | 675 | 8,327 | **17.5s** |
| before this PR | 862 | 10,845 | **36.2s** |

Files +28%, tests +30%, time **+107%** — so growth alone did not explain it.

Profiling per-testcase time showed why: the sum of testcase times was 34.7s of the 36.2s, so it was not startup or module-load overhead. Ten files held ~19s of it, all waiting on real clocks rather than on the behaviour under test. Bun runs test files serially in one process, so every one of those waits is additive on the suite wall clock.

| file | before |
|---|---|
| `runtime/middleware/idle-watchdog.test.ts` | 6.89s |
| `interaction/plugins/telegram-authorization.test.ts` | 3.72s |
| `utils/git.test.ts` | 3.01s |
| `verification/executor.test.ts` | 2.02s |
| `runtime/middleware/idle-watchdog-tool-call.test.ts` | 1.65s |
| `routing/llm-batch-route.test.ts` | 1.01s |
| otel heartbeat / reporter-lifecycle / batch-queue / resource-adoption | 2.48s |

## Result

**Full suite 45.9s -> 31.3s. Unit phase 36.2s -> 17.7s.** Green on 5+ consecutive full runs.

| | before | after |
|---|---|---|
| watchdog directory | 8.54s | **0.09s** |
| otel-heartbeat | 0.87s | **0.07s** |
| telegram-authorization | 3.72s | **~0.5s** |
| `utils/git.test.ts` | 3.01s | **0.16s** |
| `verification/executor.test.ts` | 2.02s | **0.30s** |
| `routing/llm-batch-route.test.ts` | 1.01s | **0.07s** |

Test count went **up**: 10,845 -> 10,881 (+15 new tests, +21 recovered — see below).

## How

Three commits, each reviewable on its own.

### 1. `perf(test)` — remove the wall-clock waits

Two durations were unreachable from tests, so they became injectable. **Production defaults unchanged in both cases:**

- `_gitDeps.timeoutRetryGitTimeoutMs` — was a module-private `3_000` const, so the hang test had no way to assert the SIGKILL contract without waiting the full 3s.
- `_telegramPluginDeps.basePollBackoffMs` — the `1000` literal was hardcoded in three places, so every multi-poll test paid seconds.

The rest needed no source change; the values were already reachable and nobody had scaled them. `executeWithTimeout`'s `timeoutSeconds` is only ever multiplied out to ms (`1` -> `0.1`); `llm-batch-route` now stubs `_callOpDeps.sleep` so it stops paying classify-route's 1s retry backoff for a failure it deliberately swallows.

### 2. `test` — drive the timer suites off a virtual clock

Commit 1 traded wall-clock for margin: those tests still bet that the machine schedules them promptly, and `idle-watchdog` had already been stabilized twice for exactly that (#1002, #1008).

This removes the bet. New `test/helpers/fake-clock.ts`: time moves only when the test advances it, timers fire in deadline order, microtasks drain between them so async callbacks settle. It reaches the code under test through module-scoped `_deps` (`_heartbeatDeps`, `_idleWatchdogDeps` incl. its `now()`) — **never through globals**, so the logger's own timers keep the real clock and `flush()` is unaffected.

Assertions got **stronger**, not just faster. Exact counts are now possible: "at least one tick fired" -> "exactly three ticks", which catches a heartbeat firing twice as often as configured — something the old lower bound never could. `clock.pending()` lets teardown assert timers were actually disarmed rather than merely inert. Watchdog thresholds went back to readable whole seconds.

**Verified by mutation, not by the tests passing.** A fake clock makes it easy to write a test that passes because the timer never fired. Six bugs seeded; the first pass caught four. Both survivors were real coverage holes, now closed and re-checked:

- **AC6b could not see `clearGrace()`** — the grace timer's own re-check already suppressed the cancel, so it passed with `clearGrace` disabled. Now uses a grace period longer than the idle timeout, so only a cleared timer can prevent the cancel. This one was self-inflicted: the old timings did catch it and my first rewrite weakened it.
- **The "secondary <= primary" case never ran long enough** for any tick to evaluate the condition it names. Pre-existing. Its window now extends past the threshold.

Two new tests cover behaviour that had none: `stop()` called from inside a tick (isolates the `stopped` flag from `stop()`'s `clearTimeout`) and the heartbeat's steady-state cadence.

### 3. `docs(test)` — close the rule loophole

**Every sleep removed here already complied with the rules.** `testing-rules.md` §3 bans `Bun.sleep()` in tests, but all the sites were the other spelling. Across the whole test tree: **0** real `Bun.sleep(` calls, **48** uses of `await new Promise(r => setTimeout(r, n))`. The rule prohibited the spelling nobody writes.

- §3 now covers both spellings as one rule and routes by what is being waited on: side effect landing -> poll with a cap; **timer-driven code -> inject the clock**; asserting a handle is cleared -> `withTimerSpy`. Only the first is a polling problem — that middle case is what the guide previously had nothing to say about, and reaching for polling there still burns wall-clock and still races.
- New subsection on injecting clocks: per module never globally, restore `_deps` in `afterEach`, assert exact counts, and confirm the converted test can still fail.
- The `waitForFile` carve-out is now explicit, since the guide's own example uses the newly-named form.
- `test-helpers.md` registers `makeFakeClock` and `withTimerSpy`; `forbidden-patterns.md` gets both as lookup rows.

## Drive-by: two test files that never ran

`bun run test` walks exactly `test/unit`, `test/integration`, `test/ui` (see `scripts/run-tests.ts` PHASES), so `test/helpers/*.test.ts` was never executed — 21 tests that looked like coverage and were not. Both passed once run (213ms), so this is recovered coverage, not new debt:

- `test/helpers/helpers.test.ts` -> `test/unit/execution/helpers.test.ts` — it tests `src/execution/helpers`, i.e. **production code**, merely misfiled under a same-named directory.
- `test/helpers/runtime.test.ts` -> `test/unit/helpers/runtime.test.ts` — it tests the helper itself, so it sits beside `fake-clock.test.ts`.

Checked before trusting the move: `runtime.test.ts` depends on an `afterEach` that `test/helpers/runtime.ts` registers at **import time**, which module caching would fire in only the first importing file's scope. `trackRuntime` re-registers per scope, so it holds — verified in the full suite, not standalone.

Both switched to barrel aliases while moving, which lowers the deep-relative count (2853 -> 2846) instead of raising it.

## Notes for review

- **No production behaviour changes.** Every `_deps` addition defaults to the previous hardcoded value.
- `idle-watchdog.test.ts` crossed the 800-line limit, so shared setup moved to `_idle-watchdog-harness.ts` (naming follows the existing `_tdd-test-helpers.ts`); both watchdog suites use it.
- `test/helpers/fake-clock.ts` has its own 13-test suite under `test/unit/helpers/`.

## Deliberately not included

- **The otel batch-queue / reporter-lifecycle / resource-adoption files** (~1.7s) still use real timers. They are convertible with the same harness; left out to keep this reviewable.
- **A lint ratchet for test sleeps.** 48 -> 14 remain, and a grep would lock that in — but it would have flagged only 2 of the 5 files fixed here. The other three were slow because of a *duration passed into production code* (`executeWithTimeout("sleep 30", 1)`, `receive(id, 2500)`, a 1s retry backoff) with no sleep keyword anywhere. A per-file duration budget parsed from `--reporter=junit` would catch the whole class; that is the better follow-up.

## Test plan

- [x] `bun run test` green on 5+ consecutive full runs (10,881 tests / 865 files)
- [x] `bun run typecheck`, `bun run lint` clean; all pre-commit gates pass
- [x] `idle-watchdog` stressed 20x, `executor` 15x, no failures
- [x] Mutation-tested: 6 seeded bugs, all caught after closing the 2 gaps found
- [x] A/B measured against `c5da2b8d` in a worktree with shared `node_modules`