### PR TITLE
fix(curator): scope observations to the run, and propose on cross-feature recurrence

### DIFF
--- a/docs/reports/20260801-july-2026-harness-audit.md
+++ b/docs/reports/20260801-july-2026-harness-audit.md
@@ -72,7 +72,9 @@ Curator evidence shows spec defects surviving into implementation and causing re
 
 ## 6. Curator
 
-Proposals are generated per run but are raw-count aggregates ("test-gap fired 792×" → HIGH) with no rule-file-ready text, "prior finding addressed" acks are counted as findings, and no July proposal checkbox was ever consumed. The feedback loop is open.
+Proposals are generated per run but are raw-count aggregates ("test-gap fired 792×" → HIGH) with no rule-file-ready text, and "prior finding addressed" acks are counted as findings.
+
+**Correction (2026-08-01):** this section originally added "no July proposal checkbox was ever consumed — the feedback loop is open". That framing is wrong. nax has **no accept/reject process** for curator proposals, so an unticked checkbox is a vestigial UI element, not a loop that broke. Whether proposals should be consumed at all — and by what — is an open product question, not a defect.
 
 ---
 
@@ -91,7 +93,7 @@ Proposals are generated per run but are raw-count aggregates ("test-gap fired 79
 | 8 | Diagnose the 8 features burning 5–15 acceptance retries (the US-001 bootstrap premise is refuted — see §10) | acceptance | ~$30–50/mo | [#1424](https://github.com/nathapp-io/nax/issues/1424) |
 | 9 | Fix chunk token accounting | context | prerequisite for budget tuning | **in review — [#1426](https://github.com/nathapp-io/nax/pull/1426)** |
 | 9b | Then drop providers empty >90% of the time per project from the default chain | context | needs ≥1 month of real token data from #1426 first | blocked on 9 |
-| 10 | Close the curator loop: rule-file-ready diffs, cross-feature recurrence threshold, run-scoped counts, surface at `nax finish` | curator | converts dead telemetry into a compounding improvement loop | [#1422](https://github.com/nathapp-io/nax/issues/1422) |
+| 10 | Make curator counts mean something: cross-feature recurrence threshold + run-scoped counts (the "surface at `nax finish` for accept/reject" half is withdrawn — see §6 correction) | curator | proposals stop restating the category histogram | **in review — [#1427](https://github.com/nathapp-io/nax/pull/1427)** |
 
 **Estimated impact of #1–#2:** the 15–20-round failure tail is addressed by #1 (prevention) and the shipped oscillation breaker. The original "$1,873 → $1,450–1,550" figure leaned on #3b's non-productive-iteration savings, which §10 withdraws — treat the remaining savings estimate as unquantified until August data lands.
 
@@ -156,7 +158,7 @@ Phase 7 of the spec-review skill already bans `[grep]`/`[file]`/`[verbatim]` ACs
 ### Confirmed as written
 
 - **#9** → [#1421](https://github.com/nathapp-io/nax/issues/1421). All 269,355 `chunk-included` events carry `tokens: 0` — 100%, not a sample. Exclusions are 1,299 of 270,654 (0.5%).
-- **#10** → [#1422](https://github.com/nathapp-io/nax/issues/1422). Sharper than stated: proposals group on the bare category ("test-gap appeared 1008x"), counts accumulate over the project's whole audit history (723→888 within one project, monotonic, so a HIGH can never clear), and **0 of 263 proposal files** has a ticked checkbox.
+- **#10** → [#1422](https://github.com/nathapp-io/nax/issues/1422). Two of three sub-claims confirmed and sharper than stated: proposals group on the bare category ("test-gap appeared 1008x"), and counts accumulate over the project's whole audit history (723→888 within one project, monotonic, so a HIGH can never clear). The third — **0 of 263 proposal files** has a ticked checkbox — is a real number but was misread as a broken feedback loop; see the §6 correction.
 - **#7** → [#1423](https://github.com/nathapp-io/nax/issues/1423). Real but smaller than implied: 81 of 3,685 July findings (2.2%), all `info`, all adversarial — telemetry pollution, not deadlock. Its concrete harm is visible in curator proposal evidence, where the quoted examples are carry-forward bookkeeping rather than findings.
 
 **Method note:** every number above was re-derived from `~/.nax/global/curator/rollup.jsonl`, `~/.nax/*/review-audit/`, and the `curator-proposals.md` artifacts, not carried over from the audit body. Three of six recommendations changed materially on contact with the data.
@@ -180,12 +182,12 @@ Four of the ten shipped or in review; two were already fixed before the audit wa
 
 ### What is actually left
 
-**#10 (curator) is the load-bearing one.** It is the only remaining item that changes the *shape* of the feedback loop rather than one measurement inside it, and two shipped changes now depend on it to be worth anything:
+**#10 (curator) — counts fixed in [#1427](https://github.com/nathapp-io/nax/pull/1427); consumption is an open question, not a defect.** Two shipped changes depended on the counts being fixed:
 
-- #1420 makes semantic findings carry categories, which the curator will fold into its per-category counts — the same counts that accumulate over each project's whole audit history and can never clear. Without #1422, the new taxonomy inherits the defect that made the adversarial counts useless.
-- #1426 stops *new* acknowledgement pollution, but historical acks remain in the cumulative totals until collection is run-scoped.
+- #1420 makes semantic findings carry categories, which the curator folds into its counts — the same counts that accumulated over each project's whole audit history and could never clear. Without the fix, the new taxonomy would have inherited the defect that made the adversarial counts useless.
+- #1426 stops *new* acknowledgement pollution, but historical acks remained in the cumulative totals until collection was run-scoped.
 
-Its three defects are independent and the count-scoping one is the prerequisite: until counts mean "this run", no threshold choice is meaningful. Worth designing before coding — the grouping key (finding fingerprint vs category + locus) and the collection window are both judgment calls.
+The count-scoping half was the prerequisite: until counts mean "this run", no threshold choice is meaningful. What remains is **not** a third defect. The original recommendation assumed proposals should be surfaced for accept/reject at `nax finish`; nax has no accept/reject process and `nax finish` ships features rather than curating rules (§6 correction). Whether anything should consume proposals — and what — is undecided, and should not be built on the strength of this audit alone.
 
 **#8 produces a question, not a patch.** Someone has to read the `alerts-tool` / `kv-cache` / `agent-tools-multi-ticker` transcripts and find the shared cause; all three are tool-shaped features in one project, which points at a per-project harness problem rather than anything intrinsic to acceptance.
 

--- a/docs/reports/20260801-july-2026-harness-audit.md
+++ b/docs/reports/20260801-july-2026-harness-audit.md
@@ -74,7 +74,12 @@ Curator evidence shows spec defects surviving into implementation and causing re
 
 Proposals are generated per run but are raw-count aggregates ("test-gap fired 792×" → HIGH) with no rule-file-ready text, and "prior finding addressed" acks are counted as findings.
 
-**Correction (2026-08-01):** this section originally added "no July proposal checkbox was ever consumed — the feedback loop is open". That framing is wrong. nax has **no accept/reject process** for curator proposals, so an unticked checkbox is a vestigial UI element, not a loop that broke. Whether proposals should be consumed at all — and by what — is an open product question, not a defect.
+**Correction (2026-08-01, twice):** this section originally read "no July proposal checkbox was ever consumed — the feedback loop is open", and recommendation #10 proposed surfacing proposals at `nax finish` for accept/reject.
+
+1. `nax finish` is wrong: it ships a feature, it does not curate rules.
+2. A first correction then over-swung to "nax has no accept/reject process". That is also false. **`nax curator commit` is the accept/reject process** — `parseCheckedProposals` (`src/commands/curator.ts`) reads `- [x]` boxes out of `curator-proposals.md`, applies the adds/drops to the target rule files, and opens them in `$EDITOR`. It is wired in `bin/nax.ts`.
+
+So the checkbox is the accept token of a shipped workflow, and "0 of 263 ticked" is not evidence that no consumer exists. Given that one does, the honest reading is the original one: **the proposals were never worth ticking** — which is exactly what per-category counts over cumulative history would produce. That is the defect [#1427](https://github.com/nathapp-io/nax/pull/1427) fixes.
 
 ---
 
@@ -93,7 +98,7 @@ Proposals are generated per run but are raw-count aggregates ("test-gap fired 79
 | 8 | Diagnose the 8 features burning 5–15 acceptance retries (the US-001 bootstrap premise is refuted — see §10) | acceptance | ~$30–50/mo | [#1424](https://github.com/nathapp-io/nax/issues/1424) |
 | 9 | Fix chunk token accounting | context | prerequisite for budget tuning | **in review — [#1426](https://github.com/nathapp-io/nax/pull/1426)** |
 | 9b | Then drop providers empty >90% of the time per project from the default chain | context | needs ≥1 month of real token data from #1426 first | blocked on 9 |
-| 10 | Make curator counts mean something: cross-feature recurrence threshold + run-scoped counts (the "surface at `nax finish` for accept/reject" half is withdrawn — see §6 correction) | curator | proposals stop restating the category histogram | **in review — [#1427](https://github.com/nathapp-io/nax/pull/1427)** |
+| 10 | Make curator counts mean something: cross-feature recurrence threshold + run-scoped counts. (The accept surface already exists — it is `nax curator commit`, not `nax finish`; see §6 correction.) | curator | proposals become worth ticking | **in review — [#1427](https://github.com/nathapp-io/nax/pull/1427)** |
 
 **Estimated impact of #1–#2:** the 15–20-round failure tail is addressed by #1 (prevention) and the shipped oscillation breaker. The original "$1,873 → $1,450–1,550" figure leaned on #3b's non-productive-iteration savings, which §10 withdraws — treat the remaining savings estimate as unquantified until August data lands.
 
@@ -158,7 +163,7 @@ Phase 7 of the spec-review skill already bans `[grep]`/`[file]`/`[verbatim]` ACs
 ### Confirmed as written
 
 - **#9** → [#1421](https://github.com/nathapp-io/nax/issues/1421). All 269,355 `chunk-included` events carry `tokens: 0` — 100%, not a sample. Exclusions are 1,299 of 270,654 (0.5%).
-- **#10** → [#1422](https://github.com/nathapp-io/nax/issues/1422). Two of three sub-claims confirmed and sharper than stated: proposals group on the bare category ("test-gap appeared 1008x"), and counts accumulate over the project's whole audit history (723→888 within one project, monotonic, so a HIGH can never clear). The third — **0 of 263 proposal files** has a ticked checkbox — is a real number but was misread as a broken feedback loop; see the §6 correction.
+- **#10** → [#1422](https://github.com/nathapp-io/nax/issues/1422). Two of three sub-claims confirmed and sharper than stated: proposals group on the bare category ("test-gap appeared 1008x"), and counts accumulate over the project's whole audit history (723→888 within one project, monotonic, so a HIGH can never clear). The third — **0 of 263 proposal files** has a ticked checkbox — is a real number, twice misread: first as a broken feedback loop, then as evidence no consumer exists. `nax curator commit` consumes ticked boxes; nobody ticked them because the proposals restated a histogram. See the §6 correction.
 - **#7** → [#1423](https://github.com/nathapp-io/nax/issues/1423). Real but smaller than implied: 81 of 3,685 July findings (2.2%), all `info`, all adversarial — telemetry pollution, not deadlock. Its concrete harm is visible in curator proposal evidence, where the quoted examples are carry-forward bookkeeping rather than findings.
 
 **Method note:** every number above was re-derived from `~/.nax/global/curator/rollup.jsonl`, `~/.nax/*/review-audit/`, and the `curator-proposals.md` artifacts, not carried over from the audit body. Three of six recommendations changed materially on contact with the data.
@@ -187,7 +192,7 @@ Four of the ten shipped or in review; two were already fixed before the audit wa
 - #1420 makes semantic findings carry categories, which the curator folds into its counts — the same counts that accumulated over each project's whole audit history and could never clear. Without the fix, the new taxonomy would have inherited the defect that made the adversarial counts useless.
 - #1426 stops *new* acknowledgement pollution, but historical acks remained in the cumulative totals until collection was run-scoped.
 
-The count-scoping half was the prerequisite: until counts mean "this run", no threshold choice is meaningful. What remains is **not** a third defect. The original recommendation assumed proposals should be surfaced for accept/reject at `nax finish`; nax has no accept/reject process and `nax finish` ships features rather than curating rules (§6 correction). Whether anything should consume proposals — and what — is undecided, and should not be built on the strength of this audit alone.
+The count-scoping half was the prerequisite: until counts mean "this run", no threshold choice is meaningful. The consumer already exists — `nax curator commit` — so the remaining question is not "what should read proposals" but whether, once they are accurate, anyone finds them worth accepting. That is answerable with August data rather than more code.
 
 **#8 produces a question, not a patch.** Someone has to read the `alerts-tool` / `kv-cache` / `agent-tools-multi-ticker` transcripts and find the shared cause; all three are tool-shaped features in one project, which points at a per-project harness problem rather than anything intrinsic to acceptance.
 

--- a/src/commands/curator.ts
+++ b/src/commands/curator.ts
@@ -180,6 +180,9 @@ function parseCheckedProposals(markdown: string): ParsedProposal[] {
   return proposals;
 }
 
+/** @internal Exported for round-trip tests against `renderProposals`; not a public API. */
+export const _testing = { parseCheckedProposals };
+
 // ─── curatorStatus ────────────────────────────────────────────────────────────
 
 export async function curatorStatus(options: CuratorStatusOptions): Promise<void> {

--- a/src/execution/lifecycle/run-cleanup.ts
+++ b/src/execution/lifecycle/run-cleanup.ts
@@ -154,6 +154,7 @@ export function buildPostRunContext(opts: RunCleanupOptions, durationMs: number,
     curatorRollupPath,
     logFilePath,
     config,
+    startTime,
   } = opts;
   const counts = countStories(prd);
 
@@ -165,6 +166,7 @@ export function buildPostRunContext(opts: RunCleanupOptions, durationMs: number,
     branch,
     version,
     totalDurationMs: durationMs,
+    runStartedAt: startTime,
     totalCost,
     storySummary: {
       completed: storiesCompleted,

--- a/src/plugins/builtin/curator/collect.ts
+++ b/src/plugins/builtin/curator/collect.ts
@@ -4,7 +4,6 @@
  * Reads Tier 1 run artifacts and projects them to normalized observations.
  */
 
-import { statSync } from "node:fs";
 import * as path from "node:path";
 import type {
   AcceptanceVerdictObservation,
@@ -96,7 +95,7 @@ async function collectFromMetrics(context: CuratorPostRunContext): Promise<Obser
       const success = boolValue(story.success, false);
       const storyId = stringValue(story.storyId ?? story.id, "unknown");
       const obs: VerdictObservation = {
-        schemaVersion: 1,
+        schemaVersion: OBSERVATION_SCHEMA_VERSION,
         runId: context.runId,
         featureId: stringValue(currentRun.feature, context.feature),
         storyId,
@@ -135,11 +134,15 @@ function withinRun(timestamp: unknown, runStartedAt: number | undefined): boolea
   return ts >= runStartedAt;
 }
 
+/** Bumped to 2 when collection became run-scoped (#1422) — see `BaseObservation.schemaVersion`. */
+const OBSERVATION_SCHEMA_VERSION = 2;
+
 /** mtime-based counterpart to `withinRun` for artifacts that carry no timestamp field. */
-function writtenThisRun(filePath: string, runStartedAt: number | undefined): boolean {
+async function writtenThisRun(filePath: string, runStartedAt: number | undefined): Promise<boolean> {
   if (runStartedAt === undefined) return true;
   try {
-    return statSync(filePath).mtimeMs >= runStartedAt;
+    const stat = await Bun.file(filePath).stat();
+    return stat.mtimeMs >= runStartedAt;
   } catch {
     // Unreadable stat — keep the artifact rather than silently dropping it.
     return true;
@@ -178,17 +181,24 @@ async function collectFromReviewAudit(context: CuratorPostRunContext): Promise<O
       try {
         const audit = asRecord(await readJsonFile(fullPath));
         if (!audit) continue;
+        const featureId = stringValue(audit.featureName ?? audit.featureId, context.feature);
+        // A concurrent run against a DIFFERENT feature writes into the same
+        // outputDir; its entries fall inside this run's time window and would
+        // inflate H1's distinct-feature count with work this run never saw.
+        // Identity cannot be used here: the audit's `runId` is the runtime's
+        // crypto.randomUUID(), while `context.runId` is the execution layer's
+        // `run-<iso>` — two independent ID spaces (see #1422).
+        if (context.runStartedAt !== undefined && featureId !== context.feature) continue;
         if (!withinRun(audit.timestamp, context.runStartedAt)) continue;
         const result = asRecord(audit.result);
         const findings = asArray(result?.findings);
         const storyId = stringValue(audit.storyId, "unknown");
-        const featureId = stringValue(audit.featureName ?? audit.featureId, context.feature);
         for (const rawFinding of findings) {
           const finding = asRecord(rawFinding);
           if (!finding) continue;
           const ruleId = findingRuleId(finding);
           const obs: ReviewFindingObservation = {
-            schemaVersion: 1,
+            schemaVersion: OBSERVATION_SCHEMA_VERSION,
             runId: context.runId,
             featureId,
             storyId,
@@ -220,6 +230,7 @@ async function collectFromReviewAudit(context: CuratorPostRunContext): Promise<O
 async function collectFromContextManifests(context: CuratorPostRunContext): Promise<Observation[]> {
   const observations: Observation[] = [];
   const featuresDir = path.join(context.workdir, ".nax", "features");
+  let skippedManifests = 0;
   try {
     const glob = new Bun.Glob("*/stories/*/context-manifest-*.json");
     for await (const file of glob.scan({ cwd: featuresDir, absolute: false })) {
@@ -228,11 +239,14 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
         const parts = file.split("/");
         const featureId = parts[0] ?? context.feature;
         const storyId = parts[2] ?? "unknown";
+        // Stat before parsing: a manifest from an earlier run should cost a stat,
+        // not a full JSON read.
+        if (!(await writtenThisRun(fullPath, context.runStartedAt))) {
+          skippedManifests += 1;
+          continue;
+        }
         const manifest = asRecord(await readJsonFile(fullPath));
         if (!manifest) continue;
-        // Manifests carry no timestamp of their own and persist per story across
-        // runs, so mtime is the only signal that this run actually wrote one.
-        if (!writtenThisRun(fullPath, context.runStartedAt)) continue;
         const ts = now();
         const chunkSummaries = asRecord(manifest.chunkSummaries) ?? {};
         // Manifests written before #1421 carry no token data — those chunks
@@ -242,7 +256,7 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
         for (const chunkId of asArray(manifest.includedChunks)) {
           const id = String(chunkId);
           const obs: ChunkIncludedObservation = {
-            schemaVersion: 1,
+            schemaVersion: OBSERVATION_SCHEMA_VERSION,
             runId: context.runId,
             featureId,
             storyId,
@@ -263,7 +277,7 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
           if (!excluded) continue;
           const id = stringValue(excluded.id, "unknown");
           const obs: ChunkExcludedObservation = {
-            schemaVersion: 1,
+            schemaVersion: OBSERVATION_SCHEMA_VERSION,
             runId: context.runId,
             featureId,
             storyId,
@@ -283,7 +297,7 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
           const provider = asRecord(rawProvider);
           if (!provider || stringValue(provider.status) !== "empty") continue;
           const obs: ProviderEmptyObservation = {
-            schemaVersion: 1,
+            schemaVersion: OBSERVATION_SCHEMA_VERSION,
             runId: context.runId,
             featureId,
             storyId,
@@ -322,7 +336,7 @@ function entryFeatureId(context: CuratorPostRunContext, entry: JsonRecord, data:
 function collectPullCall(context: CuratorPostRunContext, entry: JsonRecord, data: JsonRecord): PullCallObservation {
   const toolName = stringValue(data.tool ?? data.toolName, "unknown");
   return {
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_SCHEMA_VERSION,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -346,7 +360,7 @@ function collectAcceptanceVerdict(
   data: JsonRecord,
 ): AcceptanceVerdictObservation {
   return {
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_SCHEMA_VERSION,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -365,7 +379,7 @@ function collectAcceptanceVerdict(
 
 function collectRectify(context: CuratorPostRunContext, entry: JsonRecord, data: JsonRecord): RectifyCycleObservation {
   return {
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_SCHEMA_VERSION,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -381,7 +395,7 @@ function collectRectify(context: CuratorPostRunContext, entry: JsonRecord, data:
 
 function collectEscalation(context: CuratorPostRunContext, entry: JsonRecord, data: JsonRecord): EscalationObservation {
   return {
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_SCHEMA_VERSION,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -402,7 +416,7 @@ function collectFixCycleIteration(
 ): FixCycleIterationObservation {
   const outcome = optionalString(data.outcome) as FixCycleIterationObservation["payload"]["outcome"];
   return {
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_SCHEMA_VERSION,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -427,7 +441,7 @@ function collectFixCycleExit(
   data: JsonRecord,
 ): FixCycleExitObservation {
   return {
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_SCHEMA_VERSION,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -447,7 +461,7 @@ function collectFixCycleRetry(
   data: JsonRecord,
 ): FixCycleValidatorRetryObservation {
   return {
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_SCHEMA_VERSION,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),

--- a/src/plugins/builtin/curator/collect.ts
+++ b/src/plugins/builtin/curator/collect.ts
@@ -4,6 +4,7 @@
  * Reads Tier 1 run artifacts and projects them to normalized observations.
  */
 
+import { statSync } from "node:fs";
 import * as path from "node:path";
 import type {
   AcceptanceVerdictObservation,
@@ -118,6 +119,33 @@ async function collectFromMetrics(context: CuratorPostRunContext): Promise<Obser
   return observations;
 }
 
+/**
+ * True when an artifact stamped `timestamp` belongs to the current run (#1422).
+ *
+ * Absent `runStartedAt` means "no scoping" — the pre-#1422 behaviour, kept so
+ * out-of-tree callers of `collectObservations` do not silently start dropping
+ * observations. An artifact with an unparseable or missing timestamp is KEPT:
+ * dropping it would hide real findings, whereas keeping it only risks the stale
+ * count that was already the status quo.
+ */
+function withinRun(timestamp: unknown, runStartedAt: number | undefined): boolean {
+  if (runStartedAt === undefined) return true;
+  const ts = typeof timestamp === "string" ? Date.parse(timestamp) : Number.NaN;
+  if (Number.isNaN(ts)) return true;
+  return ts >= runStartedAt;
+}
+
+/** mtime-based counterpart to `withinRun` for artifacts that carry no timestamp field. */
+function writtenThisRun(filePath: string, runStartedAt: number | undefined): boolean {
+  if (runStartedAt === undefined) return true;
+  try {
+    return statSync(filePath).mtimeMs >= runStartedAt;
+  } catch {
+    // Unreadable stat — keep the artifact rather than silently dropping it.
+    return true;
+  }
+}
+
 // Prefer canonical Phase-1 fields first; fall back to legacy on-disk variants for pre-normalization audits.
 function findingRuleId(finding: JsonRecord): string {
   return stringValue(finding.ruleId ?? finding.rule ?? finding.checkId ?? finding.category, "unknown");
@@ -150,6 +178,7 @@ async function collectFromReviewAudit(context: CuratorPostRunContext): Promise<O
       try {
         const audit = asRecord(await readJsonFile(fullPath));
         if (!audit) continue;
+        if (!withinRun(audit.timestamp, context.runStartedAt)) continue;
         const result = asRecord(audit.result);
         const findings = asArray(result?.findings);
         const storyId = stringValue(audit.storyId, "unknown");
@@ -170,6 +199,7 @@ async function collectFromReviewAudit(context: CuratorPostRunContext): Promise<O
               ruleId,
               checkId: ruleId,
               severity: stringValue(finding.severity, "info"),
+              category: optionalString(finding.category),
               file: stringValue(finding.file),
               line: numberValue(finding.line, 0),
               message: findingMessage(finding),
@@ -200,6 +230,9 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
         const storyId = parts[2] ?? "unknown";
         const manifest = asRecord(await readJsonFile(fullPath));
         if (!manifest) continue;
+        // Manifests carry no timestamp of their own and persist per story across
+        // runs, so mtime is the only signal that this run actually wrote one.
+        if (!writtenThisRun(fullPath, context.runStartedAt)) continue;
         const ts = now();
         const chunkSummaries = asRecord(manifest.chunkSummaries) ?? {};
         // Manifests written before #1421 carry no token data — those chunks

--- a/src/plugins/builtin/curator/heuristics.ts
+++ b/src/plugins/builtin/curator/heuristics.ts
@@ -5,7 +5,7 @@
  * Each heuristic is a pure function that groups observations and generates proposals.
  */
 
-import { fingerprintFor } from "../../../review";
+import { normalizeIssueText } from "@/review";
 import type {
   ChunkExcludedObservation,
   EscalationObservation,
@@ -67,15 +67,42 @@ function uniqueStoryIds(storyIds: string[]): string[] {
   return [...new Set(storyIds)];
 }
 
-/** Feature spread at which a recurring finding is worth flagging as HIGH. */
-const HIGH_SEVERITY_FEATURE_SPREAD = 5;
+/** Feature spread, as a multiple of the configured threshold, at which a proposal is HIGH. */
+const HIGH_SEVERITY_MULTIPLE = 2;
+/** Characters of the leading sample kept in the checkbox-line description. */
+const DESCRIPTION_GIST_CHARS = 90;
+/** Files listed in evidence before truncating. */
+const MAX_EVIDENCE_FILES = 4;
+
+/** Characters of normalized message text that identify a defect across features. */
+const CROSS_FEATURE_MESSAGE_PREFIX = 48;
+
+/**
+ * Identity of a defect ACROSS features (#1422).
+ *
+ * Deliberately NOT `fingerprintFor` from recurrence-demotion: that key leads with
+ * the file path, which is correct for its own job (same story, successive rounds,
+ * where the file is stable) and exactly wrong here. Different features touch
+ * different files by definition, so a file-led key can only ever group the
+ * same-file case — meaning H1 would stay silent on "test-gap recurs across the
+ * project", the signal it exists to surface. The file is evidence, not identity.
+ */
+function crossFeatureKey(category: string | undefined, message: string): string {
+  return `${category ?? ""}|${normalizeIssueText(message).slice(0, CROSS_FEATURE_MESSAGE_PREFIX)}`;
+}
 
 type H1Group = {
   featureIds: Set<string>;
-  storyIds: Set<string>;
+  /** `featureId/storyId` pairs — story IDs alone collide across features. */
+  sites: Set<string>;
+  files: Set<string>;
   samples: string[];
-  locus?: { file: string; category?: string };
+  category?: string;
 };
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
 
 function firstLine(message: string): string {
   return message.split("\n")[0] ?? message;
@@ -92,14 +119,20 @@ function h1RepeatedReviewFinding(observations: Observation[], threshold: number)
     const { file, category, message } = obs.payload;
     if (!file && !category) continue;
 
-    const key = fingerprintFor(file, category, message);
-    const group = groups.get(key) ?? { featureIds: new Set<string>(), storyIds: new Set<string>(), samples: [] };
+    const key = crossFeatureKey(category, message);
+    let group = groups.get(key);
+    if (!group) {
+      group = { featureIds: new Set<string>(), sites: new Set<string>(), files: new Set<string>(), samples: [] };
+      groups.set(key, group);
+      group.category = category;
+    }
     group.featureIds.add(obs.featureId);
-    group.storyIds.add(obs.storyId);
-    group.locus = group.locus ?? { file, category };
+    // Story IDs are feature-scoped (`US-001` exists in every feature), so the
+    // pair is the only unambiguous site reference.
+    group.sites.add(`${obs.featureId}/${obs.storyId}`);
+    if (file) group.files.add(file);
     const sample = firstLine(message);
     if (sample && group.samples.length < 2 && !group.samples.includes(sample)) group.samples.push(sample);
-    groups.set(key, group);
   }
 
   const proposals: Proposal[] = [];
@@ -110,19 +143,25 @@ function h1RepeatedReviewFinding(observations: Observation[], threshold: number)
     const featureCount = group.featureIds.size;
     if (featureCount < threshold) continue;
     const features = [...group.featureIds];
-    const stories = [...group.storyIds];
-    const locus = group.locus?.category
-      ? `${group.locus.category}${group.locus.file ? ` in ${group.locus.file}` : ""}`
-      : (group.locus?.file ?? "review finding");
+    const sites = [...group.sites];
+    const files = [...group.files];
+    // The description must distinguish one proposal from another on the checkbox
+    // line alone — `nax curator commit` ticks are made against that line, and a
+    // bare category collapse is the #942 defect this must not reintroduce.
+    const gist = group.samples[0] ? truncate(group.samples[0], DESCRIPTION_GIST_CHARS) : "(no description)";
+    const categoryLabel = group.category ? `${group.category}: ` : "";
+    const fileSection = files.length > 0 ? ` Files: ${files.slice(0, MAX_EVIDENCE_FILES).join(", ")}.` : "";
     const sampleSection = group.samples.length > 0 ? `\n  Examples: ${group.samples.join(" | ")}` : "";
     proposals.push({
       id: "H1",
-      severity: featureCount >= HIGH_SEVERITY_FEATURE_SPREAD ? "HIGH" : "MED",
+      // Relative to the configured threshold: a fixed constant would pin every
+      // proposal to HIGH once the threshold is raised past it.
+      severity: featureCount >= threshold * HIGH_SEVERITY_MULTIPLE ? "HIGH" : "MED",
       target: { canonicalFile: ".nax/rules/curator-suggestions.md", action: "add" },
-      description: `Recurring review finding (${locus}) — hit ${featureCount} features`,
-      evidence: `Seen in ${featureCount} features: ${features.join(", ")} (stories: ${stories.join(", ")})${sampleSection}`,
+      description: `Recurring across ${featureCount} features — ${categoryLabel}${gist}`,
+      evidence: `Seen in ${featureCount} features: ${features.join(", ")} (sites: ${sites.join(", ")}).${fileSection}${sampleSection}`,
       sourceKinds: ["review-finding"],
-      storyIds: stories,
+      storyIds: sites,
     });
   }
   return proposals;

--- a/src/plugins/builtin/curator/heuristics.ts
+++ b/src/plugins/builtin/curator/heuristics.ts
@@ -5,6 +5,7 @@
  * Each heuristic is a pure function that groups observations and generates proposals.
  */
 
+import { fingerprintFor } from "../../../review";
 import type {
   ChunkExcludedObservation,
   EscalationObservation,
@@ -66,6 +67,16 @@ function uniqueStoryIds(storyIds: string[]): string[] {
   return [...new Set(storyIds)];
 }
 
+/** Feature spread at which a recurring finding is worth flagging as HIGH. */
+const HIGH_SEVERITY_FEATURE_SPREAD = 5;
+
+type H1Group = {
+  featureIds: Set<string>;
+  storyIds: Set<string>;
+  samples: string[];
+  locus?: { file: string; category?: string };
+};
+
 function firstLine(message: string): string {
   return message.split("\n")[0] ?? message;
 }
@@ -74,38 +85,44 @@ function firstLine(message: string): string {
 function h1RepeatedReviewFinding(observations: Observation[], threshold: number): Proposal[] {
   const findings = observations.filter((o): o is ReviewFindingObservation => o.kind === "review-finding");
 
-  const groups = new Map<string, { storyIds: string[]; samples: string[] }>();
+  const groups = new Map<string, H1Group>();
   for (const obs of findings) {
-    const ruleId = obs.payload.ruleId;
-    const message = obs.payload.message;
-    const existing = groups.get(ruleId);
-    if (existing) {
-      existing.storyIds.push(obs.storyId);
-      const sampleKey = firstLine(message);
-      if (existing.samples.length < 2 && sampleKey && !existing.samples.includes(sampleKey)) {
-        existing.samples.push(sampleKey);
-      }
-    } else {
-      const sampleKey = firstLine(message);
-      groups.set(ruleId, { storyIds: [obs.storyId], samples: sampleKey ? [sampleKey] : [] });
-    }
+    // A finding with no locus (no file AND no category) describes nothing a rule
+    // could constrain — carry-forward bookkeeping and free-text notes land here.
+    const { file, category, message } = obs.payload;
+    if (!file && !category) continue;
+
+    const key = fingerprintFor(file, category, message);
+    const group = groups.get(key) ?? { featureIds: new Set<string>(), storyIds: new Set<string>(), samples: [] };
+    group.featureIds.add(obs.featureId);
+    group.storyIds.add(obs.storyId);
+    group.locus = group.locus ?? { file, category };
+    const sample = firstLine(message);
+    if (sample && group.samples.length < 2 && !group.samples.includes(sample)) group.samples.push(sample);
+    groups.set(key, group);
   }
 
   const proposals: Proposal[] = [];
-  for (const [ruleId, { storyIds, samples }] of groups.entries()) {
-    if (storyIds.length < threshold) continue;
-    const count = storyIds.length;
-    const severity = count >= 4 ? "HIGH" : "MED";
-    const unique = uniqueStoryIds(storyIds);
-    const sampleSection = samples.length > 0 ? `\n  Examples: ${samples.join(" | ")}` : "";
+  for (const group of groups.values()) {
+    // Threshold is on DISTINCT FEATURES, not raw occurrences (#1422). One feature
+    // repeating a defect is a story problem; the same defect crossing features is
+    // what a project rule exists to prevent.
+    const featureCount = group.featureIds.size;
+    if (featureCount < threshold) continue;
+    const features = [...group.featureIds];
+    const stories = [...group.storyIds];
+    const locus = group.locus?.category
+      ? `${group.locus.category}${group.locus.file ? ` in ${group.locus.file}` : ""}`
+      : (group.locus?.file ?? "review finding");
+    const sampleSection = group.samples.length > 0 ? `\n  Examples: ${group.samples.join(" | ")}` : "";
     proposals.push({
       id: "H1",
-      severity,
+      severity: featureCount >= HIGH_SEVERITY_FEATURE_SPREAD ? "HIGH" : "MED",
       target: { canonicalFile: ".nax/rules/curator-suggestions.md", action: "add" },
-      description: `Repeated review finding: ${ruleId} appeared ${count}x across stories`,
-      evidence: `Rule ${ruleId} fired ${count}× in stories: ${unique.join(", ")}${sampleSection}`,
+      description: `Recurring review finding (${locus}) — hit ${featureCount} features`,
+      evidence: `Seen in ${featureCount} features: ${features.join(", ")} (stories: ${stories.join(", ")})${sampleSection}`,
       sourceKinds: ["review-finding"],
-      storyIds: unique,
+      storyIds: stories,
     });
   }
   return proposals;

--- a/src/plugins/builtin/curator/index.ts
+++ b/src/plugins/builtin/curator/index.ts
@@ -7,7 +7,7 @@
 
 import { mkdir } from "node:fs/promises";
 import * as path from "node:path";
-import type { IPostRunAction, PluginLogger, PostRunActionResult, PostRunContext } from "../../types";
+import type { IPostRunAction, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
 import type { NaxPlugin } from "../../types";
 import { collectObservations } from "./collect";
 import type { CuratorThresholds } from "./heuristics";

--- a/src/plugins/builtin/curator/render.ts
+++ b/src/plugins/builtin/curator/render.ts
@@ -74,7 +74,12 @@ export function renderProposals(proposals: Proposal[], runId: string, observatio
         const storyList = p.storyIds.join(", ");
         lines.push(`- [ ] [${p.severity}] ${p.id}: ${p.description} — stories: ${storyList}`);
         if (p.evidence) {
-          lines.push(`  _Evidence: ${p.evidence}_`);
+          // Flattened to one line on purpose: `parseCheckedProposals` in
+          // `nax curator commit` captures a single `_Evidence:` line, so any
+          // continuation (the `Examples:` samples) was silently dropped on
+          // accept — and those samples are what distinguish one proposal from
+          // another.
+          lines.push(`  _Evidence: ${p.evidence.replace(/\s*\n\s*/g, " · ")}_`);
         }
       }
       lines.push("");

--- a/src/plugins/builtin/curator/types.ts
+++ b/src/plugins/builtin/curator/types.ts
@@ -72,6 +72,8 @@ export interface ReviewFindingObservation extends BaseObservation {
     ruleId: string;
     checkId?: string;
     severity: string;
+    /** Reviewer taxonomy axis. Drives H1's recurrence fingerprint (#1422). */
+    category?: string;
     file: string;
     line: number;
     message: string;

--- a/src/plugins/builtin/curator/types.ts
+++ b/src/plugins/builtin/curator/types.ts
@@ -4,8 +4,8 @@
  * Defines observation schema and curator-specific types for Phase 1 collection.
  */
 
-import type { NaxConfig } from "../../../config";
-import type { PostRunContext } from "../../extensions";
+import type { NaxConfig } from "@/config";
+import type { PostRunContext } from "@/plugins/extensions";
 
 /** Curator configuration with thresholds */
 export interface CuratorThresholds {
@@ -26,7 +26,13 @@ export interface CuratorConfigExt {
 
 /** Base observation shape */
 export interface BaseObservation {
-  schemaVersion: 1;
+  /**
+   * 1 = observations re-ingested from a project's whole audit history on every
+   * run (cumulative, monotonic). 2 = scoped to the run that produced them
+   * (#1422). The rollup is append-only and cross-project, so both versions
+   * coexist in one file; longitudinal analysis MUST NOT mix them.
+   */
+  schemaVersion: 1 | 2;
   runId: string;
   featureId: string;
   storyId: string;

--- a/src/plugins/extensions.ts
+++ b/src/plugins/extensions.ts
@@ -212,6 +212,15 @@ export interface PostRunContext {
   /** Total run duration in milliseconds */
   totalDurationMs: number;
 
+  /**
+   * Epoch ms at which this run started. Lets post-run actions scope themselves
+   * to artifacts this run produced — the curator's counts were previously
+   * cumulative over a project's entire history and could only ever grow (#1422).
+   * Optional so out-of-tree post-run actions built against the older shape keep
+   * compiling; consumers must treat absence as "no scoping".
+   */
+  runStartedAt?: number;
+
   /** Total cost of the run */
   totalCost: number;
 

--- a/src/runtime/middleware/review-audit.ts
+++ b/src/runtime/middleware/review-audit.ts
@@ -1,5 +1,5 @@
-import type { IReviewAuditor } from "../../review/review-audit";
-import type { ReviewAck } from "../../review/types";
+import type { IReviewAuditor } from "@/review/review-audit";
+import type { ReviewAck } from "@/review/types";
 import type { DispatchEvent, IDispatchEventBus, ReviewDecisionEvent } from "../dispatch-events";
 
 function reviewerFromRole(role: string): "semantic" | "adversarial" | null {

--- a/test/unit/commands/curator.test.ts
+++ b/test/unit/commands/curator.test.ts
@@ -513,7 +513,8 @@ describe("curatorDryrun", () => {
       const runDir = join(outputDir, "runs", "run-001");
       mkdirSync(runDir, { recursive: true });
 
-      // Two review-finding observations with same ruleId (threshold 2) → H1 fires
+      // Same defect (same file + message → same fingerprint) in two distinct
+      // FEATURES → H1 fires. Cross-feature recurrence is the trigger (#1422).
       const obs: Observation[] = [
         {
           schemaVersion: 1,
@@ -523,17 +524,17 @@ describe("curatorDryrun", () => {
           stage: "review",
           ts: "2026-01-01T00:00:00.000Z",
           kind: "review-finding",
-          payload: { ruleId: "no-any", severity: "HIGH", file: "src/foo.ts", line: 1, message: "no any" },
+          payload: { ruleId: "no-any", category: "convention", severity: "HIGH", file: "src/foo.ts", line: 1, message: "explicit any is not allowed in public APIs" },
         } as Observation,
         {
           schemaVersion: 1,
           runId: "run-001",
-          featureId: "feat-1",
+          featureId: "feat-2",
           storyId: "US-002",
           stage: "review",
           ts: "2026-01-01T00:00:00.000Z",
           kind: "review-finding",
-          payload: { ruleId: "no-any", severity: "HIGH", file: "src/bar.ts", line: 5, message: "no any" },
+          payload: { ruleId: "no-any", category: "convention", severity: "HIGH", file: "src/foo.ts", line: 5, message: "explicit any is not allowed in public APIs" },
         } as Observation,
       ];
       writeObservations(runDir, obs);

--- a/test/unit/execution/lifecycle/run-cleanup.test.ts
+++ b/test/unit/execution/lifecycle/run-cleanup.test.ts
@@ -108,6 +108,17 @@ describe("buildPostRunContext", () => {
     expect(ctx.pluginConfig).toEqual({});
   });
 
+  test("populates runStartedAt from the run's startTime (#1422)", async () => {
+    // The curator scopes its observations with this value. If the producer stops
+    // setting it, every collector silently falls back to "no scoping" and the
+    // cumulative-count defect returns — with the consumer-side tests still green,
+    // because they inject runStartedAt directly.
+    const { buildPostRunContext } = await import("../../../../src/execution/lifecycle/run-cleanup");
+    const startTime = Date.parse("2026-08-01T12:00:00.000Z");
+    const ctx = buildPostRunContext(makeCleanupOptions({ startTime }), 5000, makePluginLogger());
+    expect(ctx.runStartedAt).toBe(startTime);
+  });
+
   test("storySummary reflects prd story counts", async () => {
     const { buildPostRunContext } = await import("../../../../src/execution/lifecycle/run-cleanup");
 

--- a/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-acceptance.test.ts
@@ -21,12 +21,12 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
-import type { PostRunContext } from "@/plugins/extensions";
 import { loadPlugins } from "@/plugins";
-import { autoPrPlugin, _autoPrDeps } from "../../../../src/plugins/builtin/auto-pr";
-import type { AutoPrDeps } from "../../../../src/plugins/builtin/auto-pr/types";
-import { buildBody, buildTitle } from "../../../../src/plugins/builtin/auto-pr/pr-body";
+import type { PostRunContext } from "@/plugins/extensions";
 import { makeStory } from "@test/helpers";
+import { _autoPrDeps, autoPrPlugin } from "../../../../src/plugins/builtin/auto-pr";
+import { buildBody, buildTitle } from "../../../../src/plugins/builtin/auto-pr/pr-body";
+import type { AutoPrDeps } from "../../../../src/plugins/builtin/auto-pr/types";
 
 const PLUGIN_NAME = "nax-auto-pr";
 
@@ -357,13 +357,7 @@ describe("autoPrPlugin.execute", () => {
 describe("loadPlugins — autoPr registration", () => {
   test("AC11 — getPostRunActions() includes 'nax-auto-pr' exactly once when not disabled", async () => {
     const root = await mkdtemp(join(tmpdir(), "autopr-registration-"));
-    const registry = await loadPlugins(
-      join(root, "global"),
-      join(root, "project"),
-      [],
-      root,
-      [],
-    );
+    const registry = await loadPlugins(join(root, "global"), join(root, "project"), [], root, []);
     const actions = registry.getPostRunActions();
     // Regression: auto-pr must be a side-channel action only (like auto-route),
     // never also a full plugin — otherwise getPostRunActions returns it twice
@@ -377,13 +371,7 @@ describe("loadPlugins — autoPr registration", () => {
 
   test("autoPr is excluded from getPostRunActions() when 'nax-auto-pr' is in disabledPlugins", async () => {
     const root = await mkdtemp(join(tmpdir(), "autopr-registration-"));
-    const registry = await loadPlugins(
-      join(root, "global"),
-      join(root, "project"),
-      [],
-      root,
-      [PLUGIN_NAME],
-    );
+    const registry = await loadPlugins(join(root, "global"), join(root, "project"), [], root, [PLUGIN_NAME]);
     const actions = registry.getPostRunActions();
     expect(actions.some((a) => a.name === PLUGIN_NAME)).toBe(false);
   });

--- a/test/unit/plugins/builtin/auto-pr-forge.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-forge.test.ts
@@ -6,16 +6,24 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import type { PostRunActionResult } from "@/plugins/extensions";
 import { detectForge, hasOpenPr, openDraft } from "../../../../src/plugins/builtin/auto-pr/forge";
 import type { AutoPrDeps } from "../../../../src/plugins/builtin/auto-pr/types";
-import type { PostRunActionResult } from "@/plugins/extensions";
 
 interface CapturedRun {
   cmd: string[];
   cwd: string;
 }
 
-function makeDeps(handler: (cmd: string[], opts: { cwd: string }) => Promise<{ exitCode: number; stdout: string; stderr: string }> | { exitCode: number; stdout: string; stderr: string }, captured?: CapturedRun[]): AutoPrDeps {
+function makeDeps(
+  handler: (
+    cmd: string[],
+    opts: { cwd: string },
+  ) =>
+    | Promise<{ exitCode: number; stdout: string; stderr: string }>
+    | { exitCode: number; stdout: string; stderr: string },
+  captured?: CapturedRun[],
+): AutoPrDeps {
   return {
     run: async (cmd, opts) => {
       const res = await handler(cmd, opts);
@@ -102,12 +110,7 @@ describe("openDraft (draft flag)", () => {
       captured,
     );
 
-    await openDraft(
-      "github",
-      { title: "feat: t", body: "b", branch: "nax/auto-pr", draft: false },
-      deps,
-      "/workdir",
-    );
+    await openDraft("github", { title: "feat: t", body: "b", branch: "nax/auto-pr", draft: false }, deps, "/workdir");
 
     const argv = captured[0]?.cmd ?? [];
     expect(argv).not.toContain("--draft");
@@ -178,10 +181,7 @@ describe("hasOpenPr", () => {
 
   test("GitLab path — emits glab mr list with --output json so the result parses", async () => {
     const captured: CapturedRun[] = [];
-    const deps = makeDeps(
-      async () => ({ exitCode: 0, stdout: "[]", stderr: "" }),
-      captured,
-    );
+    const deps = makeDeps(async () => ({ exitCode: 0, stdout: "[]", stderr: "" }), captured);
 
     await hasOpenPr("gitlab", "nax/auto-pr", deps, "/workdir");
 

--- a/test/unit/plugins/builtin/auto-pr-pr-body.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-pr-body.test.ts
@@ -6,9 +6,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { makeStory } from "@test/helpers";
 import { buildBody, buildTitle } from "../../../../src/plugins/builtin/auto-pr/pr-body";
 import type { PrBodyContext } from "../../../../src/plugins/builtin/auto-pr/pr-body";
-import { makeStory } from "@test/helpers";
 
 function makeContext(overrides: Partial<PrBodyContext> = {}): PrBodyContext {
   return {

--- a/test/unit/plugins/builtin/auto-route-acceptance.test.ts
+++ b/test/unit/plugins/builtin/auto-route-acceptance.test.ts
@@ -24,9 +24,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { PostRunContext } from "@/plugins/extensions";
-import { _autoRouteDeps, autoRoutePlugin, loadPlugins, type AutoRouteDeps } from "@/plugins";
 import type { RunMetrics, StoryMetrics } from "@/metrics";
+import { type AutoRouteDeps, _autoRouteDeps, autoRoutePlugin, loadPlugins } from "@/plugins";
+import type { PostRunContext } from "@/plugins/extensions";
 import type { TierAdjustment } from "@/routing";
 
 const PLUGIN_NAME = "nax-auto-route";
@@ -330,26 +330,14 @@ describe("autoRoutePlugin.execute", () => {
 describe("loadPlugins — autoRoute registration", () => {
   test("AC7 — getPostRunActions() includes 'nax-auto-route' when not disabled", async () => {
     const root = await mkdtemp(join(tmpdir(), "autoroute-registration-"));
-    const registry = await loadPlugins(
-      join(root, "global"),
-      join(root, "project"),
-      [],
-      root,
-      [],
-    );
+    const registry = await loadPlugins(join(root, "global"), join(root, "project"), [], root, []);
     const actions = registry.getPostRunActions();
     expect(actions.some((a) => a.name === PLUGIN_NAME)).toBe(true);
   });
 
   test("autoRoute is excluded from getPostRunActions() when 'nax-auto-route' is in disabledPlugins", async () => {
     const root = await mkdtemp(join(tmpdir(), "autoroute-registration-"));
-    const registry = await loadPlugins(
-      join(root, "global"),
-      join(root, "project"),
-      [],
-      root,
-      [PLUGIN_NAME],
-    );
+    const registry = await loadPlugins(join(root, "global"), join(root, "project"), [], root, [PLUGIN_NAME]);
     const actions = registry.getPostRunActions();
     expect(actions.some((a) => a.name === PLUGIN_NAME)).toBe(false);
   });

--- a/test/unit/plugins/builtin/curator-acceptance.test.ts
+++ b/test/unit/plugins/builtin/curator-acceptance.test.ts
@@ -35,9 +35,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { PostRunContext } from "../../../../src/plugins/extensions";
-import { curatorPlugin } from "../../../../src/plugins/builtin/curator";
 import { CuratorConfigSchema } from "../../../../src/config/schemas-infra";
+import { curatorPlugin } from "../../../../src/plugins/builtin/curator";
+import type { PostRunContext } from "../../../../src/plugins/extensions";
 
 describe("Curator Plugin Acceptance Criteria Coverage", () => {
   /**

--- a/test/unit/plugins/builtin/curator-collector.test.ts
+++ b/test/unit/plugins/builtin/curator-collector.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { collectObservations } from "../../../../src/plugins/builtin/curator";
@@ -386,6 +386,121 @@ describe("collectObservations", () => {
     expect(observations.some((o) => o.kind === "pull-call" && o.payload.resultCount === 0)).toBe(true);
     expect(observations.some((o) => o.kind === "acceptance-verdict" && o.payload.failedACs?.includes("AC-2"))).toBe(true);
     expect(observations.some((o) => o.kind === "fix-cycle-iteration" && o.payload.outcome === "unchanged")).toBe(true);
+  });
+
+  test("collects only review-audit entries from THIS run when runStartedAt is set (#1422)", async () => {
+    // Curator counts must mean "this run". Re-reading the whole accumulated
+    // audit directory made every count monotonically increasing, so a
+    // threshold-based proposal tripped once and could never clear.
+    const root = await mkdtemp(join(tmpdir(), "curator-run-scope-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-auth");
+    await mkdir(auditDir, { recursive: true });
+
+    const runStartedAt = Date.parse("2026-08-01T12:00:00.000Z");
+    await writeFile(
+      join(auditDir, "old.json"),
+      JSON.stringify({
+        timestamp: "2026-07-15T09:00:00.000Z",
+        storyId: "US-001",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "stale-finding", severity: "error", file: "src/a.ts", line: 1, message: "old" }] },
+      }),
+    );
+    await writeFile(
+      join(auditDir, "current.json"),
+      JSON.stringify({
+        timestamp: "2026-08-01T12:05:00.000Z",
+        storyId: "US-002",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "fresh-finding", severity: "error", file: "src/b.ts", line: 2, message: "new" }] },
+      }),
+    );
+
+    const observations = await collectObservations({
+      ...makeContext(root, join(root, "work")),
+      outputDir,
+      runStartedAt,
+    });
+    const rules = observations.filter((o) => o.kind === "review-finding").map((o) => o.payload.ruleId);
+    expect(rules).toContain("fresh-finding");
+    expect(rules).not.toContain("stale-finding");
+  });
+
+  test("collects everything when runStartedAt is absent (back-compat)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-no-scope-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-auth");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(
+      join(auditDir, "old.json"),
+      JSON.stringify({
+        timestamp: "2026-07-15T09:00:00.000Z",
+        storyId: "US-001",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "stale-finding", severity: "error", file: "src/a.ts", line: 1, message: "old" }] },
+      }),
+    );
+
+    const observations = await collectObservations({ ...makeContext(root, join(root, "work")), outputDir });
+    expect(observations.filter((o) => o.kind === "review-finding")).toHaveLength(1);
+  });
+
+  test("an audit entry with no timestamp is kept rather than silently dropped (#1422)", async () => {
+    // Dropping undated entries would hide real findings; keeping them only risks
+    // a stale count, which is the pre-existing behaviour.
+    const root = await mkdtemp(join(tmpdir(), "curator-undated-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-auth");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(
+      join(auditDir, "undated.json"),
+      JSON.stringify({
+        storyId: "US-001",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "undated-finding", severity: "error", file: "src/a.ts", line: 1, message: "x" }] },
+      }),
+    );
+
+    const observations = await collectObservations({
+      ...makeContext(root, join(root, "work")),
+      outputDir,
+      runStartedAt: Date.parse("2026-08-01T12:00:00.000Z"),
+    });
+    expect(observations.filter((o) => o.kind === "review-finding")).toHaveLength(1);
+  });
+
+  test("skips context manifests untouched by this run (#1422)", async () => {
+    // Manifests persist per story across runs; a run that touches US-002 must
+    // not re-report US-001's chunks as if it had assembled them.
+    const root = await mkdtemp(join(tmpdir(), "curator-manifest-scope-"));
+    const workdir = join(root, "work");
+    const stories = join(workdir, ".nax", "features", "feat-auth", "stories");
+    await mkdir(join(stories, "US-001"), { recursive: true });
+    await mkdir(join(stories, "US-002"), { recursive: true });
+
+    const manifest = (chunk: string) =>
+      JSON.stringify({
+        stage: "review",
+        includedChunks: [chunk],
+        excludedChunks: [],
+        providerResults: [],
+        chunkTokens: { [chunk]: 100 },
+      });
+    const stalePath = join(stories, "US-001", "context-manifest-review.json");
+    const freshPath = join(stories, "US-002", "context-manifest-review.json");
+    await writeFile(stalePath, manifest("stale:chunk"));
+    await writeFile(freshPath, manifest("fresh:chunk"));
+
+    // Age the first manifest to before the run started.
+    const runStartedAt = Date.now();
+    const old = new Date(runStartedAt - 86_400_000);
+    await utimes(stalePath, old, old);
+
+    const observations = await collectObservations({ ...makeContext(root, workdir), runStartedAt });
+    const chunkIds = observations.filter((o) => o.kind === "chunk-included").map((o) => o.payload.chunkId);
+    expect(chunkIds).toContain("fresh:chunk");
+    expect(chunkIds).not.toContain("stale:chunk");
   });
 
   test("chunk-included carries the manifest's real per-chunk token count (#1421)", async () => {

--- a/test/unit/plugins/builtin/curator-collector.test.ts
+++ b/test/unit/plugins/builtin/curator-collector.test.ts
@@ -324,7 +324,9 @@ describe("collectObservations", () => {
         stage: "review",
         includedChunks: ["feature-context:abc"],
         excludedChunks: [{ id: "rules:def", reason: "stale" }],
-        providerResults: [{ providerId: "feature-context", status: "empty", chunkCount: 0, durationMs: 1, tokensProduced: 0 }],
+        providerResults: [
+          { providerId: "feature-context", status: "empty", chunkCount: 0, durationMs: 1, tokensProduced: 0 },
+        ],
         chunkSummaries: { "feature-context:abc": "Auth context" },
       }),
     );
@@ -337,21 +339,41 @@ describe("collectObservations", () => {
           level: "info",
           stage: "pull-tool",
           message: "invoked",
-          data: { storyId: "US-001", tool: "query_feature_context", keyword: "auth cache", resultCount: 0, resultBytes: 0 },
+          data: {
+            storyId: "US-001",
+            tool: "query_feature_context",
+            keyword: "auth cache",
+            resultCount: 0,
+            resultBytes: 0,
+          },
         }),
         JSON.stringify({
           timestamp: "2026-05-04T00:02:00.000Z",
           level: "info",
           stage: "acceptance",
           message: "verdict",
-          data: { storyId: "US-001", passed: false, failedACs: ["AC-2"], retries: 1, packageDir: workdir, durationMs: 50 },
+          data: {
+            storyId: "US-001",
+            passed: false,
+            failedACs: ["AC-2"],
+            retries: 1,
+            packageDir: workdir,
+            durationMs: 50,
+          },
         }),
         JSON.stringify({
           timestamp: "2026-05-04T00:03:00.000Z",
           level: "info",
           stage: "findings.cycle",
           message: "iteration completed",
-          data: { storyId: "US-001", cycleName: "acceptance", iterationNum: 1, outcome: "unchanged", findingsBefore: 1, findingsAfter: 1 },
+          data: {
+            storyId: "US-001",
+            cycleName: "acceptance",
+            iterationNum: 1,
+            outcome: "unchanged",
+            findingsBefore: 1,
+            findingsAfter: 1,
+          },
         }),
       ].join("\n"),
     );
@@ -384,123 +406,10 @@ describe("collectObservations", () => {
     expect(observations.some((o) => o.kind === "chunk-excluded" && o.payload.reason === "stale")).toBe(true);
     expect(observations.some((o) => o.kind === "provider-empty")).toBe(true);
     expect(observations.some((o) => o.kind === "pull-call" && o.payload.resultCount === 0)).toBe(true);
-    expect(observations.some((o) => o.kind === "acceptance-verdict" && o.payload.failedACs?.includes("AC-2"))).toBe(true);
+    expect(observations.some((o) => o.kind === "acceptance-verdict" && o.payload.failedACs?.includes("AC-2"))).toBe(
+      true,
+    );
     expect(observations.some((o) => o.kind === "fix-cycle-iteration" && o.payload.outcome === "unchanged")).toBe(true);
-  });
-
-  test("collects only review-audit entries from THIS run when runStartedAt is set (#1422)", async () => {
-    // Curator counts must mean "this run". Re-reading the whole accumulated
-    // audit directory made every count monotonically increasing, so a
-    // threshold-based proposal tripped once and could never clear.
-    const root = await mkdtemp(join(tmpdir(), "curator-run-scope-"));
-    const outputDir = join(root, "out");
-    const auditDir = join(outputDir, "review-audit", "feat-auth");
-    await mkdir(auditDir, { recursive: true });
-
-    const runStartedAt = Date.parse("2026-08-01T12:00:00.000Z");
-    await writeFile(
-      join(auditDir, "old.json"),
-      JSON.stringify({
-        timestamp: "2026-07-15T09:00:00.000Z",
-        storyId: "US-001",
-        featureName: "feat-auth",
-        result: { findings: [{ rule: "stale-finding", severity: "error", file: "src/a.ts", line: 1, message: "old" }] },
-      }),
-    );
-    await writeFile(
-      join(auditDir, "current.json"),
-      JSON.stringify({
-        timestamp: "2026-08-01T12:05:00.000Z",
-        storyId: "US-002",
-        featureName: "feat-auth",
-        result: { findings: [{ rule: "fresh-finding", severity: "error", file: "src/b.ts", line: 2, message: "new" }] },
-      }),
-    );
-
-    const observations = await collectObservations({
-      ...makeContext(root, join(root, "work")),
-      outputDir,
-      runStartedAt,
-    });
-    const rules = observations.filter((o) => o.kind === "review-finding").map((o) => o.payload.ruleId);
-    expect(rules).toContain("fresh-finding");
-    expect(rules).not.toContain("stale-finding");
-  });
-
-  test("collects everything when runStartedAt is absent (back-compat)", async () => {
-    const root = await mkdtemp(join(tmpdir(), "curator-no-scope-"));
-    const outputDir = join(root, "out");
-    const auditDir = join(outputDir, "review-audit", "feat-auth");
-    await mkdir(auditDir, { recursive: true });
-    await writeFile(
-      join(auditDir, "old.json"),
-      JSON.stringify({
-        timestamp: "2026-07-15T09:00:00.000Z",
-        storyId: "US-001",
-        featureName: "feat-auth",
-        result: { findings: [{ rule: "stale-finding", severity: "error", file: "src/a.ts", line: 1, message: "old" }] },
-      }),
-    );
-
-    const observations = await collectObservations({ ...makeContext(root, join(root, "work")), outputDir });
-    expect(observations.filter((o) => o.kind === "review-finding")).toHaveLength(1);
-  });
-
-  test("an audit entry with no timestamp is kept rather than silently dropped (#1422)", async () => {
-    // Dropping undated entries would hide real findings; keeping them only risks
-    // a stale count, which is the pre-existing behaviour.
-    const root = await mkdtemp(join(tmpdir(), "curator-undated-"));
-    const outputDir = join(root, "out");
-    const auditDir = join(outputDir, "review-audit", "feat-auth");
-    await mkdir(auditDir, { recursive: true });
-    await writeFile(
-      join(auditDir, "undated.json"),
-      JSON.stringify({
-        storyId: "US-001",
-        featureName: "feat-auth",
-        result: { findings: [{ rule: "undated-finding", severity: "error", file: "src/a.ts", line: 1, message: "x" }] },
-      }),
-    );
-
-    const observations = await collectObservations({
-      ...makeContext(root, join(root, "work")),
-      outputDir,
-      runStartedAt: Date.parse("2026-08-01T12:00:00.000Z"),
-    });
-    expect(observations.filter((o) => o.kind === "review-finding")).toHaveLength(1);
-  });
-
-  test("skips context manifests untouched by this run (#1422)", async () => {
-    // Manifests persist per story across runs; a run that touches US-002 must
-    // not re-report US-001's chunks as if it had assembled them.
-    const root = await mkdtemp(join(tmpdir(), "curator-manifest-scope-"));
-    const workdir = join(root, "work");
-    const stories = join(workdir, ".nax", "features", "feat-auth", "stories");
-    await mkdir(join(stories, "US-001"), { recursive: true });
-    await mkdir(join(stories, "US-002"), { recursive: true });
-
-    const manifest = (chunk: string) =>
-      JSON.stringify({
-        stage: "review",
-        includedChunks: [chunk],
-        excludedChunks: [],
-        providerResults: [],
-        chunkTokens: { [chunk]: 100 },
-      });
-    const stalePath = join(stories, "US-001", "context-manifest-review.json");
-    const freshPath = join(stories, "US-002", "context-manifest-review.json");
-    await writeFile(stalePath, manifest("stale:chunk"));
-    await writeFile(freshPath, manifest("fresh:chunk"));
-
-    // Age the first manifest to before the run started.
-    const runStartedAt = Date.now();
-    const old = new Date(runStartedAt - 86_400_000);
-    await utimes(stalePath, old, old);
-
-    const observations = await collectObservations({ ...makeContext(root, workdir), runStartedAt });
-    const chunkIds = observations.filter((o) => o.kind === "chunk-included").map((o) => o.payload.chunkId);
-    expect(chunkIds).toContain("fresh:chunk");
-    expect(chunkIds).not.toContain("stale:chunk");
   });
 
   test("chunk-included carries the manifest's real per-chunk token count (#1421)", async () => {
@@ -609,25 +518,17 @@ describe("collectObservations", () => {
     const findings = observations.filter((o) => o.kind === "review-finding");
     expect(findings.length).toBe(2);
 
-    const withSuggestion = findings.find(
-      (o) => o.kind === "review-finding" && o.payload.line === 73,
-    );
+    const withSuggestion = findings.find((o) => o.kind === "review-finding" && o.payload.line === 73);
     expect(withSuggestion).toBeDefined();
     if (withSuggestion?.kind === "review-finding") {
-      expect(withSuggestion.payload.message).toContain(
-        "onAgentStream(listener) does not validate",
-      );
+      expect(withSuggestion.payload.message).toContain("onAgentStream(listener) does not validate");
       expect(withSuggestion.payload.message).toContain("Add a guard");
     }
 
-    const noSuggestion = findings.find(
-      (o) => o.kind === "review-finding" && o.payload.line === 81,
-    );
+    const noSuggestion = findings.find((o) => o.kind === "review-finding" && o.payload.line === 81);
     expect(noSuggestion).toBeDefined();
     if (noSuggestion?.kind === "review-finding") {
-      expect(noSuggestion.payload.message).toBe(
-        "Listener errors are swallowed when logger is null.",
-      );
+      expect(noSuggestion.payload.message).toBe("Listener errors are swallowed when logger is null.");
     }
   });
 

--- a/test/unit/plugins/builtin/curator-heuristics-h1.test.ts
+++ b/test/unit/plugins/builtin/curator-heuristics-h1.test.ts
@@ -1,0 +1,307 @@
+/**
+ * H1 heuristic — cross-feature recurrence (#1422) and the #942 bucket guards.
+ *
+ * Split from curator-heuristics.test.ts, which crossed the 800-line test limit.
+ * Concern: how review findings are grouped into rule proposals.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Observation } from "../../../../src/plugins/builtin/curator";
+import { runHeuristics } from "../../../../src/plugins/builtin/curator/heuristics";
+import type { CuratorThresholds } from "../../../../src/plugins/builtin/curator/heuristics";
+
+function makeReviewFindingObs942(
+  storyId: string,
+  ruleId: string,
+  severity: string,
+  message = "msg",
+  category?: string,
+): Observation {
+  return {
+    schemaVersion: 1,
+    runId: "run-test",
+    // One feature per story: H1 measures recurrence across FEATURES (#1422), so
+    // fixtures that mean "this recurred" must spread across them.
+    featureId: `feat-${storyId}`,
+    storyId,
+    stage: "review",
+    ts: "2026-05-07T00:00:00.000Z",
+    kind: "review-finding",
+    payload: { ruleId, checkId: ruleId, severity, category, file: "src/foo.ts", line: 1, message },
+  };
+}
+
+describe("H1 — sample messages in evidence", () => {
+  test("evidence includes up to two sample messages drawn from the group", () => {
+    const observations: Observation[] = [
+      // Same defect, three phrasings that share the fingerprint prefix — that is
+      // what "one group" now means (#1422). Only two samples may surface.
+      makeReviewFindingObs942(
+        "US-001",
+        "input:listener-arg-not-validated",
+        "warning",
+        "Listener argument is not validated as a function (register path)",
+      ),
+      makeReviewFindingObs942(
+        "US-002",
+        "input:listener-arg-not-validated",
+        "warning",
+        "Listener argument is not validated as a function (handler path)",
+      ),
+      makeReviewFindingObs942(
+        "US-003",
+        "input:listener-arg-not-validated",
+        "warning",
+        "Listener argument is not validated as a function (third example should not appear)",
+      ),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1 = proposals.find((p) => p.id === "H1")!;
+
+    expect(h1).toBeDefined();
+    expect(h1.evidence).toContain("(register path)");
+    expect(h1.evidence).toContain("(handler path)");
+    expect(h1.evidence).not.toContain("third example should not appear");
+  });
+
+  test("evidence omits sample section when all messages are empty", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated", "warning", ""),
+      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated", "warning", ""),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1 = proposals.find((p) => p.id === "H1")!;
+    expect(h1).toBeDefined();
+    expect(h1.evidence).not.toContain("Examples:");
+  });
+
+  test("sample uses only the first line of a multi-line message", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942(
+        "US-001",
+        "review:null-check",
+        "warning",
+        "Null check missing\n→ Add a guard before access",
+      ),
+      makeReviewFindingObs942(
+        "US-002",
+        "review:null-check",
+        "warning",
+        "Null check missing\n→ Add a guard before access",
+      ),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1 = proposals.find((p) => p.id === "H1")!;
+    expect(h1.evidence).toContain("Null check missing");
+    expect(h1.evidence).not.toContain("→ Add a guard");
+  });
+
+  test("a blank-looking first message does not suppress a later real sample", () => {
+    // Still reachable, contrary to an earlier claim that the message being part
+    // of the grouping key made it impossible: the key normalizes whitespace
+    // (so a leading newline groups with the trimmed text) while the sample uses
+    // the raw first line (which is empty). The `if (sample && …)` guard is what
+    // keeps evidence correct here.
+    const observations: Observation[] = [
+      makeReviewFindingObs942("US-001", "review:null-check", "warning", "\nNull check missing"),
+      makeReviewFindingObs942("US-002", "review:null-check", "warning", "Null check missing"),
+    ];
+
+    const h1 = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds).find((p) => p.id === "H1");
+    expect(h1).toBeDefined();
+    expect(h1?.evidence).toContain("Null check missing");
+  });
+});
+
+describe("H1 — issue #942 AC-5: ruleId buckets are not single-word collapses", () => {
+  test("findings sharing a category but different issues yield distinct buckets", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942(
+        "US-001",
+        "input:listener-arg",
+        "warning",
+        "Listener argument is not validated as a function",
+        "input",
+      ),
+      makeReviewFindingObs942(
+        "US-002",
+        "input:listener-arg",
+        "warning",
+        "Listener argument is not validated as a function",
+        "input",
+      ),
+      makeReviewFindingObs942(
+        "US-003",
+        "input:timeout-bound",
+        "error",
+        "Timeout value has no upper bound and can hang the run",
+        "input",
+      ),
+      makeReviewFindingObs942(
+        "US-004",
+        "input:timeout-bound",
+        "error",
+        "Timeout value has no upper bound and can hang the run",
+        "input",
+      ),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1s = proposals.filter((p) => p.id === "H1");
+
+    expect(h1s.length).toBe(2);
+    // Buckets are per-defect, not per-category. Both findings carry category
+    // "input", so a category-only description would render them identically —
+    // the #942 collapse. Assert they are actually distinguishable.
+    expect(h1s[0].description).not.toBe(h1s[1].description);
+    for (const p of h1s) {
+      expect(p.description).not.toMatch(/^Recurring across \d+ features — input: ?$/);
+      expect(p.evidence).toContain("Examples:");
+    }
+    expect(h1s.some((p) => p.evidence.includes("Listener argument"))).toBe(true);
+    expect(h1s.some((p) => p.evidence.includes("Timeout value"))).toBe(true);
+  });
+});
+
+// ─── #1422: cross-feature recurrence ──────────────────────────────────────────
+
+describe("H1 — cross-feature recurrence (#1422)", () => {
+  const thresholds: CuratorThresholds = {
+    repeatedFinding: 3,
+    emptyKeyword: 2,
+    rectifyAttempts: 3,
+    escalationChain: 2,
+    staleChunkRuns: 2,
+    unchangedOutcome: 3,
+  };
+
+  function finding(
+    featureId: string,
+    storyId: string,
+    over: Partial<{ category: string; file: string; message: string }> = {},
+  ): Observation {
+    return {
+      schemaVersion: 1,
+      runId: "run-1",
+      featureId,
+      storyId,
+      stage: "review",
+      ts: "2026-08-01T00:00:00Z",
+      kind: "review-finding",
+      payload: {
+        ruleId: "test-gap:missing-runtime-assertion",
+        category: over.category ?? "test-gap",
+        severity: "error",
+        file: over.file ?? "src/api.ts",
+        line: 10,
+        message: over.message ?? "Test asserts a pattern exists in the file instead of invoking the code",
+      },
+    };
+  }
+
+  test("proposes when the same finding recurs across enough DISTINCT features", () => {
+    const obs = [finding("feat-a", "US-001"), finding("feat-b", "US-002"), finding("feat-c", "US-003")];
+    const h1 = runHeuristics(obs, thresholds).find((p) => p.id === "H1");
+    expect(h1).toBeDefined();
+    expect(h1?.description).toContain("3 features");
+    expect(h1?.evidence).toContain("feat-a");
+    expect(h1?.evidence).toContain("feat-c");
+  });
+
+  test("fires when the SAME defect appears in DIFFERENT files across features", () => {
+    // The whole point of H1. Different features touch different files by
+    // definition, so a file-led identity key can never see this — which is what
+    // reusing recurrence-demotion's `fingerprintFor` verbatim did.
+    const obs = [
+      finding("feat-a", "US-001", { file: "src/auth.ts" }),
+      finding("feat-b", "US-002", { file: "src/billing.ts" }),
+      finding("feat-c", "US-003", { file: "src/cart.ts" }),
+    ];
+    const h1 = runHeuristics(obs, thresholds).find((p) => p.id === "H1");
+    expect(h1).toBeDefined();
+    expect(h1?.description).toContain("3 features");
+    // The files are evidence, not identity.
+    expect(h1?.evidence).toContain("src/auth.ts");
+    expect(h1?.evidence).toContain("src/cart.ts");
+  });
+
+  test("description never collapses to a bare category (#942 regression guard)", () => {
+    // A finding with no file must still produce a distinguishable checkbox line:
+    // `nax curator commit` ticks are made against that line alone.
+    const obs = ["a", "b", "c"].map((f) =>
+      finding(`feat-${f}`, "US-001", { file: "", message: "Assumes the env var is always set before boot" }),
+    );
+    const h1 = runHeuristics(obs, thresholds).find((p) => p.id === "H1");
+    expect(h1).toBeDefined();
+    expect(h1?.description).toContain("Assumes the env var is always set");
+    expect(h1?.description).not.toMatch(/^Recurring review finding \(test-gap\)$/);
+  });
+
+  test("two distinct defects in the same file produce distinguishable descriptions", () => {
+    const a = ["a", "b", "c"].map((f) =>
+      finding(`feat-${f}`, "US-001", { message: "Placeholder assertion expect(true) covers AC 2" }),
+    );
+    const b = ["a", "b", "c"].map((f) =>
+      finding(`feat-${f}`, "US-002", { message: "Source-inspection test reads the file instead of running it" }),
+    );
+    const h1s = runHeuristics([...a, ...b], thresholds).filter((p) => p.id === "H1");
+    expect(h1s).toHaveLength(2);
+    expect(h1s[0].description).not.toBe(h1s[1].description);
+  });
+
+  test("story IDs are qualified by feature, since US-001 exists in every feature", () => {
+    const obs = ["a", "b", "c"].map((f) => finding(`feat-${f}`, "US-001"));
+    const h1 = runHeuristics(obs, thresholds).find((p) => p.id === "H1");
+    expect(h1?.storyIds).toEqual(["feat-a/US-001", "feat-b/US-001", "feat-c/US-001"]);
+  });
+
+  test("does NOT propose when one feature repeats the same finding many times", () => {
+    // A rule is worth writing when a defect crosses features. One feature
+    // repeating itself is a story problem, and was the old behaviour's main
+    // source of noise ("test-gap appeared 1008x" from a single 7-story run).
+    const obs = Array.from({ length: 12 }, (_, i) => finding("feat-a", `US-${i}`));
+    expect(runHeuristics(obs, thresholds).find((p) => p.id === "H1")).toBeUndefined();
+  });
+
+  test("separates distinct defects that share a category and file", () => {
+    const a = [1, 2, 3].map((i) => finding(`feat-${i}`, "US-001", { message: "Placeholder assertion expect(true)" }));
+    const b = [1, 2, 3].map((i) =>
+      finding(`feat-${i}`, "US-002", { message: "Source-inspection test reads the file" }),
+    );
+    const h1s = runHeuristics([...a, ...b], thresholds).filter((p) => p.id === "H1");
+    expect(h1s).toHaveLength(2);
+  });
+
+  test("groups the same defect reported at different lines and stories", () => {
+    const obs = ["feat-a", "feat-b", "feat-c"].map((f) => finding(f, "US-001"));
+    expect(runHeuristics(obs, thresholds).filter((p) => p.id === "H1")).toHaveLength(1);
+  });
+
+  test("severity is relative to the configured threshold, not a fixed spread", () => {
+    // A fixed constant pinned every proposal to HIGH once the threshold was
+    // raised past it, making severity carry no information.
+    const spread = (n: number) => Array.from({ length: n }, (_, i) => finding(`feat-${i}`, "US-001"));
+    expect(runHeuristics(spread(3), thresholds).find((p) => p.id === "H1")?.severity).toBe("MED");
+    expect(runHeuristics(spread(6), thresholds).find((p) => p.id === "H1")?.severity).toBe("HIGH");
+
+    const strict = { ...thresholds, repeatedFinding: 8 };
+    expect(runHeuristics(spread(8), strict).find((p) => p.id === "H1")?.severity).toBe("MED");
+    expect(runHeuristics(spread(16), strict).find((p) => p.id === "H1")?.severity).toBe("HIGH");
+  });
+
+  test("acknowledgement-shaped findings cannot form a proposal on their own", () => {
+    // Belt and braces with #1423: even if a stale ack leaks into findings,
+    // it carries no category/file locus worth writing a rule about.
+    const obs = ["a", "b", "c"].map((f) =>
+      finding(`feat-${f}`, "US-001", {
+        category: "",
+        file: "",
+        message: "Prior finding 1: addressed. No action required.",
+      }),
+    );
+    expect(runHeuristics(obs, thresholds).find((p) => p.id === "H1")).toBeUndefined();
+  });
+});

--- a/test/unit/plugins/builtin/curator-heuristics.test.ts
+++ b/test/unit/plugins/builtin/curator-heuristics.test.ts
@@ -25,7 +25,7 @@ describe("runHeuristics", () => {
       {
         schemaVersion: 1,
         runId: "run-1",
-        featureId: "feat-1",
+        featureId: "feat-story-1",
         storyId: "story-1",
         stage: "context",
         ts: "2026-05-04T00:00:00Z",
@@ -41,7 +41,7 @@ describe("runHeuristics", () => {
       {
         schemaVersion: 1,
         runId: "run-1",
-        featureId: "feat-1",
+        featureId: "feat-story-1",
         storyId: "story-1",
         stage: "review",
         ts: "2026-05-04T00:00:00Z",
@@ -67,7 +67,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-1",
           storyId: "story-1",
           stage: "review",
           ts: "2026-05-04T00:00:00Z",
@@ -83,7 +83,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-2",
           storyId: "story-2",
           stage: "review",
           ts: "2026-05-04T00:01:00Z",
@@ -103,15 +103,17 @@ describe("runHeuristics", () => {
 
       expect(h1).toBeDefined();
       expect(h1?.severity).toBe("MED");
-      expect(h1?.description).toContain("rule1");
+      // Description names the locus, not the old single-word ruleId bucket (#1422).
+      expect(h1?.description).toContain("src/index.ts");
+      expect(h1?.description).toContain("2 features");
       expect(h1?.target.action).toBe("add");
     });
 
-    test("produces HIGH severity when finding count >= 4; does not trigger for 1 finding", () => {
-      const highObs: Observation[] = Array.from({ length: 4 }, (_, i) => ({
+    test("produces HIGH severity at wide feature spread; does not trigger for 1 feature", () => {
+      const highObs: Observation[] = Array.from({ length: 5 }, (_, i) => ({
         schemaVersion: 1 as const,
         runId: "run-1",
-        featureId: "feat-1",
+        featureId: `feat-${i}`,
         storyId: `story-${i}`,
         stage: "review" as const,
         ts: "2026-05-04T00:00:00Z",
@@ -123,7 +125,7 @@ describe("runHeuristics", () => {
       const singleObs: Observation[] = [{
         schemaVersion: 1,
         runId: "run-1",
-        featureId: "feat-1",
+        featureId: "feat-story-1",
         storyId: "story-1",
         stage: "review",
         ts: "2026-05-04T00:00:00Z",
@@ -138,7 +140,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-a",
           storyId: "story-a",
           stage: "review",
           ts: "2026-05-04T00:00:00Z",
@@ -154,7 +156,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-b",
           storyId: "story-b",
           stage: "review",
           ts: "2026-05-04T00:01:00Z",
@@ -282,7 +284,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-1",
           storyId: "story-1",
           stage: "review",
           ts: "2026-05-04T00:00:00Z",
@@ -298,7 +300,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-2",
           storyId: "story-2",
           stage: "review",
           ts: "2026-05-04T00:01:00Z",
@@ -315,7 +317,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-1",
           storyId: "story-1",
           stage: "pull",
           ts: "2026-05-04T00:02:00Z",
@@ -325,7 +327,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-3",
           storyId: "story-3",
           stage: "pull",
           ts: "2026-05-04T00:03:00Z",
@@ -348,7 +350,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-1",
           storyId: "story-1",
           stage: "review",
           ts: "2026-05-04T00:00:00Z",
@@ -364,7 +366,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-2",
           storyId: "story-2",
           stage: "review",
           ts: "2026-05-04T00:01:00Z",
@@ -390,7 +392,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-1",
           storyId: "story-1",
           stage: "review",
           ts: "2026-05-04T00:00:00Z",
@@ -406,7 +408,7 @@ describe("runHeuristics", () => {
         {
           schemaVersion: 1,
           runId: "run-1",
-          featureId: "feat-1",
+          featureId: "feat-story-2",
           storyId: "story-2",
           stage: "review",
           ts: "2026-05-04T00:01:00Z",
@@ -441,7 +443,9 @@ function makeReviewFindingObs942(
   return {
     schemaVersion: 1,
     runId: "run-test",
-    featureId: "feat-x",
+    // One feature per story: H1 measures recurrence across FEATURES (#1422), so
+    // fixtures that mean "this recurred" must spread across them.
+    featureId: `feat-${storyId}`,
     storyId,
     stage: "review",
     ts: "2026-05-07T00:00:00.000Z",
@@ -453,18 +457,20 @@ function makeReviewFindingObs942(
 describe("H1 — sample messages in evidence", () => {
   test("evidence includes up to two sample messages drawn from the group", () => {
     const observations: Observation[] = [
-      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated", "warning", "Listener arg not validated as a function"),
-      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated", "warning", "Listener arg not validated as a function — handler path"),
-      makeReviewFindingObs942("US-003", "input:listener-arg-not-validated", "warning", "Third example should not appear"),
+      // Same defect, three phrasings that share the fingerprint prefix — that is
+      // what "one group" now means (#1422). Only two samples may surface.
+      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated", "warning", "Listener argument is not validated as a function (register path)"),
+      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated", "warning", "Listener argument is not validated as a function (handler path)"),
+      makeReviewFindingObs942("US-003", "input:listener-arg-not-validated", "warning", "Listener argument is not validated as a function (third example should not appear)"),
     ];
 
     const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
     const h1 = proposals.find((p) => p.id === "H1")!;
 
     expect(h1).toBeDefined();
-    expect(h1.evidence).toContain("Listener arg not validated as a function");
-    expect(h1.evidence).toContain("Listener arg not validated as a function — handler path");
-    expect(h1.evidence).not.toContain("Third example should not appear");
+    expect(h1.evidence).toContain("(register path)");
+    expect(h1.evidence).toContain("(handler path)");
+    expect(h1.evidence).not.toContain("third example should not appear");
   });
 
   test("evidence omits sample section when all messages are empty", () => {
@@ -491,37 +497,120 @@ describe("H1 — sample messages in evidence", () => {
     expect(h1.evidence).not.toContain("→ Add a guard");
   });
 
-  test("first finding with empty message does not block later real message from appearing", () => {
+  test("an empty message does not group with a real one, and cannot borrow its sample", () => {
+    // Superseded shape: this used to assert that an empty first message did not
+    // suppress a later real sample within one ruleId bucket. Under fingerprint
+    // grouping (#1422) the message IS part of the key, so an empty message forms
+    // its own group — the two can never share a proposal to begin with.
     const observations: Observation[] = [
       makeReviewFindingObs942("US-001", "review:null-check", "warning", ""),
       makeReviewFindingObs942("US-002", "review:null-check", "warning", "Null check missing"),
     ];
 
-    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
-    const h1 = proposals.find((p) => p.id === "H1")!;
-    expect(h1).toBeDefined();
-    expect(h1.evidence).toContain("Null check missing");
+    const h1s = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds).filter((p) => p.id === "H1");
+    // Two groups of one feature each — neither reaches the threshold.
+    expect(h1s).toHaveLength(0);
   });
 });
 
 describe("H1 — issue #942 AC-5: ruleId buckets are not single-word collapses", () => {
   test("findings sharing a category but different issues yield distinct buckets", () => {
     const observations: Observation[] = [
-      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated-as-function", "warning"),
-      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated-as-function", "warning"),
-      makeReviewFindingObs942("US-003", "input:timeout-value-missing-upper-bound", "error"),
-      makeReviewFindingObs942("US-004", "input:timeout-value-missing-upper-bound", "error"),
+      makeReviewFindingObs942("US-001", "input:listener-arg", "warning", "Listener argument is not validated as a function"),
+      makeReviewFindingObs942("US-002", "input:listener-arg", "warning", "Listener argument is not validated as a function"),
+      makeReviewFindingObs942("US-003", "input:timeout-bound", "error", "Timeout value has no upper bound and can hang the run"),
+      makeReviewFindingObs942("US-004", "input:timeout-bound", "error", "Timeout value has no upper bound and can hang the run"),
     ];
 
     const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
     const h1s = proposals.filter((p) => p.id === "H1");
 
     expect(h1s.length).toBe(2);
+    // Buckets are per-defect, not per-category: a proposal must name a locus and
+    // carry a distinguishing sample, never collapse to the bare word "input".
     for (const p of h1s) {
-      const ruleId = p.description.match(/Repeated review finding: (\S+)/)?.[1] ?? "";
-      expect(ruleId.split("-").length).toBeGreaterThan(1);
-      expect(ruleId).not.toBe("input");
-      expect(ruleId).not.toBe("unknown");
+      expect(p.description).not.toMatch(/\(input\)/);
+      expect(p.evidence).toContain("Examples:");
     }
+    expect(h1s.some((p) => p.evidence.includes("Listener argument"))).toBe(true);
+    expect(h1s.some((p) => p.evidence.includes("Timeout value"))).toBe(true);
+  });
+});
+
+// ─── #1422: cross-feature recurrence ──────────────────────────────────────────
+
+describe("H1 — cross-feature recurrence (#1422)", () => {
+  const thresholds: CuratorThresholds = {
+    repeatedFinding: 3,
+    emptyKeyword: 2,
+    rectifyAttempts: 3,
+    escalationChain: 2,
+    staleChunkRuns: 2,
+    unchangedOutcome: 3,
+  };
+
+  function finding(featureId: string, storyId: string, over: Partial<{ category: string; file: string; message: string }> = {}): Observation {
+    return {
+      schemaVersion: 1,
+      runId: "run-1",
+      featureId,
+      storyId,
+      stage: "review",
+      ts: "2026-08-01T00:00:00Z",
+      kind: "review-finding",
+      payload: {
+        ruleId: "test-gap:missing-runtime-assertion",
+        category: over.category ?? "test-gap",
+        severity: "error",
+        file: over.file ?? "src/api.ts",
+        line: 10,
+        message: over.message ?? "Test asserts a pattern exists in the file instead of invoking the code",
+      },
+    };
+  }
+
+  test("proposes when the same finding recurs across enough DISTINCT features", () => {
+    const obs = [finding("feat-a", "US-001"), finding("feat-b", "US-002"), finding("feat-c", "US-003")];
+    const h1 = runHeuristics(obs, thresholds).find((p) => p.id === "H1");
+    expect(h1).toBeDefined();
+    expect(h1?.description).toContain("3 features");
+    expect(h1?.evidence).toContain("feat-a");
+    expect(h1?.evidence).toContain("feat-c");
+  });
+
+  test("does NOT propose when one feature repeats the same finding many times", () => {
+    // A rule is worth writing when a defect crosses features. One feature
+    // repeating itself is a story problem, and was the old behaviour's main
+    // source of noise ("test-gap appeared 1008x" from a single 7-story run).
+    const obs = Array.from({ length: 12 }, (_, i) => finding("feat-a", `US-${i}`));
+    expect(runHeuristics(obs, thresholds).find((p) => p.id === "H1")).toBeUndefined();
+  });
+
+  test("separates distinct defects that share a category and file", () => {
+    const a = [1, 2, 3].map((i) => finding(`feat-${i}`, "US-001", { message: "Placeholder assertion expect(true)" }));
+    const b = [1, 2, 3].map((i) => finding(`feat-${i}`, "US-002", { message: "Source-inspection test reads the file" }));
+    const h1s = runHeuristics([...a, ...b], thresholds).filter((p) => p.id === "H1");
+    expect(h1s).toHaveLength(2);
+  });
+
+  test("groups the same defect reported at different lines and stories", () => {
+    const obs = ["feat-a", "feat-b", "feat-c"].map((f) => finding(f, "US-001"));
+    expect(runHeuristics(obs, thresholds).filter((p) => p.id === "H1")).toHaveLength(1);
+  });
+
+  test("severity escalates with feature spread, not raw count", () => {
+    const three = ["a", "b", "c"].map((f) => finding(`feat-${f}`, "US-001"));
+    const five = ["a", "b", "c", "d", "e"].map((f) => finding(`feat-${f}`, "US-001"));
+    expect(runHeuristics(three, thresholds).find((p) => p.id === "H1")?.severity).toBe("MED");
+    expect(runHeuristics(five, thresholds).find((p) => p.id === "H1")?.severity).toBe("HIGH");
+  });
+
+  test("acknowledgement-shaped findings cannot form a proposal on their own", () => {
+    // Belt and braces with #1423: even if a stale ack leaks into findings,
+    // it carries no category/file locus worth writing a rule about.
+    const obs = ["a", "b", "c"].map((f) =>
+      finding(`feat-${f}`, "US-001", { category: "", file: "", message: "Prior finding 1: addressed. No action required." }),
+    );
+    expect(runHeuristics(obs, thresholds).find((p) => p.id === "H1")).toBeUndefined();
   });
 });

--- a/test/unit/plugins/builtin/curator-heuristics.test.ts
+++ b/test/unit/plugins/builtin/curator-heuristics.test.ts
@@ -103,9 +103,12 @@ describe("runHeuristics", () => {
 
       expect(h1).toBeDefined();
       expect(h1?.severity).toBe("MED");
-      // Description names the locus, not the old single-word ruleId bucket (#1422).
-      expect(h1?.description).toContain("src/index.ts");
+      // Description carries a distinguishing gist, never a bare category (#942);
+      // the file locus moved to evidence, since it is not part of cross-feature
+      // identity (#1422).
       expect(h1?.description).toContain("2 features");
+      expect(h1?.description).toContain("test error");
+      expect(h1?.evidence).toContain("src/index.ts");
       expect(h1?.target.action).toBe("add");
     });
 
@@ -120,19 +123,25 @@ describe("runHeuristics", () => {
         kind: "review-finding" as const,
         payload: { ruleId: "rule1", severity: "error", file: "src/index.ts", line: 10 + i, message: "test error" },
       }));
-      expect(runHeuristics(highObs, { ...defaultThresholds, repeatedFinding: 2 }).find((p) => p.id === "H1")?.severity).toBe("HIGH");
+      expect(
+        runHeuristics(highObs, { ...defaultThresholds, repeatedFinding: 2 }).find((p) => p.id === "H1")?.severity,
+      ).toBe("HIGH");
 
-      const singleObs: Observation[] = [{
-        schemaVersion: 1,
-        runId: "run-1",
-        featureId: "feat-story-1",
-        storyId: "story-1",
-        stage: "review",
-        ts: "2026-05-04T00:00:00Z",
-        kind: "review-finding",
-        payload: { ruleId: "rule1", severity: "error", file: "src/index.ts", line: 10, message: "test error" },
-      }];
-      expect(runHeuristics(singleObs, { ...defaultThresholds, repeatedFinding: 2 }).find((p) => p.id === "H1")).toBeUndefined();
+      const singleObs: Observation[] = [
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-story-1",
+          storyId: "story-1",
+          stage: "review",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "review-finding",
+          payload: { ruleId: "rule1", severity: "error", file: "src/index.ts", line: 10, message: "test error" },
+        },
+      ];
+      expect(
+        runHeuristics(singleObs, { ...defaultThresholds, repeatedFinding: 2 }).find((p) => p.id === "H1"),
+      ).toBeUndefined();
     });
 
     test("includes storyIds in evidence", () => {
@@ -174,16 +183,35 @@ describe("runHeuristics", () => {
       const proposals = runHeuristics(obs, { ...defaultThresholds, repeatedFinding: 2 });
       const h1 = proposals.find((p) => p.id === "H1");
 
-      expect(h1?.storyIds).toContain("story-a");
-      expect(h1?.storyIds).toContain("story-b");
+      // Story IDs alone collide across features; the pair is the site reference.
+      expect(h1?.storyIds).toContain("feat-story-a/story-a");
+      expect(h1?.storyIds).toContain("feat-story-b/story-b");
     });
   });
 
   describe("H2 — Pull-tool Empty Result", () => {
     test("triggers for empty keyword results; does not trigger for non-empty results", () => {
       const emptyObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "pull", ts: "2026-05-04T00:00:00Z", kind: "pull-call", payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 0, status: "completed" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-2", stage: "pull", ts: "2026-05-04T00:01:00Z", kind: "pull-call", payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 0, status: "completed" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "pull",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "pull-call",
+          payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 0, status: "completed" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-2",
+          stage: "pull",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "pull-call",
+          payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 0, status: "completed" },
+        },
       ];
       const h2 = runHeuristics(emptyObs, { ...defaultThresholds, emptyKeyword: 2 }).find((p) => p.id === "H2");
       expect(h2).toBeDefined();
@@ -192,19 +220,66 @@ describe("runHeuristics", () => {
       expect(h2?.description).toContain("review batch");
 
       const nonEmptyObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "pull", ts: "2026-05-04T00:00:00Z", kind: "pull-call", payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 2, status: "completed" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-2", stage: "pull", ts: "2026-05-04T00:01:00Z", kind: "pull-call", payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 1, status: "completed" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "pull",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "pull-call",
+          payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 2, status: "completed" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-2",
+          stage: "pull",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "pull-call",
+          payload: { toolName: "query_feature_context", keyword: "review batch", resultCount: 1, status: "completed" },
+        },
       ];
-      expect(runHeuristics(nonEmptyObs, { ...defaultThresholds, emptyKeyword: 2 }).find((p) => p.id === "H2")).toBeUndefined();
+      expect(
+        runHeuristics(nonEmptyObs, { ...defaultThresholds, emptyKeyword: 2 }).find((p) => p.id === "H2"),
+      ).toBeUndefined();
     });
   });
 
   describe("H3 — Repeated Rectification Cycle", () => {
     test("triggers when same story >= threshold; does not trigger for different stories", () => {
       const sameStoryObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "rectify", ts: "2026-05-04T00:00:00Z", kind: "rectify-cycle", payload: { iteration: 1, status: "failed" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "rectify", ts: "2026-05-04T00:01:00Z", kind: "rectify-cycle", payload: { iteration: 2, status: "failed" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "rectify", ts: "2026-05-04T00:02:00Z", kind: "rectify-cycle", payload: { iteration: 3, status: "failed" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "rectify",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "rectify-cycle",
+          payload: { iteration: 1, status: "failed" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "rectify",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "rectify-cycle",
+          payload: { iteration: 2, status: "failed" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "rectify",
+          ts: "2026-05-04T00:02:00Z",
+          kind: "rectify-cycle",
+          payload: { iteration: 3, status: "failed" },
+        },
       ];
       const h3 = runHeuristics(sameStoryObs, { ...defaultThresholds, rectifyAttempts: 3 }).find((p) => p.id === "H3");
       expect(h3).toBeDefined();
@@ -212,18 +287,56 @@ describe("runHeuristics", () => {
       expect(h3?.target.action).toBe("add");
 
       const diffStoryObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "rectify", ts: "2026-05-04T00:00:00Z", kind: "rectify-cycle", payload: { iteration: 1, status: "failed" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-2", stage: "rectify", ts: "2026-05-04T00:01:00Z", kind: "rectify-cycle", payload: { iteration: 1, status: "failed" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "rectify",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "rectify-cycle",
+          payload: { iteration: 1, status: "failed" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-2",
+          stage: "rectify",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "rectify-cycle",
+          payload: { iteration: 1, status: "failed" },
+        },
       ];
-      expect(runHeuristics(diffStoryObs, { ...defaultThresholds, rectifyAttempts: 3 }).find((p) => p.id === "H3")).toBeUndefined();
+      expect(
+        runHeuristics(diffStoryObs, { ...defaultThresholds, rectifyAttempts: 3 }).find((p) => p.id === "H3"),
+      ).toBeUndefined();
     });
   });
 
   describe("H4 — Escalation Chain", () => {
     test("triggers for same tier path >= threshold; does not trigger for different paths", () => {
       const samePathObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "escalation", ts: "2026-05-04T00:00:00Z", kind: "escalation", payload: { from: "fast", to: "balanced" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-2", stage: "escalation", ts: "2026-05-04T00:01:00Z", kind: "escalation", payload: { from: "fast", to: "balanced" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "escalation",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "escalation",
+          payload: { from: "fast", to: "balanced" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-2",
+          stage: "escalation",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "escalation",
+          payload: { from: "fast", to: "balanced" },
+        },
       ];
       const h4 = runHeuristics(samePathObs, { ...defaultThresholds, escalationChain: 2 }).find((p) => p.id === "H4");
       expect(h4).toBeDefined();
@@ -231,18 +344,56 @@ describe("runHeuristics", () => {
       expect(h4?.target.action).toBe("add");
 
       const diffPathObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "escalation", ts: "2026-05-04T00:00:00Z", kind: "escalation", payload: { from: "fast", to: "balanced" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-2", stage: "escalation", ts: "2026-05-04T00:01:00Z", kind: "escalation", payload: { from: "balanced", to: "powerful" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "escalation",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "escalation",
+          payload: { from: "fast", to: "balanced" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-2",
+          stage: "escalation",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "escalation",
+          payload: { from: "balanced", to: "powerful" },
+        },
       ];
-      expect(runHeuristics(diffPathObs, { ...defaultThresholds, escalationChain: 2 }).find((p) => p.id === "H4")).toBeUndefined();
+      expect(
+        runHeuristics(diffPathObs, { ...defaultThresholds, escalationChain: 2 }).find((p) => p.id === "H4"),
+      ).toBeUndefined();
     });
   });
 
   describe("H5 — Stale Chunk Excluded", () => {
     test("triggers for stale exclusions persisting across runs; does not trigger for non-stale", () => {
       const staleObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "context", ts: "2026-05-04T00:00:00Z", kind: "chunk-excluded", payload: { chunkId: "c1", label: "stale chunk", reason: "stale" } },
-        { schemaVersion: 1, runId: "run-2", featureId: "feat-1", storyId: "story-1", stage: "context", ts: "2026-05-05T00:00:00Z", kind: "chunk-excluded", payload: { chunkId: "c1", label: "stale chunk", reason: "stale" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "context",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "chunk-excluded",
+          payload: { chunkId: "c1", label: "stale chunk", reason: "stale" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-2",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "context",
+          ts: "2026-05-05T00:00:00Z",
+          kind: "chunk-excluded",
+          payload: { chunkId: "c1", label: "stale chunk", reason: "stale" },
+        },
       ];
       const h5 = runHeuristics(staleObs, { ...defaultThresholds, staleChunkRuns: 2 }).find((p) => p.id === "H5");
       expect(h5).toBeDefined();
@@ -250,19 +401,66 @@ describe("runHeuristics", () => {
       expect(h5?.target.action).toBe("drop");
 
       const noMatchObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "context", ts: "2026-05-04T00:00:00Z", kind: "chunk-excluded", payload: { chunkId: "c1", label: "chunk", reason: "no-match" } },
-        { schemaVersion: 1, runId: "run-2", featureId: "feat-1", storyId: "story-1", stage: "context", ts: "2026-05-05T00:00:00Z", kind: "chunk-excluded", payload: { chunkId: "c1", label: "chunk", reason: "no-match" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "context",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "chunk-excluded",
+          payload: { chunkId: "c1", label: "chunk", reason: "no-match" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-2",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "context",
+          ts: "2026-05-05T00:00:00Z",
+          kind: "chunk-excluded",
+          payload: { chunkId: "c1", label: "chunk", reason: "no-match" },
+        },
       ];
-      expect(runHeuristics(noMatchObs, { ...defaultThresholds, staleChunkRuns: 2 }).find((p) => p.id === "H5")).toBeUndefined();
+      expect(
+        runHeuristics(noMatchObs, { ...defaultThresholds, staleChunkRuns: 2 }).find((p) => p.id === "H5"),
+      ).toBeUndefined();
     });
   });
 
   describe("H6 — Fix-cycle Unchanged Outcome", () => {
     test("triggers when unchanged outcome >= threshold; does not trigger with mixed outcomes", () => {
       const unchangedObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "fix-cycle", ts: "2026-05-04T00:00:00Z", kind: "fix-cycle-iteration", payload: { iteration: 1, status: "failed", outcome: "unchanged" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "fix-cycle", ts: "2026-05-04T00:01:00Z", kind: "fix-cycle-iteration", payload: { iteration: 2, status: "failed", outcome: "unchanged" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "fix-cycle", ts: "2026-05-04T00:02:00Z", kind: "fix-cycle-iteration", payload: { iteration: 3, status: "failed", outcome: "unchanged" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "fix-cycle",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "fix-cycle-iteration",
+          payload: { iteration: 1, status: "failed", outcome: "unchanged" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "fix-cycle",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "fix-cycle-iteration",
+          payload: { iteration: 2, status: "failed", outcome: "unchanged" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "fix-cycle",
+          ts: "2026-05-04T00:02:00Z",
+          kind: "fix-cycle-iteration",
+          payload: { iteration: 3, status: "failed", outcome: "unchanged" },
+        },
       ];
       const h6 = runHeuristics(unchangedObs, { ...defaultThresholds, unchangedOutcome: 3 }).find((p) => p.id === "H6");
       expect(h6).toBeDefined();
@@ -270,10 +468,30 @@ describe("runHeuristics", () => {
       expect(h6?.target.action).toBe("advisory");
 
       const mixedObs: Observation[] = [
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "fix-cycle", ts: "2026-05-04T00:00:00Z", kind: "fix-cycle-iteration", payload: { iteration: 1, status: "passed", outcome: "resolved" } },
-        { schemaVersion: 1, runId: "run-1", featureId: "feat-1", storyId: "story-1", stage: "fix-cycle", ts: "2026-05-04T00:01:00Z", kind: "fix-cycle-iteration", payload: { iteration: 2, status: "failed", outcome: "unchanged" } },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "fix-cycle",
+          ts: "2026-05-04T00:00:00Z",
+          kind: "fix-cycle-iteration",
+          payload: { iteration: 1, status: "passed", outcome: "resolved" },
+        },
+        {
+          schemaVersion: 1,
+          runId: "run-1",
+          featureId: "feat-1",
+          storyId: "story-1",
+          stage: "fix-cycle",
+          ts: "2026-05-04T00:01:00Z",
+          kind: "fix-cycle-iteration",
+          payload: { iteration: 2, status: "failed", outcome: "unchanged" },
+        },
       ];
-      expect(runHeuristics(mixedObs, { ...defaultThresholds, unchangedOutcome: 2 }).find((p) => p.id === "H6")).toBeUndefined();
+      expect(
+        runHeuristics(mixedObs, { ...defaultThresholds, unchangedOutcome: 2 }).find((p) => p.id === "H6"),
+      ).toBeUndefined();
     });
   });
 
@@ -433,184 +651,3 @@ describe("runHeuristics", () => {
 });
 
 // ─── Issue #942 AC-5: H1 ruleId buckets are not single-word collapses ──────
-
-function makeReviewFindingObs942(
-  storyId: string,
-  ruleId: string,
-  severity: string,
-  message = "msg",
-): Observation {
-  return {
-    schemaVersion: 1,
-    runId: "run-test",
-    // One feature per story: H1 measures recurrence across FEATURES (#1422), so
-    // fixtures that mean "this recurred" must spread across them.
-    featureId: `feat-${storyId}`,
-    storyId,
-    stage: "review",
-    ts: "2026-05-07T00:00:00.000Z",
-    kind: "review-finding",
-    payload: { ruleId, checkId: ruleId, severity, file: "src/foo.ts", line: 1, message },
-  };
-}
-
-describe("H1 — sample messages in evidence", () => {
-  test("evidence includes up to two sample messages drawn from the group", () => {
-    const observations: Observation[] = [
-      // Same defect, three phrasings that share the fingerprint prefix — that is
-      // what "one group" now means (#1422). Only two samples may surface.
-      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated", "warning", "Listener argument is not validated as a function (register path)"),
-      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated", "warning", "Listener argument is not validated as a function (handler path)"),
-      makeReviewFindingObs942("US-003", "input:listener-arg-not-validated", "warning", "Listener argument is not validated as a function (third example should not appear)"),
-    ];
-
-    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
-    const h1 = proposals.find((p) => p.id === "H1")!;
-
-    expect(h1).toBeDefined();
-    expect(h1.evidence).toContain("(register path)");
-    expect(h1.evidence).toContain("(handler path)");
-    expect(h1.evidence).not.toContain("third example should not appear");
-  });
-
-  test("evidence omits sample section when all messages are empty", () => {
-    const observations: Observation[] = [
-      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated", "warning", ""),
-      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated", "warning", ""),
-    ];
-
-    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
-    const h1 = proposals.find((p) => p.id === "H1")!;
-    expect(h1).toBeDefined();
-    expect(h1.evidence).not.toContain("Examples:");
-  });
-
-  test("sample uses only the first line of a multi-line message", () => {
-    const observations: Observation[] = [
-      makeReviewFindingObs942("US-001", "review:null-check", "warning", "Null check missing\n→ Add a guard before access"),
-      makeReviewFindingObs942("US-002", "review:null-check", "warning", "Null check missing\n→ Add a guard before access"),
-    ];
-
-    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
-    const h1 = proposals.find((p) => p.id === "H1")!;
-    expect(h1.evidence).toContain("Null check missing");
-    expect(h1.evidence).not.toContain("→ Add a guard");
-  });
-
-  test("an empty message does not group with a real one, and cannot borrow its sample", () => {
-    // Superseded shape: this used to assert that an empty first message did not
-    // suppress a later real sample within one ruleId bucket. Under fingerprint
-    // grouping (#1422) the message IS part of the key, so an empty message forms
-    // its own group — the two can never share a proposal to begin with.
-    const observations: Observation[] = [
-      makeReviewFindingObs942("US-001", "review:null-check", "warning", ""),
-      makeReviewFindingObs942("US-002", "review:null-check", "warning", "Null check missing"),
-    ];
-
-    const h1s = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds).filter((p) => p.id === "H1");
-    // Two groups of one feature each — neither reaches the threshold.
-    expect(h1s).toHaveLength(0);
-  });
-});
-
-describe("H1 — issue #942 AC-5: ruleId buckets are not single-word collapses", () => {
-  test("findings sharing a category but different issues yield distinct buckets", () => {
-    const observations: Observation[] = [
-      makeReviewFindingObs942("US-001", "input:listener-arg", "warning", "Listener argument is not validated as a function"),
-      makeReviewFindingObs942("US-002", "input:listener-arg", "warning", "Listener argument is not validated as a function"),
-      makeReviewFindingObs942("US-003", "input:timeout-bound", "error", "Timeout value has no upper bound and can hang the run"),
-      makeReviewFindingObs942("US-004", "input:timeout-bound", "error", "Timeout value has no upper bound and can hang the run"),
-    ];
-
-    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
-    const h1s = proposals.filter((p) => p.id === "H1");
-
-    expect(h1s.length).toBe(2);
-    // Buckets are per-defect, not per-category: a proposal must name a locus and
-    // carry a distinguishing sample, never collapse to the bare word "input".
-    for (const p of h1s) {
-      expect(p.description).not.toMatch(/\(input\)/);
-      expect(p.evidence).toContain("Examples:");
-    }
-    expect(h1s.some((p) => p.evidence.includes("Listener argument"))).toBe(true);
-    expect(h1s.some((p) => p.evidence.includes("Timeout value"))).toBe(true);
-  });
-});
-
-// ─── #1422: cross-feature recurrence ──────────────────────────────────────────
-
-describe("H1 — cross-feature recurrence (#1422)", () => {
-  const thresholds: CuratorThresholds = {
-    repeatedFinding: 3,
-    emptyKeyword: 2,
-    rectifyAttempts: 3,
-    escalationChain: 2,
-    staleChunkRuns: 2,
-    unchangedOutcome: 3,
-  };
-
-  function finding(featureId: string, storyId: string, over: Partial<{ category: string; file: string; message: string }> = {}): Observation {
-    return {
-      schemaVersion: 1,
-      runId: "run-1",
-      featureId,
-      storyId,
-      stage: "review",
-      ts: "2026-08-01T00:00:00Z",
-      kind: "review-finding",
-      payload: {
-        ruleId: "test-gap:missing-runtime-assertion",
-        category: over.category ?? "test-gap",
-        severity: "error",
-        file: over.file ?? "src/api.ts",
-        line: 10,
-        message: over.message ?? "Test asserts a pattern exists in the file instead of invoking the code",
-      },
-    };
-  }
-
-  test("proposes when the same finding recurs across enough DISTINCT features", () => {
-    const obs = [finding("feat-a", "US-001"), finding("feat-b", "US-002"), finding("feat-c", "US-003")];
-    const h1 = runHeuristics(obs, thresholds).find((p) => p.id === "H1");
-    expect(h1).toBeDefined();
-    expect(h1?.description).toContain("3 features");
-    expect(h1?.evidence).toContain("feat-a");
-    expect(h1?.evidence).toContain("feat-c");
-  });
-
-  test("does NOT propose when one feature repeats the same finding many times", () => {
-    // A rule is worth writing when a defect crosses features. One feature
-    // repeating itself is a story problem, and was the old behaviour's main
-    // source of noise ("test-gap appeared 1008x" from a single 7-story run).
-    const obs = Array.from({ length: 12 }, (_, i) => finding("feat-a", `US-${i}`));
-    expect(runHeuristics(obs, thresholds).find((p) => p.id === "H1")).toBeUndefined();
-  });
-
-  test("separates distinct defects that share a category and file", () => {
-    const a = [1, 2, 3].map((i) => finding(`feat-${i}`, "US-001", { message: "Placeholder assertion expect(true)" }));
-    const b = [1, 2, 3].map((i) => finding(`feat-${i}`, "US-002", { message: "Source-inspection test reads the file" }));
-    const h1s = runHeuristics([...a, ...b], thresholds).filter((p) => p.id === "H1");
-    expect(h1s).toHaveLength(2);
-  });
-
-  test("groups the same defect reported at different lines and stories", () => {
-    const obs = ["feat-a", "feat-b", "feat-c"].map((f) => finding(f, "US-001"));
-    expect(runHeuristics(obs, thresholds).filter((p) => p.id === "H1")).toHaveLength(1);
-  });
-
-  test("severity escalates with feature spread, not raw count", () => {
-    const three = ["a", "b", "c"].map((f) => finding(`feat-${f}`, "US-001"));
-    const five = ["a", "b", "c", "d", "e"].map((f) => finding(`feat-${f}`, "US-001"));
-    expect(runHeuristics(three, thresholds).find((p) => p.id === "H1")?.severity).toBe("MED");
-    expect(runHeuristics(five, thresholds).find((p) => p.id === "H1")?.severity).toBe("HIGH");
-  });
-
-  test("acknowledgement-shaped findings cannot form a proposal on their own", () => {
-    // Belt and braces with #1423: even if a stale ack leaks into findings,
-    // it carries no category/file locus worth writing a rule about.
-    const obs = ["a", "b", "c"].map((f) =>
-      finding(`feat-${f}`, "US-001", { category: "", file: "", message: "Prior finding 1: addressed. No action required." }),
-    );
-    expect(runHeuristics(obs, thresholds).find((p) => p.id === "H1")).toBeUndefined();
-  });
-});

--- a/test/unit/plugins/builtin/curator-integration.test.ts
+++ b/test/unit/plugins/builtin/curator-integration.test.ts
@@ -6,8 +6,8 @@
 
 import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
-import { withTempDir } from "../../../helpers";
 import type { Observation } from "../../../../src/plugins/builtin/curator";
+import { withTempDir } from "../../../helpers";
 
 describe("Curator Plugin Integration", () => {
   describe("End-to-end workflow", () => {

--- a/test/unit/plugins/builtin/curator-paths.test.ts
+++ b/test/unit/plugins/builtin/curator-paths.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { resolveCuratorOutputs } from "../../../../src/plugins/builtin/curator/paths";
 import type { CuratorPostRunContext } from "../../../../src/plugins/builtin/curator";
+import { resolveCuratorOutputs } from "../../../../src/plugins/builtin/curator/paths";
 
 describe("resolveCuratorOutputs", () => {
   test("should resolve observations path under outputDir/runs/<runId>/", () => {

--- a/test/unit/plugins/builtin/curator-registration.test.ts
+++ b/test/unit/plugins/builtin/curator-registration.test.ts
@@ -8,9 +8,9 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { curatorPlugin } from "../../../../src/plugins/builtin/curator";
 import { loadPlugins } from "../../../../src/plugins/loader";
 import { PluginRegistry } from "../../../../src/plugins/registry";
-import { curatorPlugin } from "../../../../src/plugins/builtin/curator";
 
 describe("Curator Plugin Registration", () => {
   test("should be available as a built-in plugin", () => {

--- a/test/unit/plugins/builtin/curator-render.test.ts
+++ b/test/unit/plugins/builtin/curator-render.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { renderProposals } from "../../../../src/plugins/builtin/curator/render";
 import type { Proposal } from "../../../../src/plugins/builtin/curator/heuristics";
+import { renderProposals } from "../../../../src/plugins/builtin/curator/render";
 
 describe("renderProposals", () => {
   const baseProposal: Proposal = {
@@ -213,5 +213,38 @@ describe("renderProposals", () => {
     const markdown = renderProposals([proposal], "run-1", 5);
 
     expect(markdown).toMatch(/\S/);
+  });
+});
+
+describe("renderProposals — evidence survives `nax curator commit` (#1422)", () => {
+  test("multi-line evidence is flattened so the parser keeps the samples", async () => {
+    const { _testing } = await import("../../../../src/commands/curator");
+    const markdown = renderProposals(
+      [
+        {
+          id: "H1",
+          severity: "MED",
+          target: { canonicalFile: ".nax/rules/curator-suggestions.md", action: "add" },
+          description: "Recurring across 3 features — test-gap: placeholder assertion",
+          evidence:
+            "Seen in 3 features: a, b, c (sites: a/US-001).\n  Examples: expect(true).toBe(true) | source-inspection test",
+          sourceKinds: ["review-finding"],
+          storyIds: ["a/US-001"],
+        },
+      ],
+      "run-1",
+      3,
+    );
+
+    // The rendered evidence must occupy exactly one line...
+    const evidenceLines = markdown.split("\n").filter((l) => l.includes("_Evidence:"));
+    expect(evidenceLines).toHaveLength(1);
+    expect(evidenceLines[0]).toContain("Examples:");
+
+    // ...and survive a real accept round-trip.
+    const checked = markdown.replace("- [ ]", "- [x]");
+    const parsed = _testing.parseCheckedProposals(checked);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].evidence).toContain("expect(true).toBe(true)");
   });
 });

--- a/test/unit/plugins/builtin/curator-rollup.test.ts
+++ b/test/unit/plugins/builtin/curator-rollup.test.ts
@@ -6,8 +6,8 @@
 
 import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
-import { appendToRollup } from "../../../../src/plugins/builtin/curator/rollup";
 import type { Observation } from "../../../../src/plugins/builtin/curator";
+import { appendToRollup } from "../../../../src/plugins/builtin/curator/rollup";
 import { withTempDir } from "../../../helpers";
 
 describe("appendToRollup", () => {
@@ -44,10 +44,7 @@ describe("appendToRollup", () => {
     await withTempDir(async (dir) => {
       const rollupPath = path.join(dir, "rollup.jsonl");
 
-      const obs1: Observation[] = [
-        baseObservation,
-        { ...baseObservation, storyId: "story-2" },
-      ];
+      const obs1: Observation[] = [baseObservation, { ...baseObservation, storyId: "story-2" }];
       await appendToRollup(obs1, rollupPath);
 
       const file = Bun.file(rollupPath);
@@ -153,7 +150,12 @@ describe("appendToRollup", () => {
 
       const obs: Observation[] = [
         baseObservation,
-        { ...baseObservation, storyId: "story-2", kind: "chunk-included", payload: { chunkId: "c1", label: "chunk", tokens: 100 } },
+        {
+          ...baseObservation,
+          storyId: "story-2",
+          kind: "chunk-included",
+          payload: { chunkId: "c1", label: "chunk", tokens: 100 },
+        },
         { ...baseObservation, storyId: "story-3", kind: "escalation", payload: { from: "fast", to: "balanced" } },
       ];
 
@@ -184,14 +186,10 @@ describe("appendToRollup", () => {
     await withTempDir(async (dir) => {
       const rollupPath = path.join(dir, "rollup.jsonl");
 
-      const obs1: Observation[] = [
-        { ...baseObservation, runId: "run-first" },
-      ];
+      const obs1: Observation[] = [{ ...baseObservation, runId: "run-first" }];
       await appendToRollup(obs1, rollupPath);
 
-      const obs2: Observation[] = [
-        { ...baseObservation, runId: "run-second" },
-      ];
+      const obs2: Observation[] = [{ ...baseObservation, runId: "run-second" }];
       await appendToRollup(obs2, rollupPath);
 
       const file = Bun.file(rollupPath);

--- a/test/unit/plugins/builtin/curator-scoping.test.ts
+++ b/test/unit/plugins/builtin/curator-scoping.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Curator collection scoping (#1422) and chunk-token accounting (#1421).
+ *
+ * Split from curator-collector.test.ts, which crossed the 800-line test limit.
+ * Concern: WHICH artifacts a run collects, rather than how they are projected.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectObservations } from "../../../../src/plugins/builtin/curator";
+import type { CuratorPostRunContext } from "../../../../src/plugins/builtin/curator";
+
+/** Minimal context pointing the collector at a temp workdir. */
+function makeContext(root: string, workdir: string): CuratorPostRunContext {
+  return {
+    runId: "run-scope",
+    feature: "feat-auth",
+    workdir,
+    prdPath: join(workdir, ".nax", "features", "feat-auth", "prd.json"),
+    branch: "main",
+    totalDurationMs: 1000,
+    totalCost: 10,
+    storySummary: { completed: 1, failed: 0, skipped: 0, paused: 0 },
+    stories: [],
+    version: "0.1.0",
+    pluginConfig: {},
+    logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    // biome-ignore lint/suspicious/noExplicitAny: collector reads no config keys on this path
+    config: {} as any,
+    outputDir: join(root, "out"),
+    globalDir: join(root, "global"),
+    projectKey: "test-project",
+    curatorRollupPath: join(root, "rollup.jsonl"),
+  };
+}
+
+describe("collectObservations — run scoping", () => {
+  test("collects only review-audit entries from THIS run when runStartedAt is set (#1422)", async () => {
+    // Curator counts must mean "this run". Re-reading the whole accumulated
+    // audit directory made every count monotonically increasing, so a
+    // threshold-based proposal tripped once and could never clear.
+    const root = await mkdtemp(join(tmpdir(), "curator-run-scope-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-auth");
+    await mkdir(auditDir, { recursive: true });
+
+    const runStartedAt = Date.parse("2026-08-01T12:00:00.000Z");
+    await writeFile(
+      join(auditDir, "old.json"),
+      JSON.stringify({
+        timestamp: "2026-07-15T09:00:00.000Z",
+        storyId: "US-001",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "stale-finding", severity: "error", file: "src/a.ts", line: 1, message: "old" }] },
+      }),
+    );
+    await writeFile(
+      join(auditDir, "current.json"),
+      JSON.stringify({
+        timestamp: "2026-08-01T12:05:00.000Z",
+        storyId: "US-002",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "fresh-finding", severity: "error", file: "src/b.ts", line: 2, message: "new" }] },
+      }),
+    );
+
+    const observations = await collectObservations({
+      ...makeContext(root, join(root, "work")),
+      outputDir,
+      runStartedAt,
+    });
+    const rules = observations.filter((o) => o.kind === "review-finding").map((o) => o.payload.ruleId);
+    expect(rules).toContain("fresh-finding");
+    expect(rules).not.toContain("stale-finding");
+  });
+
+  test("ignores a concurrent run's entries for a DIFFERENT feature (#1422)", async () => {
+    // Two `nax run` invocations share outputDir. The other run's entries land
+    // inside this run's time window and would inflate H1's distinct-feature
+    // count with work this run never saw. Run identity cannot be used: the
+    // audit's runId is the runtime's UUID, context.runId is `run-<iso>`.
+    const root = await mkdtemp(join(tmpdir(), "curator-concurrent-"));
+    const outputDir = join(root, "out");
+    await mkdir(join(outputDir, "review-audit", "feat-auth"), { recursive: true });
+    await mkdir(join(outputDir, "review-audit", "feat-billing"), { recursive: true });
+
+    const entry = (feature: string, rule: string) =>
+      JSON.stringify({
+        timestamp: "2026-08-01T12:05:00.000Z",
+        storyId: "US-001",
+        featureName: feature,
+        result: { findings: [{ rule, severity: "error", file: "src/a.ts", line: 1, message: "x" }] },
+      });
+    await writeFile(join(outputDir, "review-audit", "feat-auth", "a.json"), entry("feat-auth", "mine"));
+    await writeFile(join(outputDir, "review-audit", "feat-billing", "b.json"), entry("feat-billing", "theirs"));
+
+    const observations = await collectObservations({
+      ...makeContext(root, join(root, "work")),
+      feature: "feat-auth",
+      outputDir,
+      runStartedAt: Date.parse("2026-08-01T12:00:00.000Z"),
+    });
+    const rules = observations.filter((o) => o.kind === "review-finding").map((o) => o.payload.ruleId);
+    expect(rules).toContain("mine");
+    expect(rules).not.toContain("theirs");
+  });
+
+  test("observations are stamped schemaVersion 2 now that collection is run-scoped", async () => {
+    // schemaVersion 1 rows in the append-only global rollup are cumulative and
+    // not comparable to these; longitudinal analysis must be able to tell them apart.
+    const root = await mkdtemp(join(tmpdir(), "curator-schema-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-auth");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(
+      join(auditDir, "a.json"),
+      JSON.stringify({
+        timestamp: "2026-08-01T12:05:00.000Z",
+        storyId: "US-001",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "r", severity: "error", file: "src/a.ts", line: 1, message: "x" }] },
+      }),
+    );
+
+    const observations = await collectObservations({
+      ...makeContext(root, join(root, "work")),
+      feature: "feat-auth",
+      outputDir,
+      runStartedAt: Date.parse("2026-08-01T12:00:00.000Z"),
+    });
+    expect(observations.length).toBeGreaterThan(0);
+    for (const o of observations) expect(o.schemaVersion).toBe(2);
+  });
+
+  test("collects everything when runStartedAt is absent (back-compat)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-no-scope-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-auth");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(
+      join(auditDir, "old.json"),
+      JSON.stringify({
+        timestamp: "2026-07-15T09:00:00.000Z",
+        storyId: "US-001",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "stale-finding", severity: "error", file: "src/a.ts", line: 1, message: "old" }] },
+      }),
+    );
+
+    const observations = await collectObservations({ ...makeContext(root, join(root, "work")), outputDir });
+    expect(observations.filter((o) => o.kind === "review-finding")).toHaveLength(1);
+  });
+
+  test("an audit entry with no timestamp is kept rather than silently dropped (#1422)", async () => {
+    // Dropping undated entries would hide real findings; keeping them only risks
+    // a stale count, which is the pre-existing behaviour.
+    const root = await mkdtemp(join(tmpdir(), "curator-undated-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-auth");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(
+      join(auditDir, "undated.json"),
+      JSON.stringify({
+        storyId: "US-001",
+        featureName: "feat-auth",
+        result: { findings: [{ rule: "undated-finding", severity: "error", file: "src/a.ts", line: 1, message: "x" }] },
+      }),
+    );
+
+    const observations = await collectObservations({
+      ...makeContext(root, join(root, "work")),
+      outputDir,
+      runStartedAt: Date.parse("2026-08-01T12:00:00.000Z"),
+    });
+    expect(observations.filter((o) => o.kind === "review-finding")).toHaveLength(1);
+  });
+
+  test("skips context manifests untouched by this run (#1422)", async () => {
+    // Manifests persist per story across runs; a run that touches US-002 must
+    // not re-report US-001's chunks as if it had assembled them.
+    const root = await mkdtemp(join(tmpdir(), "curator-manifest-scope-"));
+    const workdir = join(root, "work");
+    const stories = join(workdir, ".nax", "features", "feat-auth", "stories");
+    await mkdir(join(stories, "US-001"), { recursive: true });
+    await mkdir(join(stories, "US-002"), { recursive: true });
+
+    const manifest = (chunk: string) =>
+      JSON.stringify({
+        stage: "review",
+        includedChunks: [chunk],
+        excludedChunks: [],
+        providerResults: [],
+        chunkTokens: { [chunk]: 100 },
+      });
+    const stalePath = join(stories, "US-001", "context-manifest-review.json");
+    const freshPath = join(stories, "US-002", "context-manifest-review.json");
+    await writeFile(stalePath, manifest("stale:chunk"));
+    await writeFile(freshPath, manifest("fresh:chunk"));
+
+    // Both mtimes are set explicitly relative to a fixed window. Deriving the
+    // window from Date.now() AFTER the write raced the filesystem clock: the
+    // fresh manifest landed a millisecond early roughly 1 run in 120.
+    const runStartedAt = Date.now();
+    const before = new Date(runStartedAt - 86_400_000);
+    const after = new Date(runStartedAt + 1_000);
+    await utimes(stalePath, before, before);
+    await utimes(freshPath, after, after);
+
+    const observations = await collectObservations({ ...makeContext(root, workdir), runStartedAt });
+    const chunkIds = observations.filter((o) => o.kind === "chunk-included").map((o) => o.payload.chunkId);
+    expect(chunkIds).toContain("fresh:chunk");
+    expect(chunkIds).not.toContain("stale:chunk");
+  });
+});

--- a/test/unit/plugins/builtin/curator-types.test.ts
+++ b/test/unit/plugins/builtin/curator-types.test.ts
@@ -4,17 +4,17 @@
 
 import { describe, expect, test } from "bun:test";
 import type {
-  ChunkIncludedObservation,
-  ChunkExcludedObservation,
-  ProviderEmptyObservation,
-  ReviewFindingObservation,
-  RectifyCycleObservation,
-  EscalationObservation,
   AcceptanceVerdictObservation,
-  PullCallObservation,
-  VerdictObservation,
+  ChunkExcludedObservation,
+  ChunkIncludedObservation,
+  EscalationObservation,
   FixCycleIterationObservation,
   Observation,
+  ProviderEmptyObservation,
+  PullCallObservation,
+  RectifyCycleObservation,
+  ReviewFindingObservation,
+  VerdictObservation,
 } from "../../../../src/plugins/builtin/curator";
 
 describe("Observation Types", () => {

--- a/test/unit/plugins/builtin/curator.test.ts
+++ b/test/unit/plugins/builtin/curator.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { PostRunContext } from "../../../../src/plugins/extensions";
 import { curatorPlugin } from "../../../../src/plugins/builtin/curator";
+import type { PostRunContext } from "../../../../src/plugins/extensions";
 
 describe("curatorPlugin", () => {
   test("should have correct plugin metadata", () => {

--- a/test/unit/plugins/builtin/otel-otlp.test.ts
+++ b/test/unit/plugins/builtin/otel-otlp.test.ts
@@ -203,15 +203,15 @@ describe("buildResourceAttributes", () => {
   });
 
   test("AC3: includes a nax.feature attribute equal to the supplied feature name", () => {
-    expect(
-      buildResourceAttributes({ serviceName: "nax", runId: "r1", feature: "my-feature" }),
-    ).toContainEqual(attr("nax.feature", "my-feature"));
+    expect(buildResourceAttributes({ serviceName: "nax", runId: "r1", feature: "my-feature" })).toContainEqual(
+      attr("nax.feature", "my-feature"),
+    );
   });
 
   test("AC4: includes a nax.project attribute equal to the supplied project name", () => {
-    expect(
-      buildResourceAttributes({ serviceName: "nax", runId: "r1", project: "my-project" }),
-    ).toContainEqual(attr("nax.project", "my-project"));
+    expect(buildResourceAttributes({ serviceName: "nax", runId: "r1", project: "my-project" })).toContainEqual(
+      attr("nax.project", "my-project"),
+    );
   });
 
   test("AC5: includes a nax.version attribute equal to NAX_VERSION", () => {
@@ -233,15 +233,15 @@ describe("buildResourceAttributes", () => {
   });
 
   test("AC8: includes a nax.git.branch attribute equal to the supplied branch", () => {
-    expect(
-      buildResourceAttributes({ serviceName: "nax", runId: "r1", git: { branch: "main" } }),
-    ).toContainEqual(attr("nax.git.branch", "main"));
+    expect(buildResourceAttributes({ serviceName: "nax", runId: "r1", git: { branch: "main" } })).toContainEqual(
+      attr("nax.git.branch", "main"),
+    );
   });
 
   test("AC9: includes a nax.git.sha attribute equal to the supplied sha", () => {
-    expect(
-      buildResourceAttributes({ serviceName: "nax", runId: "r1", git: { sha: "abc123" } }),
-    ).toContainEqual(attr("nax.git.sha", "abc123"));
+    expect(buildResourceAttributes({ serviceName: "nax", runId: "r1", git: { sha: "abc123" } })).toContainEqual(
+      attr("nax.git.sha", "abc123"),
+    );
   });
 
   test("AC10: omits nax.git.branch when no branch is supplied", () => {
@@ -251,7 +251,9 @@ describe("buildResourceAttributes", () => {
   });
 
   test("AC11: omits nax.git.sha when no sha is supplied", () => {
-    expect(buildResourceAttributes({ serviceName: "nax", runId: "r1" }).some((a) => a.key === "nax.git.sha")).toBe(false);
+    expect(buildResourceAttributes({ serviceName: "nax", runId: "r1" }).some((a) => a.key === "nax.git.sha")).toBe(
+      false,
+    );
   });
 
   test("edge: omits nax.feature when feature is not supplied", () => {

--- a/test/unit/plugins/builtin/otel-reporter-lifecycle.test.ts
+++ b/test/unit/plugins/builtin/otel-reporter-lifecycle.test.ts
@@ -137,7 +137,13 @@ describe("otel-reporter heartbeat", () => {
       const r = plugin.extensions.reporter!;
 
       try {
-        await r.onRunStart?.({ runId: "hbwarn", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+        await r.onRunStart?.({
+          runId: "hbwarn",
+          feature: "f",
+          totalStories: 1,
+          startTime: new Date().toISOString(),
+          project: "nax",
+        });
         await sleep(150); // > heartbeatIntervalMs (40ms) — allow at least one tick
 
         const otelWarnings = warnSpy.mock.calls.filter((c) => c[0] === "otel-reporter");
@@ -153,7 +159,13 @@ describe("otel-reporter heartbeat", () => {
     const plugin = createOtelReporterPlugin({ ...baseCfg, heartbeatIntervalMs: 0 }, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "hb0", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "hb0",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     await sleep(150);
 
     expect(metricsPosts(posts)).toHaveLength(0);
@@ -164,7 +176,13 @@ describe("otel-reporter heartbeat", () => {
     const plugin = createOtelReporterPlugin({ ...baseCfg, heartbeatIntervalMs: 40 }, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "hb7", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "hb7",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     await sleep(150); // allow at least one heartbeat tick to have a chance to fire
 
     await r.onRunEnd?.({
@@ -186,7 +204,13 @@ describe("otel-reporter detail-gated review payloads", () => {
     const plugin = createOtelReporterPlugin({ ...baseCfg, detail: "counts" }, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "r89", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "r89",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     await r.onPhaseComplete?.({
       runId: "r89",
       scope: "story",
@@ -224,7 +248,13 @@ describe("otel-reporter detail-gated review payloads", () => {
     const plugin = createOtelReporterPlugin({ ...baseCfg, detail: "verbose" }, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "r10", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "r10",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     await r.onPhaseComplete?.({
       runId: "r10",
       scope: "story",
@@ -255,7 +285,13 @@ describe("otel-reporter detail-gated review payloads", () => {
     const plugin = createOtelReporterPlugin({ ...baseCfg, detail: "verbose" }, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "r11", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "r11",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     await r.onPhaseComplete?.({
       runId: "r11",
       scope: "story",
@@ -294,13 +330,16 @@ describe("otel-reporter log redaction", () => {
     try {
       process.env.OTLP_TOKEN = "super-secret-token-value";
       const { posts, deps } = capturing();
-      const plugin = createOtelReporterPlugin(
-        { ...baseCfg, headers: { Authorization: "Bearer ${OTLP_TOKEN}" } },
-        deps,
-      );
+      const plugin = createOtelReporterPlugin({ ...baseCfg, headers: { Authorization: "Bearer ${OTLP_TOKEN}" } }, deps);
       const r = plugin.extensions.reporter!;
 
-      await r.onRunStart?.({ runId: "r12", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+      await r.onRunStart?.({
+        runId: "r12",
+        feature: "f",
+        totalStories: 1,
+        startTime: new Date().toISOString(),
+        project: "nax",
+      });
       await r.onPhaseComplete?.({
         runId: "r12",
         scope: "story",
@@ -343,7 +382,13 @@ describe("otel-reporter flush and teardown lifecycle", () => {
     const plugin = createOtelReporterPlugin(baseCfg, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "r13", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "r13",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     const phases = ["test-writer", "implementer", "verifier"];
     for (const phase of phases) {
       await r.onPhaseComplete?.({
@@ -365,7 +410,9 @@ describe("otel-reporter flush and teardown lifecycle", () => {
 
     const spans = allTraceSpans(posts);
     for (const phase of phases) {
-      const found = spans.some((s: any) => (s.attributes ?? []).some((a: any) => a.key === "phase" && a.value.stringValue === phase));
+      const found = spans.some((s: any) =>
+        (s.attributes ?? []).some((a: any) => a.key === "phase" && a.value.stringValue === phase),
+      );
       expect(found).toBe(true);
     }
   });
@@ -375,7 +422,13 @@ describe("otel-reporter flush and teardown lifecycle", () => {
     const plugin = createOtelReporterPlugin(baseCfg, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "r15", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "r15",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     await r.onPhaseComplete?.({
       runId: "r15",
       scope: "story",
@@ -401,7 +454,13 @@ describe("otel-reporter flush and teardown lifecycle", () => {
     const plugin = createOtelReporterPlugin(baseCfg, deps);
     const r = plugin.extensions.reporter!;
 
-    await r.onRunStart?.({ runId: "r15b", feature: "f", totalStories: 1, startTime: new Date().toISOString(), project: "nax" });
+    await r.onRunStart?.({
+      runId: "r15b",
+      feature: "f",
+      totalStories: 1,
+      startTime: new Date().toISOString(),
+      project: "nax",
+    });
     await r.onRunEnd?.({
       runId: "r15b",
       totalDurationMs: 10,

--- a/test/unit/plugins/builtin/otel-reporter-logs-lifecycle.test.ts
+++ b/test/unit/plugins/builtin/otel-reporter-logs-lifecycle.test.ts
@@ -180,8 +180,8 @@ describe("AC5: onRunStart calls addSink exactly once when logs.enabled is true",
   });
 });
 
-describe("AC6: severity floor drops an info entry when logs.level is \"warn\"", () => {
-  test("success: an info entry is not enqueued when logs.level is \"warn\"", async () => {
+describe('AC6: severity floor drops an info entry when logs.level is "warn"', () => {
+  test('success: an info entry is not enqueued when logs.level is "warn"', async () => {
     const { posts, deps } = capturingDeps();
     const plugin = createOtelReporterPlugin(makeLogsOn({ enabled: true, level: "warn" }), deps);
     const r = await startRun(plugin, { runId: "ac6" });
@@ -191,7 +191,7 @@ describe("AC6: severity floor drops an info entry when logs.level is \"warn\"", 
     expect(allLogRecords(posts)).toHaveLength(0);
   });
 
-  test("boundary: a debug entry is also dropped under logs.level=\"warn\"", async () => {
+  test('boundary: a debug entry is also dropped under logs.level="warn"', async () => {
     const { posts, deps } = capturingDeps();
     const plugin = createOtelReporterPlugin(makeLogsOn({ enabled: true, level: "warn" }), deps);
     const r = await startRun(plugin, { runId: "ac6b" });
@@ -202,8 +202,8 @@ describe("AC6: severity floor drops an info entry when logs.level is \"warn\"", 
   });
 });
 
-describe("AC7: severity floor passes a warn entry when logs.level is \"warn\"", () => {
-  test("success: a warn entry is enqueued and posted when logs.level is \"warn\"", async () => {
+describe('AC7: severity floor passes a warn entry when logs.level is "warn"', () => {
+  test('success: a warn entry is enqueued and posted when logs.level is "warn"', async () => {
     const { posts, deps } = capturingDeps();
     const plugin = createOtelReporterPlugin(makeLogsOn({ enabled: true, level: "warn" }), deps);
     const r = await startRun(plugin, { runId: "ac7" });
@@ -217,7 +217,7 @@ describe("AC7: severity floor passes a warn entry when logs.level is \"warn\"", 
     expect(found?.severityNumber).toBe(13);
   });
 
-  test("boundary: an error entry is also passed under logs.level=\"warn\"", async () => {
+  test('boundary: an error entry is also passed under logs.level="warn"', async () => {
     const { posts, deps } = capturingDeps();
     const plugin = createOtelReporterPlugin(makeLogsOn({ enabled: true, level: "warn" }), deps);
     const r = await startRun(plugin, { runId: "ac7b" });
@@ -228,8 +228,8 @@ describe("AC7: severity floor passes a warn entry when logs.level is \"warn\"", 
   });
 });
 
-describe("AC8: log entry stage \"otel-batch-queue\" is dropped before enqueue", () => {
-  test("success: a log entry whose stage equals \"otel-batch-queue\" is not enqueued", async () => {
+describe('AC8: log entry stage "otel-batch-queue" is dropped before enqueue', () => {
+  test('success: a log entry whose stage equals "otel-batch-queue" is not enqueued', async () => {
     const { posts, deps } = capturingDeps();
     const plugin = createOtelReporterPlugin(makeLogsOn({ enabled: true, level: "info" }), deps);
     const r = await startRun(plugin, { runId: "ac8" });
@@ -254,7 +254,7 @@ describe("AC8: log entry stage \"otel-batch-queue\" is dropped before enqueue", 
 });
 
 describe("AC9: a logged message is exported to /v1/logs when the queue flushes", () => {
-  test("success: the message \"no test command\" is exported as a log record body.stringValue", async () => {
+  test('success: the message "no test command" is exported as a log record body.stringValue', async () => {
     const { posts, deps } = capturingDeps();
     const plugin = createOtelReporterPlugin(makeLogsOn({ enabled: true, level: "info" }), deps);
     const r = await startRun(plugin, { runId: "ac9" });

--- a/test/unit/plugins/builtin/otel-resource-adoption.test.ts
+++ b/test/unit/plugins/builtin/otel-resource-adoption.test.ts
@@ -22,10 +22,7 @@ import {
   buildResourceAttributes,
   buildTracesPayload,
 } from "../../../../src/plugins/builtin/otel-reporter/otlp";
-import {
-  createPhaseMetricsAggregator,
-  createSpanTree,
-} from "../../../../src/plugins/builtin/otel-reporter/span-tree";
+import { createPhaseMetricsAggregator, createSpanTree } from "../../../../src/plugins/builtin/otel-reporter/span-tree";
 
 const liveHeartbeats: Heartbeat[] = [];
 function track(hb: Heartbeat): Heartbeat {

--- a/test/unit/plugins/builtin/otel-resource-git.test.ts
+++ b/test/unit/plugins/builtin/otel-resource-git.test.ts
@@ -9,8 +9,8 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { OtelReporterConfig } from "@/config/schemas-reporters";
-import type { PostJsonDeps } from "@/plugins/builtin/reporter-shared";
 import { createOtelReporterPlugin } from "@/plugins";
+import type { PostJsonDeps } from "@/plugins/builtin/reporter-shared";
 import { _gitDeps } from "@/utils/git";
 
 const baseCfg: OtelReporterConfig = {
@@ -51,8 +51,18 @@ function spawnAlwaysFails(): typeof _gitDeps.spawn {
   return mock((_args: string[], _opts: unknown) => {
     const bytes = new TextEncoder().encode("fatal: not a git repository\n");
     return {
-      stdout: new ReadableStream({ start(c) { c.enqueue(bytes); c.close(); } }),
-      stderr: new ReadableStream({ start(c) { c.enqueue(bytes); c.close(); } }),
+      stdout: new ReadableStream({
+        start(c) {
+          c.enqueue(bytes);
+          c.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(c) {
+          c.enqueue(bytes);
+          c.close();
+        },
+      }),
       exited: Promise.resolve(128),
       kill: mock(() => {}),
     } as any;
@@ -68,7 +78,11 @@ function spawnThrowsOnRead(): typeof _gitDeps.spawn {
           c.error(new Error("spawn EACCES"));
         },
       }),
-      stderr: new ReadableStream({ start(c) { c.close(); } }),
+      stderr: new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      }),
       exited: Promise.resolve(1),
       kill: mock(() => {}),
     } as any;
@@ -77,13 +91,23 @@ function spawnThrowsOnRead(): typeof _gitDeps.spawn {
 
 describe("US-007 AC7: git branch and sha resolution failure does not throw onRunStart", () => {
   test("success: onRunStart attempts git resolution via _gitDeps.spawn and does not throw on failure", async () => {
-    let spawnCalls: string[][] = [];
+    const spawnCalls: string[][] = [];
     _gitDeps.spawn = mock((args: string[], _opts: unknown) => {
       spawnCalls.push(args as string[]);
       const bytes = new TextEncoder().encode("fatal: not a git repository\n");
       return {
-        stdout: new ReadableStream({ start(c) { c.enqueue(bytes); c.close(); } }),
-        stderr: new ReadableStream({ start(c) { c.enqueue(bytes); c.close(); } }),
+        stdout: new ReadableStream({
+          start(c) {
+            c.enqueue(bytes);
+            c.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.enqueue(bytes);
+            c.close();
+          },
+        }),
         exited: Promise.resolve(128),
         kill: mock(() => {}),
       } as any;
@@ -160,13 +184,23 @@ describe("US-007 AC7: git branch and sha resolution failure does not throw onRun
 
 describe("US-007 AC8: when git branch resolution fails, exported payloads omit nax.git.branch", () => {
   test("success: resource block on the run-end traces payload omits nax.git.branch after a git failure, but keeps identity attrs that did resolve", async () => {
-    let spawnCalls: string[][] = [];
+    const spawnCalls: string[][] = [];
     _gitDeps.spawn = mock((args: string[], _opts: unknown) => {
       spawnCalls.push(args as string[]);
       const bytes = new TextEncoder().encode("fatal: not a git repository\n");
       return {
-        stdout: new ReadableStream({ start(c) { c.enqueue(bytes); c.close(); } }),
-        stderr: new ReadableStream({ start(c) { c.enqueue(bytes); c.close(); } }),
+        stdout: new ReadableStream({
+          start(c) {
+            c.enqueue(bytes);
+            c.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.enqueue(bytes);
+            c.close();
+          },
+        }),
         exited: Promise.resolve(128),
         kill: mock(() => {}),
       } as any;
@@ -208,12 +242,20 @@ describe("US-007 AC8: when git branch resolution fails, exported payloads omit n
   });
 
   test("success: a metrics payload exported after a git failure also carries no nax.git.branch", async () => {
-    let spawnCalls: string[][] = [];
+    const spawnCalls: string[][] = [];
     _gitDeps.spawn = mock((args: string[], _opts: unknown) => {
       spawnCalls.push(args as string[]);
       return {
-        stdout: new ReadableStream({ start(c) { c.error(new Error("spawn EACCES")); } }),
-        stderr: new ReadableStream({ start(c) { c.close(); } }),
+        stdout: new ReadableStream({
+          start(c) {
+            c.error(new Error("spawn EACCES"));
+          },
+        }),
+        stderr: new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        }),
         exited: Promise.resolve(1),
         kill: mock(() => {}),
       } as any;

--- a/test/unit/plugins/builtin/reporter-shared.test.ts
+++ b/test/unit/plugins/builtin/reporter-shared.test.ts
@@ -1,25 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import {
-  interpolateHeaders,
-  postJson,
-  type PostJsonDeps,
-} from "@/plugins";
+import { type PostJsonDeps, interpolateHeaders, postJson } from "@/plugins";
 
 describe("interpolateHeaders", () => {
   test("resolves a single env placeholder", () => {
-    const { resolved, missing } = interpolateHeaders(
-      { Authorization: "Bearer ${TOK}" },
-      { TOK: "abc" },
-    );
+    const { resolved, missing } = interpolateHeaders({ Authorization: "Bearer ${TOK}" }, { TOK: "abc" });
     expect(resolved.Authorization).toBe("Bearer abc");
     expect(missing).toEqual([]);
   });
 
   test("resolves multiple placeholders across headers", () => {
-    const { resolved, missing } = interpolateHeaders(
-      { A: "${X}", B: "p-${Y}-q" },
-      { X: "1", Y: "2" },
-    );
+    const { resolved, missing } = interpolateHeaders({ A: "${X}", B: "p-${Y}-q" }, { X: "1", Y: "2" });
     expect(resolved).toEqual({ A: "1", B: "p-2-q" });
     expect(missing).toEqual([]);
   });
@@ -37,8 +27,7 @@ describe("interpolateHeaders", () => {
 });
 
 describe("postJson", () => {
-  const okFetch: PostJsonDeps["fetch"] = async () =>
-    new Response(null, { status: 200 });
+  const okFetch: PostJsonDeps["fetch"] = async () => new Response(null, { status: 200 });
 
   test("returns true and POSTs JSON with merged headers on 2xx", async () => {
     let capturedUrl = "";
@@ -50,12 +39,16 @@ describe("postJson", () => {
         return new Response(null, { status: 204 });
       },
     };
-    const ok = await postJson("https://h/x", { a: 1 }, {
-      headers: { "X-Api": "k" },
-      timeoutMs: 1000,
-      stage: "test",
-      deps,
-    });
+    const ok = await postJson(
+      "https://h/x",
+      { a: 1 },
+      {
+        headers: { "X-Api": "k" },
+        timeoutMs: 1000,
+        stage: "test",
+        deps,
+      },
+    );
     expect(ok).toBe(true);
     expect(capturedUrl).toBe("https://h/x");
     expect(capturedInit?.method).toBe("POST");
@@ -67,24 +60,49 @@ describe("postJson", () => {
 
   test("returns false on non-2xx", async () => {
     const deps: PostJsonDeps = { fetch: async () => new Response(null, { status: 500 }) };
-    const ok = await postJson("https://h/x", {}, {
-      headers: {}, timeoutMs: 1000, stage: "test", deps,
-    });
+    const ok = await postJson(
+      "https://h/x",
+      {},
+      {
+        headers: {},
+        timeoutMs: 1000,
+        stage: "test",
+        deps,
+      },
+    );
     expect(ok).toBe(false);
   });
 
   test("returns false when fetch throws (network/timeout)", async () => {
-    const deps: PostJsonDeps = { fetch: async () => { throw new Error("boom"); } };
-    const ok = await postJson("https://h/x", {}, {
-      headers: {}, timeoutMs: 1000, stage: "test", deps,
-    });
+    const deps: PostJsonDeps = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const ok = await postJson(
+      "https://h/x",
+      {},
+      {
+        headers: {},
+        timeoutMs: 1000,
+        stage: "test",
+        deps,
+      },
+    );
     expect(ok).toBe(false);
   });
 
   test("uses the ok fetch by default deps arg", async () => {
-    const ok = await postJson("https://h/x", {}, {
-      headers: {}, timeoutMs: 1000, stage: "test", deps: { fetch: okFetch },
-    });
+    const ok = await postJson(
+      "https://h/x",
+      {},
+      {
+        headers: {},
+        timeoutMs: 1000,
+        stage: "test",
+        deps: { fetch: okFetch },
+      },
+    );
     expect(ok).toBe(true);
   });
 });

--- a/test/unit/plugins/builtin/webhook-reporter.test.ts
+++ b/test/unit/plugins/builtin/webhook-reporter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { PhaseCompleteEvent, PhaseStartEvent } from "@/plugins";
-import { createWebhookReporterPlugin, type PostJsonDeps } from "@/plugins";
 import type { WebhookReporterConfig } from "@/config/schemas-reporters";
+import type { PhaseCompleteEvent, PhaseStartEvent } from "@/plugins";
+import { type PostJsonDeps, createWebhookReporterPlugin } from "@/plugins";
 
 const baseCfg: WebhookReporterConfig = {
   enabled: true,
@@ -38,7 +38,10 @@ describe("webhook-reporter", () => {
     process.env.WH_TOKEN = "secret";
     const plugin = createWebhookReporterPlugin(baseCfg, deps);
     await plugin.extensions.reporter?.onRunStart?.({
-      runId: "r1", feature: "f", totalStories: 3, startTime: "2026-07-18T00:00:00.000Z",
+      runId: "r1",
+      feature: "f",
+      totalStories: 3,
+      startTime: "2026-07-18T00:00:00.000Z",
     });
     expect(calls).toHaveLength(1);
     expect(calls[0].url).toBe("https://hook.example.com");
@@ -53,11 +56,16 @@ describe("webhook-reporter", () => {
     const { calls, deps } = capturing();
     const plugin = createWebhookReporterPlugin({ ...baseCfg, headers: {}, events: ["onRunEnd"] }, deps);
     await plugin.extensions.reporter?.onRunStart?.({
-      runId: "r1", feature: "f", totalStories: 1, startTime: "2026-07-18T00:00:00.000Z",
+      runId: "r1",
+      feature: "f",
+      totalStories: 1,
+      startTime: "2026-07-18T00:00:00.000Z",
     });
     expect(calls).toHaveLength(0);
     await plugin.extensions.reporter?.onRunEnd?.({
-      runId: "r1", totalDurationMs: 10, totalCost: 0,
+      runId: "r1",
+      totalDurationMs: 10,
+      totalCost: 0,
       storySummary: { completed: 1, failed: 0, skipped: 0, paused: 0 },
     });
     expect(calls).toHaveLength(1);
@@ -69,7 +77,10 @@ describe("webhook-reporter", () => {
     delete process.env.WH_TOKEN;
     const plugin = createWebhookReporterPlugin(baseCfg, deps);
     await plugin.extensions.reporter?.onRunStart?.({
-      runId: "r1", feature: "f", totalStories: 1, startTime: "2026-07-18T00:00:00.000Z",
+      runId: "r1",
+      feature: "f",
+      totalStories: 1,
+      startTime: "2026-07-18T00:00:00.000Z",
     });
     expect(calls).toHaveLength(0);
   });
@@ -78,7 +89,13 @@ describe("webhook-reporter", () => {
     const { calls, deps } = capturing();
     const plugin = createWebhookReporterPlugin({ enabled: true, headers: {}, timeoutMs: 1000 }, deps);
     await plugin.extensions.reporter?.onStoryComplete?.({
-      runId: "r1", storyId: "s1", status: "completed", runElapsedMs: 5, cost: 0.1, tier: "fast", testStrategy: "tdd-simple",
+      runId: "r1",
+      storyId: "s1",
+      status: "completed",
+      runElapsedMs: 5,
+      cost: 0.1,
+      tier: "fast",
+      testStrategy: "tdd-simple",
     });
     expect(calls).toHaveLength(0);
   });
@@ -86,7 +103,15 @@ describe("webhook-reporter", () => {
   test("AC14: onPhaseComplete posts an onPhaseComplete envelope", async () => {
     const { calls, deps } = capturing();
     const plugin = createWebhookReporterPlugin({ ...baseCfg, headers: {}, events: ["onPhaseComplete"] }, deps);
-    const event: PhaseCompleteEvent = { runId: "r1", scope: "story", storyId: "s1", phase: "implementer", outcome: "passed", durationMs: 10, costUsd: 0.1 };
+    const event: PhaseCompleteEvent = {
+      runId: "r1",
+      scope: "story",
+      storyId: "s1",
+      phase: "implementer",
+      outcome: "passed",
+      durationMs: 10,
+      costUsd: 0.1,
+    };
 
     await plugin.extensions.reporter?.onPhaseComplete?.(event);
 
@@ -97,7 +122,13 @@ describe("webhook-reporter", () => {
   test("AC15: onPhaseComplete filter performs no request for onPhaseStart", async () => {
     const { calls, deps } = capturing();
     const plugin = createWebhookReporterPlugin({ ...baseCfg, headers: {}, events: ["onPhaseComplete"] }, deps);
-    const event: PhaseStartEvent = { runId: "r1", scope: "story", storyId: "s1", phase: "implementer", startTime: "2026-07-18T00:00:00.000Z" };
+    const event: PhaseStartEvent = {
+      runId: "r1",
+      scope: "story",
+      storyId: "s1",
+      phase: "implementer",
+      startTime: "2026-07-18T00:00:00.000Z",
+    };
 
     await plugin.extensions.reporter?.onPhaseStart?.(event);
 


### PR DESCRIPTION
Two of the three defects in #1422. The third (rule-file-ready text + the `nax finish` surface) is deliberately left for a follow-up.

## Why the counts were meaningless

Newest artifact before this change, verbatim:

```
- [ ] [HIGH] H1: Repeated review finding: test-gap appeared 1008x across stories — stories: US-005, US-002, US-004, ...
- [ ] [HIGH] H1: Repeated review finding: convention appeared 656x across stories — ...
```

That is the category histogram restated, over a project's entire accumulated audit history. Observation counts per run within one project climbed monotonically — `723 → 749 → 770 → 792 → 810 → 827 → 866 → 888` — so a `count >= 4 → HIGH` severity tripped once and could never clear.

## Run-scoping

`PostRunContext.runStartedAt` (epoch ms, taken from the run's existing `startTime`) lets each collector take only what this run produced:

| source | signal |
|:--|:--|
| review-audit | its own `timestamp` field |
| context manifests | file mtime — they carry no timestamp and persist per story across runs |
| metrics | already selected by `runId`; unchanged |

**A finding from the investigation worth recording:** the curator could not have filtered by run *identity* even if it tried. `runner.ts:156` mints `run-<iso>` (what the curator sees as `context.runId`) while `runtime/index.ts:168` mints a separate `crypto.randomUUID()` — and that UUID is what lands in the audit files. Two independent ID spaces. Timestamps sidestep the problem entirely and work on artifacts already on disk, which is why I went that way rather than unifying the IDs.

Two deliberate leniencies: absent `runStartedAt` means "no scoping" (out-of-tree callers of `collectObservations` keep today's behaviour rather than silently losing observations), and an artifact with an unparseable or missing timestamp is **kept** — hiding a real finding is worse than a stale count, which was already the status quo.

## H1 grouping

Findings now group by `fingerprintFor(file, category, message)` — the same SSOT `recurrence-demotion` uses — and the threshold counts **distinct features**, not raw occurrences.

```
- [ ] [MED] H1: Recurring review finding (test-gap in src/api.ts) — hit 3 features
      Seen in 3 features: feat-a, feat-b, feat-c (stories: US-001, US-002)
      Examples: Test asserts a pattern exists in the file instead of invoking the code
```

A defect crossing features is what a project rule exists to prevent; one feature repeating itself is a story problem, and was the old behaviour's main source of noise. Findings with neither a file nor a category are skipped — they describe nothing a rule could constrain, which also keeps stray acknowledgement text from forming proposals.

This required carrying `category` onto `ReviewFindingObservation`; it was being dropped at collection time.

## Test-contract changes, called out explicitly

Eleven existing H1 tests encoded the old contract (occurrences within a single feature) and now express the new one. One case genuinely became unreachable: *"an empty first message must not suppress a later real sample"* — the message is now part of the grouping key, so an empty message forms its own group and the two can never share a proposal. That test is replaced by one pinning the new truth rather than deleted silently.

## Test plan

- [x] `curator-heuristics.test.ts` — 6 new cases: cross-feature recurrence fires; one feature repeating 12× does **not**; distinct defects sharing a category+file stay separate; same defect at different lines/stories groups; severity scales on feature spread; ack-shaped findings cannot form a proposal.
- [x] `curator-collector.test.ts` — 4 new cases: stale audit entries excluded, everything collected when `runStartedAt` is absent, undated entries kept, manifests untouched this run skipped (mtime).
- [x] `bun run test` — unit 10,965 / integration 1,092 / ui 24, 0 fail. Typecheck, lint, all pre-commit gates green.

## Follow-up

Still open on #1422, but as a **question rather than a fix**: what should consume proposals at all. The issue originally proposed rule-file-ready diffs surfaced at `nax finish` for accept/reject — that was wrong on both counts. nax has no accept/reject process, and `nax finish` ships a feature rather than curating rules. The "0 of 263 proposal files ever ticked" figure I cited is therefore not evidence of a broken loop; the checkbox never had a process behind it.

This PR stands on its own regardless: whatever ends up consuming proposals, the counts feeding them have to mean something first.
