### PR TITLE
feat(prompts): pre-brief test-authoring roles with adversarial test-gap lenses

### DIFF
--- a/docs/reports/20260801-july-2026-harness-audit.md
+++ b/docs/reports/20260801-july-2026-harness-audit.md
@@ -1,0 +1,94 @@
+# July 2026 Harness Audit — Token Cost & Quality Analysis
+
+**Date:** 2026-08-01
+**Data sources:** `~/.nax/global/curator/rollup.jsonl` (653k July events), per-project `prompt-audit/` (4,900 transcripts), `review-audit/` (1,378 reviewer verdicts), `cost/*.jsonl` across nax, rs-stock, koda, nathapp-nestjs, iot-system.
+**Scope:** 2026-07-01 → 2026-07-31. 595 story verdicts, $1,873 total spend, 9.7% story failure rate.
+**Goal:** identify harness improvements for spec-writing, spec-review, `nax plan`/prd.json, role prompts, context, and rules — optimizing for token savings (more accurate specs, fewer turns) and quality assurance.
+
+---
+
+## 1. Cost structure — rectification is the dominant spend
+
+| Stage | Cost | Share | Calls | Tokens |
+|:------|-----:|------:|------:|-------:|
+| rectification | $626.83 | **43.6%** | 909 | 296.8M |
+| run (implementer) | $365.33 | 25.4% | 735 | 340.1M |
+| acceptance | $266.33 | 18.5% | 1,155 | 255.9M |
+| review | $109.31 | 7.6% | 1,423 | 90.6M |
+| verify | $55.46 | 3.9% | 339 | 216.0M |
+| plan | $15.54 | 1.1% | 236 | 20.0M |
+
+- Fixing first drafts costs **1.7×** producing them. Rectification prompts (759) outnumber initial implementer runs (538).
+- Story cost distribution: p50 $1.87, p90 $6.75, p99 $21.34, max $49.85.
+- Plan is nearly free (1.1%) — under-investing in spec/plan accuracy is false economy when downstream rework is 43.6%.
+
+### Fix-cycle efficiency
+
+1,176 fix iterations across 513 stories (p50 2, p90 4, max 8 per story). Outcomes:
+
+| Outcome | Count | Share |
+|:--------|------:|------:|
+| resolved | 799 | 67.9% |
+| regressed | 154 | 13.1% |
+| regressed-different-source | 144 | 12.2% |
+| unchanged | 73 | 6.2% |
+| partial | 6 | 0.5% |
+
+**31.5% of all fix iterations produced no progress** (~$200/mo waste at rectification's per-call average). Exit reasons include 58 `agent-gave-up`. Escalations: 70 (43 → powerful, 27 → balanced).
+
+## 2. Review outcomes — test-gap dominates everything
+
+- First-round pass rate: **semantic 82%** (411 stories), **adversarial 69%** (405 stories).
+- Rounds/story tail: 67 stories needed ≥3 semantic rounds; worst story took 20 combined rounds (koda w1-observability-pages US-003: 11 semantic + 9 adversarial).
+- Adversarial blocking-finding categories: **test-gap 263 (~67% of categorized)**, assumption 40, error-path 38, input 30, abandonment 15, convention 5, bug 1.
+- Semantic blocking findings carry **no category** (269 × `None`) — invisible to recurrence-demotion, curator aggregation, and telemetry.
+- The dominant failure pattern (verified in transcripts, e.g. koda w1-observability-pages US-004): test-writer/implementer writes **source-inspection tests** (assert a pattern exists in a file) instead of runtime-behavior tests → adversarial blocks with test-gap → a full rectification round rewrites the tests. The adversarial reviewer's own "Test Audit Gap" heuristic describes exactly what it will reject — but the test-authoring prompts never see it. The harness pays a review round + a rectification round per story to teach knowledge it already had.
+
+### Sub-threshold verdict bug — RESOLVED (verified during this audit)
+
+28 July verdicts were `passed:false` with every finding below `blockingThreshold`. All adversarial hits trace to nax ≤0.75.0/0.74.0/0.73.x; the semantic side was fixed by #1347 and the adversarial side by **#1378 (`aa34bd71`), shipped in v0.75.2** — the July 0.75.0 occurrences (otel-telemetry-expansion US-003 ×4) predate that release. The exact observed shape (model `passed:false`, `severity:error` finding demoted to `unverifiable` by evidence substantiation, no AC drops → review passes) is covered by `test/unit/review/adversarial-verifiedby.test.ts` ("downgrades blocking finding when verifiedBy.observed is not in source"). No further code change needed; recommendation #2 closes as verified-fixed.
+
+## 3. Spec / plan / PRD defects visible downstream
+
+Curator evidence shows spec defects surviving into implementation and causing repeated review rounds:
+
+- **Grep ACs fail structurally** — a shell-grep AC could not match multiline code (`ac4-pattern-3-grep-ac-fails`); the code was correct, the AC unsatisfiable.
+- **Stale verbatim constants** — AC specified `constituents-dow.csv`; reality is `constituents-dowjones.csv`. Implementation right, AC wrong, test mocked the wrong URL → reviewer oscillation.
+- **Hand-written fixture claims** — AC required "only t* is True"; the generated fixture had 17 Trues → unsatisfiable, 4+ blocking rounds.
+- **Story-ID copy-paste** — 598 convention findings, largely `test_us009_*` names inside US-004 (sibling-pattern copying, prompt never pins the story ID).
+- The worst review-round stories (20, 17, 15 rounds) all match the known unsatisfiable-spec pattern, not implementation failure.
+
+## 4. Acceptance stage
+
+1,155 acceptance calls for 132 story verdicts (gen 301, test-fix 132, diagnose 102, source-fix 37 transcripts). The retry tail is **always US-001**: alerts-tool 15, kv-cache 14, agent-tools-multi-ticker 13 — the first story pays acceptance-harness bootstrap; later stories retry ~0 (p50 = p90 = 0).
+
+## 5. Context engine & rules
+
+- **231k chunks included vs 1,054 excluded** (all reason=budget) — the budget almost never binds; context assembly is concatenation, not selection.
+- `chunk-included` events record `tokens: 0` — chunk token accounting is broken, so the budget cannot be tuned empirically.
+- `provider-empty` dominates: feature-context 68k, git-history 67k, session-scratch 66k, code-neighbor 62k, test-coverage 55k empties; static-rules is essentially always present.
+
+## 6. Curator
+
+Proposals are generated per run but are raw-count aggregates ("test-gap fired 792×" → HIGH) with no rule-file-ready text, "prior finding addressed" acks are counted as findings, and no July proposal checkbox was ever consumed. The feedback loop is open.
+
+---
+
+## 7. Recommendations (ranked by expected savings)
+
+| # | Change | Area | Expected effect | Status |
+|--:|:-------|:-----|:----------------|:-------|
+| 1 | Feed adversarial audit lenses forward into test-authoring prompts (test-gap pre-brief: runtime-behavior tests, no source-inspection/placeholder tests, per-AC coverage) | prompts (test-writer, single-session, tdd-simple, batch, implementer-lite) | test-gap = 67% of adversarial blocks; halving it cuts ~15–20% of rectification spend + one review round per affected story | **implemented — this branch** |
+| 2 | Fix adversarial sub-threshold verdict | review verdict | kills ~28 phantom fail rounds/mo | **already fixed in v0.75.2 (#1378); coverage verified** |
+| 3 | Generic fix-cycle circuit-breaker with full-reveal revalidation (#1335 rescope) — run all reviewers once before counting regressed-different-source; bail after 2 consecutive non-productive iterations | fix-cycle | 31.5% of iterations are non-productive; caps the 15–20-round tail | open |
+| 4 | Spec-review "verbatim reality check": verify every literal constant/URL/filename in an AC against the codebase or live source; fixture-shape claims must be derivable from the generation procedure; reject shell-grep ACs | spec-review skill | targets the most expensive deadlock stories | open |
+| 5 | Pin story ID in implementer/test-writer prompts ("test names must use this story's ID") | prompts | ~598 convention findings | folded into #1 |
+| 6 | Give the semantic reviewer a category taxonomy (reuse adversarial's) | prompts (semantic) | unlocks demotion/curator/telemetry for 53% of review rounds | open |
+| 7 | Stop emitting "prior finding addressed" acks as findings — move to an `acks` array | review schema | cleans finding telemetry; curator stops proposing rules from acks | open |
+| 8 | Bootstrap the acceptance harness at plan time (or copy US-001's resolved harness config to siblings) | acceptance | removes the 13–15-retry US-001 tail (~$30–50/mo) | open |
+| 9 | Fix chunk token accounting; then drop providers empty >90% of the time per project from the default chain | context | prerequisite for budget tuning | open |
+| 10 | Close the curator loop: emit rule-file-ready diffs against `.nax/rules/`, threshold on cross-feature recurrence, surface at `nax finish` for accept/reject | curator | converts dead telemetry into a compounding improvement loop | open |
+
+**Estimated impact of #1–#3:** July's $1,873 → roughly $1,450–1,550 at equal throughput, with the 15–20-round failure tail largely eliminated.
+
+**Strategic observation:** the harness detects known failure modes post-hoc (adversarial review) instead of preventing them pre-hoc (test-writer/spec prompts). Every recommendation is a form of moving knowledge one stage earlier in the pipeline.

--- a/docs/reports/20260801-july-2026-harness-audit.md
+++ b/docs/reports/20260801-july-2026-harness-audit.md
@@ -9,7 +9,9 @@
 
 ## 1. Cost structure — rectification is the dominant spend
 
-| Stage | Cost | Share | Calls | Tokens |
+Stage-attributed cost from `cost/*.jsonl` totals $1,438.80 (the $1,873 headline sums story verdicts, which include spend the stage ledger does not attribute). Shares below are of the stage-ledger total.
+
+| Stage | Cost | Share of stage cost | Calls | Tokens |
 |:------|-----:|------:|------:|-------:|
 | rectification | $626.83 | **43.6%** | 909 | 296.8M |
 | run (implementer) | $365.33 | 25.4% | 735 | 340.1M |
@@ -18,7 +20,7 @@
 | verify | $55.46 | 3.9% | 339 | 216.0M |
 | plan | $15.54 | 1.1% | 236 | 20.0M |
 
-- Fixing first drafts costs **1.7×** producing them. Rectification prompts (759) outnumber initial implementer runs (538).
+- Fixing first drafts costs **1.7×** producing them. Rectification outnumbers initial implementation on both ledgers: 909 vs 735 LLM calls (cost ledger above) and 759 vs 538 session transcripts (`prompt-audit/`).
 - Story cost distribution: p50 $1.87, p90 $6.75, p99 $21.34, max $49.85.
 - Plan is nearly free (1.1%) — under-investing in spec/plan accuracy is false economy when downstream rework is 43.6%.
 
@@ -90,5 +92,18 @@ Proposals are generated per run but are raw-count aggregates ("test-gap fired 79
 | 10 | Close the curator loop: emit rule-file-ready diffs against `.nax/rules/`, threshold on cross-feature recurrence, surface at `nax finish` for accept/reject | curator | converts dead telemetry into a compounding improvement loop | open |
 
 **Estimated impact of #1–#3:** July's $1,873 → roughly $1,450–1,550 at equal throughput, with the 15–20-round failure tail largely eliminated.
+
+## 8. Implementation status (this branch — `feat/test-quality-prebrief`)
+
+**#1 — Test-gap pre-brief: implemented.**
+- `src/prompts/sections/test-quality.ts` — new `buildTestQualitySection(role, variant?, storyId?)`: a compact (<1,600 chars) "Review-Proof Tests" section distilling the adversarial Test Audit Gap rejection criteria — runtime-behavior tests only, explicit ban on source-inspection and placeholder/tautological tests, per-AC and per-exported-symbol coverage, boundary/error-path lenses, mount-and-interact for UI-level ACs.
+- Recommendation #5 folded in: when a story ID is available, the section pins it for test names (the 598 sibling-copy convention findings).
+- Wired into `TddPromptBuilder.build()` as section 6.8 for the roles that author tests: `test-writer`, `single-session`, `tdd-simple`, `batch`, and `implementer` (lite variant only). `verifier`, `no-test`, and standard `implementer` prompts are unchanged.
+- Tests: `test/unit/prompts/sections/test-quality.test.ts` (19 tests incl. a size-budget guard) + wiring assertions in `test/unit/prompts/builder.test.ts`. Full suite, typecheck, and lint green.
+- **Measurement plan:** compare August's adversarial first-round pass rate (July baseline: 69%) and test-gap share of blocking findings (July baseline: 263, ~67%) from `review-audit/`; compare rectification share of stage cost (July baseline: 43.6%) from `cost/*.jsonl`.
+
+**#2 — Adversarial sub-threshold verdict: closed as verified-fixed** (§2 above). #1378 shipped in v0.75.2; the July hits were pre-fix versions; regression coverage exists in `test/unit/review/adversarial-verifiedby.test.ts`. No code change on this branch.
+
+**Code review (this branch):** independent review found no critical/high issues; three mediums were fixed — heading level (`##` → `#` so the section is not a markdown child of Behavioral Guardrails), the exported-symbol bullet scoped to AC-dependent exports (was contradicting the guardrails "tests cover ACs only" rule), and implementer-lite's isolation section relaxed ("MAY add tests for uncovered ACs; do NOT weaken existing tests") so it no longer contradicts the role-task and pre-brief sections. The source-inspection ban was also added to the adversarial reviewer's own Test Audit Gap catalogue so the pre-brief's attribution is accurate on both sides.
 
 **Strategic observation:** the harness detects known failure modes post-hoc (adversarial review) instead of preventing them pre-hoc (test-writer/spec prompts). Every recommendation is a form of moving knowledge one stage earlier in the pipeline.

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -105,6 +105,7 @@ What new exported units lack corresponding test files?
 - Bodies that always pass: \`expect(true).toBe(true)\`, \`expect(x).toBe(x)\`, \`expect(1).toBe(1)\`, an empty test body, or \`assert(true)\`.
 - Tests skipped/disabled (\`it.skip\`, \`test.todo\`, \`xit\`, commented-out assertions) that an AC depends on.
 - Assertions that never exercise the implementation (e.g. asserting on a literal, not on a value the production code produced).
+- Source-inspection tests: reading a source file and asserting it contains a pattern, string, or symbol instead of invoking the code and asserting its runtime behavior.
 
 For each such finding: set \`acIndex\` to the AC the fake test purports to cover, \`acQuote\` to a verbatim substring of that AC, and \`verifiedBy.observed\` to the placeholder line itself (e.g. \`expect(true).toBe(true)\`). Do **not** downgrade these to \`warning\` — a green suite built on placeholder assertions is a failing implementation with hidden evidence.
 

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -42,6 +42,7 @@ import {
   buildStoryReminderSection,
   buildStorySection,
   buildTddLanguageSection,
+  buildTestQualitySection,
   buildVerdictSection,
 } from "../sections";
 import type { GuardrailRole } from "../sections";
@@ -240,6 +241,16 @@ export class TddPromptBuilder {
       guardrailIsolation,
     );
     if (guardrails) acc.add(this.s("guardrails", guardrails));
+
+    // (6.8) Test-quality pre-brief — adversarial test-gap lenses forwarded to
+    // test-authoring roles (July 2026 audit: test-gap was 67% of adversarial
+    // blocking findings; pre-briefing avoids a review + rectification round).
+    const testQuality = buildTestQualitySection(
+      this.role,
+      this.options.variant as "standard" | "lite" | undefined,
+      this.story_?.id,
+    );
+    if (testQuality) acc.add(this.s("test-quality", testQuality));
 
     if (this.role !== "verifier") {
       const selfVerify = buildSelfVerificationSection(this.role, this.selfVerification_);

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -211,8 +211,13 @@ export class TddPromptBuilder {
       acc.add(this.s("verdict", buildVerdictSection(this.story_)));
     }
 
-    // (6) Isolation rules
-    const isolation = this.options.isolation as "strict" | "lite" | undefined;
+    // (6) Isolation rules — for implementer, the "lite" variant relaxes the
+    // no-test-edits rule (session 2 of three-session-tdd-lite fills coverage
+    // gaps), so the variant doubles as the isolation mode.
+    const isolation =
+      this.role === "implementer" && this.options.variant === "lite"
+        ? "lite"
+        : (this.options.isolation as "strict" | "lite" | undefined);
     acc.add(this.s("isolation", buildIsolationSection(this.role, isolation, this.testCommand_)));
 
     // (6.5) TDD language convention

--- a/src/prompts/sections/index.ts
+++ b/src/prompts/sections/index.ts
@@ -16,4 +16,5 @@ export { buildAcceptanceSection } from "./acceptance";
 export type { AcceptanceEntry } from "./acceptance";
 export { buildSelfVerificationSection } from "./self-verification";
 export { buildBehavioralGuardrailsSection } from "./behavioral-guardrails";
+export { buildTestQualitySection } from "./test-quality";
 export type { GuardrailLevel, GuardrailRole } from "./behavioral-guardrails";

--- a/src/prompts/sections/isolation.ts
+++ b/src/prompts/sections/isolation.ts
@@ -68,6 +68,12 @@ export function buildIsolationSection(
   }
 
   if (role === "implementer") {
+    // lite mode — session 2 of three-session-tdd-lite: the implementer also
+    // fills AC coverage gaps the test-writer left, so a blanket "do not modify
+    // test files" would contradict the role-task and test-quality sections.
+    if (mode === "lite") {
+      return `${header}\n\nisolation scope: Implement source code in src/ to make tests pass. You MAY add tests for acceptance criteria that have no coverage yet; do NOT weaken, delete, or skip existing tests. Run tests frequently to track progress.${footer}`;
+    }
     return `${header}\n\nisolation scope: Implement source code in src/ to make tests pass. Do not modify test files. Run tests frequently to track progress.${footer}`;
   }
 

--- a/src/prompts/sections/test-quality.ts
+++ b/src/prompts/sections/test-quality.ts
@@ -1,0 +1,45 @@
+/**
+ * Test-Quality Section — adversarial test-gap pre-brief.
+ *
+ * July 2026 audit: test-gap was 67% of adversarial blocking findings, and each
+ * one cost a review round plus a rectification round (~43.6% of total spend was
+ * rectification). The adversarial reviewer's "Test Audit Gap" heuristics
+ * describe exactly what it rejects — this section forwards them to the roles
+ * that AUTHOR tests, so the knowledge arrives before the tests are written.
+ *
+ * Kept deliberately compact (<1600 chars): this is a token-saving measure and
+ * must not become a token sink. The full lens catalogue stays in
+ * adversarial-review-builder.ts; only the rejection criteria are pre-briefed.
+ */
+
+import type { PromptRole } from "../core";
+
+/** Roles that author tests unconditionally. */
+const AUTHORING_ROLES: ReadonlySet<PromptRole> = new Set(["test-writer", "single-session", "tdd-simple", "batch"]);
+
+/**
+ * Build the review-proof-tests pre-brief for test-authoring roles.
+ *
+ * Returns "" for roles that do not author tests. The `implementer` role
+ * authors tests only in its "lite" variant (session 2 of three-session-tdd-lite
+ * fills AC coverage gaps), so it receives the section only then.
+ */
+export function buildTestQualitySection(role: PromptRole, variant?: "standard" | "lite", storyId?: string): string {
+  const authors = AUTHORING_ROLES.has(role) || (role === "implementer" && variant === "lite");
+  if (!authors) return "";
+
+  const storyIdLine = storyId
+    ? `\n- Test names must use THIS story's ID (${storyId}) — never a sibling story's ID copied from a nearby test.`
+    : "";
+
+  return `## Review-Proof Tests
+
+An adversarial reviewer will audit your tests after implementation and BLOCK the story on any test-gap finding. Each block costs a full rectification round. Write tests that survive that audit the first time:
+
+- Every acceptance criterion needs a test that INVOKES the code at runtime and asserts its observable behavior (return value, thrown error, rendered/mounted output, emitted event, persisted state).
+- NEVER write source-inspection tests — asserting that a file contains a pattern, string, or symbol proves nothing about behavior and WILL be blocked as test-gap.
+- No placeholder or tautological tests: \`expect(true).toBe(true)\`, asserting on literals, empty bodies, \`.skip\`/\`.todo\` on an AC-covering test — all blocked as test-gap.
+- Every new exported symbol must be exercised by at least one test.
+- Cover the boundary and error paths the reviewer probes: empty/null/zero/negative inputs, and failure modes (errors must surface, not be swallowed).
+- For UI/page-level ACs, mount the page/component and simulate the interaction — testing only the underlying unit leaves the wiring unaudited.${storyIdLine}`;
+}

--- a/src/prompts/sections/test-quality.ts
+++ b/src/prompts/sections/test-quality.ts
@@ -32,14 +32,14 @@ export function buildTestQualitySection(role: PromptRole, variant?: "standard" |
     ? `\n- Test names must use THIS story's ID (${storyId}) — never a sibling story's ID copied from a nearby test.`
     : "";
 
-  return `## Review-Proof Tests
+  return `# Review-Proof Tests
 
 An adversarial reviewer will audit your tests after implementation and BLOCK the story on any test-gap finding. Each block costs a full rectification round. Write tests that survive that audit the first time:
 
 - Every acceptance criterion needs a test that INVOKES the code at runtime and asserts its observable behavior (return value, thrown error, rendered/mounted output, emitted event, persisted state).
 - NEVER write source-inspection tests — asserting that a file contains a pattern, string, or symbol proves nothing about behavior and WILL be blocked as test-gap.
 - No placeholder or tautological tests: \`expect(true).toBe(true)\`, asserting on literals, empty bodies, \`.skip\`/\`.todo\` on an AC-covering test — all blocked as test-gap.
-- Every new exported symbol must be exercised by at least one test.
+- Every new exported symbol an AC depends on must be exercised by at least one test.
 - Cover the boundary and error paths the reviewer probes: empty/null/zero/negative inputs, and failure modes (errors must surface, not be swallowed).
-- For UI/page-level ACs, mount the page/component and simulate the interaction — testing only the underlying unit leaves the wiring unaudited.${storyIdLine}`;
+- For UI/page-level ACs, mount the page/component and simulate the interaction — a test that only exercises the underlying unit reads as no coverage for the AC's wiring.${storyIdLine}`;
 }

--- a/test/unit/prompts/builder.test.ts
+++ b/test/unit/prompts/builder.test.ts
@@ -326,19 +326,22 @@ describe("PromptBuilder — test-quality pre-brief section", () => {
     "%s prompt contains the Review-Proof Tests pre-brief with the story ID pinned",
     async (role) => {
       const prompt = await PromptBuilder.for(role).story(makeStory({ id: "US-007" })).build();
-      expect(prompt).toContain("## Review-Proof Tests");
+      expect(prompt).toContain("# Review-Proof Tests");
       expect(prompt).toContain("(US-007)");
     },
   );
 
   test("batch prompt contains the pre-brief (no per-story ID pin)", async () => {
     const prompt = await PromptBuilder.for("batch").stories([makeStory({ id: "B-001" })]).build();
-    expect(prompt).toContain("## Review-Proof Tests");
+    expect(prompt).toContain("# Review-Proof Tests");
   });
 
-  test("implementer lite variant (fills coverage gaps) receives the pre-brief", async () => {
+  test("implementer lite variant (fills coverage gaps) receives the pre-brief and relaxed isolation", async () => {
     const prompt = await PromptBuilder.for("implementer", { variant: "lite" }).story(makeStory()).build();
-    expect(prompt).toContain("## Review-Proof Tests");
+    expect(prompt).toContain("# Review-Proof Tests");
+    // Isolation must not contradict the pre-brief: lite may add tests for uncovered ACs.
+    expect(prompt).toContain("MAY add tests");
+    expect(prompt).not.toMatch(/do not modify test files/i);
   });
 
   test.each([
@@ -347,7 +350,7 @@ describe("PromptBuilder — test-quality pre-brief section", () => {
     ["no-test — never writes tests", "no-test", undefined],
   ])("%s prompt omits the pre-brief", async (_label, role, options) => {
     const prompt = await PromptBuilder.for(role as PromptRole, options).story(makeStory()).build();
-    expect(prompt).not.toContain("## Review-Proof Tests");
+    expect(prompt).not.toContain("# Review-Proof Tests");
   });
 });
 

--- a/test/unit/prompts/builder.test.ts
+++ b/test/unit/prompts/builder.test.ts
@@ -317,4 +317,38 @@ describe("PromptBuilder — batch role: build()", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Test-quality pre-brief wiring (July 2026 audit recommendation #1)
+// ---------------------------------------------------------------------------
+
+describe("PromptBuilder — test-quality pre-brief section", () => {
+  test.each(["test-writer", "single-session", "tdd-simple"] as PromptRole[])(
+    "%s prompt contains the Review-Proof Tests pre-brief with the story ID pinned",
+    async (role) => {
+      const prompt = await PromptBuilder.for(role).story(makeStory({ id: "US-007" })).build();
+      expect(prompt).toContain("## Review-Proof Tests");
+      expect(prompt).toContain("(US-007)");
+    },
+  );
+
+  test("batch prompt contains the pre-brief (no per-story ID pin)", async () => {
+    const prompt = await PromptBuilder.for("batch").stories([makeStory({ id: "B-001" })]).build();
+    expect(prompt).toContain("## Review-Proof Tests");
+  });
+
+  test("implementer lite variant (fills coverage gaps) receives the pre-brief", async () => {
+    const prompt = await PromptBuilder.for("implementer", { variant: "lite" }).story(makeStory()).build();
+    expect(prompt).toContain("## Review-Proof Tests");
+  });
+
+  test.each([
+    ["implementer standard — does not author tests", "implementer", { variant: "standard" as const }],
+    ["verifier — reviews, never authors", "verifier", undefined],
+    ["no-test — never writes tests", "no-test", undefined],
+  ])("%s prompt omits the pre-brief", async (_label, role, options) => {
+    const prompt = await PromptBuilder.for(role as PromptRole, options).story(makeStory()).build();
+    expect(prompt).not.toContain("## Review-Proof Tests");
+  });
+});
+
 

--- a/test/unit/prompts/sections/isolation.test.ts
+++ b/test/unit/prompts/sections/isolation.test.ts
@@ -55,6 +55,20 @@ describe("buildIsolationSection — implementer role", () => {
     const result = buildIsolationSection("implementer", undefined, "bun test");
     expect(result).toContain("bun test");
   });
+
+  test("lite mode allows adding tests for uncovered ACs instead of forbidding all test edits", () => {
+    const result = buildIsolationSection("implementer", "lite");
+    // Session 2 of three-session-tdd-lite fills coverage gaps; a blanket
+    // "do not modify test files" would contradict the role-task section.
+    expect(result).toContain("MAY add tests");
+    expect(result).not.toMatch(/do not modify test files/i);
+    expect(result.toLowerCase()).toMatch(/do not weaken/i);
+  });
+
+  test("explicit strict mode keeps the standard no-test-edits rule", () => {
+    const result = buildIsolationSection("implementer", "strict");
+    expect(result.toLowerCase()).toMatch(/do not modify.*test|test.*do not modify/i);
+  });
 });
 
 describe("buildIsolationSection — verifier role", () => {

--- a/test/unit/prompts/sections/test-quality.test.ts
+++ b/test/unit/prompts/sections/test-quality.test.ts
@@ -17,7 +17,7 @@ describe("buildTestQualitySection — test-authoring roles", () => {
   test.each([...TEST_AUTHORING_ROLES])("returns the pre-brief for %s", (role) => {
     const section = buildTestQualitySection(role);
     expect(section).not.toBe("");
-    expect(section).toContain("## Review-Proof Tests");
+    expect(section).toContain("# Review-Proof Tests");
   });
 
   test.each([...TEST_AUTHORING_ROLES])("%s pre-brief names the adversarial reviewer as the gate", (role) => {
@@ -58,7 +58,7 @@ describe("buildTestQualitySection — test-authoring roles", () => {
 describe("buildTestQualitySection — implementer lite variant fills coverage gaps", () => {
   test("implementer with lite variant receives the pre-brief", () => {
     const section = buildTestQualitySection("implementer", "lite");
-    expect(section).toContain("## Review-Proof Tests");
+    expect(section).toContain("# Review-Proof Tests");
   });
 
   test("implementer standard variant does not author tests — no section", () => {
@@ -83,7 +83,7 @@ describe("buildTestQualitySection — story ID pinning", () => {
 
   test("omits the story-ID line when no story ID is given", () => {
     const section = buildTestQualitySection("test-writer");
-    expect(section).not.toContain("US-");
+    expect(section).not.toContain("THIS story's ID");
   });
 });
 

--- a/test/unit/prompts/sections/test-quality.test.ts
+++ b/test/unit/prompts/sections/test-quality.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for buildTestQualitySection — the adversarial test-gap pre-brief
+ * injected into test-authoring role prompts (July 2026 audit, recommendation #1).
+ *
+ * test-gap was 67% of adversarial blocking findings in July 2026; this section
+ * moves the reviewer's audit lenses into the prompts of the roles that author
+ * tests, so the knowledge arrives before the tests are written instead of one
+ * review round + one rectification round later.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildTestQualitySection } from "../../../../src/prompts/sections/test-quality";
+
+const TEST_AUTHORING_ROLES = ["test-writer", "single-session", "tdd-simple", "batch"] as const;
+
+describe("buildTestQualitySection — test-authoring roles", () => {
+  test.each([...TEST_AUTHORING_ROLES])("returns the pre-brief for %s", (role) => {
+    const section = buildTestQualitySection(role);
+    expect(section).not.toBe("");
+    expect(section).toContain("## Review-Proof Tests");
+  });
+
+  test.each([...TEST_AUTHORING_ROLES])("%s pre-brief names the adversarial reviewer as the gate", (role) => {
+    const section = buildTestQualitySection(role);
+    // The section must explain WHY (an adversarial reviewer audits with these
+    // exact lenses) — motivation is what makes the model comply.
+    expect(section.toLowerCase()).toContain("adversarial");
+    expect(section).toContain("test-gap");
+  });
+
+  test("pre-brief bans source-inspection tests", () => {
+    const section = buildTestQualitySection("test-writer");
+    // The dominant July failure: tests that assert a pattern exists in a file
+    // instead of invoking the code. The ban must be explicit.
+    expect(section).toContain("source-inspection");
+    expect(section).toMatch(/invoke|execute|call/i);
+  });
+
+  test("pre-brief bans placeholder and tautological tests", () => {
+    const section = buildTestQualitySection("test-writer");
+    expect(section).toContain("expect(true).toBe(true)");
+    expect(section).toMatch(/\.skip|todo/);
+  });
+
+  test("pre-brief requires per-AC runtime coverage and exported-symbol coverage", () => {
+    const section = buildTestQualitySection("test-writer");
+    expect(section).toMatch(/every (acceptance criterion|AC)/i);
+    expect(section).toMatch(/export/i);
+  });
+
+  test("pre-brief covers boundary and error-path lenses", () => {
+    const section = buildTestQualitySection("test-writer");
+    expect(section).toMatch(/error path/i);
+    expect(section).toMatch(/empty|null|zero/i);
+  });
+});
+
+describe("buildTestQualitySection — implementer lite variant fills coverage gaps", () => {
+  test("implementer with lite variant receives the pre-brief", () => {
+    const section = buildTestQualitySection("implementer", "lite");
+    expect(section).toContain("## Review-Proof Tests");
+  });
+
+  test("implementer standard variant does not author tests — no section", () => {
+    expect(buildTestQualitySection("implementer", "standard")).toBe("");
+    expect(buildTestQualitySection("implementer")).toBe("");
+  });
+});
+
+describe("buildTestQualitySection — non-authoring roles get nothing", () => {
+  test.each(["verifier", "no-test"] as const)("returns empty string for %s", (role) => {
+    expect(buildTestQualitySection(role)).toBe("");
+  });
+});
+
+describe("buildTestQualitySection — story ID pinning", () => {
+  test("pins the story ID in test names when provided", () => {
+    const section = buildTestQualitySection("test-writer", undefined, "US-004");
+    // July 2026: 598 convention findings were sibling-copy story IDs
+    // (test_us009_* inside US-004). The section pins the real ID.
+    expect(section).toContain("US-004");
+  });
+
+  test("omits the story-ID line when no story ID is given", () => {
+    const section = buildTestQualitySection("test-writer");
+    expect(section).not.toContain("US-");
+  });
+});
+
+describe("buildTestQualitySection — size budget", () => {
+  test("stays under 1600 characters — this is a token-saving change, not a token sink", () => {
+    const section = buildTestQualitySection("test-writer", undefined, "US-001");
+    expect(section.length).toBeLessThan(1600);
+  });
+});


### PR DESCRIPTION
## Summary

July 2026 audit (full report: `docs/reports/20260801-july-2026-harness-audit.md`, added in this PR):

- **test-gap was 67% of adversarial blocking findings** (263 of ~392 categorized) and **rectification was 43.6% of stage-attributed spend** ($627 of $1,439) — bigger than initial implementation (25.4%).
- The dominant pattern: test-authoring sessions write source-inspection or placeholder tests → adversarial review blocks with test-gap → a full rectification round rewrites them. The adversarial reviewer's own "Test Audit Gap" heuristics describe exactly what it rejects — but the roles that author tests never saw them. Each block pays a review round + a rectification round to teach knowledge the harness already had.

This PR moves that knowledge one stage earlier (audit recommendation #1):

- **New `buildTestQualitySection()`** (`src/prompts/sections/test-quality.ts`) — a compact (<1,600 chars) "Review-Proof Tests" pre-brief: runtime-behavior tests only, explicit ban on source-inspection and placeholder/tautological tests, per-AC coverage + AC-dependent exported symbols, boundary/error-path lenses, mount-and-interact for UI-level ACs, and story-ID pinning in test names (598 sibling-copy convention findings in July — audit recommendation #5, folded in).
- **Wired into `TddPromptBuilder`** as section 6.8 for exactly the roles that author tests: `test-writer`, `single-session`, `tdd-simple`, `batch`, and `implementer` (lite variant only). `verifier`, `no-test`, and standard `implementer` prompts unchanged.
- **Implementer-lite isolation made variant-aware** — lite MAY add tests for uncovered ACs (matching its role-task) instead of the blanket "do not modify test files"; must not weaken existing tests. Removes a three-way contradiction between isolation, role-task, and the new pre-brief.
- **Adversarial Test Audit Gap catalogue** gains the source-inspection case, so reviewer and pre-brief state the same contract.

Audit recommendation #2 (adversarial sub-threshold verdict) closes as **verified-fixed**: #1378 shipped in v0.75.2; the July `passed:false`-with-only-advisory-findings hits were all pre-fix versions; the exact failure shape is covered by `test/unit/review/adversarial-verifiedby.test.ts`.

## Code review

Independently reviewed; no critical/high findings. Three mediums fixed in the follow-up commit (heading level, exported-symbol scope vs guardrails contradiction, implementer-lite isolation contradiction) plus low-severity attribution/assertion/report-figure cleanups.

## Test plan

- [x] 19 new unit tests for `buildTestQualitySection` (role/variant gating matrix, content anchors, story-ID pinning, <1,600-char size-budget regression fence)
- [x] Builder wiring assertions in `test/unit/prompts/builder.test.ts` (present for authoring roles incl. implementer-lite; absent for verifier / no-test / implementer-standard; lite isolation relaxed)
- [x] Isolation lite/strict variant tests in `test/unit/prompts/sections/isolation.test.ts`
- [x] `bun run test:bail` — all phases pass
- [x] `bun run typecheck`, `bun run lint` — clean
- [ ] Measure August vs July baselines: adversarial first-round pass rate (69%), test-gap share of blocking findings (~67%), rectification share of stage cost (43.6%)