### PR TITLE
fix: dead lint-overlay glob + packing score/tokens sort (context-engine v2 gap findings 2, 4)

### DIFF
--- a/src/cli/rules.ts
+++ b/src/cli/rules.ts
@@ -49,7 +49,7 @@ export const _rulesCLIDeps = {
   },
   globCanonicalRuleFiles: (workdir: string): string[] => {
     try {
-      return [...new Bun.Glob("**/.nax/rules/**/*.md").scanSync({ cwd: workdir, absolute: false })].sort();
+      return [...new Bun.Glob("**/.nax/rules/**/*.md").scanSync({ cwd: workdir, absolute: false, dot: true })].sort();
     } catch {
       return [];
     }

--- a/src/cli/rules.ts
+++ b/src/cli/rules.ts
@@ -31,6 +31,12 @@ import { errorMessage } from "../utils/errors";
 // Injectable deps
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** Cap on the package-overlay glob scan (monorepo-awareness.md §6). */
+const MAX_CANONICAL_RULE_GLOB_FILES = 500;
+
+/** Directories that never legitimately contain a `.nax/rules` overlay root. */
+const CANONICAL_RULE_GLOB_EXCLUDE_SEGMENTS = ["/node_modules/", "/.git/"];
+
 export const _rulesCLIDeps = {
   readFile: async (path: string): Promise<string> => Bun.file(path).text(),
   writeFile: async (path: string, content: string): Promise<void> => {
@@ -49,7 +55,14 @@ export const _rulesCLIDeps = {
   },
   globCanonicalRuleFiles: (workdir: string): string[] => {
     try {
-      return [...new Bun.Glob("**/.nax/rules/**/*.md").scanSync({ cwd: workdir, absolute: false, dot: true })].sort();
+      const found: string[] = [];
+      for (const file of new Bun.Glob("**/.nax/rules/**/*.md").scanSync({ cwd: workdir, absolute: false, dot: true })) {
+        if (found.length >= MAX_CANONICAL_RULE_GLOB_FILES) break;
+        const normalized = `/${file}/`;
+        if (CANONICAL_RULE_GLOB_EXCLUDE_SEGMENTS.some((seg) => normalized.includes(seg))) continue;
+        found.push(file);
+      }
+      return found.sort();
     } catch {
       return [];
     }

--- a/src/context/engine/packing.ts
+++ b/src/context/engine/packing.ts
@@ -3,8 +3,9 @@
  *
  * Selects which chunks fit within the token budget.
  *
- * Phase 0-2: Greedy algorithm — sort by score descending, always include
- * floor items (static + feature kinds) first regardless of budget.
+ * Phase 0-2: Greedy algorithm — sort by score/tokens (density) descending,
+ * always include floor items (static + feature kinds) first regardless of
+ * budget.
  *
  * Budget floor rule (spec §AC-6):
  *   "static" and "feature" chunks are always included even when their total
@@ -65,7 +66,9 @@ export function packChunks(chunks: ScoredChunk[], budgetTokens: number, availabl
     availableBudgetTokens !== undefined ? Math.min(budgetTokens, availableBudgetTokens) : budgetTokens;
 
   const floorChunks = chunks.filter((c) => FLOOR_KINDS.includes(c.kind));
-  const nonFloorChunks = chunks.filter((c) => !FLOOR_KINDS.includes(c.kind)).sort((a, b) => b.score - a.score);
+  const nonFloorChunks = chunks
+    .filter((c) => !FLOOR_KINDS.includes(c.kind))
+    .sort((a, b) => b.score / b.tokens - a.score / a.tokens);
 
   const packed: PackedChunk[] = [];
   const budgetExcludedIds: string[] = [];

--- a/src/context/engine/packing.ts
+++ b/src/context/engine/packing.ts
@@ -12,6 +12,15 @@
  *   tokens exceed budgetTokens. The manifest records reason:
  *   "budget-exceeded-by-floor" for any chunk that causes an overflow.
  *
+ * Known limitation (spec §AC-7): density-greedy is the standard heuristic
+ * for fractional knapsack, but for the 0/1 case (chunks are atomic — no
+ * partial packing) it is not guaranteed to land within 5% of the brute-force
+ * optimum in adversarial inputs (e.g. one huge high-density chunk that
+ * excludes many smaller lower-density ones which would sum to more value).
+ * A true 5%-bound requires either the standard "best-of(greedy, largest
+ * single item that fits)" repair or a small-input DP, neither implemented
+ * yet — tracked as a follow-up alongside the AC-7 property test.
+ *
  * Phase 3+: Optional 0/1 knapsack DP (in packing.ts) if greedy proves
  * suboptimal. Floor rule still applies in Phase 3+.
  */
@@ -25,6 +34,15 @@ import type { ChunkKind } from "./types";
 
 /** Chunk kinds that are always included (budget floor) */
 export const FLOOR_KINDS: ChunkKind[] = ["static", "feature", "test-coverage"];
+
+/**
+ * Score per token — the packing priority metric (spec §AC-7). A zero-token
+ * chunk has no cost, so it is ranked as maximally dense rather than
+ * producing NaN/Infinity from a bare division.
+ */
+function scoreDensity(chunk: ScoredChunk): number {
+  return chunk.tokens > 0 ? chunk.score / chunk.tokens : Number.POSITIVE_INFINITY;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -68,7 +86,7 @@ export function packChunks(chunks: ScoredChunk[], budgetTokens: number, availabl
   const floorChunks = chunks.filter((c) => FLOOR_KINDS.includes(c.kind));
   const nonFloorChunks = chunks
     .filter((c) => !FLOOR_KINDS.includes(c.kind))
-    .sort((a, b) => b.score / b.tokens - a.score / a.tokens);
+    .sort((a, b) => scoreDensity(b) - scoreDensity(a));
 
   const packed: PackedChunk[] = [];
   const budgetExcludedIds: string[] = [];

--- a/test/unit/cli/rules.test.ts
+++ b/test/unit/cli/rules.test.ts
@@ -280,7 +280,37 @@ describe("rulesLintCommand", () => {
     expect(calls).toContain("/repo/packages/web");
   });
 
-  test("real globCanonicalRuleFiles finds hidden .nax/rules dirs (dot:true)", async () => {
+  test("end-to-end: real glob discovery feeds package-overlay roots into loadCanonicalRules", async () => {
+    // Uses the REAL (unstubbed) globCanonicalRuleFiles against a real temp
+    // dir, so this fails if the dot:true fix regresses — unlike the two
+    // tests above, which stub the glob and so can't detect that class of bug.
+    _rulesCLIDeps.globCanonicalRuleFiles = origGlobCanonicalRuleFiles;
+    const calls: string[] = [];
+    _rulesCLIDeps.loadCanonicalRules = async (workdir: string) => {
+      calls.push(workdir);
+      return [];
+    };
+
+    await withTempDir(async (workdir) => {
+      await mkdir(join(workdir, ".nax", "rules"), { recursive: true });
+      await mkdir(join(workdir, "packages", "api", ".nax", "rules"), { recursive: true });
+      await Bun.write(join(workdir, ".nax", "rules", "root.md"), "# root\n");
+      await Bun.write(join(workdir, "packages", "api", ".nax", "rules", "api.md"), "# api\n");
+
+      await rulesLintCommand({ dir: workdir });
+
+      expect(calls).toContain(workdir);
+      expect(calls).toContain(join(workdir, "packages", "api"));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// globCanonicalRuleFiles (real implementation)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("globCanonicalRuleFiles", () => {
+  test("finds hidden .nax/rules dirs (dot:true)", async () => {
     await withTempDir(async (workdir) => {
       await mkdir(join(workdir, ".nax", "rules"), { recursive: true });
       await mkdir(join(workdir, "packages", "api", ".nax", "rules"), { recursive: true });

--- a/test/unit/cli/rules.test.ts
+++ b/test/unit/cli/rules.test.ts
@@ -6,7 +6,10 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { NaxError } from "../../../src/errors";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { NaxError } from "@/errors";
+import { withTempDir } from "@test/helpers";
 import {
   neutralizeContent,
   rulesExportCommand,
@@ -275,6 +278,20 @@ describe("rulesLintCommand", () => {
     expect(calls).toContain("/repo");
     expect(calls).toContain("/repo/packages/api");
     expect(calls).toContain("/repo/packages/web");
+  });
+
+  test("real globCanonicalRuleFiles finds hidden .nax/rules dirs (dot:true)", async () => {
+    await withTempDir(async (workdir) => {
+      await mkdir(join(workdir, ".nax", "rules"), { recursive: true });
+      await mkdir(join(workdir, "packages", "api", ".nax", "rules"), { recursive: true });
+      await Bun.write(join(workdir, ".nax", "rules", "root.md"), "# root\n");
+      await Bun.write(join(workdir, "packages", "api", ".nax", "rules", "api.md"), "# api\n");
+
+      const found = origGlobCanonicalRuleFiles(workdir);
+
+      expect(found).toContain(".nax/rules/root.md");
+      expect(found).toContain("packages/api/.nax/rules/api.md");
+    });
   });
 });
 

--- a/test/unit/context/engine/packing.test.ts
+++ b/test/unit/context/engine/packing.test.ts
@@ -61,6 +61,31 @@ describe("packChunks — greedy", () => {
     expect(packedIds).toContain("mid:1");
     expect(result.budgetExcludedIds).toContain("low:1");
   });
+
+  test("non-floor chunks are ordered by score density (score/tokens), not raw score", () => {
+    // "bulky" has higher raw score (0.9) but far lower density (0.9/900 = 0.001)
+    // than "dense" (0.5/100 = 0.005). A raw-score sort would pack "bulky" first
+    // and exclude "dense"; a density sort does the opposite.
+    const chunks = [
+      makeScored({ id: "bulky", kind: "session", score: 0.9, tokens: 900 }),
+      makeScored({ id: "dense", kind: "session", score: 0.5, tokens: 100 }),
+    ];
+    const result = packChunks(chunks, 900);
+    expect(result.packed.map((c) => c.id)).toEqual(["dense"]);
+    expect(result.budgetExcludedIds).toContain("bulky");
+  });
+
+  test("a zero-token chunk does not produce NaN/Infinity that breaks the sort", () => {
+    const chunks = [
+      makeScored({ id: "free", kind: "session", score: 0.1, tokens: 0 }),
+      makeScored({ id: "normal", kind: "session", score: 0.9, tokens: 100 }),
+    ];
+    const result = packChunks(chunks, 100);
+    const packedIds = result.packed.map((c) => c.id);
+    // Zero-token chunk is free to include and should not exclude "normal".
+    expect(packedIds).toContain("free");
+    expect(packedIds).toContain("normal");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two small, self-contained fixes from the [Context Engine v2 gap analysis (2026-08-02)](.) — its own two "one-line fix" callouts (findings 2 and 4 of 26).

- **`src/cli/rules.ts`** — `globCanonicalRuleFiles` scanned `**/.nax/rules/**/*.md` without `dot: true`, so `Bun.Glob` silently skipped hidden `.nax` dirs and always returned 0 hits. `nax rules lint`'s monorepo package-overlay discovery has therefore never actually run — a package-scoped rules violation would pass lint clean and only hard-fail at runtime. Fixed, plus excluded `node_modules`/`.git` and capped the scan at 500 files per `monorepo-awareness.md` §6.
- **`src/context/engine/packing.ts`** — the greedy packer sorted non-floor chunks by raw `score` descending instead of `score/tokens` (density), per spec AC-7. A large low-value chunk could out-rank several small high-value ones. Fixed the comparator; guarded zero-token chunks against `NaN`/`Infinity`; documented (rather than silently overclaimed) that pure density-greedy still doesn't guarantee AC-7's 5%-of-optimal bound in adversarial inputs — a knapsack-repair or property test is flagged as follow-up, not implemented here.

## Review

Ran an independent code-reviewer pass on the first commit (`bae7c669`). It verified both fixes empirically (reverted `dot:true` and confirmed the new test fails; hand-checked `collectCanonicalRuleRoots`), and raised:
- **HIGH** — the packing sort change shipped with no test that discriminates score-desc from density-desc ordering, and the doc comment overclaimed full AC-7 conformance.
- **MEDIUM** — the new glob test proved the glob returns paths but not that `rulesLintCommand` actually uses them.
- **LOW** — zero-token chunk could yield `NaN`/`Infinity` in the sort (harmless today, but implicit); uncapped glob scan.

All addressed in the second commit (`1f647833`): a discriminating packing test, a zero-token regression test, an end-to-end `rulesLintCommand` test using the real (unstubbed) glob against a real temp dir, and the glob exclude/cap.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (biome + all custom checks)
- [x] `bun run test` — 11,084 unit / 1,092 integration / 24 UI, 0 failures
- [x] New tests independently verified to fail against the pre-fix code (dot:true reverted → glob test fails; raw-score sort → density-ordering test fails)