### PR TITLE
fix(curator): scope the rollup by project, and stop the byte cap acting as the window policy

### DIFF
--- a/docs/reports/20260801-july-2026-harness-audit.md
+++ b/docs/reports/20260801-july-2026-harness-audit.md
@@ -248,7 +248,28 @@ Two side effects worth recording. A 24-character prefix would have surfaced rule
 
 **Two defects found in the process,** neither covered by tests because every curator test builds its own rollup in a temp dir:
 
-- [#1429](https://github.com/nathapp-io/nax/issues/1429) — the rollup is one global file shared by every project, so a run's heuristic window can be filled by another repo's runs and H1's distinct-feature count can mix projects. The 8 MB tail cap also binds before `windowRuns`: on the real rollup the "20-run" window contains 2 runs.
+- [#1429](https://github.com/nathapp-io/nax/issues/1429) — the rollup is one global file shared by every project, so a run's heuristic window can be filled by another repo's runs and H1's distinct-feature count can mix projects. The 8 MB tail cap also binds before `windowRuns`: on the real rollup the "20-run" window contains 2 runs. **Fixed in [#1432](https://github.com/nathapp-io/nax/pull/1432)** — see §13.
 - [#1430](https://github.com/nathapp-io/nax/issues/1430) — `nax curator gc` is never invoked automatically and loads the whole rollup into memory. The file is 618 MB / 1.13M rows on a live machine, which the prune command cannot itself process.
 
 **Caveats.** July semantic findings carry no category (778 `(none)` in Project A, 246 in nax) — the gap #1420 closed — so August grouping will differ. The replay shows what would be *proposed*, never whether a resulting rule prevents anything. It also used per-project rollups, which is more favourable than production's shared file (#1429); real recall is likely lower still.
+
+## 13. Rollup scoping fixed ([#1432](https://github.com/nathapp-io/nax/pull/1432), 2026-08-01)
+
+§12's replay found two defects the replay itself had papered over — it built one rollup per project, while production shares a single global file. Both are now fixed.
+
+**The window was not the project's.** `~/.nax/global/curator/rollup.jsonl` is one file for every project on the machine, and nothing in a row identified its origin: `featureId` and `storyId` are project-local names that collide freely across repos. Reproduced through the real plugin — five interleaved runs across two projects, and the proposal written into the first project's run directory read:
+
+```
+Recurring across 5 features — feat-a, beta-x, feat-b, beta-y, feat-c
+Files: src/a.ts, src/x.ts, src/b.ts, src/y.ts
+```
+
+Three of those features and two of those files belong to the other repo, while the proposal targets the first project's `.nax/rules/`. The same root cause let `nax curator gc --keep 50` prune by global recency, so a busy project evicts a quiet one's entire history.
+
+Observations now carry `projectKey` (schemaVersion 3) and readers filter on it. Rows predating this carry no `projectKey` and no way to recover one, so they are dropped from windows and preserved by `gc` — claiming them would reintroduce the contamination, and deleting them on one project's behalf is not that project's decision.
+
+**The byte cap was acting as the window policy.** `MAX_WINDOW_TAIL_BYTES` bound before `windowRuns`: on the real rollup an 8 MB tail held 2 runs where 20 were configured, and nothing reported it, so proposals rested on less history than configured while appearing not to. Reads now grow from the tail until enough of this project's runs are found, the file is exhausted, or a 64 MB ceiling is hit; exhausting the file is explicitly *not* truncation, and a real shortfall is logged.
+
+**Consequence worth stating plainly:** this does not shrink an existing rollup. Almost all 648 MB of it is unattributable pre-#1429 rows, now deliberately preserved. Measured against the real file, a window read escalates to the ceiling and returns 0 runs in 229 ms — correct, bounded, and empty until a project accumulates new history. Reclaiming that space needs the retention decision and the streaming rewrite in #1430.
+
+**Method note.** Both defects were invisible to a test file written specifically to cover this seam (`curator-seam.test.ts`, added for the #1428 regression), because every test built a small single-project rollup in a temp dir. Neither a shared multi-project file nor a file larger than the tail read existed anywhere in the suite. That is the third time this month the same shape has appeared — the type was wired, the producer was not, and the tests sat on one side of the seam. Self-review of the fix then found three more defects in the new code, including a zero-length tail read that spun forever; they are recorded in the PR.

--- a/src/commands/curator.ts
+++ b/src/commands/curator.ts
@@ -415,9 +415,19 @@ export async function curatorGc(options: CuratorGcOptions): Promise<void> {
   const lines = rollupText.trim().split("\n").filter(Boolean);
   const observations = lines.map((l) => JSON.parse(l) as Observation);
 
-  // Group by runId, find max ts per runId
+  // The rollup defaults to ONE global file shared by every project on the
+  // machine (#1429), so pruning by global recency lets a busy project evict a
+  // quiet one. Only rows this project owns are eligible; a neighbour's rows —
+  // and pre-#1429 rows, which belong to no project — are preserved verbatim.
+  // Retention for those unattributable rows is #1430's problem, not one
+  // project's to decide.
+  const projectKey = getProjectKey(config, resolved.projectDir);
+  const isMine = (obs: Observation): boolean => obs.projectKey === projectKey;
+
+  // Group this project's rows by runId, find max ts per runId
   const maxTsByRunId = new Map<string, string>();
   for (const obs of observations) {
+    if (!isMine(obs)) continue;
     const existing = maxTsByRunId.get(obs.runId);
     if (!existing || obs.ts > existing) {
       maxTsByRunId.set(obs.runId, obs.ts);
@@ -430,18 +440,19 @@ export async function curatorGc(options: CuratorGcOptions): Promise<void> {
     .map(([runId]) => runId);
 
   if (uniqueRunIds.length <= keep) {
-    console.log(`[gc] ${uniqueRunIds.length} unique run(s) in rollup — at or below keep=${keep}. Nothing to prune.`);
+    console.log(
+      `[gc] ${uniqueRunIds.length} unique run(s) for ${projectKey} in rollup — at or below keep=${keep}. Nothing to prune.`,
+    );
     return;
   }
 
   const keepSet = new Set(uniqueRunIds.slice(0, keep));
-  const filtered = observations.filter((obs) => keepSet.has(obs.runId));
+  const filtered = observations.filter((obs) => !isMine(obs) || keepSet.has(obs.runId));
   const newContent = `${filtered.map((obs) => JSON.stringify(obs)).join("\n")}\n`;
 
   await _curatorCmdDeps.writeFile(rollupPath, newContent);
 
   // Delete curator artifacts from per-run directories that are no longer kept
-  const projectKey = getProjectKey(config, resolved.projectDir);
   const outputDir = _curatorCmdDeps.projectOutputDir(projectKey, config.outputDir as string | undefined);
   const perRunsDir = join(outputDir, "runs");
   for (const runId of uniqueRunIds) {

--- a/src/plugins/builtin/curator/collect.ts
+++ b/src/plugins/builtin/curator/collect.ts
@@ -96,6 +96,7 @@ async function collectFromMetrics(context: CuratorPostRunContext): Promise<Obser
       const storyId = stringValue(story.storyId ?? story.id, "unknown");
       const obs: VerdictObservation = {
         schemaVersion: OBSERVATION_SCHEMA_VERSION,
+        projectKey: context.projectKey,
         runId: context.runId,
         featureId: stringValue(currentRun.feature, context.feature),
         storyId,
@@ -134,8 +135,8 @@ function withinRun(timestamp: unknown, runStartedAt: number | undefined): boolea
   return ts >= runStartedAt;
 }
 
-/** Bumped to 2 when collection became run-scoped (#1422) — see `BaseObservation.schemaVersion`. */
-const OBSERVATION_SCHEMA_VERSION = 2;
+/** 2 when collection became run-scoped (#1422); 3 when rows gained `projectKey` (#1429). */
+const OBSERVATION_SCHEMA_VERSION = 3;
 
 /** mtime-based counterpart to `withinRun` for artifacts that carry no timestamp field. */
 async function writtenThisRun(filePath: string, runStartedAt: number | undefined): Promise<boolean> {
@@ -199,6 +200,7 @@ async function collectFromReviewAudit(context: CuratorPostRunContext): Promise<O
           const ruleId = findingRuleId(finding);
           const obs: ReviewFindingObservation = {
             schemaVersion: OBSERVATION_SCHEMA_VERSION,
+            projectKey: context.projectKey,
             runId: context.runId,
             featureId,
             storyId,
@@ -257,6 +259,7 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
           const id = String(chunkId);
           const obs: ChunkIncludedObservation = {
             schemaVersion: OBSERVATION_SCHEMA_VERSION,
+            projectKey: context.projectKey,
             runId: context.runId,
             featureId,
             storyId,
@@ -278,6 +281,7 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
           const id = stringValue(excluded.id, "unknown");
           const obs: ChunkExcludedObservation = {
             schemaVersion: OBSERVATION_SCHEMA_VERSION,
+            projectKey: context.projectKey,
             runId: context.runId,
             featureId,
             storyId,
@@ -298,6 +302,7 @@ async function collectFromContextManifests(context: CuratorPostRunContext): Prom
           if (!provider || stringValue(provider.status) !== "empty") continue;
           const obs: ProviderEmptyObservation = {
             schemaVersion: OBSERVATION_SCHEMA_VERSION,
+            projectKey: context.projectKey,
             runId: context.runId,
             featureId,
             storyId,
@@ -337,6 +342,7 @@ function collectPullCall(context: CuratorPostRunContext, entry: JsonRecord, data
   const toolName = stringValue(data.tool ?? data.toolName, "unknown");
   return {
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
+    projectKey: context.projectKey,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -361,6 +367,7 @@ function collectAcceptanceVerdict(
 ): AcceptanceVerdictObservation {
   return {
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
+    projectKey: context.projectKey,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -380,6 +387,7 @@ function collectAcceptanceVerdict(
 function collectRectify(context: CuratorPostRunContext, entry: JsonRecord, data: JsonRecord): RectifyCycleObservation {
   return {
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
+    projectKey: context.projectKey,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -396,6 +404,7 @@ function collectRectify(context: CuratorPostRunContext, entry: JsonRecord, data:
 function collectEscalation(context: CuratorPostRunContext, entry: JsonRecord, data: JsonRecord): EscalationObservation {
   return {
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
+    projectKey: context.projectKey,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -417,6 +426,7 @@ function collectFixCycleIteration(
   const outcome = optionalString(data.outcome) as FixCycleIterationObservation["payload"]["outcome"];
   return {
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
+    projectKey: context.projectKey,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -442,6 +452,7 @@ function collectFixCycleExit(
 ): FixCycleExitObservation {
   return {
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
+    projectKey: context.projectKey,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),
@@ -462,6 +473,7 @@ function collectFixCycleRetry(
 ): FixCycleValidatorRetryObservation {
   return {
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
+    projectKey: context.projectKey,
     runId: context.runId,
     featureId: entryFeatureId(context, entry, data),
     storyId: entryStoryId(entry, data),

--- a/src/plugins/builtin/curator/index.ts
+++ b/src/plugins/builtin/curator/index.ts
@@ -105,8 +105,20 @@ const curatorAction: IPostRunAction = {
         await appendToRollup(observations, rollupPath);
 
         const thresholds = getCuratorThresholds(context);
-        const window = await readHeuristicWindow(rollupPath, HEURISTIC_WINDOW_RUNS);
-        const proposals = runHeuristics(window.length > 0 ? window : observations, thresholds);
+        const window = await readHeuristicWindow(rollupPath, HEURISTIC_WINDOW_RUNS, {
+          projectKey: curatorContext.projectKey,
+        });
+        if (window.truncated) {
+          // Silent truncation reads as "20 runs of history" when it was 2 (#1429).
+          context.logger.warn("Curator window truncated at the byte ceiling", {
+            runsFound: window.runIds.length,
+            runsRequested: HEURISTIC_WINDOW_RUNS,
+          });
+        }
+        const proposals = runHeuristics(
+          window.observations.length > 0 ? window.observations : observations,
+          thresholds,
+        );
         const markdown = renderProposals(proposals, context.runId, observations.length);
 
         const proposalsMdPath = path.join(runDir, "curator-proposals.md");

--- a/src/plugins/builtin/curator/index.ts
+++ b/src/plugins/builtin/curator/index.ts
@@ -110,9 +110,13 @@ const curatorAction: IPostRunAction = {
         });
         if (window.truncated) {
           // Silent truncation reads as "20 runs of history" when it was 2 (#1429).
+          // `unattributedRows` is the usual explanation on an existing rollup:
+          // pre-#1429 rows carry no project and are skipped, so the ceiling can
+          // be reached having found little or nothing of this project's own.
           context.logger.warn("Curator window truncated at the byte ceiling", {
             runsFound: window.runIds.length,
             runsRequested: HEURISTIC_WINDOW_RUNS,
+            unattributedRows: window.unattributedRows,
           });
         }
         const proposals = runHeuristics(
@@ -187,3 +191,4 @@ export type {
 } from "./types";
 export { collectObservations, resolveCuratorOutputs };
 export { readHeuristicWindow } from "./rollup";
+export type { HeuristicWindow, HeuristicWindowOptions } from "./rollup";

--- a/src/plugins/builtin/curator/rollup.ts
+++ b/src/plugins/builtin/curator/rollup.ts
@@ -9,11 +9,43 @@ import * as path from "node:path";
 import type { Observation } from "./types";
 
 /**
- * Bytes read from the tail of the rollup when building the heuristic window.
- * The rollup is append-only and unbounded between `nax curator gc` runs, so the
- * window is taken from the end rather than by parsing the whole file.
+ * Bytes read from the tail of the rollup on the first attempt. The rollup is
+ * append-only and unbounded between `nax curator gc` runs, so the window is
+ * taken from the end rather than by parsing the whole file.
  */
-const MAX_WINDOW_TAIL_BYTES = 8 * 1024 * 1024;
+const INITIAL_WINDOW_TAIL_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Ceiling on the tail read, doubling from `INITIAL_WINDOW_TAIL_BYTES`.
+ *
+ * The initial read is a guess at "enough history"; it is not the window policy.
+ * On a real 618 MB rollup an 8 MB tail held 2 runs where 20 were configured
+ * (#1429), because pre-#1427 rows re-ingested the whole audit history and are
+ * enormous. Reading further back is correct; reading without a ceiling is not,
+ * since project-scoped filtering means a quiet project's 20th-newest run could
+ * be arbitrarily far from the end.
+ */
+const MAX_WINDOW_TAIL_BYTES = 64 * 1024 * 1024;
+
+/** Options for `readHeuristicWindow`; byte bounds are overridable for tests. */
+export interface HeuristicWindowOptions {
+  /** Only rows from this project are returned — see `BaseObservation.projectKey`. */
+  projectKey: string;
+  tailBytes?: number;
+  maxTailBytes?: number;
+}
+
+export interface HeuristicWindow {
+  observations: Observation[];
+  /** Distinct runIds represented, newest first. */
+  runIds: string[];
+  /**
+   * True when the byte ceiling was hit before `windowRuns` runs were found —
+   * i.e. more history exists but was not read. False when the file was simply
+   * exhausted: that is not truncation, there is just less history than asked for.
+   */
+  truncated: boolean;
+}
 
 /**
  * Append observations to a rollup file (JSONL format).
@@ -44,8 +76,41 @@ export async function appendToRollup(observations: Observation[], rollupPath: st
   }
 }
 
+const EMPTY_WINDOW: HeuristicWindow = { observations: [], runIds: [], truncated: false };
+
+/** Parse a tail slice, dropping the partial first line when the read started mid-file. */
+function parseTail(text: string, startedMidFile: boolean, projectKey: string): Observation[] {
+  const lines = text.split("\n");
+  if (startedMidFile) lines.shift();
+
+  const observations: Observation[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const obs = JSON.parse(line) as Observation;
+      // Rows written before #1429 carry no projectKey and no way to recover
+      // one, so they are dropped rather than claimed by whichever project
+      // happens to be reading — that would be the contamination this prevents.
+      if (obs.projectKey === projectKey) observations.push(obs);
+    } catch {
+      // Truncated or malformed line — skip it, keep the rest.
+    }
+  }
+  return observations;
+}
+
+/** The last `windowRuns` distinct runIds present, walking backwards so recency wins. */
+function newestRunIds(observations: Observation[], windowRuns: number): Set<string> {
+  const keep = new Set<string>();
+  for (let i = observations.length - 1; i >= 0 && keep.size < windowRuns; i -= 1) {
+    const runId = observations[i]?.runId;
+    if (runId) keep.add(runId);
+  }
+  return keep;
+}
+
 /**
- * Observations from the most recent `windowRuns` runs in the rollup.
+ * Observations from this project's most recent `windowRuns` runs in the rollup.
  *
  * Heuristics that measure recurrence ACROSS features (H1) cannot run on a single
  * run's observations: collection is run-scoped and a run covers one feature, so
@@ -53,38 +118,43 @@ export async function appendToRollup(observations: Observation[], rollupPath: st
  * this needs — and because collection is run-scoped, each finding appears in it
  * exactly once, which is what makes counting it meaningful.
  *
+ * The rollup is shared by every project on the machine, so the window MUST be
+ * filtered by `projectKey` before anything counts features (#1429). Reads grow
+ * from the tail until enough of this project's runs are found, the file is
+ * exhausted, or the ceiling is hit — the last case sets `truncated`.
+ *
  * Never throws: a missing, empty, or partially corrupt rollup yields whatever
  * could be read. The curator must not affect the run's exit code.
  */
-export async function readHeuristicWindow(rollupPath: string, windowRuns: number): Promise<Observation[]> {
+export async function readHeuristicWindow(
+  rollupPath: string,
+  windowRuns: number,
+  options: HeuristicWindowOptions,
+): Promise<HeuristicWindow> {
+  const maxTail = options.maxTailBytes ?? MAX_WINDOW_TAIL_BYTES;
   try {
     const file = Bun.file(rollupPath);
-    if (!(await file.exists())) return [];
+    if (!(await file.exists())) return EMPTY_WINDOW;
     const size = file.size;
-    const start = Math.max(0, size - MAX_WINDOW_TAIL_BYTES);
-    const text = await (start > 0 ? file.slice(start).text() : file.text());
-    // A non-zero start almost certainly lands mid-line; drop the partial head.
-    const lines = text.split("\n");
-    if (start > 0) lines.shift();
 
-    const observations: Observation[] = [];
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        observations.push(JSON.parse(line) as Observation);
-      } catch {
-        // Truncated or malformed line — skip it, keep the rest.
+    let tail = Math.min(options.tailBytes ?? INITIAL_WINDOW_TAIL_BYTES, maxTail);
+    while (true) {
+      const start = Math.max(0, size - tail);
+      const text = await (start > 0 ? file.slice(start).text() : file.text());
+      const observations = parseTail(text, start > 0, options.projectKey);
+      const keep = newestRunIds(observations, windowRuns);
+
+      const exhausted = start === 0;
+      if (keep.size >= windowRuns || exhausted || tail >= maxTail) {
+        return {
+          observations: observations.filter((o) => keep.has(o.runId)),
+          runIds: [...keep],
+          truncated: keep.size < windowRuns && !exhausted,
+        };
       }
+      tail = Math.min(tail * 2, maxTail);
     }
-
-    // Keep the last `windowRuns` distinct runIds, walking backwards so recency wins.
-    const keep = new Set<string>();
-    for (let i = observations.length - 1; i >= 0 && keep.size < windowRuns; i -= 1) {
-      const runId = observations[i]?.runId;
-      if (runId) keep.add(runId);
-    }
-    return observations.filter((o) => keep.has(o.runId));
   } catch {
-    return [];
+    return EMPTY_WINDOW;
   }
 }

--- a/src/plugins/builtin/curator/rollup.ts
+++ b/src/plugins/builtin/curator/rollup.ts
@@ -45,6 +45,13 @@ export interface HeuristicWindow {
    * exhausted: that is not truncation, there is just less history than asked for.
    */
   truncated: boolean;
+  /**
+   * Rows in the read span that belong to no project (pre-#1429 history). On an
+   * existing rollup these dominate, so a window can be empty while the file is
+   * hundreds of megabytes — reporting the count is what makes that legible
+   * instead of looking like a bug.
+   */
+  unattributedRows: number;
 }
 
 /**
@@ -76,14 +83,24 @@ export async function appendToRollup(observations: Observation[], rollupPath: st
   }
 }
 
-const EMPTY_WINDOW: HeuristicWindow = { observations: [], runIds: [], truncated: false };
+/** Fresh each time: a shared literal would let one caller's mutation poison every later empty read. */
+function emptyWindow(): HeuristicWindow {
+  return { observations: [], runIds: [], truncated: false, unattributedRows: 0 };
+}
+
+interface ParsedTail {
+  observations: Observation[];
+  /** Rows belonging to no project — pre-#1429 history. Explains an empty window. */
+  unattributed: number;
+}
 
 /** Parse a tail slice, dropping the partial first line when the read started mid-file. */
-function parseTail(text: string, startedMidFile: boolean, projectKey: string): Observation[] {
+function parseTail(text: string, startedMidFile: boolean, projectKey: string): ParsedTail {
   const lines = text.split("\n");
   if (startedMidFile) lines.shift();
 
   const observations: Observation[] = [];
+  let unattributed = 0;
   for (const line of lines) {
     if (!line.trim()) continue;
     try {
@@ -92,11 +109,12 @@ function parseTail(text: string, startedMidFile: boolean, projectKey: string): O
       // one, so they are dropped rather than claimed by whichever project
       // happens to be reading — that would be the contamination this prevents.
       if (obs.projectKey === projectKey) observations.push(obs);
+      else if (!obs.projectKey) unattributed += 1;
     } catch {
       // Truncated or malformed line — skip it, keep the rest.
     }
   }
-  return observations;
+  return { observations, unattributed };
 }
 
 /** The last `windowRuns` distinct runIds present, walking backwards so recency wins. */
@@ -131,17 +149,19 @@ export async function readHeuristicWindow(
   windowRuns: number,
   options: HeuristicWindowOptions,
 ): Promise<HeuristicWindow> {
-  const maxTail = options.maxTailBytes ?? MAX_WINDOW_TAIL_BYTES;
+  const maxTail = Math.max(1, options.maxTailBytes ?? MAX_WINDOW_TAIL_BYTES);
   try {
     const file = Bun.file(rollupPath);
-    if (!(await file.exists())) return EMPTY_WINDOW;
+    if (!(await file.exists())) return emptyWindow();
     const size = file.size;
 
-    let tail = Math.min(options.tailBytes ?? INITIAL_WINDOW_TAIL_BYTES, maxTail);
+    // Floored at one byte: a zero tail would read nothing, double to zero, and
+    // spin forever.
+    let tail = Math.max(1, Math.min(options.tailBytes ?? INITIAL_WINDOW_TAIL_BYTES, maxTail));
     while (true) {
       const start = Math.max(0, size - tail);
       const text = await (start > 0 ? file.slice(start).text() : file.text());
-      const observations = parseTail(text, start > 0, options.projectKey);
+      const { observations, unattributed } = parseTail(text, start > 0, options.projectKey);
       const keep = newestRunIds(observations, windowRuns);
 
       const exhausted = start === 0;
@@ -150,11 +170,12 @@ export async function readHeuristicWindow(
           observations: observations.filter((o) => keep.has(o.runId)),
           runIds: [...keep],
           truncated: keep.size < windowRuns && !exhausted,
+          unattributedRows: unattributed,
         };
       }
-      tail = Math.min(tail * 2, maxTail);
+      tail = Math.max(1, Math.min(tail * 2, maxTail));
     }
   } catch {
-    return EMPTY_WINDOW;
+    return emptyWindow();
   }
 }

--- a/src/plugins/builtin/curator/types.ts
+++ b/src/plugins/builtin/curator/types.ts
@@ -29,10 +29,18 @@ export interface BaseObservation {
   /**
    * 1 = observations re-ingested from a project's whole audit history on every
    * run (cumulative, monotonic). 2 = scoped to the run that produced them
-   * (#1422). The rollup is append-only and cross-project, so both versions
-   * coexist in one file; longitudinal analysis MUST NOT mix them.
+   * (#1422). 3 = carries `projectKey` (#1429). The rollup is append-only, so
+   * all three coexist in one file; longitudinal analysis MUST NOT mix them.
    */
-  schemaVersion: 1 | 2;
+  schemaVersion: 1 | 2 | 3;
+  /**
+   * Which project produced this row. The rollup defaults to ONE global file
+   * shared by every project on the machine (`~/.nax/global/curator/rollup.jsonl`),
+   * and nothing else in the row identifies its origin — `featureId` and `storyId`
+   * are project-local names that collide freely across repos. Readers MUST filter
+   * on this before counting anything (#1429).
+   */
+  projectKey: string;
   runId: string;
   featureId: string;
   storyId: string;

--- a/test/unit/commands/curator.test.ts
+++ b/test/unit/commands/curator.test.ts
@@ -51,9 +51,10 @@ function makeResolvedProject(projectDir: string): ResolvedProject {
   };
 }
 
-function makeObservation(kind: Observation["kind"], runId = "run-001"): Observation {
+function makeObservation(kind: Observation["kind"], runId = "run-001", projectKey = "test-proj"): Observation {
   return {
-    schemaVersion: 1,
+    schemaVersion: 3,
+    projectKey,
     runId,
     featureId: "feat-1",
     storyId: "US-001",
@@ -670,6 +671,64 @@ describe("curatorGc", () => {
       expect(writtenContent2).toBeDefined();
       const uniqueRunIds = new Set(writtenContent2!.trim().split("\n").filter(Boolean).map((l) => (JSON.parse(l) as Observation).runId));
       expect(uniqueRunIds.size).toBe(50);
+    });
+
+    test("prunes only this project's runs, leaving a neighbour project's rows untouched", async () => {
+      // The rollup defaults to one global file for the whole machine (#1429).
+      // An unscoped `--keep N` lets a busy project evict a quiet one entirely.
+      const obs: Observation[] = [
+        { ...makeObservation("verdict", "mine-001"), ts: "2026-01-01T00:00:00.000Z" },
+        { ...makeObservation("verdict", "other-001", "neighbour"), ts: "2026-01-02T00:00:00.000Z" },
+        { ...makeObservation("verdict", "other-002", "neighbour"), ts: "2026-01-03T00:00:00.000Z" },
+        { ...makeObservation("verdict", "mine-002"), ts: "2026-01-04T00:00:00.000Z" },
+        { ...makeObservation("verdict", "mine-003"), ts: "2026-01-05T00:00:00.000Z" },
+      ];
+      writeRollup(rollupPath, obs);
+
+      let written: string | undefined;
+      _deps.writeFile = mock(async (_p: string, content: string) => {
+        written = content;
+        await Bun.write(rollupPath, content);
+      });
+
+      await curatorGc({ keep: 2 });
+      expect(written).toBeDefined();
+      const rows = written!
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as Observation);
+
+      // Two most recent of MINE kept, my oldest dropped.
+      expect(rows.filter((r) => r.projectKey === "test-proj").map((r) => r.runId)).toEqual(["mine-002", "mine-003"]);
+      // The neighbour is not mine to prune — both rows survive.
+      expect(rows.filter((r) => r.projectKey === "neighbour").map((r) => r.runId)).toEqual(["other-001", "other-002"]);
+    });
+
+    test("rows predating project attribution are preserved, not pruned on one project's behalf", async () => {
+      // Pre-#1429 rows carry no projectKey. They belong to no project, so no
+      // project's gc may delete them; retention for them is #1430's problem.
+      const { projectKey: _unattributed, ...legacy } = makeObservation("verdict", "legacy-001");
+      const obs: Observation[] = [
+        { ...legacy, ts: "2026-01-01T00:00:00.000Z" } as Observation,
+        { ...makeObservation("verdict", "mine-001"), ts: "2026-01-02T00:00:00.000Z" },
+        { ...makeObservation("verdict", "mine-002"), ts: "2026-01-03T00:00:00.000Z" },
+      ];
+      writeRollup(rollupPath, obs);
+
+      let written: string | undefined;
+      _deps.writeFile = mock(async (_p: string, content: string) => {
+        written = content;
+        await Bun.write(rollupPath, content);
+      });
+
+      await curatorGc({ keep: 1 });
+      const runIds = written!
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => (JSON.parse(l) as Observation).runId);
+      expect(runIds).toEqual(["legacy-001", "mine-002"]);
     });
 
     test("deletes observations.jsonl and curator-proposals.md from pruned per-run dirs", async () => {

--- a/test/unit/plugins/builtin/curator-scoping.test.ts
+++ b/test/unit/plugins/builtin/curator-scoping.test.ts
@@ -107,9 +107,11 @@ describe("collectObservations — run scoping", () => {
     expect(rules).not.toContain("theirs");
   });
 
-  test("observations are stamped schemaVersion 2 now that collection is run-scoped", async () => {
+  test("observations are stamped with the current schema version and their project", async () => {
     // schemaVersion 1 rows in the append-only global rollup are cumulative and
-    // not comparable to these; longitudinal analysis must be able to tell them apart.
+    // not comparable to these; longitudinal analysis must be able to tell them
+    // apart. Version 3 adds projectKey — without it a row in the shared global
+    // rollup cannot be attributed to the repo that produced it (#1429).
     const root = await mkdtemp(join(tmpdir(), "curator-schema-"));
     const outputDir = join(root, "out");
     const auditDir = join(outputDir, "review-audit", "feat-auth");
@@ -131,7 +133,10 @@ describe("collectObservations — run scoping", () => {
       runStartedAt: Date.parse("2026-08-01T12:00:00.000Z"),
     });
     expect(observations.length).toBeGreaterThan(0);
-    for (const o of observations) expect(o.schemaVersion).toBe(2);
+    for (const o of observations) {
+      expect(o.schemaVersion).toBe(3);
+      expect(o.projectKey).toBe("test-project");
+    }
   });
 
   test("collects everything when runStartedAt is absent (back-compat)", async () => {

--- a/test/unit/plugins/builtin/curator-seam.test.ts
+++ b/test/unit/plugins/builtin/curator-seam.test.ts
@@ -34,7 +34,13 @@ const THRESHOLDS: CuratorThresholds = {
 
 const DEFECT = "Test asserts a pattern exists in the source file instead of invoking the code";
 
-function makeContext(root: string, feature: string, runId: string, runStartedAt: number): CuratorPostRunContext {
+function makeContext(
+  root: string,
+  feature: string,
+  runId: string,
+  runStartedAt: number,
+  projectKey = "p",
+): CuratorPostRunContext {
   return {
     runId,
     feature,
@@ -50,17 +56,18 @@ function makeContext(root: string, feature: string, runId: string, runStartedAt:
     logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
     // biome-ignore lint/suspicious/noExplicitAny: collector reads no config keys on this path
     config: {} as any,
-    outputDir: join(root, "out"),
+    outputDir: join(root, "out", projectKey),
     globalDir: join(root, "global"),
-    projectKey: "p",
+    projectKey,
+    // One global rollup shared by every project — the production default (#1429).
     curatorRollupPath: join(root, "rollup.jsonl"),
     runStartedAt,
   };
 }
 
 /** One run over one feature, writing a review-audit entry the way production does. */
-async function runOnce(root: string, feature: string, runId: string, file: string, when: string) {
-  const dir = join(root, "out", "review-audit", feature);
+async function runOnce(root: string, feature: string, runId: string, file: string, when: string, projectKey = "p") {
+  const dir = join(root, "out", projectKey, "review-audit", feature);
   await mkdir(dir, { recursive: true });
   await writeFile(
     join(dir, `${runId}.json`),
@@ -73,10 +80,15 @@ async function runOnce(root: string, feature: string, runId: string, file: strin
       },
     }),
   );
-  const ctx = makeContext(root, feature, runId, Date.parse(when) - 60_000);
+  const ctx = makeContext(root, feature, runId, Date.parse(when) - 60_000, projectKey);
   const observations = await collectObservations(ctx);
   await appendToRollup(observations, ctx.curatorRollupPath);
   return ctx;
+}
+
+/** The window as the plugin asks for it: scoped to the run's own project. */
+async function windowFor(ctx: CuratorPostRunContext, runs: number) {
+  return readHeuristicWindow(ctx.curatorRollupPath, runs, { projectKey: ctx.projectKey });
 }
 
 describe("collector → heuristics seam", () => {
@@ -99,7 +111,7 @@ describe("collector → heuristics seam", () => {
     ctx = await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z");
     ctx = await runOnce(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z");
 
-    const window = await readHeuristicWindow(ctx.curatorRollupPath, 10);
+    const { observations: window } = await windowFor(ctx, 10);
     const features = new Set(window.filter((o) => o.kind === "review-finding").map((o) => o.featureId));
     expect([...features].sort()).toEqual(["feat-a", "feat-b", "feat-c"]);
 
@@ -116,7 +128,7 @@ describe("collector → heuristics seam", () => {
     let ctx = await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z");
     ctx = await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z");
 
-    const window = await readHeuristicWindow(ctx.curatorRollupPath, 10);
+    const { observations: window } = await windowFor(ctx, 10);
     expect(window.filter((o) => o.kind === "review-finding")).toHaveLength(2);
   });
 
@@ -126,7 +138,7 @@ describe("collector → heuristics seam", () => {
     ctx = await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z");
     ctx = await runOnce(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z");
 
-    const window = await readHeuristicWindow(ctx.curatorRollupPath, 2);
+    const { observations: window } = await windowFor(ctx, 2);
     const runs = new Set(window.map((o) => o.runId));
     expect(runs.has("run-1")).toBe(false);
     expect([...runs].sort()).toEqual(["run-2", "run-3"]);
@@ -134,41 +146,157 @@ describe("collector → heuristics seam", () => {
 
   test("a missing or empty rollup yields an empty window rather than throwing", async () => {
     const root = await mkdtemp(join(tmpdir(), "curator-seam-empty-"));
-    expect(await readHeuristicWindow(join(root, "nope.jsonl"), 5)).toEqual([]);
+    const opts = { projectKey: "p" };
+    expect((await readHeuristicWindow(join(root, "nope.jsonl"), 5, opts)).observations).toEqual([]);
     const empty = join(root, "empty.jsonl");
     await writeFile(empty, "");
-    expect(await readHeuristicWindow(empty, 5)).toEqual([]);
+    expect((await readHeuristicWindow(empty, 5, opts)).observations).toEqual([]);
   });
 
   test("malformed rollup lines are skipped, not fatal", async () => {
     const root = await mkdtemp(join(tmpdir(), "curator-seam-malformed-"));
     const p = join(root, "rollup.jsonl");
+    await writeFile(p, ["{not json", JSON.stringify(rollupRow("run-1", "p")), ""].join("\n"));
+    const { observations } = await readHeuristicWindow(p, 5, { projectKey: "p" });
+    expect(observations).toHaveLength(1);
+  });
+});
+
+/** A minimal well-formed rollup row, for tests that write the rollup directly. */
+function rollupRow(runId: string, projectKey: string | undefined, featureId = "f") {
+  return {
+    schemaVersion: 3,
+    ...(projectKey !== undefined && { projectKey }),
+    runId,
+    featureId,
+    storyId: "US-001",
+    stage: "review",
+    ts: "2026-08-01T10:00:00.000Z",
+    kind: "verdict",
+    payload: {},
+  };
+}
+
+describe("the rollup is shared by every project (#1429)", () => {
+  test("a project's window excludes another project's rows", async () => {
+    // The production default is ONE global rollup for the whole machine, so
+    // another repo's runs are interleaved with this one's in the same file.
+    const root = await mkdtemp(join(tmpdir(), "curator-scope-window-"));
+    await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z", "alpha");
+    await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z", "beta");
+    const ctx = await runOnce(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z", "alpha");
+
+    const { observations } = await windowFor(ctx, 20);
+    expect(new Set(observations.map((o) => o.projectKey))).toEqual(new Set(["alpha"]));
+    expect(new Set(observations.map((o) => o.runId))).toEqual(new Set(["run-1", "run-3"]));
+  });
+
+  test("H1 never counts a foreign project's features toward cross-feature recurrence", async () => {
+    // The consequence that matters: a proposal written into alpha's run dir,
+    // targeting alpha's .nax/rules/, grounded in beta's features and files.
+    const root = await mkdtemp(join(tmpdir(), "curator-scope-h1-"));
+    await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z", "alpha");
+    await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z", "beta");
+    await runOnce(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z", "beta");
+    const ctx = await runOnce(root, "feat-d", "run-4", "src/d.ts", "2026-08-01T13:00:00.000Z", "beta");
+
+    const { observations } = await windowFor(ctx, 20);
+    const h1 = runHeuristics(observations, THRESHOLDS).find((p) => p.id === "H1");
+    // Three of beta's features, never alpha's — even though alpha's row sits in
+    // the same file, inside the same window, carrying the same defect text.
+    expect(h1?.description).toContain("3 features");
+    expect(h1?.evidence).toContain("feat-b");
+    expect(h1?.evidence).toContain("feat-d");
+    expect(h1?.evidence).not.toContain("feat-a");
+  });
+
+  test("a run's own window still spans its own features", async () => {
+    // Scoping must not over-correct into per-run isolation — that was #1428.
+    const root = await mkdtemp(join(tmpdir(), "curator-scope-own-"));
+    await runOnce(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z", "alpha");
+    await runOnce(root, "feat-b", "run-2", "src/b.ts", "2026-08-01T11:00:00.000Z", "alpha");
+    const ctx = await runOnce(root, "feat-c", "run-3", "src/c.ts", "2026-08-01T12:00:00.000Z", "alpha");
+
+    const { observations } = await windowFor(ctx, 20);
+    const h1 = runHeuristics(observations, THRESHOLDS).find((p) => p.id === "H1");
+    expect(h1?.description).toContain("3 features");
+  });
+
+  test("rows written before project scoping are dropped, not attributed to the caller", async () => {
+    // Pre-#1429 rows carry no projectKey and no way to recover one. Claiming
+    // them would reintroduce exactly the contamination this fixes; they are
+    // also the pre-#1427 rows inflated by whole-history re-ingestion.
+    const root = await mkdtemp(join(tmpdir(), "curator-scope-legacy-"));
+    const p = join(root, "rollup.jsonl");
     await writeFile(
       p,
-      [
-        "{not json",
-        JSON.stringify({
-          schemaVersion: 2,
-          runId: "run-1",
-          featureId: "f",
-          storyId: "s",
-          stage: "review",
-          ts: "t",
-          kind: "verdict",
-          payload: {},
-        }),
-        "",
-      ].join("\n"),
+      [rollupRow("old-1", undefined), rollupRow("new-1", "alpha")].map((r) => JSON.stringify(r)).join("\n") + "\n",
     );
-    const window = await readHeuristicWindow(p, 5);
-    expect(window).toHaveLength(1);
+    const { observations } = await readHeuristicWindow(p, 20, { projectKey: "alpha" });
+    expect(observations.map((o) => o.runId)).toEqual(["new-1"]);
+  });
+});
+
+describe("the window's byte ceiling must not masquerade as its run policy (#1429)", () => {
+  /** A rollup whose rows are far larger than the initial tail read. */
+  async function bigRollup(root: string, runs: number, padBytes: number): Promise<string> {
+    const p = join(root, "rollup.jsonl");
+    const lines: string[] = [];
+    for (let i = 0; i < runs; i += 1) {
+      const row = rollupRow(`run-${i}`, "alpha", `feat-${i}`);
+      lines.push(JSON.stringify({ ...row, payload: { pad: "x".repeat(padBytes) } }));
+    }
+    await writeFile(p, `${lines.join("\n")}\n`);
+    return p;
+  }
+
+  test("reads further back when the initial tail holds fewer runs than requested", async () => {
+    // On the real rollup an 8 MB tail held 2 runs, not the 20 configured. The
+    // byte cap is a memory guard; it must not silently become the window size.
+    const root = await mkdtemp(join(tmpdir(), "curator-window-expand-"));
+    const p = await bigRollup(root, 10, 500);
+    const { runIds, truncated } = await readHeuristicWindow(p, 10, {
+      projectKey: "alpha",
+      tailBytes: 600,
+      maxTailBytes: 1024 * 1024,
+    });
+    expect(runIds).toHaveLength(10);
+    expect(truncated).toBe(false);
+  });
+
+  test("reports the shortfall when the hard ceiling is reached", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-window-cap-"));
+    const p = await bigRollup(root, 10, 500);
+    const { runIds, truncated } = await readHeuristicWindow(p, 10, {
+      projectKey: "alpha",
+      tailBytes: 600,
+      maxTailBytes: 1200,
+    });
+    expect(runIds.length).toBeLessThan(10);
+    expect(truncated).toBe(true);
+  });
+
+  test("a window that fits reports no truncation even when fewer runs exist than requested", async () => {
+    // Exhausting the file is not truncation — there is simply no more history.
+    const root = await mkdtemp(join(tmpdir(), "curator-window-short-"));
+    const p = await bigRollup(root, 3, 10);
+    const { runIds, truncated } = await readHeuristicWindow(p, 20, { projectKey: "alpha" });
+    expect(runIds).toHaveLength(3);
+    expect(truncated).toBe(false);
   });
 });
 
 describe("curator plugin — end to end", () => {
   /** Drive the real post-run action, as the runner does. */
-  async function executeRun(root: string, feature: string, runId: string, file: string, when: string) {
-    const dir = join(root, "out", "review-audit", feature);
+  async function executeRun(
+    root: string,
+    feature: string,
+    runId: string,
+    file: string,
+    when: string,
+    projectKey = "p",
+  ) {
+    const dir = join(root, "out", projectKey, "review-audit", feature);
     await mkdir(dir, { recursive: true });
     await writeFile(
       join(dir, `${runId}.json`),
@@ -182,7 +310,7 @@ describe("curator plugin — end to end", () => {
       }),
     );
     const ctx = {
-      ...makeContext(root, feature, runId, Date.parse(when) - 60_000),
+      ...makeContext(root, feature, runId, Date.parse(when) - 60_000, projectKey),
       config: {
         curator: {
           enabled: true,
@@ -199,7 +327,7 @@ describe("curator plugin — end to end", () => {
       } as any,
     };
     await curatorPlugin.extensions.postRunAction?.execute(ctx);
-    return join(root, "out", "runs", runId, "curator-proposals.md");
+    return join(root, "out", projectKey, "runs", runId, "curator-proposals.md");
   }
 
   test("three runs over three features produce one cross-feature proposal", async () => {
@@ -216,6 +344,23 @@ describe("curator plugin — end to end", () => {
     expect(markdown).toContain("feat-c");
     // Files differ per feature; they are evidence, never identity.
     expect(markdown).toContain("src/a.ts");
+  });
+
+  test("a busy neighbour project cannot crowd out or contaminate this project's proposals", async () => {
+    // alpha's three runs are interleaved with beta's, so an unscoped window
+    // would cite beta's features as evidence for a rule written into alpha.
+    const root = await mkdtemp(join(tmpdir(), "curator-plugin-neighbour-"));
+    await executeRun(root, "feat-a", "run-1", "src/a.ts", "2026-08-01T10:00:00.000Z", "alpha");
+    await executeRun(root, "beta-x", "run-2", "src/x.ts", "2026-08-01T10:30:00.000Z", "beta");
+    await executeRun(root, "feat-b", "run-3", "src/b.ts", "2026-08-01T11:00:00.000Z", "alpha");
+    await executeRun(root, "beta-y", "run-4", "src/y.ts", "2026-08-01T11:30:00.000Z", "beta");
+    const proposalsPath = await executeRun(root, "feat-c", "run-5", "src/c.ts", "2026-08-01T12:00:00.000Z", "alpha");
+
+    const markdown = await Bun.file(proposalsPath).text();
+    expect(markdown).toContain("Recurring across 3 features");
+    expect(markdown).not.toContain("beta-");
+    expect(markdown).toContain("feat-a");
+    expect(markdown).toContain("feat-c");
   });
 
   test("the first run of a project proposes nothing, rather than erroring", async () => {

--- a/test/unit/plugins/builtin/curator-seam.test.ts
+++ b/test/unit/plugins/builtin/curator-seam.test.ts
@@ -276,6 +276,28 @@ describe("the window's byte ceiling must not masquerade as its run policy (#1429
     expect(truncated).toBe(true);
   });
 
+  test("a degenerate byte bound terminates instead of spinning", async () => {
+    // A zero tail reads nothing and doubles to zero — the growth loop must not
+    // depend on the caller passing a sane starting size.
+    const root = await mkdtemp(join(tmpdir(), "curator-window-zero-"));
+    const p = await bigRollup(root, 3, 10);
+    const { runIds } = await readHeuristicWindow(p, 5, { projectKey: "alpha", tailBytes: 0 });
+    expect(runIds).toHaveLength(3);
+  });
+
+  test("counts rows belonging to no project, so an empty window is legible", async () => {
+    // On an existing rollup pre-#1429 rows dominate: the window is empty while
+    // the file is hundreds of MB. Without this count that looks like a bug.
+    const root = await mkdtemp(join(tmpdir(), "curator-window-legacy-"));
+    const p = join(root, "rollup.jsonl");
+    const rows = [rollupRow("old-1", undefined), rollupRow("old-2", undefined), rollupRow("new-1", "alpha")];
+    await writeFile(p, `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`);
+
+    const window = await readHeuristicWindow(p, 20, { projectKey: "alpha" });
+    expect(window.runIds).toEqual(["new-1"]);
+    expect(window.unattributedRows).toBe(2);
+  });
+
   test("a window that fits reports no truncation even when fewer runs exist than requested", async () => {
     // Exhausting the file is not truncation — there is simply no more history.
     const root = await mkdtemp(join(tmpdir(), "curator-window-short-"));


### PR DESCRIPTION
Closes #1429. Found while replaying the curator over real artifacts for #1422.

## The defect

The rollup defaults to **one global file shared by every project** on the machine (`~/.nax/global/curator/rollup.jsonl`), and nothing in a row identified its origin — `featureId` and `storyId` are project-local names that collide freely across repos.

Reproduced through the real plugin before fixing. Five interleaved runs, alpha and beta, one shared rollup — the proposal written into **alpha's** run dir:

```
Recurring across 5 features — feat-a, beta-x, feat-b, beta-y, feat-c
Files: src/a.ts, src/x.ts, src/b.ts, src/y.ts
```

Three of those features and two of those files belong to a different repo, and the proposal targets alpha's `.nax/rules/`.

Same root cause, second consequence: `nax curator gc --keep 50` kept the 50 most recent runIds globally, so a busy project evicts a quiet one's entire history.

## The fix

Observations carry `projectKey` (schemaVersion 3) and readers filter on it. Rows predating this carry no `projectKey` and no way to recover one, so they are dropped from windows and **preserved** by gc — claiming them would reintroduce the contamination, and deleting them on one project's behalf is not that project's call.

## Second, independent defect in the same file

`MAX_WINDOW_TAIL_BYTES` bound before `windowRuns`. On the real 618 MB rollup the 8 MB tail held **2 runs** where 20 were configured:

```
window: runs=2 observations=17241
```

The byte cap is a memory guard; it was silently acting as the window policy, so proposals rested on less history than configured with nothing reporting it. Reads now grow from the tail until enough of this project's runs are found, the file is exhausted, or a 64 MB ceiling is hit — and the shortfall is logged. Exhausting the file is explicitly *not* truncation: there is simply less history than asked for.

## Why the tests missed both

`curator-seam.test.ts` drives the real collector→rollup→window→heuristics path — it is what caught the #1428 regression — but every test built a small single-project rollup in a temp dir. Neither a shared multi-project file nor a file larger than the tail read existed anywhere in the suite. Both are now covered.

Each new test was verified to fail against the unfixed code: removing the `projectKey` filter fails 4, removing the tail expansion fails 1.

## Not in scope

`curator gc` still reads the whole rollup into memory and is never invoked automatically, and retention for unattributable legacy rows is undecided — both are #1430. Note that until those legacy rows are dealt with, gc will not shrink an existing 618 MB rollup.

## Test plan

- [x] `bun run test` — 1092 pass, 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint` — deep-relatives ratchet down 1 (2852 vs 2853 baseline)
- [x] Each new assertion verified to fail without its fix