### PR TITLE
docs(audit): record the curator replay against real July artifacts

### DIFF
--- a/docs/reports/20260801-july-2026-harness-audit.md
+++ b/docs/reports/20260801-july-2026-harness-audit.md
@@ -176,18 +176,18 @@ Phase 7 of the spec-review skill already bans `[grep]`/`[file]`/`[verbatim]` ACs
 | 2 | Adversarial sub-threshold verdict | **shipped before the audit** — #1378 / v0.75.2, coverage verified |
 | 3 | Oscillation circuit-breaker | **shipped before the audit** — ping-pong-only counting (#1355) |
 | 6 | Semantic category taxonomy | **shipped** — [#1420](https://github.com/nathapp-io/nax/pull/1420) |
-| 7 | Reviewer `acks` channel | **in review** — [#1426](https://github.com/nathapp-io/nax/pull/1426) |
-| 9 | Chunk token accounting | **in review** — [#1426](https://github.com/nathapp-io/nax/pull/1426) |
+| 7 | Reviewer `acks` channel | **shipped** — [#1426](https://github.com/nathapp-io/nax/pull/1426) |
+| 9 | Chunk token accounting | **shipped** — [#1426](https://github.com/nathapp-io/nax/pull/1426) |
 | 4 | Spec-review data-literal check | open — [spec-kit#18](https://github.com/nathapp-io/nax-spec-kit-skills/issues/18) |
 | 8 | Acceptance retry tail | open, diagnostic — [#1424](https://github.com/nathapp-io/nax/issues/1424) |
-| 10 | Curator loop | open, largest remaining — [#1422](https://github.com/nathapp-io/nax/issues/1422) |
+| 10 | Curator loop | counts **shipped** ([#1427](https://github.com/nathapp-io/nax/pull/1427) + [#1428](https://github.com/nathapp-io/nax/pull/1428)); recall re-scoped — [#1422](https://github.com/nathapp-io/nax/issues/1422), §12 |
 | 3b | Non-productive-iteration bail | **withdrawn** — §10 |
 
-Four of the ten shipped or in review; two were already fixed before the audit was written; one is withdrawn.
+Six of the ten shipped; two were already fixed before the audit was written; one is withdrawn.
 
 ### What is actually left
 
-**#10 (curator) — counts fixed in [#1427](https://github.com/nathapp-io/nax/pull/1427); consumption is an open question, not a defect.** Two shipped changes depended on the counts being fixed:
+**#10 (curator) — counts fixed in [#1427](https://github.com/nathapp-io/nax/pull/1427) / [#1428](https://github.com/nathapp-io/nax/pull/1428), then replayed against real data; see §12 for the outcome.** Two shipped changes depended on the counts being fixed:
 
 - #1420 makes semantic findings carry categories, which the curator folds into its counts — the same counts that accumulated over each project's whole audit history and could never clear. Without the fix, the new taxonomy would have inherited the defect that made the adversarial counts useless.
 - #1426 stops *new* acknowledgement pollution, but historical acks remained in the cumulative totals until collection was run-scoped.
@@ -212,3 +212,41 @@ Nothing shipped this month can be evaluated yet — August data does not exist o
 The last three are correctness checks — they should go to ~100%, ~0, and ~100% immediately, and if they do not, the change did not take effect. The first three are the ones that actually cost money, and they need a month of runs before the comparison means anything.
 
 **Strategic observation:** the harness detects known failure modes post-hoc (adversarial review) instead of preventing them pre-hoc (test-writer/spec prompts). Every recommendation is a form of moving knowledge one stage earlier in the pipeline.
+
+## 12. Curator replay against real July artifacts (2026-08-01)
+
+§11 said the curator's remaining question was "answerable with August data rather than more code". It was answerable sooner: the shipped pipeline can be replayed over July's own artifacts. Criteria were fixed before looking at any result.
+
+**Method.** Real `collectObservations` → `appendToRollup` → `readHeuristicWindow(20)` → `runHeuristics`, shipped default thresholds, no reimplementation of the pipeline. Audit files were staged into a scratchpad mirror incrementally so run N never saw run N+1's artifacts — the collector has no upper time bound, and in production the future does not exist yet. `~/.nax` was read-only. Only the `review-audit` source was replayed, so H2–H6 could not fire; H1 is what #1427 / #1428 changed.
+
+**Result: 2 distinct proposals from 419 runs and 8,070 findings.**
+
+| | |
+|:--|--:|
+| runs replayed | 419 |
+| review findings in corpus | 8,070 |
+| runs producing ≥1 proposal | 34 |
+| distinct proposals | 2 |
+| max proposals in any single run | 1 |
+
+The per-category spam is gone — median 0 proposals per run, no bare-category description, no single-feature proposal — and both survivors are real defects (an untested redaction branch shared by two rs-stock adapters; a dead `ROOT = Path(...)` constant). But two proposals from 8,070 findings is effectively zero recall.
+
+**The binding constraint is the identity key, not the threshold.** `crossFeatureKey` is `category | normalizeIssueText(message)[0:48]`, and two reviewers describing the same defect in different features almost never agree on their first 48 normalized characters. At the shipped threshold of 2 there are only 3 qualifying groups in the entire corpus, so lowering the threshold cannot help. Cross-feature groups (≥2 features), ack-leak prose excluded:
+
+| project | findings | shipped (48) | 32 | 24 |
+|:---|---:|---:|---:|---:|
+| rs-stock | 4,740 | 3 | 17 | 34 |
+| nathapp-nestjs-platform | 1,414 | 0 | 6 | 10 |
+| nax | 1,013 | 0 | 1 | 3 |
+| koda | 375 | 0 | 0 | 0 |
+
+Category-only keys yield 7–9 groups but with up to 180 features in one — the collapse §6 identified in the first place. The useful range lies between, and nothing currently measures where.
+
+Two side effects worth recording. A 24-character prefix would have surfaced rule-shaped recurrences the 48-character key missed (dead test constants across 4 features; imports from private underscore modules across 3; changed test files failing the Ruff gate across 3). And 4 of its top 8 groups are carry-forward verdict prose grouping on its boilerplate opener — the #1423 leak that #1426 already fixed, 4.1% of the July corpus and ~0 going forward.
+
+**Two defects found in the process,** neither covered by tests because every curator test builds its own rollup in a temp dir:
+
+- [#1429](https://github.com/nathapp-io/nax/issues/1429) — the rollup is one global file shared by every project, so a run's heuristic window can be filled by another repo's runs and H1's distinct-feature count can mix projects. The 8 MB tail cap also binds before `windowRuns`: on the real rollup the "20-run" window contains 2 runs.
+- [#1430](https://github.com/nathapp-io/nax/issues/1430) — `nax curator gc` is never invoked automatically and loads the whole rollup into memory. The file is 618 MB / 1.13M rows on a live machine, which the prune command cannot itself process.
+
+**Caveats.** July semantic findings carry no category (778 `(none)` in rs-stock, 246 in nax) — the gap #1420 closed — so August grouping will differ. The replay shows what would be *proposed*, never whether a resulting rule prevents anything. It also used per-project rollups, which is more favourable than production's shared file (#1429); real recall is likely lower still.

--- a/docs/reports/20260801-july-2026-harness-audit.md
+++ b/docs/reports/20260801-july-2026-harness-audit.md
@@ -1,7 +1,9 @@
 # July 2026 Harness Audit — Token Cost & Quality Analysis
 
 **Date:** 2026-08-01
-**Data sources:** `~/.nax/global/curator/rollup.jsonl` (653k July events), per-project `prompt-audit/` (4,900 transcripts), `review-audit/` (1,378 reviewer verdicts), `cost/*.jsonl` across nax, rs-stock, koda, nathapp-nestjs, iot-system.
+**Data sources:** `~/.nax/global/curator/rollup.jsonl` (653k July events), per-project `prompt-audit/` (4,900 transcripts), `review-audit/` (1,378 reviewer verdicts), `cost/*.jsonl` across nax and five other projects driven by nax.
+
+Projects other than nax are anonymised as **Project A**, **Project B**, … in order of review-finding volume, and their feature identifiers are elided. The labels are stable across this document.
 **Scope:** 2026-07-01 → 2026-07-31. 595 story verdicts, $1,873 total spend, 9.7% story failure rate.
 **Goal:** identify harness improvements for spec-writing, spec-review, `nax plan`/prd.json, role prompts, context, and rules — optimizing for token savings (more accurate specs, fewer turns) and quality assurance.
 
@@ -41,10 +43,10 @@ Stage-attributed cost from `cost/*.jsonl` totals $1,438.80 (the $1,873 headline 
 ## 2. Review outcomes — test-gap dominates everything
 
 - First-round pass rate: **semantic 82%** (411 stories), **adversarial 69%** (405 stories).
-- Rounds/story tail: 67 stories needed ≥3 semantic rounds; worst story took 20 combined rounds (koda w1-observability-pages US-003: 11 semantic + 9 adversarial).
+- Rounds/story tail: 67 stories needed ≥3 semantic rounds; worst story took 20 combined rounds (Project C, US-003: 11 semantic + 9 adversarial).
 - Adversarial blocking-finding categories: **test-gap 263 (~67% of categorized)**, assumption 40, error-path 38, input 30, abandonment 15, convention 5, bug 1.
 - Semantic blocking findings carry **no category** (269 × `None`) — invisible to recurrence-demotion, curator aggregation, and telemetry.
-- The dominant failure pattern (verified in transcripts, e.g. koda w1-observability-pages US-004): test-writer/implementer writes **source-inspection tests** (assert a pattern exists in a file) instead of runtime-behavior tests → adversarial blocks with test-gap → a full rectification round rewrites the tests. The adversarial reviewer's own "Test Audit Gap" heuristic describes exactly what it will reject — but the test-authoring prompts never see it. The harness pays a review round + a rectification round per story to teach knowledge it already had.
+- The dominant failure pattern (verified in transcripts, e.g. Project C, US-004): test-writer/implementer writes **source-inspection tests** (assert a pattern exists in a file) instead of runtime-behavior tests → adversarial blocks with test-gap → a full rectification round rewrites the tests. The adversarial reviewer's own "Test Audit Gap" heuristic describes exactly what it will reject — but the test-authoring prompts never see it. The harness pays a review round + a rectification round per story to teach knowledge it already had.
 
 ### Sub-threshold verdict bug — RESOLVED (verified during this audit)
 
@@ -62,7 +64,7 @@ Curator evidence shows spec defects surviving into implementation and causing re
 
 ## 4. Acceptance stage
 
-1,155 acceptance calls for 132 story verdicts (gen 301, test-fix 132, diagnose 102, source-fix 37 transcripts). The retry tail is **always US-001**: alerts-tool 15, kv-cache 14, agent-tools-multi-ticker 13 — the first story pays acceptance-harness bootstrap; later stories retry ~0 (p50 = p90 = 0).
+1,155 acceptance calls for 132 story verdicts (gen 301, test-fix 132, diagnose 102, source-fix 37 transcripts). The retry tail is **always US-001**: three tool-shaped features in one project took 15, 14 and 13 retries — the first story pays acceptance-harness bootstrap; later stories retry ~0 (p50 = p90 = 0).
 
 ## 5. Context engine & rules
 
@@ -194,7 +196,7 @@ Six of the ten shipped; two were already fixed before the audit was written; one
 
 The count-scoping half was the prerequisite: until counts mean "this run", no threshold choice is meaningful. The consumer already exists — `nax curator commit` — so the remaining question is not "what should read proposals" but whether, once they are accurate, anyone finds them worth accepting. That is answerable with August data rather than more code.
 
-**#8 produces a question, not a patch.** Someone has to read the `alerts-tool` / `kv-cache` / `agent-tools-multi-ticker` transcripts and find the shared cause; all three are tool-shaped features in one project, which points at a per-project harness problem rather than anything intrinsic to acceptance.
+**#8 produces a question, not a patch.** Someone has to read those three features' transcripts (§4) and find the shared cause; all three are tool-shaped features in one project, which points at a per-project harness problem rather than anything intrinsic to acceptance.
 
 ### Measurement debt
 
@@ -229,16 +231,16 @@ The last three are correctness checks — they should go to ~100%, ~0, and ~100%
 | distinct proposals | 2 |
 | max proposals in any single run | 1 |
 
-The per-category spam is gone — median 0 proposals per run, no bare-category description, no single-feature proposal — and both survivors are real defects (an untested redaction branch shared by two rs-stock adapters; a dead `ROOT = Path(...)` constant). But two proposals from 8,070 findings is effectively zero recall.
+The per-category spam is gone — median 0 proposals per run, no bare-category description, no single-feature proposal — and both survivors are real defects (an untested error-redaction branch shared by two sibling adapters in one project; a module-level constant defined but never referenced). But two proposals from 8,070 findings is effectively zero recall.
 
 **The binding constraint is the identity key, not the threshold.** `crossFeatureKey` is `category | normalizeIssueText(message)[0:48]`, and two reviewers describing the same defect in different features almost never agree on their first 48 normalized characters. At the shipped threshold of 2 there are only 3 qualifying groups in the entire corpus, so lowering the threshold cannot help. Cross-feature groups (≥2 features), ack-leak prose excluded:
 
 | project | findings | shipped (48) | 32 | 24 |
 |:---|---:|---:|---:|---:|
-| rs-stock | 4,740 | 3 | 17 | 34 |
-| nathapp-nestjs-platform | 1,414 | 0 | 6 | 10 |
+| Project A | 4,740 | 3 | 17 | 34 |
+| Project B | 1,414 | 0 | 6 | 10 |
 | nax | 1,013 | 0 | 1 | 3 |
-| koda | 375 | 0 | 0 | 0 |
+| Project C | 375 | 0 | 0 | 0 |
 
 Category-only keys yield 7–9 groups but with up to 180 features in one — the collapse §6 identified in the first place. The useful range lies between, and nothing currently measures where.
 
@@ -249,4 +251,4 @@ Two side effects worth recording. A 24-character prefix would have surfaced rule
 - [#1429](https://github.com/nathapp-io/nax/issues/1429) — the rollup is one global file shared by every project, so a run's heuristic window can be filled by another repo's runs and H1's distinct-feature count can mix projects. The 8 MB tail cap also binds before `windowRuns`: on the real rollup the "20-run" window contains 2 runs.
 - [#1430](https://github.com/nathapp-io/nax/issues/1430) — `nax curator gc` is never invoked automatically and loads the whole rollup into memory. The file is 618 MB / 1.13M rows on a live machine, which the prune command cannot itself process.
 
-**Caveats.** July semantic findings carry no category (778 `(none)` in rs-stock, 246 in nax) — the gap #1420 closed — so August grouping will differ. The replay shows what would be *proposed*, never whether a resulting rule prevents anything. It also used per-project rollups, which is more favourable than production's shared file (#1429); real recall is likely lower still.
+**Caveats.** July semantic findings carry no category (778 `(none)` in Project A, 246 in nax) — the gap #1420 closed — so August grouping will differ. The replay shows what would be *proposed*, never whether a resulting rule prevents anything. It also used per-project rollups, which is more favourable than production's shared file (#1429); real recall is likely lower still.


### PR DESCRIPTION
Follow-up to #1427 / #1428. Adds §12 to the July harness audit and updates the §11 status table.

## What this records

Rather than close #1422 on green unit tests, I replayed the shipped curator pipeline over real July artifacts: the real `collectObservations` → `appendToRollup` → `readHeuristicWindow(20)` → `runHeuristics`, with audit files staged incrementally so run N never saw run N+1's artifacts. `~/.nax` was read-only throughout.

**419 runs, 8,070 findings, 2 distinct proposals.**

The per-category spam is gone (median 0 proposals/run, no bare-category descriptions, no single-feature proposals) and both survivors are real defects. But two proposals from 8,070 findings is effectively zero recall, and the cause is the identity key rather than the threshold — at the shipped threshold of 2 there are only 3 qualifying groups corpus-wide, so lowering it cannot help.

#1422 has been re-scoped accordingly: from "counts are cumulative and per-category" (fixed) to "the cross-feature identity key has near-zero recall".

## Two defects found in the process

Both filed, neither covered by tests, because every curator test builds its own rollup in a temp dir:

- #1429 — the rollup is one global file shared by every project, so a run's heuristic window can be filled by another repo's runs and H1's distinct-feature count can mix projects. The 8 MB tail cap also binds before `windowRuns`: on the real rollup the "20-run" window holds 2 runs.
- #1430 — `nax curator gc` is never invoked automatically and loads the entire rollup into memory; the file is 618 MB / 1.13M rows on a live machine.

## Caveats, stated in the doc

July semantic findings carry no category (the gap #1420 closed), so August grouping will differ. The replay shows what would be proposed, never whether a resulting rule prevents anything. It used per-project rollups, which is more favourable than production's shared file — real recall is likely lower still.

## Test plan

- [x] Docs only; no source changes.