### PR TITLE
fix: pre-release review of #1417–#1438 — gc crash, window streaming, parse-boundary hardening

### DIFF
--- a/src/commands/curator.ts
+++ b/src/commands/curator.ts
@@ -457,7 +457,9 @@ export async function curatorGc(options: CuratorGcOptions): Promise<void> {
     }
   }
 
-  const dropped = Math.max(0, uniqueRunIds.length - keepSet.size);
+  // Runs evicted, NOT rows — `result.dropped` below counts rows, and the two
+  // sat one line apart under near-identical names.
+  const droppedRuns = Math.max(0, uniqueRunIds.length - keepSet.size);
   console.log(
     `[gc] Pruned rollup for ${projectKey}: kept ${keepSet.size} of ${uniqueRunIds.length} run(s), dropped ${result.dropped} row(s).`,
   );
@@ -469,5 +471,5 @@ export async function curatorGc(options: CuratorGcOptions): Promise<void> {
       `[gc] ${result.keptUnattributed} unattributed row(s) predate project scoping (#1429) and can never be read back. Run with --sweep-unattributed to drop them machine-wide.`,
     );
   }
-  if (dropped === 0 && sweep) console.log("[gc] No run-level pruning was needed; only the unattributed sweep ran.");
+  if (droppedRuns === 0 && sweep) console.log("[gc] No run-level pruning was needed; only the unattributed sweep ran.");
 }

--- a/src/plugins/builtin/curator/heuristics.ts
+++ b/src/plugins/builtin/curator/heuristics.ts
@@ -74,7 +74,25 @@ const DESCRIPTION_GIST_CHARS = 90;
 /** Files listed in evidence before truncating. */
 const MAX_EVIDENCE_FILES = 4;
 
-/** Characters of normalized message text that identify a defect across features. */
+/**
+ * Characters of normalized message text that identify a defect across features.
+ *
+ * Shorter than `normalizeIssueText`'s own 160-char clamp, and deliberately so:
+ * that clamp identifies one finding across successive rounds of ONE story, where
+ * the reviewer is describing the same file and the wording barely moves. Across
+ * features the wording diverges much faster — different files, symbols and
+ * quoted snippets — so a 160-char key would put every occurrence in its own
+ * group and H1 could never reach its feature threshold.
+ *
+ * The cost is the mirror image: two genuinely distinct defects that share a
+ * category AND the first 48 normalized characters merge into one proposal. That
+ * is accepted. Reviewer messages lead with the generic description and trail
+ * into the specifics, so a shared 48-char lead is itself decent evidence the two
+ * are the same class of defect — which is the granularity a *rule* proposal
+ * wants. Do NOT "fix" this by mixing a hash of the full message into the key:
+ * that makes identity exact-match, and exact cross-feature message equality
+ * essentially never happens, which silently disables the heuristic.
+ */
 const CROSS_FEATURE_MESSAGE_PREFIX = 48;
 
 /**

--- a/src/plugins/builtin/curator/index.ts
+++ b/src/plugins/builtin/curator/index.ts
@@ -192,3 +192,6 @@ export type {
 export { collectObservations, resolveCuratorOutputs };
 export { readHeuristicWindow } from "./rollup";
 export type { HeuristicWindow, HeuristicWindowOptions } from "./rollup";
+// Both rollup readers depend on this reassembling rows across chunk boundaries;
+// exported so it is reachable through the barrel rather than only its callers.
+export { streamJsonlLines } from "./jsonl-stream";

--- a/src/plugins/builtin/curator/jsonl-stream.ts
+++ b/src/plugins/builtin/curator/jsonl-stream.ts
@@ -1,0 +1,34 @@
+/**
+ * Curator Rollup — shared JSONL line reader.
+ *
+ * The rollup is one append-only file shared by every project on the machine and
+ * is unbounded between `nax curator gc` runs; on a real machine it reached
+ * 618 MB / 1.13M rows. Every reader of it must therefore be bounded by what it
+ * retains, not by the file — which means never materialising the text or a
+ * line array.
+ *
+ * Takes a `BunFile` rather than a path so callers can stream a `slice()` (the
+ * heuristic window reads a tail) through the same reader as a whole file.
+ */
+
+/**
+ * Yield a JSONL source line by line without materialising it.
+ *
+ * Resident memory is one chunk plus the carry — a single line — regardless of
+ * source size. A final line with no trailing newline is still yielded.
+ */
+export async function* streamJsonlLines(file: Bun.BunFile): AsyncGenerator<string> {
+  const decoder = new TextDecoder();
+  let carry = "";
+  for await (const chunk of file.stream()) {
+    carry += decoder.decode(chunk, { stream: true });
+    let nl = carry.indexOf("\n");
+    while (nl !== -1) {
+      yield carry.slice(0, nl);
+      carry = carry.slice(nl + 1);
+      nl = carry.indexOf("\n");
+    }
+  }
+  carry += decoder.decode();
+  if (carry.length > 0) yield carry;
+}

--- a/src/plugins/builtin/curator/rollup-prune.ts
+++ b/src/plugins/builtin/curator/rollup-prune.ts
@@ -14,8 +14,9 @@
  * original rollup intact rather than truncating it.
  */
 
-import { rename, unlink } from "node:fs/promises";
+import { rename, unlink, writeFile } from "node:fs/promises";
 import { appendFile } from "node:fs/promises";
+import { streamJsonlLines } from "./jsonl-stream";
 import type { Observation } from "./types";
 
 /**
@@ -43,22 +44,8 @@ export interface PruneResult {
 }
 
 /** Stream a JSONL file line by line without materialising it. */
-async function* streamLines(filePath: string): AsyncGenerator<string> {
-  const stream = Bun.file(filePath).stream();
-  const decoder = new TextDecoder();
-  let carry = "";
-  for await (const chunk of stream) {
-    carry += decoder.decode(chunk, { stream: true });
-    let nl = carry.indexOf("\n");
-    while (nl !== -1) {
-      yield carry.slice(0, nl);
-      carry = carry.slice(nl + 1);
-      nl = carry.indexOf("\n");
-    }
-  }
-  carry += decoder.decode();
-  // A final line without a trailing newline is still a row.
-  if (carry.length > 0) yield carry;
+function streamLines(filePath: string): AsyncGenerator<string> {
+  return streamJsonlLines(Bun.file(filePath));
 }
 
 /**
@@ -112,8 +99,14 @@ export interface PruneRollupInput {
 export async function pruneRollup(input: PruneRollupInput): Promise<PruneResult> {
   const { rollupPath, projectKey, keepRunIds, dropUnattributed = false } = input;
   const tmpPath = `${rollupPath}.gc-tmp`;
-  // A temp file left by an interrupted earlier run would otherwise be appended to.
-  await unlink(tmpPath).catch(() => {});
+  // Truncating creation, not append: a temp file left by an interrupted earlier
+  // run would otherwise be appended to. It must also happen UNCONDITIONALLY —
+  // when every row is dropped the buffer never flushes, and a temp file created
+  // only on first flush would leave the rename below with nothing to rename.
+  // That is the real `--sweep-unattributed` case: a rollup written entirely
+  // before #1429 has no attributable row, so `keepRunIds` is empty and the
+  // correct result is an empty rollup, not ENOENT.
+  await writeFile(tmpPath, "");
 
   const result: PruneResult = { kept: 0, dropped: 0, keptOtherProjects: 0, keptUnattributed: 0 };
   let buffer = "";

--- a/src/plugins/builtin/curator/rollup-prune.ts
+++ b/src/plugins/builtin/curator/rollup-prune.ts
@@ -43,11 +43,6 @@ export interface PruneResult {
   keptUnattributed: number;
 }
 
-/** Stream a JSONL file line by line without materialising it. */
-function streamLines(filePath: string): AsyncGenerator<string> {
-  return streamJsonlLines(Bun.file(filePath));
-}
-
 /**
  * Pass 1 — the newest timestamp per run id, for this project only.
  *
@@ -59,7 +54,7 @@ function streamLines(filePath: string): AsyncGenerator<string> {
  */
 export async function scanProjectRunIds(rollupPath: string, projectKey: string): Promise<string[]> {
   const maxTsByRunId = new Map<string, string>();
-  for await (const line of streamLines(rollupPath)) {
+  for await (const line of streamJsonlLines(Bun.file(rollupPath))) {
     if (!line.trim()) continue;
     let obs: Observation;
     try {
@@ -99,15 +94,6 @@ export interface PruneRollupInput {
 export async function pruneRollup(input: PruneRollupInput): Promise<PruneResult> {
   const { rollupPath, projectKey, keepRunIds, dropUnattributed = false } = input;
   const tmpPath = `${rollupPath}.gc-tmp`;
-  // Truncating creation, not append: a temp file left by an interrupted earlier
-  // run would otherwise be appended to. It must also happen UNCONDITIONALLY —
-  // when every row is dropped the buffer never flushes, and a temp file created
-  // only on first flush would leave the rename below with nothing to rename.
-  // That is the real `--sweep-unattributed` case: a rollup written entirely
-  // before #1429 has no attributable row, so `keepRunIds` is empty and the
-  // correct result is an empty rollup, not ENOENT.
-  await writeFile(tmpPath, "");
-
   const result: PruneResult = { kept: 0, dropped: 0, keptOtherProjects: 0, keptUnattributed: 0 };
   let buffer = "";
 
@@ -117,8 +103,19 @@ export async function pruneRollup(input: PruneRollupInput): Promise<PruneResult>
     buffer = "";
   };
 
+  // Inside the try with every other filesystem op, so one catch owns temp-file
+  // cleanup for the whole function.
   try {
-    for await (const line of streamLines(rollupPath)) {
+    // Truncating creation, not append: a temp file left by an interrupted
+    // earlier run would otherwise be appended to. It must also happen
+    // UNCONDITIONALLY — when every row is dropped the buffer never flushes, and
+    // a temp file created only on first flush would leave the rename below with
+    // nothing to rename. That is the real `--sweep-unattributed` case: a rollup
+    // written entirely before #1429 has no attributable row, so `keepRunIds` is
+    // empty and the correct result is an empty rollup, not ENOENT.
+    await writeFile(tmpPath, "");
+
+    for await (const line of streamJsonlLines(Bun.file(rollupPath))) {
       if (!line.trim()) continue;
 
       let obs: Observation | null = null;

--- a/src/plugins/builtin/curator/rollup.ts
+++ b/src/plugins/builtin/curator/rollup.ts
@@ -6,6 +6,7 @@
 
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import * as path from "node:path";
+import { streamJsonlLines } from "./jsonl-stream";
 import type { Observation } from "./types";
 
 /**
@@ -94,14 +95,27 @@ interface ParsedTail {
   unattributed: number;
 }
 
-/** Parse a tail slice, dropping the partial first line when the read started mid-file. */
-function parseTail(text: string, startedMidFile: boolean, projectKey: string): ParsedTail {
-  const lines = text.split("\n");
-  if (startedMidFile) lines.shift();
-
+/**
+ * Parse a tail slice, dropping the partial first line when the read started mid-file.
+ *
+ * Streamed rather than read into a string (#1439). The tail can be up to
+ * `MAX_WINDOW_TAIL_BYTES`, and slurping it would hold the text AND a line array
+ * of every row in it — the same unbounded materialisation `rollup-prune.ts`
+ * streams to avoid, on a path that runs after EVERY run rather than only on
+ * `gc`. Streaming leaves only this project's rows resident, which is the return
+ * value anyway.
+ */
+async function parseTail(file: Bun.BunFile, startedMidFile: boolean, projectKey: string): Promise<ParsedTail> {
   const observations: Observation[] = [];
   let unattributed = 0;
-  for (const line of lines) {
+  let first = true;
+  for await (const line of streamJsonlLines(file)) {
+    // The slice began mid-row, so the first line is a fragment of a row whose
+    // start was never read.
+    if (first) {
+      first = false;
+      if (startedMidFile) continue;
+    }
     if (!line.trim()) continue;
     try {
       const obs = JSON.parse(line) as Observation;
@@ -160,8 +174,11 @@ export async function readHeuristicWindow(
     let tail = Math.max(1, Math.min(options.tailBytes ?? INITIAL_WINDOW_TAIL_BYTES, maxTail));
     while (true) {
       const start = Math.max(0, size - tail);
-      const text = await (start > 0 ? file.slice(start).text() : file.text());
-      const { observations, unattributed } = parseTail(text, start > 0, options.projectKey);
+      const { observations, unattributed } = await parseTail(
+        start > 0 ? file.slice(start) : file,
+        start > 0,
+        options.projectKey,
+      );
       const keep = newestRunIds(observations, windowRuns);
 
       const exhausted = start === 0;

--- a/src/review/acks.ts
+++ b/src/review/acks.ts
@@ -14,8 +14,15 @@
 
 import type { ReviewAck } from "./types";
 
-/** Ceiling on retained acknowledgements; the rest are dropped rather than bloating every audit record. */
-const MAX_ACKS = 50;
+/**
+ * Ceiling on retained acknowledgements; the rest are dropped rather than
+ * bloating every audit record.
+ *
+ * Bounds a single reviewer response here, and — exported for it — the merged
+ * total in `semantic-debate.ts`, where N debaters' responses are concatenated
+ * into one audit entry and would otherwise persist N × this.
+ */
+export const MAX_ACKS = 50;
 /** Ceiling on a single `note`, matching the clipping other reviewer text gets. */
 const MAX_NOTE_CHARS = 500;
 

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -21,7 +21,7 @@ export * from "./requote-response";
 export * from "./severity";
 export { validateLLMShape, parseLLMResponse } from "./semantic-helpers";
 // Review acknowledgements (#1423) — shared read path for both reviewers.
-export { extractAcks } from "./acks";
+export { extractAcks, MAX_ACKS } from "./acks";
 // Semantic finding taxonomy. `src/prompts/builders/review-builder.ts` must keep
 // using the leaf path (importing this barrel from src/prompts would close a
 // cycle — see that file's header); every other consumer goes through here.

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -12,6 +12,7 @@ import { pickBaseSelectorKind } from "../debate";
 import type { DebateRunner, DebateRunnerOptions, DebateStageConfig } from "../debate";
 import { getSafeLogger } from "../logger";
 import { filterByAcGroundingMinimal } from "./ac-quote-validator";
+import { MAX_ACKS } from "./acks";
 import { llmFindingsToReviewFindings } from "./finding-projection";
 import {
   type LLMFinding,
@@ -147,7 +148,9 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     const parsed = parseLLMResponse(p.output);
     if (parsed) {
       allFindings.push(...parsed.findings);
-      if (parsed.acks) acks.push(...parsed.acks);
+      // `extractAcks` caps each response; the merge across debaters has to
+      // respect the same ceiling or a 3-debater panel persists 3 × MAX_ACKS.
+      if (parsed.acks) acks.push(...parsed.acks.slice(0, MAX_ACKS - acks.length));
     }
   }
   const debateAcks = acks.length > 0 ? acks : undefined;

--- a/src/review/semantic-helpers.ts
+++ b/src/review/semantic-helpers.ts
@@ -68,14 +68,24 @@ export function validateLLMShape(parsed: unknown): LLMResponse | null {
   const acks = extractAcks(obj.acks);
   return {
     passed: obj.passed,
-    findings: (obj.findings as LLMFinding[]).map(withNormalizedCategory),
+    // Non-object entries are discarded HERE rather than defended against by
+    // every consumer. `findings: [null]` and `findings: ["prose"]` are both
+    // shapes an LLM produces, and every downstream reader dereferences
+    // `f.severity` / `f.file` unguarded — so a malformed entry that survives the
+    // parse boundary becomes a crash somewhere far from its cause.
+    findings: (obj.findings as unknown[]).filter(isFindingShaped).map(withNormalizedCategory),
     ...(acks.length > 0 && { acks }),
   };
 }
 
+/** A finding must at least be an object; field-level validity is the consumer's business. */
+function isFindingShaped(f: unknown): f is LLMFinding {
+  return typeof f === "object" && f !== null && !Array.isArray(f);
+}
+
 /** Copy a finding with its category canonicalised; leaves every other field untouched. */
 function withNormalizedCategory(f: LLMFinding): LLMFinding {
-  const category = normalizeSemanticCategory(f?.category);
+  const category = normalizeSemanticCategory(f.category);
   // Absent stays absent: `""` and "field omitted" are the same signal on the
   // wire, and adding an empty key would show up in audit artifacts as noise.
   if (category === "") return f;

--- a/src/runtime/middleware/cost.ts
+++ b/src/runtime/middleware/cost.ts
@@ -94,7 +94,6 @@ export function attachCostSubscriber(
       ts: event.timestamp,
       runId,
       ...(projectKey !== undefined ? { projectKey } : {}),
-      ...(projectKey !== undefined ? { projectKey } : {}),
       schemaVersion: COST_ROW_SCHEMA_VERSION,
       agentName: event.agentName,
       stage: event.stage,

--- a/test/unit/commands/curator-gc.test.ts
+++ b/test/unit/commands/curator-gc.test.ts
@@ -388,6 +388,24 @@ describe("curatorGc", () => {
       expect((await readRollupRows(rollupPath)).map((r) => r.runId)).toEqual(["mine-001"]);
     });
 
+    test("--sweep-unattributed empties a rollup that is entirely pre-#1429 history", async () => {
+      // The motivating case: a 618 MB rollup written before project scoping, so
+      // NO row is attributable and `keepRunIds` is empty. Every row is dropped,
+      // which means the prune buffer never fills and the temp file is never
+      // created — the rename must still land on an empty rollup, not ENOENT.
+      const { projectKey: _dropped, ...legacy } = makeObservation("verdict", "legacy-001");
+      writeRollup(rollupPath, [
+        { ...legacy, ts: "2026-01-01T00:00:00.000Z" } as Observation,
+        { ...legacy, runId: "legacy-002", ts: "2026-01-02T00:00:00.000Z" } as Observation,
+      ]);
+
+      await curatorGc({ keep: 50, sweepUnattributed: true });
+
+      expect(await Bun.file(rollupPath).exists()).toBe(true);
+      expect(await Bun.file(rollupPath).text()).toBe("");
+      expect(existsSync(`${rollupPath}.gc-tmp`)).toBe(false);
+    });
+
     test("keeps rows that fail to parse rather than silently dropping them", async () => {
       // We cannot tell whose a corrupt row is, so deleting it is not ours to do.
       writeRollup(rollupPath, [

--- a/test/unit/plugins/builtin/curator-rollup.test.ts
+++ b/test/unit/plugins/builtin/curator-rollup.test.ts
@@ -1,12 +1,13 @@
 /**
  * Curator Rollup Tests
  *
- * Tests for append-only rollup functionality.
+ * Tests for append-only rollup functionality and the shared JSONL line
+ * reader both rollup readers stream through (#1439).
  */
 
 import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
-import type { Observation } from "../../../../src/plugins/builtin/curator";
+import { type Observation, streamJsonlLines } from "../../../../src/plugins/builtin/curator";
 import { appendToRollup } from "../../../../src/plugins/builtin/curator/rollup";
 import { withTempDir } from "../../../helpers";
 
@@ -267,6 +268,113 @@ describe("appendToRollup", () => {
       expect(kinds).toContain("chunk-included");
       expect(kinds).toContain("chunk-excluded");
       expect(kinds).toContain("escalation");
+    });
+  });
+});
+
+/** Rows padded past any plausible chunk size, so every row straddles a boundary. */
+const CHUNK_STRADDLING_PAD = 200_000;
+
+async function collect(file: Bun.BunFile): Promise<string[]> {
+  const lines: string[] = [];
+  for await (const line of streamJsonlLines(file)) lines.push(line);
+  return lines;
+}
+
+describe("streamJsonlLines", () => {
+  test("reassembles rows that straddle chunk boundaries", async () => {
+    await withTempDir(async (dir) => {
+      const p = path.join(dir, "rollup.jsonl");
+      const rows = Array.from({ length: 12 }, (_, i) => ({ i, pad: "x".repeat(CHUNK_STRADDLING_PAD) }));
+      await Bun.write(p, `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`);
+
+      const lines = await collect(Bun.file(p));
+
+      expect(lines).toHaveLength(12);
+      expect(lines.map((l) => (JSON.parse(l) as { i: number }).i)).toEqual(rows.map((r) => r.i));
+    });
+  });
+
+  test("preserves multi-byte characters split across a chunk boundary", async () => {
+    // The reason the decoder is driven with `{ stream: true }`. Reviewer prose
+    // in the rollup is full of `—`, `·` and `→`; decoding each chunk
+    // independently replaces whichever one lands on the seam with U+FFFD.
+    //
+    // The padding itself must be multi-byte. A row of ASCII padding carrying a
+    // few non-ASCII characters in one small field passes either way — no chunk
+    // boundary ever lands inside those few bytes, so the test proves nothing.
+    // Filling the row with 3-byte characters makes a split mid-character
+    // certain rather than lucky.
+    await withTempDir(async (dir) => {
+      const p = path.join(dir, "rollup.jsonl");
+      const pad = "→".repeat(CHUNK_STRADDLING_PAD / 2);
+      const rows = Array.from({ length: 12 }, (_, i) => ({ i, pad }));
+      await Bun.write(p, `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`);
+
+      const lines = await collect(Bun.file(p));
+
+      expect(lines).toHaveLength(12);
+      for (const line of lines) {
+        expect((JSON.parse(line) as { pad: string }).pad).toBe(pad);
+      }
+      expect(lines.join("")).not.toContain("�");
+    });
+  });
+
+  test("a byte-sliced start yields exactly one leading fragment, then intact rows", async () => {
+    // `readHeuristicWindow` reads a tail by byte offset, so the first line is a
+    // fragment of a row whose start was never read — and `parseTail` drops
+    // exactly one line on that basis. If the reader ever yielded zero or two
+    // fragments, that caller would silently drop a good row or admit a broken one.
+    await withTempDir(async (dir) => {
+      const p = path.join(dir, "rollup.jsonl");
+      const rows = Array.from({ length: 12 }, (_, i) => ({ i, pad: "x".repeat(CHUNK_STRADDLING_PAD) }));
+      await Bun.write(p, `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`);
+
+      // Mid-row by construction: rows are ~200 KB, so this lands inside row 1.
+      const lines = await collect(Bun.file(p).slice(CHUNK_STRADDLING_PAD / 2));
+
+      const parses = lines.map((l) => {
+        try {
+          JSON.parse(l);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(parses[0]).toBe(false);
+      expect(parses.slice(1).every(Boolean)).toBe(true);
+    });
+  });
+
+  test("yields a final row that has no trailing newline", async () => {
+    await withTempDir(async (dir) => {
+      const p = path.join(dir, "rollup.jsonl");
+      await Bun.write(p, '{"i":1}\n{"i":2}');
+
+      expect(await collect(Bun.file(p))).toEqual(['{"i":1}', '{"i":2}']);
+    });
+  });
+
+  test("yields nothing for an empty source rather than one empty line", async () => {
+    // `pruneRollup` counts every yielded line; a phantom row would inflate its
+    // kept/dropped tallies on an empty rollup.
+    await withTempDir(async (dir) => {
+      const p = path.join(dir, "rollup.jsonl");
+      await Bun.write(p, "");
+
+      expect(await collect(Bun.file(p))).toEqual([]);
+    });
+  });
+
+  test("preserves blank lines rather than collapsing them", async () => {
+    // Callers decide what a blank line means (both skip it via `.trim()`); the
+    // reader must not make that decision for them by silently dropping rows.
+    await withTempDir(async (dir) => {
+      const p = path.join(dir, "rollup.jsonl");
+      await Bun.write(p, '{"i":1}\n\n{"i":2}\n');
+
+      expect(await collect(Bun.file(p))).toEqual(['{"i":1}', "", '{"i":2}']);
     });
   });
 });

--- a/test/unit/plugins/builtin/curator-seam.test.ts
+++ b/test/unit/plugins/builtin/curator-seam.test.ts
@@ -298,6 +298,25 @@ describe("the window's byte ceiling must not masquerade as its run policy (#1429
     expect(window.unattributedRows).toBe(2);
   });
 
+  test("rows spanning a stream-chunk boundary survive intact", async () => {
+    // The window reads its tail through the same streaming reader the prune
+    // uses, so rows no longer arrive whole — a row can straddle two chunks.
+    // Padding each row past any plausible chunk size forces that split; a
+    // reader that lost the carry would drop or corrupt these rows silently.
+    const root = await mkdtemp(join(tmpdir(), "curator-window-chunked-"));
+    const p = await bigRollup(root, 6, 300_000);
+    const { observations, runIds } = await readHeuristicWindow(p, 6, {
+      projectKey: "alpha",
+      maxTailBytes: 64 * 1024 * 1024,
+    });
+    expect(runIds).toHaveLength(6);
+    expect(observations).toHaveLength(6);
+    // Every payload is intact — a mid-chunk split would truncate one.
+    for (const obs of observations) {
+      expect((obs.payload as unknown as { pad: string }).pad).toHaveLength(300_000);
+    }
+  });
+
   test("a window that fits reports no truncation even when fewer runs exist than requested", async () => {
     // Exhausting the file is not truncation — there is simply no more history.
     const root = await mkdtemp(join(tmpdir(), "curator-window-short-"));

--- a/test/unit/review/semantic-categories.test.ts
+++ b/test/unit/review/semantic-categories.test.ts
@@ -127,6 +127,26 @@ describe("validateLLMShape() — normalization at the parse boundary", () => {
     expect(parsed?.findings[0]).not.toHaveProperty("category");
   });
 
+  test("drops non-object entries instead of passing them to consumers that dereference them", () => {
+    // An LLM that emits `findings: [null]` or a bare string used to survive the
+    // parse boundary untouched, then threw on the first `f.severity` read deep
+    // in a consumer. The parse boundary is where a malformed entry is cheap to
+    // discard — every consumer downstream assumes a finding-shaped object.
+    const parsed = parseLLMResponse(
+      JSON.stringify({
+        passed: false,
+        findings: [
+          null,
+          "the tests are inadequate",
+          42,
+          { severity: "error", category: "partial", file: "src/a.ts", line: 1, issue: "real", suggestion: "fix" },
+        ],
+      }),
+    );
+    expect(parsed?.findings).toHaveLength(1);
+    expect(parsed?.findings[0]).toMatchObject({ issue: "real", category: "partial" });
+  });
+
   test("preserves every other field on the finding", () => {
     const finding = parseLLMResponse(wire("Contradiction"))?.findings[0];
     expect(finding).toMatchObject({

--- a/test/unit/review/semantic-debate-audit-shape.test.ts
+++ b/test/unit/review/semantic-debate-audit-shape.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { DebateResult, DebateRunner } from "../../../src/debate";
 import { reviewConfigSelector } from "../../../src/config/selectors";
 import type { NaxRuntime, ReviewAuditDecision } from "../../../src/runtime";
+import { MAX_ACKS } from "@/review";
 import { runSemanticDebate } from "../../../src/review/semantic-debate";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import type { SemanticStory } from "../../../src/review/types";
@@ -166,4 +167,58 @@ describe("semantic-debate reviewer audit shape (#942 AC-1 / AC-2)", () => {
     }
   });
 
+  test("aggregate acks across proposals are capped, not multiplied by debater count", async () => {
+    // extractAcks caps each response at MAX_ACKS, but debate concatenates every
+    // proposal's acks into one audit record — N debaters could carry N × the
+    // ceiling into every entry. The cap is a bound on what gets persisted, so it
+    // has to hold after the merge too.
+    const acksFor = (debater: string) =>
+      JSON.stringify({
+        passed: true,
+        findings: [],
+        acks: Array.from({ length: MAX_ACKS }, (_, i) => ({
+          priorFinding: `${debater}:src/f${i}.ts:${i}`,
+          status: "addressed",
+        })),
+      });
+
+    const debateResult: DebateResult = {
+      ...makeDebateResult(acksFor("a")),
+      proposals: [
+        { debater: { agent: "claude" }, output: acksFor("a") },
+        { debater: { agent: "claude" }, output: acksFor("b") },
+        { debater: { agent: "claude" }, output: acksFor("c") },
+      ],
+    };
+
+    const agentManager = makeMockAgentManager();
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
+    createdRuntimes.push(runtime);
+
+    await runSemanticDebate({
+      naxConfig: reviewConfigSelector.select(makeNaxConfig()),
+      runtime,
+      workdir: "/tmp/test",
+      agentManager,
+      featureName: "feat-x",
+      story: STORY,
+      diffMode: "embedded",
+      diff: "some diff",
+      stat: "",
+      semanticConfig: CFG,
+      effectiveRef: "abc123",
+      startTime: Date.now(),
+      prompt: "review this diff",
+      productionExcludePatterns: [],
+      blockingThreshold: undefined,
+      createDebateRunner: () => makeMockDebateRunner(debateResult),
+    });
+
+    const acks = decisions[0]?.acks ?? [];
+    expect(acks).toHaveLength(MAX_ACKS);
+    // Truncation keeps the earliest proposals rather than interleaving.
+    expect(acks[0]?.priorFinding).toStartWith("a:");
+  });
 });


### PR DESCRIPTION
Pre-release review of the 15 PRs merged since `064f9083` (#1417–#1438), plus fixes for everything it found.

The review graded the window **A− (88/100)** — the diff is unusually well-documented and schema versioning is handled properly. One real crash bug, one memory-consistency gap, and four minor items.

## Findings and fixes

| Commit | Severity | Finding |
|:---|:---|:---|
| `162a98c0` | **HIGH** | `nax curator gc --sweep-unattributed` crashed with ENOENT when every row was dropped |
| `d0bd7a5e` | MEDIUM | `readHeuristicWindow` slurped up to 64 MB while its sibling streamed |
| `fc76502a` | LOW | Non-object findings survived the semantic parse boundary |
| `2ebaecca` | LOW | Merged debate acks were unbounded (N debaters × `MAX_ACKS`) |
| `65efc419` | LOW | Duplicated `projectKey` spread on cost error rows |
| `e3fa22d0` | NIT | Undocumented `CROSS_FEATURE_MESSAGE_PREFIX`; `dropped` vs `result.dropped` |
| `89a0e2f2` | — | Self-review follow-ups (see below) |

### HIGH — gc crashed on the case it was built for (#1437 regression)

`pruneRollup` created its temp file only on the first buffer flush, and `flush()` returns early on an empty buffer. When no row survived, the temp file never existed and the closing `rename` threw ENOENT.

That is precisely the `--sweep-unattributed` scenario: a rollup written before #1429 has no attributable row, so `scanProjectRunIds` returns `[]`, `keepRunIds` is empty, and every row is dropped. The one command able to shrink a fully-legacy rollup crashed on one — the same shape of defect #1430 fixed for memory. A 0-byte rollup hit it too.

Reproduced before fixing:

```
THREW: ENOENT: no such file or directory, rename '…/rollup.jsonl.gc-tmp' -> '…/rollup.jsonl'
```

**Behaviour change worth noting in release notes:** a gc that drops everything now leaves a 0-byte rollup where it previously crashed and left the original intact. That is the intended outcome, but it makes the command genuinely destructive on a fully-legacy rollup.

### MEDIUM — the window did not stream

`rollup-prune.ts` was written to stream because the rollup reached 618 MB. `readHeuristicWindow` — which runs after **every** run, not just `gc` — did the opposite: read the tail into a string, `split("\n")` into a line array, parse all of it. Worst case held a 64 MB string plus a line entry per row, across four doubling passes.

The line reader is now extracted to `curator/jsonl-stream.ts`, taking a `BunFile` so a `slice()` streams through the same path as a whole file. Only this project's rows stay resident, which is the return value anyway.

## Self-review follow-ups (`89a0e2f2`)

Reviewing my own diff surfaced a test that could not fail. The multi-byte UTF-8 test padded rows with 200 KB of ASCII and put `→ é 🙂` in one small field — no chunk boundary ever lands inside those few bytes, so it passed whether or not the decoder was driven with `{ stream: true }`.

Caught by mutation: removing `{ stream: true }` left all six tests green. Filling the row with 3-byte characters makes the split certain, and the same mutation now fails the test. Reading the test, it looked fine.

Also in that commit: `pruneRollup`'s temp-file creation moved inside the `try` so one catch owns cleanup for the whole function, and the one-line `streamLines` pass-through left by the extraction was inlined.

## Test coverage added

- Prune that drops every row → empty rollup, no leftover temp file
- `jsonl-stream`: chunk-straddling rows, multi-byte splits, byte-sliced start (exactly one leading fragment — what `parseTail` relies on), final carry, empty source, blank lines
- Semantic parse boundary: `[null, "prose", 42, {…}]` → 1 finding
- Debate acks: 3 debaters × 50 acks → 50

## One correction to the original review

I first proposed adding a full-message hash to `crossFeatureKey` to reduce collisions. **That would have been a regression.** `normalizeIssueText` only lowercases and collapses whitespace — it does not strip paths or identifiers — so cross-feature messages never match exactly. A hash makes identity exact-match, every occurrence lands in its own group, and H1 stops firing. The 48-char prefix is deliberate fuzziness, clamped below `normalizeIssueText`'s own 160.

`e3fa22d0` documents the tradeoff and warns off the hash instead of implementing it.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean, all 8 ratchets at baseline (deep-relatives 2845, file-sizes 13, nax-error 112)
- `bun run test` — **12,210 tests, 0 fail** across unit / integration / ui

## Out of scope

Separately discovered while reviewing: `.nax/rules/` does not exist here and `context.rules.allowLegacyClaudeMd` defaults to `false`, so `StaticRulesProvider` loads **zero** project rules on every nax run — the `.claude/rules/` files never reach a nax-driven agent. Not touched here; it changes agent behaviour on every run and needs its own PR.
