### PR TITLE
fix(curator): run recurrence heuristics over the rollup window, not one run

### DIFF
--- a/src/plugins/builtin/curator/index.ts
+++ b/src/plugins/builtin/curator/index.ts
@@ -8,13 +8,13 @@
 import { mkdir } from "node:fs/promises";
 import * as path from "node:path";
 import type { IPostRunAction, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
-import type { NaxPlugin } from "../../types";
+import type { NaxPlugin } from "@/plugins/types";
 import { collectObservations } from "./collect";
 import type { CuratorThresholds } from "./heuristics";
 import { runHeuristics } from "./heuristics";
 import { resolveCuratorOutputs } from "./paths";
 import { renderProposals } from "./render";
-import { appendToRollup } from "./rollup";
+import { appendToRollup, readHeuristicWindow } from "./rollup";
 import type { CuratorPostRunContext } from "./types";
 
 const PLUGIN_NAME = "nax-curator";
@@ -96,16 +96,21 @@ const curatorAction: IPostRunAction = {
           observations.map((o) => JSON.stringify(o)).join("\n") + (observations.length > 0 ? "\n" : ""),
         );
 
-        // Run heuristics and render proposals
+        // Append THIS run's observations first, then run heuristics over the
+        // accumulated window. Recurrence heuristics measure repetition across
+        // features, and collection is run-scoped to a single feature — running
+        // them on `observations` alone makes the distinct-feature count 1 and H1
+        // can never fire. The rollup is the cross-run record they need, and
+        // run-scoped collection is what keeps each finding in it exactly once.
+        await appendToRollup(observations, rollupPath);
+
         const thresholds = getCuratorThresholds(context);
-        const proposals = runHeuristics(observations, thresholds);
+        const window = await readHeuristicWindow(rollupPath, HEURISTIC_WINDOW_RUNS);
+        const proposals = runHeuristics(window.length > 0 ? window : observations, thresholds);
         const markdown = renderProposals(proposals, context.runId, observations.length);
 
         const proposalsMdPath = path.join(runDir, "curator-proposals.md");
         await Bun.write(proposalsMdPath, markdown);
-
-        // Append to cross-run rollup
-        await appendToRollup(observations, rollupPath);
       }
 
       return {
@@ -125,6 +130,13 @@ const curatorAction: IPostRunAction = {
 /**
  * Built-in curator plugin.
  */
+/**
+ * Runs of history the recurrence heuristics see. Bounded so a long-lived rollup
+ * does not make every proposal permanent: a defect fixed 30 runs ago should stop
+ * being proposed. Below `nax curator gc`'s default retention of 50 runs.
+ */
+const HEURISTIC_WINDOW_RUNS = 20;
+
 export const curatorPlugin: NaxPlugin = {
   name: PLUGIN_NAME,
   version: PLUGIN_VERSION,
@@ -162,3 +174,4 @@ export type {
   FixCycleValidatorRetryObservation,
 } from "./types";
 export { collectObservations, resolveCuratorOutputs };
+export { readHeuristicWindow } from "./rollup";

--- a/src/plugins/builtin/curator/rollup.ts
+++ b/src/plugins/builtin/curator/rollup.ts
@@ -9,6 +9,13 @@ import * as path from "node:path";
 import type { Observation } from "./types";
 
 /**
+ * Bytes read from the tail of the rollup when building the heuristic window.
+ * The rollup is append-only and unbounded between `nax curator gc` runs, so the
+ * window is taken from the end rather than by parsing the whole file.
+ */
+const MAX_WINDOW_TAIL_BYTES = 8 * 1024 * 1024;
+
+/**
  * Append observations to a rollup file (JSONL format).
  *
  * Creates parent directory if needed. Appends one JSON line per observation.
@@ -34,5 +41,50 @@ export async function appendToRollup(observations: Observation[], rollupPath: st
     await appendFile(rollupPath, newLines);
   } catch {
     // Write errors are logged but never thrown — curator must not affect run exit code
+  }
+}
+
+/**
+ * Observations from the most recent `windowRuns` runs in the rollup.
+ *
+ * Heuristics that measure recurrence ACROSS features (H1) cannot run on a single
+ * run's observations: collection is run-scoped and a run covers one feature, so
+ * the distinct-feature count is always 1. The rollup is the cross-run record
+ * this needs — and because collection is run-scoped, each finding appears in it
+ * exactly once, which is what makes counting it meaningful.
+ *
+ * Never throws: a missing, empty, or partially corrupt rollup yields whatever
+ * could be read. The curator must not affect the run's exit code.
+ */
+export async function readHeuristicWindow(rollupPath: string, windowRuns: number): Promise<Observation[]> {
+  try {
+    const file = Bun.file(rollupPath);
+    if (!(await file.exists())) return [];
+    const size = file.size;
+    const start = Math.max(0, size - MAX_WINDOW_TAIL_BYTES);
+    const text = await (start > 0 ? file.slice(start).text() : file.text());
+    // A non-zero start almost certainly lands mid-line; drop the partial head.
+    const lines = text.split("\n");
+    if (start > 0) lines.shift();
+
+    const observations: Observation[] = [];
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        observations.push(JSON.parse(line) as Observation);
+      } catch {
+        // Truncated or malformed line — skip it, keep the rest.
+      }
+    }
+
+    // Keep the last `windowRuns` distinct runIds, walking backwards so recency wins.
+    const keep = new Set<string>();
+    for (let i = observations.length - 1; i >= 0 && keep.size < windowRuns; i -= 1) {
+      const runId = observations[i]?.runId;
+      if (runId) keep.add(runId);
+    }
+    return observations.filter((o) => keep.has(o.runId));
+  } catch {
+    return [];
   }
 }

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -9,15 +9,15 @@
  * src/prompts, so importing semantic.ts here would form a cycle.
  */
 
+import type { AcDroppedEntry, AcGroundingMinimalRejection } from "@/review/ac-quote-validator";
+import type { LLMFinding } from "@/review/semantic-helpers";
+import type { SemanticReviewConfig, SemanticStory } from "@/review/types";
 import type { Iteration } from "../../findings";
-import type { AcDroppedEntry, AcGroundingMinimalRejection } from "../../review/ac-quote-validator";
 // Leaf import (not the `src/review` barrel) for the same reason as the type
 // imports above: semantic.ts imports this builder from src/prompts, so pulling
 // the barrel in would close a cycle. `semantic-categories` has no imports of
 // its own, so the leaf is cycle-free.
 import { SEMANTIC_CATEGORY_ENUM_LINE } from "../../review/semantic-categories";
-import type { LLMFinding } from "../../review/semantic-helpers";
-import type { SemanticReviewConfig, SemanticStory } from "../../review/types";
 import { wrapJsonPrompt } from "../../utils/llm-json";
 import { buildReviewOutOfScopeBlock } from "../sections";
 import { buildPriorIterationsBlock } from "./prior-iterations-builder";

--- a/src/runtime/middleware/review-audit.ts
+++ b/src/runtime/middleware/review-audit.ts
@@ -1,3 +1,4 @@
+import type { AdversarialAcceptAnalysis, AdversarialDropAnalysis } from "@/review/ac-structural-counterfactual";
 import type { IReviewAuditor } from "@/review/review-audit";
 import type { ReviewAck } from "@/review/types";
 import type { DispatchEvent, IDispatchEventBus, ReviewDecisionEvent } from "../dispatch-events";
@@ -57,12 +58,8 @@ export function attachReviewAuditSubscriber(
       unparsedPreview: event.unparsedPreview,
       diffAvailable: event.diffAvailable,
       // Cast unknown[] from the event boundary to the typed audit shapes.
-      adversarialDropAnalysis: event.adversarialDropAnalysis as
-        | import("../../review/ac-structural-counterfactual").AdversarialDropAnalysis[]
-        | undefined,
-      adversarialAcceptAnalysis: event.adversarialAcceptAnalysis as
-        | import("../../review/ac-structural-counterfactual").AdversarialAcceptAnalysis[]
-        | undefined,
+      adversarialDropAnalysis: event.adversarialDropAnalysis as AdversarialDropAnalysis[] | undefined,
+      adversarialAcceptAnalysis: event.adversarialAcceptAnalysis as AdversarialAcceptAnalysis[] | undefined,
     });
   });
 

--- a/test/unit/plugins/builtin/curator-seam.test.ts
+++ b/test/unit/plugins/builtin/curator-seam.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The collector→heuristics seam.
+ *
+ * Both sides of this seam had green tests while the integration was broken:
+ * heuristics tests fed multi-feature observation arrays straight to
+ * `runHeuristics`, and collector tests checked which observations came back
+ * without ever running heuristics on them. Nothing asserted what the heuristics
+ * actually receive in production.
+ *
+ * The regression: collection is run-scoped (one run = one feature), so a run's
+ * own observations can only ever contain ONE featureId — while H1 thresholds on
+ * DISTINCT features. H1 could never fire. Cross-feature recurrence needs
+ * cross-run input, which is what the rollup is for.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectObservations, curatorPlugin, readHeuristicWindow } from "../../../../src/plugins/builtin/curator";
+import type { CuratorPostRunContext } from "../../../../src/plugins/builtin/curator";
+import { runHeuristics } from "../../../../src/plugins/builtin/curator/heuristics";
+import type { CuratorThresholds } from "../../../../src/plugins/builtin/curator/heuristics";
+import { appendToRollup } from "../../../../src/plugins/builtin/curator/rollup";
+
+const THRESHOLDS: CuratorThresholds = {
+  repeatedFinding: 3,
+  emptyKeyword: 2,
+  rectifyAttempts: 3,
+  escalationChain: 2,
+  staleChunkRuns: 2,
+  unchangedOutcome: 3,
+};
+
+const DEFECT = "Test asserts a pattern exists in the source file instead of invoking the code";
+
+function makeContext(root: string, feature: string, runId: string, runStartedAt: number): CuratorPostRunContext {
+  return {
+    runId,
+    feature,
+    workdir: join(root, "work"),
+    prdPath: "",
+    branch: "main",
+    totalDurationMs: 1,
+    totalCost: 0,
+    storySummary: { completed: 1, failed: 0, skipped: 0, paused: 0 },
+    stories: [],
+    version: "0.1.0",
+    pluginConfig: {},
+    logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    // biome-ignore lint/suspicious/noExplicitAny: collector reads no config keys on this path
+    config: {} as any,
+    outputDir: join(root, "out"),
+    globalDir: join(root, "global"),
+    projectKey: "p",
+    curatorRollupPath: join(root, "rollup.jsonl"),
+    runStartedAt,
+  };
+}
+
+/** One run over one feature, writing a review-audit entry the way production does. */
+async function runOnce(root: string, feature: string, runId: string, file: string, when: string) {
+  const dir = join(root, "out", "review-audit", feature);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, `${runId}.json`),
+    JSON.stringify({
+      timestamp: when,
+      storyId: "US-001",
+      featureName: feature,
+      result: {
+        findings: [{ rule: "test-gap:x", category: "test-gap", severity: "error", file, line: 1, message: DEFECT }],
+      },
+    }),
+  );
+  const ctx = makeContext(root, feature, runId, Date.parse(when) - 60_000);
+  const observations = await collectObservations(ctx);
+  await appendToRollup(observations, ctx.curatorRollupPath);
+  return ctx;
+}
+
+describe("collector → heuristics seam", () => {
+  test("a single run's own observations carry exactly one featureId", async () => {
+    // This is the fact that made H1 unfireable on run-scoped input. Pinning it
+    // so nobody 'fixes' H1 by feeding it a single run again.
+    const root = await mkdtemp(join(tmpdir(), "curator-seam-single-"));
+    const ctx = await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T12:05:00.000Z");
+    const observations = await collectObservations(ctx);
+    const features = new Set(observations.filter((o) => o.kind === "review-finding").map((o) => o.featureId));
+    expect([...features]).toEqual(["feat-a"]);
+    expect(runHeuristics(observations, THRESHOLDS).filter((p) => p.id === "H1")).toHaveLength(0);
+  });
+
+  test("H1 fires on the accumulated window across runs and features", async () => {
+    // The scenario the whole heuristic exists for: the same defect recurring in
+    // three separate features, each its own run, each touching its own file.
+    const root = await mkdtemp(join(tmpdir(), "curator-seam-window-"));
+    let ctx = await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z");
+    ctx = await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z");
+    ctx = await runOnce(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z");
+
+    const window = await readHeuristicWindow(ctx.curatorRollupPath, 10);
+    const features = new Set(window.filter((o) => o.kind === "review-finding").map((o) => o.featureId));
+    expect([...features].sort()).toEqual(["feat-a", "feat-b", "feat-c"]);
+
+    const h1 = runHeuristics(window, THRESHOLDS).find((p) => p.id === "H1");
+    expect(h1).toBeDefined();
+    expect(h1?.description).toContain("3 features");
+  });
+
+  test("each run contributes its findings to the window exactly once", async () => {
+    // Run-scoped collection is what makes the window trustworthy: before it, a
+    // run re-ingested the whole audit directory and every earlier finding was
+    // appended again under a new runId.
+    const root = await mkdtemp(join(tmpdir(), "curator-seam-once-"));
+    let ctx = await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z");
+    ctx = await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z");
+
+    const window = await readHeuristicWindow(ctx.curatorRollupPath, 10);
+    expect(window.filter((o) => o.kind === "review-finding")).toHaveLength(2);
+  });
+
+  test("the window keeps only the most recent runs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-seam-bound-"));
+    let ctx = await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z");
+    ctx = await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z");
+    ctx = await runOnce(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z");
+
+    const window = await readHeuristicWindow(ctx.curatorRollupPath, 2);
+    const runs = new Set(window.map((o) => o.runId));
+    expect(runs.has("run-1")).toBe(false);
+    expect([...runs].sort()).toEqual(["run-2", "run-3"]);
+  });
+
+  test("a missing or empty rollup yields an empty window rather than throwing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-seam-empty-"));
+    expect(await readHeuristicWindow(join(root, "nope.jsonl"), 5)).toEqual([]);
+    const empty = join(root, "empty.jsonl");
+    await writeFile(empty, "");
+    expect(await readHeuristicWindow(empty, 5)).toEqual([]);
+  });
+
+  test("malformed rollup lines are skipped, not fatal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-seam-malformed-"));
+    const p = join(root, "rollup.jsonl");
+    await writeFile(
+      p,
+      [
+        "{not json",
+        JSON.stringify({
+          schemaVersion: 2,
+          runId: "run-1",
+          featureId: "f",
+          storyId: "s",
+          stage: "review",
+          ts: "t",
+          kind: "verdict",
+          payload: {},
+        }),
+        "",
+      ].join("\n"),
+    );
+    const window = await readHeuristicWindow(p, 5);
+    expect(window).toHaveLength(1);
+  });
+});
+
+describe("curator plugin — end to end", () => {
+  /** Drive the real post-run action, as the runner does. */
+  async function executeRun(root: string, feature: string, runId: string, file: string, when: string) {
+    const dir = join(root, "out", "review-audit", feature);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, `${runId}.json`),
+      JSON.stringify({
+        timestamp: when,
+        storyId: "US-001",
+        featureName: feature,
+        result: {
+          findings: [{ rule: "test-gap:x", category: "test-gap", severity: "error", file, line: 1, message: DEFECT }],
+        },
+      }),
+    );
+    const ctx = {
+      ...makeContext(root, feature, runId, Date.parse(when) - 60_000),
+      config: {
+        curator: {
+          enabled: true,
+          thresholds: {
+            repeatedFinding: 3,
+            emptyKeyword: 2,
+            rectifyAttempts: 3,
+            escalationChain: 2,
+            staleChunkRuns: 2,
+            unchangedOutcome: 3,
+          },
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: partial config is all this path reads
+      } as any,
+    };
+    await curatorPlugin.extensions.postRunAction?.execute(ctx);
+    return join(root, "out", "runs", runId, "curator-proposals.md");
+  }
+
+  test("three runs over three features produce one cross-feature proposal", async () => {
+    // The regression this file exists for: everything below passed its own unit
+    // tests while the assembled pipeline emitted nothing.
+    const root = await mkdtemp(join(tmpdir(), "curator-plugin-e2e-"));
+    await executeRun(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z");
+    await executeRun(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z");
+    const proposalsPath = await executeRun(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z");
+
+    const markdown = await Bun.file(proposalsPath).text();
+    expect(markdown).toContain("Recurring across 3 features");
+    expect(markdown).toContain("feat-a");
+    expect(markdown).toContain("feat-c");
+    // Files differ per feature; they are evidence, never identity.
+    expect(markdown).toContain("src/a.ts");
+  });
+
+  test("the first run of a project proposes nothing, rather than erroring", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-plugin-first-"));
+    const proposalsPath = await executeRun(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z");
+    const markdown = await Bun.file(proposalsPath).text();
+    expect(markdown).toContain("Curator Proposals");
+    expect(markdown).not.toContain("Recurring across");
+  });
+});


### PR DESCRIPTION
**Regression fix for #1427, which is on `main`.** H1 has been unfireable since that merge.

## The bug

The two halves of #1427 are mutually destructive:

- Collection is run-scoped — one run covers one feature, and #1427 explicitly drops foreign features.
- H1 thresholds on **distinct features**.

So the distinct-feature count of a run's own observations is always 1, and H1 can never reach a threshold of 3. Verified through the real plugin before fixing:

```
review-finding observations collected: 1
distinct featureIds among them: [ "feat-a" ]
H1 proposals: 0
```

Three features reporting the identical defect — the exact scenario the heuristic exists for — produced nothing. Before #1427 H1 fired noisily; after it, never. I made the headline case strictly worse while believing I had fixed it.

## Why no test caught it, including the review

Both suites sit on one side of the seam and neither crosses it:

| suite | what it does | what it misses |
|:--|:--|:--|
| `curator-heuristics*.test.ts` | feeds multi-feature arrays **directly** to `runHeuristics` | never sees what collection actually yields |
| `curator-collector.test.ts` | asserts which observations come back | never runs heuristics on them |

Both green, integration broken. The code review reviewed each half against its own tests and missed it too.

## The fix

Cross-feature recurrence needs cross-run input, and the rollup already exists for exactly that — *"append-only rollup writer for cross-run observation aggregation"*.

`readHeuristicWindow(rollupPath, windowRuns)` reads the last N runs; the plugin now appends this run's observations **first**, then runs heuristics over that window.

Run-scoped collection stays and is what makes the window trustworthy: each finding is appended exactly once, where previously every run re-ingested the whole audit directory and re-stamped it with a new runId. That was the real value of #1427's scoping half — it just needed the heuristics moved to the other side of it.

Bounded two ways: **20 runs** (below `nax curator gc`'s default retention of 50, so a defect fixed long ago stops being proposed) and an **8 MB tail read**, since the rollup is unbounded between gc runs. Missing, empty, truncated, and malformed rollups all degrade to "whatever could be read" — the curator must never affect a run's exit code.

## Proof through the real plugin

Three runs, three features, three different files:

```
- [ ] [MED] H1: Recurring across 3 features — test-gap: Test asserts a pattern exists in the
      source file instead of invoking the code — stories: feat-a/US-001, feat-b/US-001, feat-c/US-001
  _Evidence: Seen in 3 features: feat-a, feat-b, feat-c (sites: …). Files: src/a.ts, src/b.ts, src/c.ts.
   · Examples: Test asserts a pattern exists in the source file instead of invoking the code_
```

## Test plan

New `curator-seam.test.ts` tests the seam itself, not either side:

- [x] a single run's observations carry exactly **one** featureId, and H1 yields nothing on them — pins the fact that broke this, so nobody re-fixes H1 by feeding it a single run
- [x] H1 fires on the accumulated window across runs and features
- [x] each run contributes its findings to the window exactly once
- [x] the window keeps only the most recent runs
- [x] missing / empty / malformed rollups degrade rather than throw
- [x] **plugin end to end**: three runs → one cross-feature proposal in the rendered markdown; first run of a project proposes nothing rather than erroring
- [x] `bun run test` — unit 10,981 / integration 1,092 / ui 24, 0 fail. Typecheck, lint, all gates green.