### PR TITLE
fix(plan): stop hoisting story-local out-of-scope blocks to feature level

### DIFF
--- a/src/operations/plan-fidelity.ts
+++ b/src/operations/plan-fidelity.ts
@@ -7,29 +7,47 @@
  * it is not. spec-review remains the explicit gate before any story executes.
  */
 import { getSafeLogger } from "../logger";
-import { applyOutOfScopeFallback, findMissingOutOfScope, findSpecDriftViolations } from "../prd";
+import {
+  applyOutOfScopeFallback,
+  demoteStoryScopedOutOfScope,
+  findMissingOutOfScope,
+  findSpecDriftViolations,
+} from "../prd";
 import type { PRD } from "../prd/types";
 
 /**
- * Scope-fidelity backfill shared by the plan ops (single + refine).
+ * Scope-fidelity repair shared by the plan ops (single + refine).
  *
  * Feature-level exclusions have exactly one home (`prd.outOfScope`), so unlike
  * a dropped AC — where restoring it would require knowing which story owns it —
- * a dropped exclusion can be repaired deterministically. The prompt asks the planner for its own wording; whatever
- * it drops is appended verbatim from the spec here, and the warning records
- * that the planner needed the safety net.
+ * both directions of drift are repairable deterministically:
  *
- * Returns the backfilled PRD (the input reference when nothing was missing).
+ * - **Over-hoisting** — a story-local `**Out of scope:**` block promoted to
+ *   feature level is pushed back down onto its owning story (#1446). Runs first
+ *   so the backfill's substring check sees the corrected list.
+ * - **Dropping** — the prompt asks the planner for its own wording; whatever it
+ *   drops is appended verbatim from the spec.
+ *
+ * Each warning records that the planner needed the safety net. Returns the input
+ * reference when the PRD was already faithful.
  */
 export function backfillOutOfScope(prd: PRD, specContent: string, featureName: string): PRD {
-  const missing = findMissingOutOfScope(specContent, prd);
-  if (missing.length === 0) return prd;
+  const scoped = demoteStoryScopedOutOfScope(prd, specContent);
+  if (scoped !== prd) {
+    getSafeLogger()?.warn("plan", "Story-local out-of-scope blocks hoisted to feature level — demoted to their story", {
+      featureName,
+      hoistedCount: (prd.outOfScope ?? []).length - (scoped.outOfScope ?? []).length,
+    });
+  }
+
+  const missing = findMissingOutOfScope(specContent, scoped);
+  if (missing.length === 0) return scoped;
   getSafeLogger()?.warn("plan", "Spec out-of-scope statements dropped from PRD — backfilled verbatim from the spec", {
     featureName,
     missingCount: missing.length,
     missing,
   });
-  return applyOutOfScopeFallback(prd, specContent);
+  return applyOutOfScopeFallback(scoped, specContent);
 }
 
 /**

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -22,10 +22,15 @@ export type {
 export { isStalled, markStoryAsBlocked, generateHumanHaltSummary, getContextFiles, getExpectedFiles } from "./types";
 export { findSpecDriftViolations } from "./spec-drift";
 export type { SpecDriftViolation } from "./spec-drift";
+export type { StoryScopedExclusion } from "./out-of-scope-extract";
 export {
   MAX_OUT_OF_SCOPE_ITEMS,
-  applyOutOfScopeFallback,
   extractSpecOutOfScope,
+  extractStoryScopedOutOfScope,
+} from "./out-of-scope-extract";
+export {
+  applyOutOfScopeFallback,
+  demoteStoryScopedOutOfScope,
   findMissingOutOfScope,
   normalizeOutOfScopeList,
   propagateOutOfScopeToStories,

--- a/src/prd/out-of-scope-extract.ts
+++ b/src/prd/out-of-scope-extract.ts
@@ -1,0 +1,440 @@
+/**
+ * Out-of-scope *extraction* — the markdown side of scope fidelity.
+ *
+ * Pure, deterministic parsing of a spec's deferrals: what did the author say
+ * this feature (or one story) will NOT do? Reconciling that against a PRD lives
+ * in `./out-of-scope`; this file never sees a `PRD`.
+ *
+ * ## Two territories, deliberately separated
+ *
+ * A spec declares deferrals at two levels, and conflating them is a real defect
+ * (#1446): the feature-level list is copied onto EVERY story, so a story-local
+ * block promoted to it waives one story's deferral across all the others.
+ * {@link storyScopeBoundary} is the dividing line — {@link extractSpecOutOfScope}
+ * takes only what is above it, {@link extractStoryScopedOutOfScope} only what is
+ * below.
+ *
+ * ## Matching semantics
+ *
+ * Out-of-scope items are prose, not executable assertions, so a planner is
+ * allowed to expand an item ("no Ink TUI" -> "no Ink TUI; deferred to arc 3").
+ * Comparison is therefore on {@link canonical} form (whitespace collapsed,
+ * backticks stripped, lowercased) and by substring, never by equality.
+ */
+
+/** An extracted item plus the line its declaration started on. */
+interface PlacedItem {
+  readonly lineIndex: number;
+  readonly text: string;
+}
+
+/** A deferral the spec declared inside one story's territory. */
+export interface StoryScopedExclusion {
+  /** Owning story, from the nearest `US-00N` heading above — null when none. */
+  readonly storyId: string | null;
+  readonly text: string;
+}
+
+/**
+ * Upper bound on extracted items. A spec listing more than this has an
+ * out-of-scope section that is really a design document; truncating keeps the
+ * planner prompt and every downstream story prompt bounded.
+ */
+export const MAX_OUT_OF_SCOPE_ITEMS = 25;
+
+/** The section title itself, without heading syntax — `Out of Scope`, `Non-Goals`, … */
+const OUT_OF_SCOPE_TITLE = /^(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?|not[\s-]in[\s-]scope)\b/i;
+
+/** `## Out of Scope`, `### Non-Goals`, `## Not in scope`, `## Out-of-scope`, … */
+const OUT_OF_SCOPE_HEADING = /^(#{1,6})\s*(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?|not[\s-]in[\s-]scope)\b/i;
+
+/** Any markdown ATX heading, captured so section nesting can be compared. */
+const ANY_HEADING = /^(#{1,6})\s/;
+
+/** A fenced code block delimiter (``` or ~~~), with optional info string. */
+const FENCE = /^\s*(?:```|~~~)/;
+
+/** A markdown table separator row: `|---|:--:|`. Carries no content. */
+const TABLE_SEPARATOR = /^\s*\|?[\s:|-]+\|[\s:|-]*$/;
+
+/** A markdown table row. */
+const TABLE_ROW = /^\s*\|.*\|\s*$/;
+
+/**
+ * The heading that begins per-story decomposition. Everything after it is
+ * story-scoped territory (see {@link storyScopeBoundary}).
+ */
+const STORY_SECTION_HEADING = /^#{1,3}\s*(?:stories|acceptance\s+criteria|user\s+stories)\b/i;
+
+/**
+ * A heading naming the story it opens — `### US-001 — Next-fire verdict`.
+ * Ownership of a story-scoped declaration is the nearest such heading above it,
+ * which is how spec-kit specs decompose their `## Acceptance Criteria` section.
+ */
+const STORY_ID_HEADING = /^#{1,6}\s.*\b(US-\d+)\b/i;
+
+/** A setext underline — `===` (H1) or `---` (H2) beneath a title line. */
+const SETEXT_UNDERLINE = /^\s*(?:=+|-+)\s*$/;
+
+/**
+ * Strip inline emphasis/backticks so heading matching is not defeated by
+ * formatting. `## **Out of Scope**` and `## \`Out of Scope\`` are the same
+ * heading as `## Out of Scope` — treating them differently silently drops the
+ * entire section, which is the exact failure this module exists to prevent.
+ */
+function stripEmphasis(text: string): string {
+  return text.replace(/\*\*/g, "").replace(/[*`_]/g, "");
+}
+
+/**
+ * Heading level when `line` opens an out-of-scope section, else null.
+ *
+ * Accepts ATX (`## Out of Scope`, with optional emphasis and a trailing colon)
+ * and setext (a bare title line underlined with `===`/`---`, which `nextLine`
+ * supplies). Setext `=` is level 1, `-` is level 2 — matching CommonMark, so
+ * section-end comparison against ATX levels stays correct.
+ */
+function outOfScopeHeadingLevel(line: string, nextLine: string | undefined): number | null {
+  const atx = stripEmphasis(line).match(OUT_OF_SCOPE_HEADING);
+  if (atx) return atx[1].length;
+
+  if (nextLine !== undefined && SETEXT_UNDERLINE.test(nextLine)) {
+    const title = stripEmphasis(line).trim().replace(/:$/, "");
+    if (OUT_OF_SCOPE_TITLE.test(title)) return nextLine.trim().startsWith("=") ? 1 : 2;
+  }
+  return null;
+}
+
+/** True when `line` is a setext underline for the (non-blank) line before it. */
+function isSetextUnderline(lines: string[], index: number): boolean {
+  if (!SETEXT_UNDERLINE.test(lines[index])) return false;
+  const prev = lines[index - 1];
+  return prev !== undefined && prev.trim().length > 0 && !ANY_HEADING.test(prev);
+}
+
+/**
+ * A bold lead-in declaring deferred work inline, e.g.
+ * `**Out of scope (deferred):** mid-phase resume`. The marker must be the first
+ * thing on the line (after an optional bullet) so prose that merely says
+ * "… is out of scope for this story" is never mistaken for a declaration.
+ */
+export const INLINE_MARKER = /^\s*(?:[-*]\s*)?\*\*\s*(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?)[^*]*\*\*\s*:?\s*/i;
+
+/** A list item — used both to split bullets and to bound folded prose. */
+const LIST_ITEM_START = /^\s*(?:[-*+\u2022\u2023\u25E6\u2043\u2219]|\d+\.)\s+/;
+
+/** Collapse whitespace, strip backticks, lowercase — the comparison form. */
+export function canonical(text: string): string {
+  return text.replace(/`/g, "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/** Strip a leading `-`/`*`/`1.` bullet marker. */
+function stripBullet(line: string): string {
+  return line.replace(LIST_ITEM_START, "").trim();
+}
+
+/**
+ * Lines belonging to the out-of-scope section that starts at `startIndex`.
+ * The section ends at the next heading whose level is the same as or shallower
+ * than the section heading's — a deeper sub-heading (e.g. `### Deferred arcs`
+ * under `## Out of Scope`) is still part of the section.
+ */
+function sectionLines(lines: string[], startIndex: number, level: number): string[] {
+  const collected: string[] = [];
+  let inFence = false;
+
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Fenced code inside an out-of-scope section is illustrative, never an
+    // exclusion. Folding it as prose would inject a garbage entry that is then
+    // propagated onto every story prompt.
+    if (FENCE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    // A deeper heading (`### Deferred arcs` under `## Out of Scope`) is a label
+    // inside the section, so its bullets still count. The `level === 1` guard is
+    // a safety rail: when the section heading is H1, *every* other section in the
+    // document nests under it, and folding the whole file into the exclusion list
+    // would push it into every story prompt. Over-capture is the dangerous
+    // direction here, so an H1 section ends at the first heading of any depth.
+    const heading = line.match(ANY_HEADING);
+    if (heading && (heading[1].length <= level || level === 1)) break;
+    // A deeper sub-heading is a label, but it still separates the items around
+    // it — without this blank line two prose exclusions under adjacent
+    // sub-headings would fold into one entry (and one `scopeIndex`).
+    if (heading) {
+      collected.push("");
+      continue;
+    }
+
+    // A setext underline ends the section when it belongs to a following title
+    // (that title is the next section's heading, and the title line itself was
+    // already collected — drop it).
+    if (isSetextUnderline(lines, i)) {
+      const setextLevel = line.trim().startsWith("=") ? 1 : 2;
+      if (setextLevel <= level) {
+        collected.pop();
+        break;
+      }
+      collected.pop();
+      continue; // deeper sub-heading — a label, same as the ATX case
+    }
+
+    collected.push(line);
+  }
+  return collected;
+}
+
+/**
+ * Split a section body into items: one per bullet (continuation lines folded
+ * in), or — when the section has no bullets at all — one per prose paragraph.
+ */
+function itemsFromSection(body: string[]): string[] {
+  const items: string[] = [];
+  let current: string[] = [];
+  const flush = () => {
+    // An inline `**Out of scope:**` lead-in can also appear *inside* the section;
+    // strip the redundant marker so the item dedupes against the same statement
+    // written as a plain bullet.
+    const text = current.join(" ").replace(INLINE_MARKER, "").replace(/\s+/g, " ").trim();
+    if (text) items.push(text);
+    current = [];
+  };
+
+  const hasBullets = body.some((line) => LIST_ITEM_START.test(line));
+  for (const [index, line] of body.entries()) {
+    if (line.trim().length === 0) {
+      flush();
+      continue;
+    }
+    // A row immediately followed by a separator is the table header — column
+    // labels, not an exclusion.
+    if (TABLE_ROW.test(line) && TABLE_SEPARATOR.test(body[index + 1] ?? "")) continue;
+    // Tables are a common way to write "deferred item | reason". Each data row is
+    // one exclusion; keeping the pipes would turn the whole table into a single
+    // unreadable entry, and skipping tables outright would drop the section when
+    // the table IS the content.
+    if (TABLE_SEPARATOR.test(line)) continue;
+    if (TABLE_ROW.test(line)) {
+      flush();
+      const cells = line
+        .trim()
+        .replace(/^\||\|$/g, "")
+        .split("|")
+        .map((c) => c.trim())
+        .filter((c) => c.length > 0);
+      if (cells.length > 0) current.push(cells.join(" — "));
+      flush();
+      continue;
+    }
+    if (hasBullets && LIST_ITEM_START.test(line)) {
+      flush();
+      current.push(stripBullet(line));
+      continue;
+    }
+    current.push(line.trim());
+  }
+  flush();
+  return items;
+}
+
+/**
+ * Indices of every line inside a fenced code block.
+ *
+ * Fenced content is illustrative — a spec documenting markdown (which spec-kit
+ * specs routinely do) contains a literal `## Out of Scope` example. Treating it
+ * as a real declaration fabricates an exclusion that is then backfilled into the
+ * PRD, pushed onto every story, and rendered to the implementer as a hard
+ * boundary. Every scan over raw lines must consult this.
+ */
+function fencedLineIndices(lines: string[]): Set<number> {
+  const fenced = new Set<number>();
+  let inFence = false;
+  for (const [i, line] of lines.entries()) {
+    if (FENCE.test(line)) {
+      fenced.add(i);
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) fenced.add(i);
+  }
+  return fenced;
+}
+
+/**
+ * One item per inline `**Out of scope …:**` lead-in, each tagged with the line
+ * its marker sat on so a caller can attribute it to the owning story.
+ *
+ * Two shapes, both common:
+ * - Text on the same line, folded across wrapped prose lines.
+ * - A bare marker followed by a bullet list — the single most common idiom.
+ *   Handled explicitly because the prose fold stops at the first list item,
+ *   which previously left the marker empty and the bullets claimed by nobody.
+ */
+function itemsFromInlineMarkers(lines: string[], fenced: Set<number>, start: number, end: number): PlacedItem[] {
+  const items: PlacedItem[] = [];
+  for (let i = start; i < end; i++) {
+    if (fenced.has(i) || !INLINE_MARKER.test(lines[i])) continue;
+
+    const remainder = lines[i].replace(INLINE_MARKER, "").trim();
+    let j = i + 1;
+
+    if (remainder.length === 0) {
+      // Bare marker — consume the bullet list (or prose block) beneath it.
+      const body: string[] = [];
+      while (j < lines.length && !fenced.has(j) && lines[j].trim().length > 0 && !ANY_HEADING.test(lines[j])) {
+        body.push(lines[j]);
+        j += 1;
+      }
+      items.push(...itemsFromSection(body).map((text) => ({ lineIndex: i, text })));
+      i = j - 1;
+      continue;
+    }
+
+    const parts = [remainder];
+    while (
+      j < lines.length &&
+      !fenced.has(j) &&
+      lines[j].trim().length > 0 &&
+      !ANY_HEADING.test(lines[j]) &&
+      !LIST_ITEM_START.test(lines[j])
+    ) {
+      parts.push(lines[j].trim());
+      j += 1;
+    }
+    const text = parts.join(" ").replace(/\s+/g, " ").trim();
+    if (text) items.push({ lineIndex: i, text });
+    i = j - 1;
+  }
+  return items;
+}
+
+/** Sentinels meaning "nothing deferred" — never a real exclusion. */
+const EMPTY_SENTINELS = new Set(["none", "none.", "n/a", "na", "nothing", "nothing.", "tbd", "-"]);
+
+/** A label introducing a list ("The following are deferred:"), not an exclusion itself. */
+function isListLeadIn(item: string): boolean {
+  return item.trimEnd().endsWith(":");
+}
+
+/** Deduplicate on canonical form, keeping first-seen (spec) wording, then cap. */
+export function dedupeAndCap(items: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of items) {
+    const key = canonical(item);
+    // A sentinel or a trailing-colon lead-in would otherwise be rendered to every
+    // implementer as a hard boundary ("do NOT implement these: None.") and become
+    // a citable `scopeIndex` target.
+    if (EMPTY_SENTINELS.has(key) || isListLeadIn(item)) continue;
+    if (key.length === 0 || seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+    if (out.length >= MAX_OUT_OF_SCOPE_ITEMS) break;
+  }
+  return out;
+}
+
+/**
+ * Index of the first `## Stories` / `## Acceptance Criteria` heading, or
+ * `lines.length` when the spec has none.
+ *
+ * Declarations after this point belong to a *story*, not the feature.
+ * spec-writing tells authors to give risk-sensitive stories their own
+ * `**Out of scope:**` list under the story's AC block; hoisting those to feature
+ * level propagated one story's deferral onto every other story — US-001's
+ * implementer would be told US-002's deferred work is a hard boundary.
+ *
+ * A top-level (`#`/`##`) heading is exempt: a document section named
+ * `## Out of Scope` is feature-level wherever the author placed it, including
+ * after the story sections.
+ */
+export function storyScopeBoundary(lines: string[]): number {
+  const index = lines.findIndex((line) => STORY_SECTION_HEADING.test(stripEmphasis(line)));
+  return index === -1 ? lines.length : index;
+}
+
+/**
+ * Every feature-level out-of-scope statement declared by the spec, in document
+ * order: bullets (or paragraphs) under an `## Out of Scope` / `## Non-Goals`
+ * heading, plus any inline `**Out of scope …:**` lead-in.
+ *
+ * Story-scoped declarations are excluded. spec-writing tells authors to give
+ * risk-sensitive stories their own `**Out of scope:**` list under the story's AC
+ * block; only declarations before the first `## Stories` / `## Acceptance
+ * Criteria` heading — or in a top-level `##` section anywhere — are feature-level
+ * (see {@link storyScopeBoundary}).
+ *
+ * Scope / assumptions (deliberate — the downstream gate warns, never fails):
+ * - A sub-heading inside the section is treated as a label, not an item; its
+ *   bullets are still collected.
+ * - Fenced code blocks are skipped entirely, not folded — so a spec that
+ *   documents markdown by example cannot inject a fabricated exclusion. The
+ *   corollary: text written *inside* a fence is silently dropped, so exclusions
+ *   must be bullets, table rows, or prose, never fenced.
+ */
+export function extractSpecOutOfScope(specContent: string): string[] {
+  if (!specContent.trim()) return [];
+  const lines = specContent.split("\n");
+
+  const fenced = fencedLineIndices(lines);
+  const boundary = storyScopeBoundary(lines);
+  const items: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (fenced.has(i)) continue;
+    const level = outOfScopeHeadingLevel(lines[i], lines[i + 1]);
+    if (level === null) continue;
+    // A sub-heading after story decomposition begins is that story's own
+    // deferral, not the feature's. Top-level sections stay feature-level.
+    if (level > 2 && i > boundary) continue;
+    // Setext consumes its underline; ATX does not.
+    const bodyStart = SETEXT_UNDERLINE.test(lines[i + 1] ?? "") ? i + 1 : i;
+    items.push(...itemsFromSection(sectionLines(lines, bodyStart, level)));
+  }
+  items.push(...itemsFromInlineMarkers(lines, fenced, 0, boundary).map((item) => item.text));
+
+  return dedupeAndCap(items);
+}
+
+/** Nearest `US-00N` heading at or above `index`, else null. */
+function owningStoryId(lines: string[], index: number): string | null {
+  for (let i = index; i >= 0; i--) {
+    const match = stripEmphasis(lines[i]).match(STORY_ID_HEADING);
+    if (match) return match[1].toUpperCase();
+  }
+  return null;
+}
+
+/**
+ * Every deferral the spec declared inside *story* territory — the mirror image
+ * of {@link extractSpecOutOfScope}, which deliberately excludes exactly these.
+ *
+ * A `**Out of scope:**` block (or a sub-heading deeper than `##`) after
+ * {@link storyScopeBoundary} belongs to one story. A top-level `## Out of Scope`
+ * section is feature-level wherever it sits, so it is skipped here — the feature
+ * extractor already owns it, and claiming it in both places would let a genuine
+ * feature-level statement be demoted off the list.
+ */
+export function extractStoryScopedOutOfScope(specContent: string): StoryScopedExclusion[] {
+  if (!specContent.trim()) return [];
+  const lines = specContent.split("\n");
+  const boundary = storyScopeBoundary(lines);
+  if (boundary >= lines.length) return [];
+
+  const fenced = fencedLineIndices(lines);
+  const placed: PlacedItem[] = [];
+  for (let i = boundary; i < lines.length; i++) {
+    if (fenced.has(i)) continue;
+    const level = outOfScopeHeadingLevel(lines[i], lines[i + 1]);
+    if (level === null || level <= 2) continue;
+    const bodyStart = SETEXT_UNDERLINE.test(lines[i + 1] ?? "") ? i + 1 : i;
+    placed.push(...itemsFromSection(sectionLines(lines, bodyStart, level)).map((text) => ({ lineIndex: i, text })));
+  }
+  placed.push(...itemsFromInlineMarkers(lines, fenced, boundary, lines.length));
+
+  return placed.map(({ lineIndex, text }) => ({ storyId: owningStoryId(lines, lineIndex), text }));
+}

--- a/src/prd/out-of-scope-extract.ts
+++ b/src/prd/out-of-scope-extract.ts
@@ -352,9 +352,15 @@ export function dedupeAndCap(items: string[]): string[] {
  * A top-level (`#`/`##`) heading is exempt: a document section named
  * `## Out of Scope` is feature-level wherever the author placed it, including
  * after the story sections.
+ *
+ * Fenced lines are skipped: spec-kit specs document their own markdown by
+ * example, so a literal ` ```markdown / ## Stories ` block would otherwise move
+ * the boundary to the top of the file and reclassify the entire preamble as
+ * story territory.
  */
 export function storyScopeBoundary(lines: string[]): number {
-  const index = lines.findIndex((line) => STORY_SECTION_HEADING.test(stripEmphasis(line)));
+  const fenced = fencedLineIndices(lines);
+  const index = lines.findIndex((line, i) => !fenced.has(i) && STORY_SECTION_HEADING.test(stripEmphasis(line)));
   return index === -1 ? lines.length : index;
 }
 
@@ -400,11 +406,24 @@ export function extractSpecOutOfScope(specContent: string): string[] {
   return dedupeAndCap(items);
 }
 
-/** Nearest `US-00N` heading at or above `index`, else null. */
+/**
+ * The story that owns a declaration at `index`: the nearest `US-00N` heading
+ * above it, or null when nothing owns it.
+ *
+ * Walking back stops at the first top-level (`#`/`##`) heading that is not
+ * itself a story heading, because such a section *closes* story territory — an
+ * `## Constraints` block placed after the story list is document-level again,
+ * and its deferrals belong to the feature, not to whichever story happened to
+ * be listed last. Returning null there is what makes the caller keep the
+ * statement at feature level instead of pinning it to an unrelated story.
+ */
 function owningStoryId(lines: string[], index: number): string | null {
   for (let i = index; i >= 0; i--) {
-    const match = stripEmphasis(lines[i]).match(STORY_ID_HEADING);
-    if (match) return match[1].toUpperCase();
+    const line = stripEmphasis(lines[i]);
+    const story = line.match(STORY_ID_HEADING);
+    if (story) return story[1].toUpperCase();
+    const heading = line.match(ANY_HEADING);
+    if (heading && heading[1].length <= 2) return null;
   }
   return null;
 }

--- a/src/prd/out-of-scope.ts
+++ b/src/prd/out-of-scope.ts
@@ -58,26 +58,54 @@ const STORY_ONLY_PREFIX = /^\s*US-\d+\s+only\s*:/i;
  */
 const MIN_DEMOTION_MATCH_LENGTH = 16;
 
-/** The story-scoped declaration a feature-level entry came from, if any. */
-function hoistSource(
+/**
+ * How much of a story-local declaration an entry must account for before the
+ * *reverse* match (entry shorter than the declaration — the planner trimmed the
+ * spec's wording) is trusted.
+ *
+ * Without it, a story block that merely quotes a feature-level boundary in
+ * passing — "this story does not change the database schema, and no new
+ * migrations are added" — swallows the genuine feature entry "no new migrations
+ * are added" and demotes it off the feature list. Requiring the entry to be at
+ * least half the declaration keeps trimming supported while a passing mention
+ * stays feature-level.
+ */
+const MIN_DEMOTION_COVERAGE = 0.5;
+
+/**
+ * Stories owning a feature-level entry that was hoisted out of story territory —
+ * empty when the entry is genuinely feature-level and must stay put.
+ *
+ * All matching stories, not just the first: two stories may declare the same
+ * deferral, and demoting to one would silently strip it from the other.
+ */
+function hoistOwners(
   entry: string,
   storyScoped: readonly StoryScopedExclusion[],
   featureLevel: readonly string[],
-): StoryScopedExclusion | null {
-  if (STORY_ONLY_PREFIX.test(entry)) return null;
+): string[] {
+  if (STORY_ONLY_PREFIX.test(entry)) return [];
   const key = canonical(entry.replace(INLINE_MARKER, ""));
-  if (key.length < MIN_DEMOTION_MATCH_LENGTH) return null;
+  if (key.length < MIN_DEMOTION_MATCH_LENGTH) return [];
   // A statement the spec ALSO makes at feature level is feature-level, however
-  // many stories restate it under their own AC block.
-  if (featureLevel.some((item) => key.includes(item))) return null;
-  return (
-    storyScoped.find((item) => {
-      const declared = canonical(item.text);
-      if (declared.length < MIN_DEMOTION_MATCH_LENGTH) return false;
-      // Either direction: the planner may expand the spec's wording or trim it.
-      return key.includes(declared) || declared.includes(key);
-    }) ?? null
-  );
+  // many stories restate it under their own AC block. Checked both directions:
+  // the planner may have expanded or trimmed the spec's feature-level wording,
+  // and either way removing it from the feature list is the dangerous error.
+  if (featureLevel.some((item) => key.includes(item) || item.includes(key))) return [];
+
+  const owners = new Set<string>();
+  for (const item of storyScoped) {
+    // A declaration no story owns (an `## Constraints` section after the story
+    // list) cannot be demoted anywhere — treat it as feature-level.
+    if (!item.storyId) continue;
+    const declared = canonical(item.text);
+    if (declared.length < MIN_DEMOTION_MATCH_LENGTH) continue;
+    const matches = key.includes(declared)
+      ? true
+      : declared.includes(key) && key.length >= declared.length * MIN_DEMOTION_COVERAGE;
+    if (matches) owners.add(item.storyId);
+  }
+  return [...owners];
 }
 
 /**
@@ -89,13 +117,25 @@ function hoistSource(
  * onto EVERY story — so one story's deferral becomes a waiver the adversarial
  * reviewer can cite to close a finding in a story it never covered.
  *
- * Each such entry is moved onto its owning story's own `outOfScope` (dropped
- * when no story owns it, or the owner is absent from the PRD — the statement is
- * story-scoped either way, and keeping it at feature level is the defect).
- * Returns the input PRD unchanged when nothing was hoisted.
+ * Each such entry is moved onto the `outOfScope` of every story that declared
+ * it. Returns the input PRD unchanged when nothing was hoisted.
+ *
+ * **Fail-safe in the dangerous direction.** Demoting wrongly is far worse than
+ * not demoting: the entry disappears from the feature list, and the backfill
+ * cannot restore it because `extractSpecOutOfScope` never declared it. So an
+ * entry is only ever moved when a real destination exists — no owning story, an
+ * owner absent from the PRD, or an empty result after stripping the lead-in all
+ * leave it at feature level, exactly as `main` behaved.
  *
  * Runs before the backfill: {@link extractSpecOutOfScope} never yields
  * story-scoped items, so the two can never fight over the same statement.
+ *
+ * **Best-effort by construction.** Matching is substring-on-canonical-form, so a
+ * planner that paraphrases a story-local block rather than copying it is not
+ * detected here. The plan prompt is the primary control; this is the backstop
+ * for the common verbatim (and lead-in-retaining) hoist. It also only runs at
+ * plan time — a `prd.json` already on disk with a hoisted entry is not repaired
+ * by `loadPRD`.
  */
 export function demoteStoryScopedOutOfScope(prd: PRD, specContent: string): PRD {
   const entries = prd.outOfScope ?? [];
@@ -104,19 +144,19 @@ export function demoteStoryScopedOutOfScope(prd: PRD, specContent: string): PRD 
   if (storyScoped.length === 0) return prd;
 
   const featureLevel = extractSpecOutOfScope(specContent).map(canonical);
+  const storyIds = new Set(prd.userStories.map((story) => story.id));
   const demoted = new Map<string, string[]>();
   const kept: string[] = [];
   for (const entry of entries) {
-    const source = hoistSource(entry, storyScoped, featureLevel);
-    if (!source) {
-      kept.push(entry);
-      continue;
-    }
     // The literal lead-in survives the hoist often enough to be a signal in its
     // own right; strip it so the demoted entry reads as a plain exclusion.
     const text = entry.replace(INLINE_MARKER, "").trim();
-    if (!source.storyId || !text) continue;
-    demoted.set(source.storyId, [...(demoted.get(source.storyId) ?? []), text]);
+    const owners = text ? hoistOwners(entry, storyScoped, featureLevel).filter((id) => storyIds.has(id)) : [];
+    if (owners.length === 0) {
+      kept.push(entry);
+      continue;
+    }
+    for (const owner of owners) demoted.set(owner, [...(demoted.get(owner) ?? []), text]);
   }
   if (kept.length === entries.length) return prd;
 

--- a/src/prd/out-of-scope.ts
+++ b/src/prd/out-of-scope.ts
@@ -1,5 +1,5 @@
 /**
- * Feature-level out-of-scope preservation — deterministic scope-fidelity check.
+ * Feature-level out-of-scope preservation — deterministic scope-fidelity repair.
  *
  * A spec's `## Out of Scope` / `## Non-Goals` section states what the feature
  * deliberately does NOT do. Story-level `Scope — In: … Out: …` bullets in a
@@ -10,338 +10,26 @@
  * it which deferred arcs to stay away from.
  *
  * This module is the single source of truth for "what did the spec defer, and
- * did the PRD keep it?". It is pure and deterministic — no LLM, no I/O — so it
- * can back the prompt rule, the `verify` backfill, and the `plan-refine`
- * self-heal turn without divergence. The prompt asks the planner to emit
- * `outOfScope`; {@link applyOutOfScopeFallback} guarantees the field regardless
- * of whether the planner complied.
+ * did the PRD keep it, at the right level?". It is pure and deterministic — no
+ * LLM, no I/O — so it can back the prompt rule, the `verify` backfill, and the
+ * `plan-refine` self-heal turn without divergence. The prompt asks the planner
+ * to emit `outOfScope`; {@link applyOutOfScopeFallback} guarantees the field
+ * regardless of whether the planner complied, and
+ * {@link demoteStoryScopedOutOfScope} un-does the opposite failure — a
+ * story-local block the planner promoted to feature level.
  *
- * ## Matching semantics
- *
- * Out-of-scope items are prose, not executable assertions, so a planner is
- * allowed to expand an item ("no Ink TUI" →
- * "no Ink TUI; deferred to arc 3"). An item counts as preserved when its
- * canonical form (whitespace collapsed, backticks stripped, lowercased) is a
- * contiguous substring of a single PRD entry. Anything else is treated as
- * dropped and is backfilled verbatim from the spec.
+ * Spec parsing itself lives in `./out-of-scope-extract`.
  */
 
+import {
+  INLINE_MARKER,
+  canonical,
+  dedupeAndCap,
+  extractSpecOutOfScope,
+  extractStoryScopedOutOfScope,
+} from "./out-of-scope-extract";
+import type { StoryScopedExclusion } from "./out-of-scope-extract";
 import type { PRD, UserStory } from "./types";
-
-/**
- * Upper bound on extracted items. A spec listing more than this has an
- * out-of-scope section that is really a design document; truncating keeps the
- * planner prompt and every downstream story prompt bounded.
- */
-export const MAX_OUT_OF_SCOPE_ITEMS = 25;
-
-/** The section title itself, without heading syntax — `Out of Scope`, `Non-Goals`, … */
-const OUT_OF_SCOPE_TITLE = /^(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?|not[\s-]in[\s-]scope)\b/i;
-
-/** `## Out of Scope`, `### Non-Goals`, `## Not in scope`, `## Out-of-scope`, … */
-const OUT_OF_SCOPE_HEADING = /^(#{1,6})\s*(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?|not[\s-]in[\s-]scope)\b/i;
-
-/** Any markdown ATX heading, captured so section nesting can be compared. */
-const ANY_HEADING = /^(#{1,6})\s/;
-
-/** A fenced code block delimiter (``` or ~~~), with optional info string. */
-const FENCE = /^\s*(?:```|~~~)/;
-
-/** A markdown table separator row: `|---|:--:|`. Carries no content. */
-const TABLE_SEPARATOR = /^\s*\|?[\s:|-]+\|[\s:|-]*$/;
-
-/** A markdown table row. */
-const TABLE_ROW = /^\s*\|.*\|\s*$/;
-
-/**
- * The heading that begins per-story decomposition. Everything after it is
- * story-scoped territory (see {@link storyScopeBoundary}).
- */
-const STORY_SECTION_HEADING = /^#{1,3}\s*(?:stories|acceptance\s+criteria|user\s+stories)\b/i;
-
-/** A setext underline — `===` (H1) or `---` (H2) beneath a title line. */
-const SETEXT_UNDERLINE = /^\s*(?:=+|-+)\s*$/;
-
-/**
- * Strip inline emphasis/backticks so heading matching is not defeated by
- * formatting. `## **Out of Scope**` and `## \`Out of Scope\`` are the same
- * heading as `## Out of Scope` — treating them differently silently drops the
- * entire section, which is the exact failure this module exists to prevent.
- */
-function stripEmphasis(text: string): string {
-  return text.replace(/\*\*/g, "").replace(/[*`_]/g, "");
-}
-
-/**
- * Heading level when `line` opens an out-of-scope section, else null.
- *
- * Accepts ATX (`## Out of Scope`, with optional emphasis and a trailing colon)
- * and setext (a bare title line underlined with `===`/`---`, which `nextLine`
- * supplies). Setext `=` is level 1, `-` is level 2 — matching CommonMark, so
- * section-end comparison against ATX levels stays correct.
- */
-function outOfScopeHeadingLevel(line: string, nextLine: string | undefined): number | null {
-  const atx = stripEmphasis(line).match(OUT_OF_SCOPE_HEADING);
-  if (atx) return atx[1].length;
-
-  if (nextLine !== undefined && SETEXT_UNDERLINE.test(nextLine)) {
-    const title = stripEmphasis(line).trim().replace(/:$/, "");
-    if (OUT_OF_SCOPE_TITLE.test(title)) return nextLine.trim().startsWith("=") ? 1 : 2;
-  }
-  return null;
-}
-
-/** True when `line` is a setext underline for the (non-blank) line before it. */
-function isSetextUnderline(lines: string[], index: number): boolean {
-  if (!SETEXT_UNDERLINE.test(lines[index])) return false;
-  const prev = lines[index - 1];
-  return prev !== undefined && prev.trim().length > 0 && !ANY_HEADING.test(prev);
-}
-
-/**
- * A bold lead-in declaring deferred work inline, e.g.
- * `**Out of scope (deferred):** mid-phase resume`. The marker must be the first
- * thing on the line (after an optional bullet) so prose that merely says
- * "… is out of scope for this story" is never mistaken for a declaration.
- */
-const INLINE_MARKER = /^\s*(?:[-*]\s*)?\*\*\s*(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?)[^*]*\*\*\s*:?\s*/i;
-
-/** A list item — used both to split bullets and to bound folded prose. */
-const LIST_ITEM_START = /^\s*(?:[-*+\u2022\u2023\u25E6\u2043\u2219]|\d+\.)\s+/;
-
-/** Collapse whitespace, strip backticks, lowercase — the comparison form. */
-function canonical(text: string): string {
-  return text.replace(/`/g, "").replace(/\s+/g, " ").trim().toLowerCase();
-}
-
-/** Strip a leading `-`/`*`/`1.` bullet marker. */
-function stripBullet(line: string): string {
-  return line.replace(LIST_ITEM_START, "").trim();
-}
-
-/**
- * Lines belonging to the out-of-scope section that starts at `startIndex`.
- * The section ends at the next heading whose level is the same as or shallower
- * than the section heading's — a deeper sub-heading (e.g. `### Deferred arcs`
- * under `## Out of Scope`) is still part of the section.
- */
-function sectionLines(lines: string[], startIndex: number, level: number): string[] {
-  const collected: string[] = [];
-  let inFence = false;
-
-  for (let i = startIndex + 1; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Fenced code inside an out-of-scope section is illustrative, never an
-    // exclusion. Folding it as prose would inject a garbage entry that is then
-    // propagated onto every story prompt.
-    if (FENCE.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-
-    // A deeper heading (`### Deferred arcs` under `## Out of Scope`) is a label
-    // inside the section, so its bullets still count. The `level === 1` guard is
-    // a safety rail: when the section heading is H1, *every* other section in the
-    // document nests under it, and folding the whole file into the exclusion list
-    // would push it into every story prompt. Over-capture is the dangerous
-    // direction here, so an H1 section ends at the first heading of any depth.
-    const heading = line.match(ANY_HEADING);
-    if (heading && (heading[1].length <= level || level === 1)) break;
-    // A deeper sub-heading is a label, but it still separates the items around
-    // it — without this blank line two prose exclusions under adjacent
-    // sub-headings would fold into one entry (and one `scopeIndex`).
-    if (heading) {
-      collected.push("");
-      continue;
-    }
-
-    // A setext underline ends the section when it belongs to a following title
-    // (that title is the next section's heading, and the title line itself was
-    // already collected — drop it).
-    if (isSetextUnderline(lines, i)) {
-      const setextLevel = line.trim().startsWith("=") ? 1 : 2;
-      if (setextLevel <= level) {
-        collected.pop();
-        break;
-      }
-      collected.pop();
-      continue; // deeper sub-heading — a label, same as the ATX case
-    }
-
-    collected.push(line);
-  }
-  return collected;
-}
-
-/**
- * Split a section body into items: one per bullet (continuation lines folded
- * in), or — when the section has no bullets at all — one per prose paragraph.
- */
-function itemsFromSection(body: string[]): string[] {
-  const items: string[] = [];
-  let current: string[] = [];
-  const flush = () => {
-    // An inline `**Out of scope:**` lead-in can also appear *inside* the section;
-    // strip the redundant marker so the item dedupes against the same statement
-    // written as a plain bullet.
-    const text = current.join(" ").replace(INLINE_MARKER, "").replace(/\s+/g, " ").trim();
-    if (text) items.push(text);
-    current = [];
-  };
-
-  const hasBullets = body.some((line) => LIST_ITEM_START.test(line));
-  for (const [index, line] of body.entries()) {
-    if (line.trim().length === 0) {
-      flush();
-      continue;
-    }
-    // A row immediately followed by a separator is the table header — column
-    // labels, not an exclusion.
-    if (TABLE_ROW.test(line) && TABLE_SEPARATOR.test(body[index + 1] ?? "")) continue;
-    // Tables are a common way to write "deferred item | reason". Each data row is
-    // one exclusion; keeping the pipes would turn the whole table into a single
-    // unreadable entry, and skipping tables outright would drop the section when
-    // the table IS the content.
-    if (TABLE_SEPARATOR.test(line)) continue;
-    if (TABLE_ROW.test(line)) {
-      flush();
-      const cells = line
-        .trim()
-        .replace(/^\||\|$/g, "")
-        .split("|")
-        .map((c) => c.trim())
-        .filter((c) => c.length > 0);
-      if (cells.length > 0) current.push(cells.join(" — "));
-      flush();
-      continue;
-    }
-    if (hasBullets && LIST_ITEM_START.test(line)) {
-      flush();
-      current.push(stripBullet(line));
-      continue;
-    }
-    current.push(line.trim());
-  }
-  flush();
-  return items;
-}
-
-/**
- * Indices of every line inside a fenced code block.
- *
- * Fenced content is illustrative — a spec documenting markdown (which spec-kit
- * specs routinely do) contains a literal `## Out of Scope` example. Treating it
- * as a real declaration fabricates an exclusion that is then backfilled into the
- * PRD, pushed onto every story, and rendered to the implementer as a hard
- * boundary. Every scan over raw lines must consult this.
- */
-function fencedLineIndices(lines: string[]): Set<number> {
-  const fenced = new Set<number>();
-  let inFence = false;
-  for (const [i, line] of lines.entries()) {
-    if (FENCE.test(line)) {
-      fenced.add(i);
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) fenced.add(i);
-  }
-  return fenced;
-}
-
-/**
- * One item per inline `**Out of scope …:**` lead-in.
- *
- * Two shapes, both common:
- * - Text on the same line, folded across wrapped prose lines.
- * - A bare marker followed by a bullet list — the single most common idiom.
- *   Handled explicitly because the prose fold stops at the first list item,
- *   which previously left the marker empty and the bullets claimed by nobody.
- */
-function itemsFromInlineMarkers(lines: string[], fenced: Set<number>, boundary: number): string[] {
-  const items: string[] = [];
-  for (let i = 0; i < boundary; i++) {
-    if (fenced.has(i) || !INLINE_MARKER.test(lines[i])) continue;
-
-    const remainder = lines[i].replace(INLINE_MARKER, "").trim();
-    let j = i + 1;
-
-    if (remainder.length === 0) {
-      // Bare marker — consume the bullet list (or prose block) beneath it.
-      const body: string[] = [];
-      while (j < lines.length && !fenced.has(j) && lines[j].trim().length > 0 && !ANY_HEADING.test(lines[j])) {
-        body.push(lines[j]);
-        j += 1;
-      }
-      items.push(...itemsFromSection(body));
-      i = j - 1;
-      continue;
-    }
-
-    const parts = [remainder];
-    while (
-      j < lines.length &&
-      !fenced.has(j) &&
-      lines[j].trim().length > 0 &&
-      !ANY_HEADING.test(lines[j]) &&
-      !LIST_ITEM_START.test(lines[j])
-    ) {
-      parts.push(lines[j].trim());
-      j += 1;
-    }
-    const text = parts.join(" ").replace(/\s+/g, " ").trim();
-    if (text) items.push(text);
-    i = j - 1;
-  }
-  return items;
-}
-
-/** Sentinels meaning "nothing deferred" — never a real exclusion. */
-const EMPTY_SENTINELS = new Set(["none", "none.", "n/a", "na", "nothing", "nothing.", "tbd", "-"]);
-
-/** A label introducing a list ("The following are deferred:"), not an exclusion itself. */
-function isListLeadIn(item: string): boolean {
-  return item.trimEnd().endsWith(":");
-}
-
-/** Deduplicate on canonical form, keeping first-seen (spec) wording, then cap. */
-function dedupeAndCap(items: string[]): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const item of items) {
-    const key = canonical(item);
-    // A sentinel or a trailing-colon lead-in would otherwise be rendered to every
-    // implementer as a hard boundary ("do NOT implement these: None.") and become
-    // a citable `scopeIndex` target.
-    if (EMPTY_SENTINELS.has(key) || isListLeadIn(item)) continue;
-    if (key.length === 0 || seen.has(key)) continue;
-    seen.add(key);
-    out.push(item);
-    if (out.length >= MAX_OUT_OF_SCOPE_ITEMS) break;
-  }
-  return out;
-}
-
-/**
- * Index of the first `## Stories` / `## Acceptance Criteria` heading, or
- * `lines.length` when the spec has none.
- *
- * Declarations after this point belong to a *story*, not the feature.
- * spec-writing tells authors to give risk-sensitive stories their own
- * `**Out of scope:**` list under the story's AC block; hoisting those to feature
- * level propagated one story's deferral onto every other story — US-001's
- * implementer would be told US-002's deferred work is a hard boundary.
- *
- * A top-level (`#`/`##`) heading is exempt: a document section named
- * `## Out of Scope` is feature-level wherever the author placed it, including
- * after the story sections.
- */
-function storyScopeBoundary(lines: string[]): number {
-  const index = lines.findIndex((line) => STORY_SECTION_HEADING.test(stripEmphasis(line)));
-  return index === -1 ? lines.length : index;
-}
 
 /**
  * Coerce a raw `outOfScope` value from LLM output into a clean string list.
@@ -358,45 +46,85 @@ export function normalizeOutOfScopeList(raw: unknown): string[] | undefined {
 }
 
 /**
- * Every feature-level out-of-scope statement declared by the spec, in document
- * order: bullets (or paragraphs) under an `## Out of Scope` / `## Non-Goals`
- * heading, plus any inline `**Out of scope …:**` lead-in.
- *
- * Story-scoped declarations are excluded. spec-writing tells authors to give
- * risk-sensitive stories their own `**Out of scope:**` list under the story's AC
- * block; only declarations before the first `## Stories` / `## Acceptance
- * Criteria` heading — or in a top-level `##` section anywhere — are feature-level
- * (see {@link storyScopeBoundary}).
- *
- * Scope / assumptions (deliberate — the downstream gate warns, never fails):
- * - A sub-heading inside the section is treated as a label, not an item; its
- *   bullets are still collected.
- * - Fenced code blocks are skipped entirely, not folded — so a spec that
- *   documents markdown by example cannot inject a fabricated exclusion. The
- *   corollary: text written *inside* a fence is silently dropped, so exclusions
- *   must be bullets, table rows, or prose, never fenced.
+ * An entry already scoped to one story by the spec author, per the spec-writing
+ * guide's `US-00N only:` convention. Already correct — never demoted again.
  */
-export function extractSpecOutOfScope(specContent: string): string[] {
-  if (!specContent.trim()) return [];
-  const lines = specContent.split("\n");
+const STORY_ONLY_PREFIX = /^\s*US-\d+\s+only\s*:/i;
 
-  const fenced = fencedLineIndices(lines);
-  const boundary = storyScopeBoundary(lines);
-  const items: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (fenced.has(i)) continue;
-    const level = outOfScopeHeadingLevel(lines[i], lines[i + 1]);
-    if (level === null) continue;
-    // A sub-heading after story decomposition begins is that story's own
-    // deferral, not the feature's. Top-level sections stay feature-level.
-    if (level > 2 && i > boundary) continue;
-    // Setext consumes its underline; ATX does not.
-    const bodyStart = SETEXT_UNDERLINE.test(lines[i + 1] ?? "") ? i + 1 : i;
-    items.push(...itemsFromSection(sectionLines(lines, bodyStart, level)));
+/**
+ * Shortest canonical form long enough to match on. A two-word story-local
+ * fragment would substring-match unrelated feature-level entries and demote
+ * them, so a candidate below this length is left alone.
+ */
+const MIN_DEMOTION_MATCH_LENGTH = 16;
+
+/** The story-scoped declaration a feature-level entry came from, if any. */
+function hoistSource(
+  entry: string,
+  storyScoped: readonly StoryScopedExclusion[],
+  featureLevel: readonly string[],
+): StoryScopedExclusion | null {
+  if (STORY_ONLY_PREFIX.test(entry)) return null;
+  const key = canonical(entry.replace(INLINE_MARKER, ""));
+  if (key.length < MIN_DEMOTION_MATCH_LENGTH) return null;
+  // A statement the spec ALSO makes at feature level is feature-level, however
+  // many stories restate it under their own AC block.
+  if (featureLevel.some((item) => key.includes(item))) return null;
+  return (
+    storyScoped.find((item) => {
+      const declared = canonical(item.text);
+      if (declared.length < MIN_DEMOTION_MATCH_LENGTH) return false;
+      // Either direction: the planner may expand the spec's wording or trim it.
+      return key.includes(declared) || declared.includes(key);
+    }) ?? null
+  );
+}
+
+/**
+ * Undo the planner's hoist of a *story-local* deferral to feature level (#1446).
+ *
+ * The prompt asks the planner to enumerate every `**Out of scope …:**` lead-in
+ * in the spec, and it obliges for the ones under a story's AC block too. Those
+ * then reach {@link propagateOutOfScopeToStories}, which copies the feature list
+ * onto EVERY story — so one story's deferral becomes a waiver the adversarial
+ * reviewer can cite to close a finding in a story it never covered.
+ *
+ * Each such entry is moved onto its owning story's own `outOfScope` (dropped
+ * when no story owns it, or the owner is absent from the PRD — the statement is
+ * story-scoped either way, and keeping it at feature level is the defect).
+ * Returns the input PRD unchanged when nothing was hoisted.
+ *
+ * Runs before the backfill: {@link extractSpecOutOfScope} never yields
+ * story-scoped items, so the two can never fight over the same statement.
+ */
+export function demoteStoryScopedOutOfScope(prd: PRD, specContent: string): PRD {
+  const entries = prd.outOfScope ?? [];
+  if (entries.length === 0) return prd;
+  const storyScoped = extractStoryScopedOutOfScope(specContent);
+  if (storyScoped.length === 0) return prd;
+
+  const featureLevel = extractSpecOutOfScope(specContent).map(canonical);
+  const demoted = new Map<string, string[]>();
+  const kept: string[] = [];
+  for (const entry of entries) {
+    const source = hoistSource(entry, storyScoped, featureLevel);
+    if (!source) {
+      kept.push(entry);
+      continue;
+    }
+    // The literal lead-in survives the hoist often enough to be a signal in its
+    // own right; strip it so the demoted entry reads as a plain exclusion.
+    const text = entry.replace(INLINE_MARKER, "").trim();
+    if (!source.storyId || !text) continue;
+    demoted.set(source.storyId, [...(demoted.get(source.storyId) ?? []), text]);
   }
-  items.push(...itemsFromInlineMarkers(lines, fenced, boundary));
+  if (kept.length === entries.length) return prd;
 
-  return dedupeAndCap(items);
+  const userStories: UserStory[] = prd.userStories.map((story) => {
+    const extra = demoted.get(story.id);
+    return extra ? { ...story, outOfScope: dedupeAndCap([...(story.outOfScope ?? []), ...extra]) } : story;
+  });
+  return { ...prd, outOfScope: kept.length > 0 ? kept : undefined, userStories };
 }
 
 /**

--- a/src/prompts/builders/plan-builder.ts
+++ b/src/prompts/builders/plan-builder.ts
@@ -65,11 +65,15 @@ const EXPECTED_FILES_SCHEMA_FIELD = `"expectedFiles": ["string — NEW files thi
  * statements to the implementer, which never sees the spec itself. Backfilled
  * deterministically by `applyOutOfScopeFallback` when the planner drops items —
  * this field asks for the planner's own (usually better-worded) version first.
+ *
+ * The feature-level qualifier is load-bearing: this list is copied onto EVERY
+ * story by `propagateOutOfScopeToStories`, so a story-local block hoisted here
+ * waives that story's deferral across all the others (#1446).
  */
-const OUT_OF_SCOPE_SCHEMA_FIELD = `"outOfScope": ["string — verbatim from the spec's Out of Scope / Non-Goals section: what this feature deliberately does NOT do. Omit if the spec declares none."],`;
+const OUT_OF_SCOPE_SCHEMA_FIELD = `"outOfScope": ["string — verbatim from the spec's FEATURE-LEVEL Out of Scope / Non-Goals section: what this feature deliberately does NOT do. A '**Out of scope:**' block under one story's acceptance criteria is that story's own — put it in that story's outOfScope, never here. Omit if the spec declares none."],`;
 
 /** Per-story exclusions, distinct from the feature-level list above. */
-const STORY_OUT_OF_SCOPE_SCHEMA_FIELD = `"outOfScope": ["string — optional, exclusions specific to THIS story beyond the feature-level list. Omit if none."],`;
+const STORY_OUT_OF_SCOPE_SCHEMA_FIELD = `"outOfScope": ["string — optional, exclusions specific to THIS story: any '**Out of scope:**' block under this story's acceptance criteria in the spec, plus anything else beyond the feature-level list. Omit if none."],`;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -230,7 +234,9 @@ Re-check routing.complexity and routing.testStrategy against the current codebas
 If a story changes existing behavior, extracts a shared helper, extends an existing function signature, or replaces a warning/stub path with real behavior, ensure there is at least one acceptance criterion protecting backward compatibility or proving the old placeholder behavior is gone.
 
 #### out-of-scope-preservation
-If the spec has an "Out of Scope", "Non-Goals", or "Not in scope" section — or an inline \`**Out of scope …:**\` lead-in — enumerate every item it states and confirm each appears in the top-level \`outOfScope\` array. Restore any that are missing, verbatim. Never convert one into an acceptance criterion, and never delete one because it looks obvious. Where a story sits close to one of these boundaries, echo the item into that story's \`**Scope** — Out:\` bullet too.
+If the spec has a feature-level "Out of Scope", "Non-Goals", or "Not in scope" section — or an inline \`**Out of scope …:**\` lead-in that appears BEFORE the first "Stories" / "Acceptance Criteria" heading — enumerate every item it states and confirm each appears in the top-level \`outOfScope\` array. Restore any that are missing, verbatim. Never convert one into an acceptance criterion, and never delete one because it looks obvious. Where a story sits close to one of these boundaries, echo the item into that story's \`**Scope** — Out:\` bullet too.
+
+A \`**Out of scope:**\` block written UNDER one story's acceptance criteria is that story's own deferral, not the feature's. Put it in that story's \`outOfScope\` array. Never lift it to the top-level array: that array is copied onto every story, so a hoisted story-local deferral tells the other stories' implementers that work is deliberately excluded when it is not.
 
 #### scope-consistency
 Check each story's title, description, scope, contextFiles, and acceptance criteria for internal consistency. If the story says a file or command is in scope anywhere else, do not list it as out of scope. If the title or acceptance criteria clearly include CLI, output, tests, or helper extraction work, the Scope section must reflect that accurately.${specGuardItems}

--- a/test/unit/operations/plan-refine-out-of-scope.test.ts
+++ b/test/unit/operations/plan-refine-out-of-scope.test.ts
@@ -155,3 +155,61 @@ describe("planRefineOp.verify — out-of-scope backfill", () => {
     expect(result?.outOfScope).toBeUndefined();
   });
 });
+
+describe("planRefineOp.verify — story-local hoist demotion (#1446)", () => {
+  const HOIST_SPEC = [
+    "## Out of Scope",
+    "",
+    "- An interactive Ink TUI",
+    "",
+    "## Acceptance Criteria",
+    "",
+    "### US-001 — Import endpoint",
+    "",
+    "**Out of scope:** body-size limits on the import endpoint, deferred to arc 3.",
+  ].join("\n");
+
+  function makeVerifyCtx() {
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+    return {
+      packageView: view,
+      config: view.select(planRefineOp.config),
+      readFile: async (_p: string) => null,
+      fileExists: async (_p: string) => false,
+    };
+  }
+
+  const input = {
+    specContent: HOIST_SPEC,
+    codebaseContext: "",
+    featureName: "f",
+    branchName: "feat/f",
+    outputPath: "/tmp/p.json",
+  };
+
+  test("demotes a hoisted story-local block onto its owning story, and warns", async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const hoisted = makePrd(["An interactive Ink TUI", "body-size limits on the import endpoint, deferred to arc 3."]);
+
+      const result = await planRefineOp.verify!(hoisted, input as never, makeVerifyCtx() as never);
+
+      expect(result?.outOfScope).toEqual(["An interactive Ink TUI"]);
+      expect(result?.userStories[0].outOfScope).toEqual([
+        "body-size limits on the import endpoint, deferred to arc 3.",
+      ]);
+      const warn = warnSpy.mock.calls.find((c) => c[0] === "plan" && String(c[1]).includes("hoisted"));
+      expect(warn).toBeDefined();
+      expect((warn?.[2] as Record<string, unknown>).hoistedCount).toBe(1);
+    });
+  });
+
+  test("the demotion does not trip the backfill into restoring it at feature level", async () => {
+    const hoisted = makePrd(["An interactive Ink TUI", "body-size limits on the import endpoint, deferred to arc 3."]);
+
+    const result = await planRefineOp.verify!(hoisted, input as never, makeVerifyCtx() as never);
+
+    expect(result?.outOfScope).not.toContain("body-size limits on the import endpoint, deferred to arc 3.");
+  });
+});

--- a/test/unit/prd/out-of-scope.test.ts
+++ b/test/unit/prd/out-of-scope.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   MAX_OUT_OF_SCOPE_ITEMS,
   applyOutOfScopeFallback,
+  demoteStoryScopedOutOfScope,
   extractSpecOutOfScope,
+  extractStoryScopedOutOfScope,
   findMissingOutOfScope,
   propagateOutOfScopeToStories,
   stripPropagatedOutOfScope,
@@ -369,5 +371,206 @@ describe("stripPropagatedOutOfScope", () => {
     expect(stripPropagatedOutOfScope(prd)).toBe(prd);
     const noFeatureLevel = makePRD({ userStories: [makeStory({ outOfScope: ["no CLI wiring"] })] });
     expect(stripPropagatedOutOfScope(noFeatureLevel)).toBe(noFeatureLevel);
+  });
+});
+
+describe("extractStoryScopedOutOfScope", () => {
+  const spec = [
+    "# Feature",
+    "",
+    "## Out of Scope",
+    "",
+    "- An interactive Ink TUI",
+    "",
+    "## Acceptance Criteria",
+    "",
+    "### US-001 — Next-fire verdict",
+    "",
+    "- [unit] returns a NextFire for an enabled daily row",
+    "",
+    "**Out of scope:** no risk-sensitive domain applies to this story — the fields",
+    "are read-only derivations of existing rows.",
+    "",
+    "### US-003 — Impact endpoint",
+    "",
+    "- [integration] GET /api/calendar/impact returns the affected band",
+    "",
+    "**Out of scope:** pagination of `entries` — the range cap bounds the response.",
+  ].join("\n");
+
+  test("attributes each story-local block to the nearest preceding story heading", () => {
+    expect(extractStoryScopedOutOfScope(spec)).toEqual([
+      {
+        storyId: "US-001",
+        text: "no risk-sensitive domain applies to this story — the fields are read-only derivations of existing rows.",
+      },
+      { storyId: "US-003", text: "pagination of `entries` — the range cap bounds the response." },
+    ]);
+  });
+
+  test("excludes feature-level declarations — the extractor already owns those", () => {
+    const texts = extractStoryScopedOutOfScope(spec).map((item) => item.text);
+    expect(texts).not.toContain("An interactive Ink TUI");
+  });
+
+  test("treats a top-level `## Out of Scope` section placed after the stories as feature-level", () => {
+    const trailing = ["## Acceptance Criteria", "", "### US-001 — A", "", "## Out of Scope", "", "- no TUI"].join("\n");
+    expect(extractStoryScopedOutOfScope(trailing)).toEqual([]);
+  });
+
+  test("returns nothing when the spec has no story sections at all", () => {
+    expect(extractStoryScopedOutOfScope("## Out of Scope\n\n- no TUI\n")).toEqual([]);
+  });
+
+  test("ignores a story-local block written inside a fenced code block", () => {
+    const fencedSpec = [
+      "## Acceptance Criteria",
+      "",
+      "### US-001 — A",
+      "",
+      "```markdown",
+      "**Out of scope:** rate-limiting on this endpoint, deferred to arc 3.",
+      "```",
+    ].join("\n");
+    expect(extractStoryScopedOutOfScope(fencedSpec)).toEqual([]);
+  });
+
+  test("collects a deeper `### Out of scope` sub-heading under a story", () => {
+    const subheading = [
+      "## Acceptance Criteria",
+      "",
+      "### US-002 — B",
+      "",
+      "#### Out of scope",
+      "",
+      "- rate-limiting on this endpoint, deferred to arc 3",
+    ].join("\n");
+    expect(extractStoryScopedOutOfScope(subheading)).toEqual([
+      { storyId: "US-002", text: "rate-limiting on this endpoint, deferred to arc 3" },
+    ]);
+  });
+});
+
+describe("demoteStoryScopedOutOfScope", () => {
+  const spec = [
+    "## Out of Scope",
+    "",
+    "- An interactive Ink TUI",
+    "",
+    "## Acceptance Criteria",
+    "",
+    "### US-002 — Import endpoint",
+    "",
+    "- [integration] POST /api/import accepts a labelled bundle",
+    "",
+    "**Out of scope:** body-size limits on the import endpoint, deferred to arc 3.",
+  ].join("\n");
+
+  const twoStories = () => [makeStory({ id: "US-001" }), makeStory({ id: "US-002" })];
+
+  test("moves an unprefixed hoist off the feature list and onto its owning story", () => {
+    const prd = makePRD({
+      outOfScope: ["An interactive Ink TUI", "body-size limits on the import endpoint, deferred to arc 3."],
+      userStories: twoStories(),
+    });
+
+    const demoted = demoteStoryScopedOutOfScope(prd, spec);
+
+    expect(demoted.outOfScope).toEqual(["An interactive Ink TUI"]);
+    expect(demoted.userStories[0].outOfScope).toBeUndefined();
+    expect(demoted.userStories[1].outOfScope).toEqual(["body-size limits on the import endpoint, deferred to arc 3."]);
+  });
+
+  test("keeps an entry already prefixed with `US-00N only:` at feature level", () => {
+    const prd = makePRD({
+      outOfScope: ["US-002 only: body-size limits on the import endpoint, deferred to arc 3."],
+      userStories: twoStories(),
+    });
+
+    expect(demoteStoryScopedOutOfScope(prd, spec)).toBe(prd);
+  });
+
+  test("keeps an entry the spec also declares at feature level", () => {
+    const bothLevels = [
+      "## Out of Scope",
+      "",
+      "- body-size limits on the import endpoint, deferred to arc 3.",
+      "",
+      "## Acceptance Criteria",
+      "",
+      "### US-002 — Import endpoint",
+      "",
+      "**Out of scope:** body-size limits on the import endpoint, deferred to arc 3.",
+    ].join("\n");
+    const prd = makePRD({
+      outOfScope: ["body-size limits on the import endpoint, deferred to arc 3."],
+      userStories: twoStories(),
+    });
+
+    expect(demoteStoryScopedOutOfScope(prd, bothLevels)).toBe(prd);
+  });
+
+  test("strips a retained `**Out of scope:**` lead-in from the demoted entry", () => {
+    const prd = makePRD({
+      outOfScope: ["**Out of scope:** body-size limits on the import endpoint, deferred to arc 3."],
+      userStories: twoStories(),
+    });
+
+    expect(demoteStoryScopedOutOfScope(prd, spec).userStories[1].outOfScope).toEqual([
+      "body-size limits on the import endpoint, deferred to arc 3.",
+    ]);
+  });
+
+  test("drops a hoist whose owning story is absent from the PRD", () => {
+    const prd = makePRD({
+      outOfScope: ["An interactive Ink TUI", "body-size limits on the import endpoint, deferred to arc 3."],
+      userStories: [makeStory({ id: "US-001" })],
+    });
+
+    const demoted = demoteStoryScopedOutOfScope(prd, spec);
+
+    expect(demoted.outOfScope).toEqual(["An interactive Ink TUI"]);
+    expect(demoted.userStories[0].outOfScope).toBeUndefined();
+  });
+
+  test("appends to a story that already carries its own exclusions", () => {
+    const prd = makePRD({
+      outOfScope: ["body-size limits on the import endpoint, deferred to arc 3."],
+      userStories: [makeStory({ id: "US-001" }), makeStory({ id: "US-002", outOfScope: ["no CLI wiring"] })],
+    });
+
+    expect(demoteStoryScopedOutOfScope(prd, spec).userStories[1].outOfScope).toEqual([
+      "no CLI wiring",
+      "body-size limits on the import endpoint, deferred to arc 3.",
+    ]);
+  });
+
+  test("matches a planner rewording that expands the spec's own wording", () => {
+    const prd = makePRD({
+      outOfScope: ["body-size limits on the import endpoint, deferred to arc 3. Tracked separately."],
+      userStories: twoStories(),
+    });
+
+    expect(demoteStoryScopedOutOfScope(prd, spec).outOfScope).toBeUndefined();
+  });
+
+  test("returns the same PRD reference when nothing was hoisted", () => {
+    const prd = makePRD({ outOfScope: ["An interactive Ink TUI"], userStories: twoStories() });
+    expect(demoteStoryScopedOutOfScope(prd, spec)).toBe(prd);
+  });
+
+  test("survives propagation — the demoted entry reaches only its owning story", () => {
+    const prd = makePRD({
+      outOfScope: ["An interactive Ink TUI", "body-size limits on the import endpoint, deferred to arc 3."],
+      userStories: twoStories(),
+    });
+
+    const propagated = propagateOutOfScopeToStories(demoteStoryScopedOutOfScope(prd, spec));
+
+    expect(propagated.userStories[0].outOfScope).toEqual(["An interactive Ink TUI"]);
+    expect(propagated.userStories[1].outOfScope).toEqual([
+      "An interactive Ink TUI",
+      "body-size limits on the import endpoint, deferred to arc 3.",
+    ]);
   });
 });

--- a/test/unit/prd/out-of-scope.test.ts
+++ b/test/unit/prd/out-of-scope.test.ts
@@ -521,16 +521,15 @@ describe("demoteStoryScopedOutOfScope", () => {
     ]);
   });
 
-  test("drops a hoist whose owning story is absent from the PRD", () => {
+  test("keeps a hoist at feature level when its owning story is absent from the PRD", () => {
+    // Nowhere to demote to. Dropping it would delete a boundary the backfill
+    // cannot restore, since the spec never declared it at feature level.
     const prd = makePRD({
       outOfScope: ["An interactive Ink TUI", "body-size limits on the import endpoint, deferred to arc 3."],
       userStories: [makeStory({ id: "US-001" })],
     });
 
-    const demoted = demoteStoryScopedOutOfScope(prd, spec);
-
-    expect(demoted.outOfScope).toEqual(["An interactive Ink TUI"]);
-    expect(demoted.userStories[0].outOfScope).toBeUndefined();
+    expect(demoteStoryScopedOutOfScope(prd, spec)).toBe(prd);
   });
 
   test("appends to a story that already carries its own exclusions", () => {
@@ -572,5 +571,153 @@ describe("demoteStoryScopedOutOfScope", () => {
       "An interactive Ink TUI",
       "body-size limits on the import endpoint, deferred to arc 3.",
     ]);
+  });
+});
+
+describe("demoteStoryScopedOutOfScope — fail-safe rails", () => {
+  const twoStories = () => [makeStory({ id: "US-001" }), makeStory({ id: "US-002" })];
+
+  test("keeps a deferral declared in a non-story section placed after the stories", () => {
+    // `## Constraints` closes story territory — the deferral is the feature's,
+    // and the last `US-00N` heading in the file must not claim it.
+    const trailing = [
+      "## Acceptance Criteria",
+      "",
+      "### US-001 — A",
+      "",
+      "### US-002 — B",
+      "",
+      "## Constraints",
+      "",
+      "- **Out of scope:** cross-repo migration of the legacy importer, deferred.",
+    ].join("\n");
+    const prd = makePRD({
+      outOfScope: ["cross-repo migration of the legacy importer, deferred."],
+      userStories: twoStories(),
+    });
+
+    expect(demoteStoryScopedOutOfScope(prd, trailing)).toBe(prd);
+  });
+
+  test("keeps an entry when the spec's story headings are not `US-00N`", () => {
+    const noIds = [
+      "## Acceptance Criteria",
+      "",
+      "### Story One — A",
+      "",
+      "**Out of scope:** rate limiting on the ingest endpoint, deferred to arc 3.",
+    ].join("\n");
+    const prd = makePRD({
+      outOfScope: ["rate limiting on the ingest endpoint, deferred to arc 3."],
+      userStories: twoStories(),
+    });
+
+    expect(demoteStoryScopedOutOfScope(prd, noIds)).toBe(prd);
+  });
+
+  test("keeps a feature entry that a story block merely quotes in passing", () => {
+    const quoted = [
+      "## Acceptance Criteria",
+      "",
+      "### US-002 — B",
+      "",
+      "**Out of scope:** this story does not change the database schema, and no new migrations are added",
+    ].join("\n");
+    const prd = makePRD({ outOfScope: ["no new migrations are added"], userStories: twoStories() });
+
+    expect(demoteStoryScopedOutOfScope(prd, quoted)).toBe(prd);
+  });
+
+  test("keeps a short entry that would substring-match unrelated declarations", () => {
+    const spec = [
+      "## Acceptance Criteria",
+      "",
+      "### US-002 — B",
+      "",
+      "**Out of scope:** no retries on the outbound webhook call, deferred to arc 3.",
+    ].join("\n");
+    const prd = makePRD({ outOfScope: ["no retries"], userStories: twoStories() });
+
+    expect(demoteStoryScopedOutOfScope(prd, spec)).toBe(prd);
+  });
+
+  test("keeps a too-short entry even when it covers most of a story declaration", () => {
+    // "rate limiting" is 13 chars — under the match floor, and generic enough
+    // that a substring hit against any story's wording proves nothing. The
+    // coverage ratio alone would wave it through.
+    const spec = [
+      "## Acceptance Criteria",
+      "",
+      "### US-002 — B",
+      "",
+      "**Out of scope:** rate limiting deferred.",
+    ].join("\n");
+    const prd = makePRD({ outOfScope: ["rate limiting"], userStories: twoStories() });
+
+    expect(demoteStoryScopedOutOfScope(prd, spec)).toBe(prd);
+  });
+
+  test("keeps an entry the spec declares feature-level in longer wording than the planner emitted", () => {
+    const spec = [
+      "## Out of Scope",
+      "",
+      "- No Ink TUI rendering — deferred to arc 3",
+      "",
+      "## Acceptance Criteria",
+      "",
+      "### US-002 — B",
+      "",
+      "**Out of scope:** No Ink TUI rendering — deferred to arc 3",
+    ].join("\n");
+    const prd = makePRD({ outOfScope: ["No Ink TUI rendering"], userStories: twoStories() });
+
+    expect(demoteStoryScopedOutOfScope(prd, spec)).toBe(prd);
+  });
+
+  test("demotes onto every story that declared the same deferral, not just the first", () => {
+    const shared = [
+      "## Acceptance Criteria",
+      "",
+      "### US-001 — A",
+      "",
+      "**Out of scope:** prune atomicity under concurrent submits, best-effort for now.",
+      "",
+      "### US-002 — B",
+      "",
+      "**Out of scope:** prune atomicity under concurrent submits, best-effort for now.",
+    ].join("\n");
+    const prd = makePRD({
+      outOfScope: ["prune atomicity under concurrent submits, best-effort for now."],
+      userStories: twoStories(),
+    });
+
+    const demoted = demoteStoryScopedOutOfScope(prd, shared);
+
+    expect(demoted.outOfScope).toBeUndefined();
+    expect(demoted.userStories[0].outOfScope).toEqual([
+      "prune atomicity under concurrent submits, best-effort for now.",
+    ]);
+    expect(demoted.userStories[1].outOfScope).toEqual([
+      "prune atomicity under concurrent submits, best-effort for now.",
+    ]);
+  });
+
+  test("a fenced `## Stories` example does not move the story boundary", () => {
+    const fenced = [
+      "# Spec",
+      "",
+      "```markdown",
+      "## Stories",
+      "```",
+      "",
+      "**Out of scope:** cross-repo migration of the legacy importer, deferred.",
+      "",
+      "## Acceptance Criteria",
+      "",
+      "### US-001 — A",
+    ].join("\n");
+
+    expect(extractSpecOutOfScope(fenced)).toEqual(["cross-repo migration of the legacy importer, deferred."]);
+    expect(extractStoryScopedOutOfScope(fenced)).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #1446.

## Problem

`nax plan` promoted a `**Out of scope:**` block written under **one story's**
acceptance criteria into the PRD's feature-level `outOfScope` array.
`propagateOutOfScopeToStories` then copies that array onto **every** story — so
one story's deferral became a waiver for all of them, and the adversarial
reviewer could cite it to close a legitimate finding in a story the deferral
never covered. Observed 3 times in 5 plans.

## Root cause: the prompt, not the extractor

`storyScopeBoundary` already stops extraction at the first `## Stories` /
`## Acceptance Criteria` heading, so the deterministic extractor never picked
these blocks up. Two prompt surfaces did:

- `plan-builder.ts:69` — the schema field said "verbatim from the spec's Out of
  Scope / Non-Goals section", with no feature-level qualifier.
- `plan-builder.ts:233` — the `out-of-scope-preservation` refine item said
  "or an inline `**Out of scope …:**` lead-in — enumerate every item it states".
  A story-local lead-in matches that literally, so the refine pass re-added the
  hoist even on a draft that got it right.

## Changes

**1. Prompt (the fix).** Both surfaces now say feature-level, name the
story-local block explicitly, and route it to that story's own `outOfScope`. The
refine item is scoped to declarations before the story boundary.

**2. Deterministic backstop.** `extractStoryScopedOutOfScope` (the mirror of
`extractSpecOutOfScope` — everything *below* the boundary, attributed to the
owning `US-00N` heading) plus `demoteStoryScopedOutOfScope`, which moves a
hoisted entry onto the stories that declared it and off the feature list. Wired
into `backfillOutOfScope` ahead of the backfill, with a warning, so all four
plan strategies get it.

Left alone: entries already prefixed `US-00N only:` (the spec-writing
convention), and anything the spec also declares at feature level.

**3. File split.** Markdown parsing moved to `out-of-scope-extract.ts`; PRD
reconciliation stays in `out-of-scope.ts` (600-line source limit). Verified as a
pure move — the only behavioural change in the relocated code is the intended
`itemsFromInlineMarkers` signature.

## Fail-safe design

Demoting *wrongly* is much worse than not demoting: the entry leaves
`prd.outOfScope` and the backfill cannot restore it, because
`extractSpecOutOfScope` never declared it. Code review caught four such paths in
the first commit (two silent deletions); the second commit makes every ambiguous
case resolve to "leave it at feature level", matching `main`:

| Case | Behaviour |
|---|---|
| Deferral under a non-story section (`## Constraints`) after the story list | kept — a top-level heading closes story territory |
| Spec whose story headings are not `US-00N` | kept (no owner) |
| Owning story absent from the PRD | kept |
| Fenced ` ```markdown / ## Stories ` example in the spec | boundary now skips fences, so the preamble stays feature-level |
| Story block that merely *quotes* a feature boundary in passing | kept — the reverse match needs ≥50% coverage |
| Planner trimmed a feature-level item | kept — the feature guard is bidirectional |
| Two stories declare the same deferral | demoted onto **both** |

## Verification

- **23 new tests** across `test/unit/prd/out-of-scope.test.ts` and
  `test/unit/operations/plan-refine-out-of-scope.test.ts` (unit + the real
  `planRefineOp.verify` wiring).
- **Mutation-verified**: reverting any single guard — the match floor, the
  coverage ratio, the bidirectional feature check, the owner-present filter, the
  fail-safe keep, multi-owner demotion, the territory-closing heading, the
  fence-aware boundary — fails at least one test. No-op'ing the demotion fails
  11; removing the `backfillOutOfScope` call fails 2.
- **Real corpus** (the five specs in the issue's evidence table): injecting each
  story-local block as a verbatim hoist → **7/7 caught, correct story each
  time**; run against the already-hand-patched PRDs → **0 demotions**.
- `bun run typecheck`, `bun run lint`, full `bun run test` green — 11080 unit /
  1092 integration / 24 ui, 0 fail.

## Known limits

- Matching is substring-on-canonical-form, so a planner that **paraphrases** a
  story-local block rather than copying it is not caught by the backstop. The
  prompt change is the primary control; spec-review phase 9 remains the gate.
- Demotion runs at plan time only — a `prd.json` already on disk with a hoisted
  entry is not repaired by `loadPRD`. Both limits are documented in the
  function's docstring.
