### PR TITLE
fix: close rules-integrity fail-open (gap-analysis finding 1)

### DIFF
--- a/scripts/baselines/deep-relatives-baseline.json
+++ b/scripts/baselines/deep-relatives-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 2845,
-  "updatedAt": "2026-08-02T02:21:58.776Z",
+  "count": 2846,
+  "updatedAt": "2026-08-02T14:06:26.371Z",
   "byFile": {
     "src/pipeline/stages/acceptance-setup.ts": 1,
     "src/pipeline/stages/prompt.ts": 5,
@@ -125,6 +125,7 @@
     "test/unit/pipeline/stages/context-digest.test.ts": 4,
     "test/unit/pipeline/stages/routing-idempotence.test.ts": 5,
     "test/unit/pipeline/stages/acceptance-setup-regeneration.test.ts": 3,
+    "test/unit/pipeline/stages/context-rules-fallback.test.ts": 1,
     "test/unit/pipeline/stages/completion-skip-persistence.test.ts": 4,
     "test/unit/pipeline/stages/autofix-prompts.test.ts": 2,
     "test/unit/pipeline/stages/prompt-acceptance.test.ts": 4,

--- a/src/cli/rules.ts
+++ b/src/cli/rules.ts
@@ -23,7 +23,7 @@
 
 import { mkdir } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { CANONICAL_RULES_DIR, loadCanonicalRules } from "../context/rules/canonical-loader";
+import { CANONICAL_RULES_DIR, NEUTRALITY_RULES, loadCanonicalRules } from "../context/rules/canonical-loader";
 import { NaxError } from "../errors";
 import { errorMessage } from "../utils/errors";
 
@@ -150,13 +150,13 @@ export async function rulesExportCommand(options: RulesExportOptions): Promise<v
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Apply basic neutralization to source content:
- *   - Remove <system-reminder> tags
- *   - Replace "the <Word> tool" → "the <capability>"
- *   - Replace CLAUDE.md references → "project conventions"
- *   - Replace .claude/ directory references → ".nax/rules/"
- *   - Replace IMPORTANT: → "Note:"
- *   - Strip emoji characters
+ * Apply basic neutralization to source content, driven by the SAME
+ * `NEUTRALITY_RULES` table the lint command validates against
+ * (src/context/rules/canonical-loader.ts). Migrate and lint previously kept
+ * two independent pattern lists that drifted — migrated content could still
+ * fail lint (missing AGENTS.md/GEMINI.md/.codex//.gemini//<ide_diagnostics>
+ * handling, case-sensitive tool-phrasing). A single table makes that
+ * impossible by construction.
  *
  * Returns the neutralized content and a count of replacements made.
  */
@@ -164,21 +164,15 @@ export function neutralizeContent(content: string): { content: string; replaceme
   let result = content;
   let replacements = 0;
 
-  const apply = (pattern: RegExp, replacement: string): void => {
-    const matches = [...result.matchAll(pattern)].length;
-    if (matches > 0) {
-      result = result.replace(pattern, replacement);
-      replacements += matches;
+  for (const rule of NEUTRALITY_RULES) {
+    for (const { pattern, replacement } of rule.neutralizeSteps ?? []) {
+      const matches = [...result.matchAll(pattern)].length;
+      if (matches > 0) {
+        result = result.replace(pattern, replacement);
+        replacements += matches;
+      }
     }
-  };
-
-  apply(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, "");
-  apply(/<system-reminder>/gi, "");
-  apply(/\bthe ([A-Z][a-zA-Z]+) tool\b/g, "the $1 capability");
-  apply(/CLAUDE\.md/g, "project conventions file");
-  apply(/\.claude\//g, ".nax/rules/");
-  apply(/\bIMPORTANT:/g, "Note:");
-  apply(/\p{Extended_Pictographic}/gu, "");
+  }
 
   return { content: result.trim(), replacements };
 }

--- a/src/commands/curator.ts
+++ b/src/commands/curator.ts
@@ -11,7 +11,6 @@ import { basename, join, resolve, sep } from "node:path";
 import type { NaxConfig } from "../config";
 import { getProjectKey, loadConfig } from "../config";
 import { CANONICAL_RULES_DIR, lintForNeutrality } from "../context/rules/canonical-loader";
-import { NaxError } from "../errors";
 import type { CuratorThresholds } from "../plugins/builtin/curator/heuristics";
 import { runHeuristics } from "../plugins/builtin/curator/heuristics";
 import { renderProposals } from "../plugins/builtin/curator/render";
@@ -250,26 +249,37 @@ export async function curatorStatus(options: CuratorStatusOptions): Promise<void
 
 // ─── curatorCommit ────────────────────────────────────────────────────────────
 
-/** Root namespace every curator proposal target must resolve inside. */
-const CURATOR_TARGET_ROOT = ".nax";
+/**
+ * Shapes a proposal's `### <path>` heading is allowed to take, matched
+ * against the RESOLVED path relative to the project root (never the raw
+ * heading text — `resolve()` collapses any `..` first, so a heading like
+ * `.nax/rules/../x.md` is judged on where it actually lands, `.nax/x.md`,
+ * which matches neither shape below and is rejected).
+ *
+ * These are exactly the two shapes built-in heuristics emit today (see
+ * plugins/builtin/curator/heuristics.ts): `.nax/rules/<file>.md` (one
+ * optional subdirectory, matching canonical-loader.ts's own depth-2 limit)
+ * and `.nax/features/<id>/context.md`.
+ */
+const CURATOR_TARGET_SHAPES = [/^\.nax\/rules\/([^/]+\/)?[^/]+\.md$/, /^\.nax\/features\/[^/]+\/context\.md$/];
 
 /**
  * Resolve a proposal's `### <path>` heading to an absolute path, rejecting
- * anything that escapes the `.nax/` namespace under the project root.
+ * anything outside the allow-listed target shapes.
  *
  * `canonicalFile` comes from re-parsing `curator-proposals.md` — a file the
  * operator (or a corrupted run) may have hand-edited — so it is untrusted
- * input. Built-in heuristics target both `.nax/rules/curator-suggestions.md`
- * and `.nax/features/<id>/context.md` (see plugins/builtin/curator/heuristics.ts),
- * so containment is scoped to `.nax/` generally, not `.nax/rules/` alone —
- * but `join()` on its own would still happily resolve a
- * `### ../../../etc/whatever` heading outside the project entirely.
+ * input. `join()`/`resolve()` alone would happily resolve a
+ * `### ../../../etc/whatever` heading outside the project entirely; this
+ * additionally confines targets to the two shapes curator actually writes.
  */
 function resolveCanonicalTargetPath(projectDir: string, canonicalFile: string): string | null {
-  const allowedRoot = resolve(projectDir, CURATOR_TARGET_ROOT);
   const target = resolve(projectDir, canonicalFile);
-  if (target !== allowedRoot && !target.startsWith(allowedRoot + sep)) return null;
-  return target;
+  const root = resolve(projectDir);
+  if (target !== root && !target.startsWith(root + sep)) return null; // escaped the project
+
+  const relative = target.slice(root.length + 1).replaceAll(sep, "/");
+  return CURATOR_TARGET_SHAPES.some((shape) => shape.test(relative)) ? target : null;
 }
 
 /** Whether a resolved target path falls inside the canonical rules store (`.nax/rules/`). */
@@ -300,32 +310,39 @@ export async function curatorCommit(options: CuratorCommitOptions): Promise<void
   }
 
   const modifiedFiles = new Set<string>();
+  // Proposals dropped from this commit for reasons other than the existing
+  // "no content to drop" skip below — invalid target path, or (for adds
+  // targeting the rules store) failing the neutrality linter. These skip
+  // rather than abort the whole commit: unlike the drop-conflict checks
+  // further down (which indicate genuine data corruption risk), an invalid
+  // heading or a stray "the X tool" phrase in ONE proposal's free-text
+  // description shouldn't block every other selected proposal in the batch.
+  const skippedProposals = new Set<ParsedProposal>();
 
-  // Validate ALL proposal target paths before any writes: every `### <path>`
-  // heading must resolve inside .nax/. Re-parsed from a file the operator
-  // may have hand-edited, so it's untrusted — a `..`-escaping heading must
-  // abort the whole commit, not just get skipped.
+  // Resolve every proposal's target path up front; invalid targets are
+  // skipped, not applied. Re-parsed from a file the operator may have
+  // hand-edited, so it's untrusted.
   const resolvedTargets = new Map<ParsedProposal, string>();
   for (const proposal of proposals) {
     const targetPath = resolveCanonicalTargetPath(resolved.projectDir, proposal.canonicalFile);
     if (targetPath === null) {
-      throw new NaxError(
-        `Proposal target "${proposal.canonicalFile}" resolves outside ${CURATOR_TARGET_ROOT}/ — abort`,
-        "CURATOR_TARGET_PATH_INVALID",
-        { stage: "curator-commit", canonicalFile: proposal.canonicalFile },
+      console.log(
+        `[skip] Proposal target "${proposal.canonicalFile}" is not an allowed curator target (.nax/rules/*.md or .nax/features/<id>/context.md) — skipping.`,
       );
+      skippedProposals.add(proposal);
+      continue;
     }
     resolvedTargets.set(proposal, targetPath);
   }
 
-  // Validate ALL add/advisory content targeting the canonical rules store
-  // before any writes: appending text that fails the neutrality linter (e.g.
-  // an "IMPORTANT:" or emoji surfaced verbatim from a run finding) would
-  // silently break the whole store the next time it loads (the orchestrator
-  // treats that as fatal). Proposals targeting other .nax/ files (e.g.
-  // feature context.md) aren't part of that contract and are left alone.
-  const adds = proposals.filter((p) => p.action === "add" || p.action === "advisory");
-  for (const add of adds) {
+  // Lint add/advisory content targeting the canonical rules store before any
+  // writes: appending text that fails the neutrality linter (e.g. an
+  // "IMPORTANT:" or emoji surfaced verbatim from a run finding) would break
+  // the whole store the next time it loads (the orchestrator now treats
+  // that as fatal). Proposals targeting other allowed files (e.g. feature
+  // context.md) aren't part of that contract and are left alone.
+  for (const add of proposals) {
+    if (skippedProposals.has(add) || (add.action !== "add" && add.action !== "advisory")) continue;
     const targetPath = resolvedTargets.get(add);
     if (!targetPath || !isWithinCanonicalRulesDir(resolved.projectDir, targetPath)) continue;
 
@@ -333,16 +350,13 @@ export async function curatorCommit(options: CuratorCommitOptions): Promise<void
     const violations = lintForNeutrality(content, add.canonicalFile);
     if (violations.length > 0) {
       const summary = violations.map((v) => `${v.pattern}: "${v.line.slice(0, 80)}"`).join("; ");
-      throw new NaxError(
-        `Proposal for ${add.canonicalFile} fails the neutrality linter (${summary}) — abort`,
-        "CURATOR_CONTENT_LINT_FAILED",
-        { stage: "curator-commit", canonicalFile: add.canonicalFile, violationCount: violations.length },
-      );
+      console.log(`[skip] Proposal for ${add.canonicalFile} fails the neutrality linter (${summary}) — skipping.`);
+      skippedProposals.add(add);
     }
   }
 
   // Validate all drops before any writes: key token must exist, no overlapping ranges
-  const drops = proposals.filter((p) => p.action === "drop");
+  const drops = proposals.filter((p) => p.action === "drop" && !skippedProposals.has(p));
   const dropFileState = new Map<string, { existing: string; usedLines: Set<number> }>();
   const skippedDrops = new Set<ParsedProposal>();
 
@@ -405,6 +419,7 @@ export async function curatorCommit(options: CuratorCommitOptions): Promise<void
   }
 
   // Apply adds second (validated above)
+  const adds = proposals.filter((p) => (p.action === "add" || p.action === "advisory") && !skippedProposals.has(p));
   for (const add of adds) {
     const targetPath = resolvedTargets.get(add);
     if (!targetPath) continue;

--- a/src/commands/curator.ts
+++ b/src/commands/curator.ts
@@ -7,9 +7,11 @@
 
 import { readdirSync } from "node:fs";
 import { unlink } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { basename, join, resolve, sep } from "node:path";
 import type { NaxConfig } from "../config";
 import { getProjectKey, loadConfig } from "../config";
+import { CANONICAL_RULES_DIR, lintForNeutrality } from "../context/rules/canonical-loader";
+import { NaxError } from "../errors";
 import type { CuratorThresholds } from "../plugins/builtin/curator/heuristics";
 import { runHeuristics } from "../plugins/builtin/curator/heuristics";
 import { renderProposals } from "../plugins/builtin/curator/render";
@@ -248,6 +250,34 @@ export async function curatorStatus(options: CuratorStatusOptions): Promise<void
 
 // ─── curatorCommit ────────────────────────────────────────────────────────────
 
+/** Root namespace every curator proposal target must resolve inside. */
+const CURATOR_TARGET_ROOT = ".nax";
+
+/**
+ * Resolve a proposal's `### <path>` heading to an absolute path, rejecting
+ * anything that escapes the `.nax/` namespace under the project root.
+ *
+ * `canonicalFile` comes from re-parsing `curator-proposals.md` — a file the
+ * operator (or a corrupted run) may have hand-edited — so it is untrusted
+ * input. Built-in heuristics target both `.nax/rules/curator-suggestions.md`
+ * and `.nax/features/<id>/context.md` (see plugins/builtin/curator/heuristics.ts),
+ * so containment is scoped to `.nax/` generally, not `.nax/rules/` alone —
+ * but `join()` on its own would still happily resolve a
+ * `### ../../../etc/whatever` heading outside the project entirely.
+ */
+function resolveCanonicalTargetPath(projectDir: string, canonicalFile: string): string | null {
+  const allowedRoot = resolve(projectDir, CURATOR_TARGET_ROOT);
+  const target = resolve(projectDir, canonicalFile);
+  if (target !== allowedRoot && !target.startsWith(allowedRoot + sep)) return null;
+  return target;
+}
+
+/** Whether a resolved target path falls inside the canonical rules store (`.nax/rules/`). */
+function isWithinCanonicalRulesDir(projectDir: string, targetPath: string): boolean {
+  const rulesRoot = resolve(projectDir, CANONICAL_RULES_DIR);
+  return targetPath === rulesRoot || targetPath.startsWith(rulesRoot + sep);
+}
+
 export async function curatorCommit(options: CuratorCommitOptions): Promise<void> {
   const resolved = await _curatorCmdDeps.resolveProject({ dir: options.project });
   const config = await _curatorCmdDeps.loadConfig(resolved.projectDir);
@@ -271,13 +301,55 @@ export async function curatorCommit(options: CuratorCommitOptions): Promise<void
 
   const modifiedFiles = new Set<string>();
 
+  // Validate ALL proposal target paths before any writes: every `### <path>`
+  // heading must resolve inside .nax/. Re-parsed from a file the operator
+  // may have hand-edited, so it's untrusted — a `..`-escaping heading must
+  // abort the whole commit, not just get skipped.
+  const resolvedTargets = new Map<ParsedProposal, string>();
+  for (const proposal of proposals) {
+    const targetPath = resolveCanonicalTargetPath(resolved.projectDir, proposal.canonicalFile);
+    if (targetPath === null) {
+      throw new NaxError(
+        `Proposal target "${proposal.canonicalFile}" resolves outside ${CURATOR_TARGET_ROOT}/ — abort`,
+        "CURATOR_TARGET_PATH_INVALID",
+        { stage: "curator-commit", canonicalFile: proposal.canonicalFile },
+      );
+    }
+    resolvedTargets.set(proposal, targetPath);
+  }
+
+  // Validate ALL add/advisory content targeting the canonical rules store
+  // before any writes: appending text that fails the neutrality linter (e.g.
+  // an "IMPORTANT:" or emoji surfaced verbatim from a run finding) would
+  // silently break the whole store the next time it loads (the orchestrator
+  // treats that as fatal). Proposals targeting other .nax/ files (e.g.
+  // feature context.md) aren't part of that contract and are left alone.
+  const adds = proposals.filter((p) => p.action === "add" || p.action === "advisory");
+  for (const add of adds) {
+    const targetPath = resolvedTargets.get(add);
+    if (!targetPath || !isWithinCanonicalRulesDir(resolved.projectDir, targetPath)) continue;
+
+    const content = buildAddContent(add);
+    const violations = lintForNeutrality(content, add.canonicalFile);
+    if (violations.length > 0) {
+      const summary = violations.map((v) => `${v.pattern}: "${v.line.slice(0, 80)}"`).join("; ");
+      throw new NaxError(
+        `Proposal for ${add.canonicalFile} fails the neutrality linter (${summary}) — abort`,
+        "CURATOR_CONTENT_LINT_FAILED",
+        { stage: "curator-commit", canonicalFile: add.canonicalFile, violationCount: violations.length },
+      );
+    }
+  }
+
   // Validate all drops before any writes: key token must exist, no overlapping ranges
   const drops = proposals.filter((p) => p.action === "drop");
   const dropFileState = new Map<string, { existing: string; usedLines: Set<number> }>();
   const skippedDrops = new Set<ParsedProposal>();
 
   for (const drop of drops) {
-    const targetPath = join(resolved.projectDir, drop.canonicalFile);
+    // Non-null: every proposal's target path was resolved and validated above.
+    const targetPath = resolvedTargets.get(drop);
+    if (!targetPath) continue;
 
     if (!dropFileState.has(targetPath)) {
       const fileExists = await Bun.file(targetPath).exists();
@@ -323,7 +395,8 @@ export async function curatorCommit(options: CuratorCommitOptions): Promise<void
     if (skippedDrops.has(drop)) {
       continue;
     }
-    const targetPath = join(resolved.projectDir, drop.canonicalFile);
+    const targetPath = resolvedTargets.get(drop);
+    if (!targetPath) continue;
     const existing = await _curatorCmdDeps.readFile(targetPath).catch(() => "");
     const filtered = filterDropContent(existing, drop.description);
     await _curatorCmdDeps.writeFile(targetPath, filtered);
@@ -331,10 +404,10 @@ export async function curatorCommit(options: CuratorCommitOptions): Promise<void
     console.log(`[drop] Applied to ${drop.canonicalFile}`);
   }
 
-  // Apply adds second
-  const adds = proposals.filter((p) => p.action === "add" || p.action === "advisory");
+  // Apply adds second (validated above)
   for (const add of adds) {
-    const targetPath = join(resolved.projectDir, add.canonicalFile);
+    const targetPath = resolvedTargets.get(add);
+    if (!targetPath) continue;
     const content = buildAddContent(add);
     await _curatorCmdDeps.appendFile(targetPath, content);
     modifiedFiles.add(targetPath);

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -16,6 +16,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { NaxError } from "../../errors";
 import { getLogger } from "../../logger";
 import { errorMessage } from "../../utils/errors";
+import { NeutralityLintError } from "../rules/canonical-loader";
 import { AGENT_PROFILES, getAgentProfile } from "./agent-profiles";
 import { renderForAgent } from "./agent-renderer";
 import { dedupeChunks } from "./dedupe";
@@ -309,8 +310,8 @@ export class ContextOrchestrator {
     }
 
     // Step 2: parallel fetch with timeout — failures return empty, never throw,
-    // except a "static" (rules) provider, which escalates (see catch below).
-    // Per-provider status is recorded for manifest auditability (Finding 3).
+    // except a NeutralityLintError, which escalates (see catch below). Per-
+    // provider status is recorded for manifest auditability (Finding 3).
     const fetchResults = await Promise.all(
       activeProviders.map(async (provider) => {
         const providerStart = _orchestratorDeps.now();
@@ -338,10 +339,11 @@ export class ContextOrchestrator {
           const errMsg = errorMessage(err);
           const status = errMsg.includes("timed out") ? ("timeout" as const) : ("failed" as const);
 
-          // A rules-store failure is a silent fail-open otherwise — see
-          // IContextProvider.fetch (types.ts) for the documented exception.
-          if (provider.kind === "static") {
-            const msg = `Rules provider "${provider.id}" ${status} — aborting rather than proceeding ruleless`;
+          // Escalate on THIS error type only (see IContextProvider.fetch in
+          // types.ts) — not `provider.kind === "static"` generally, since a
+          // static provider timeout/IO error should still soft-skip.
+          if (err instanceof NeutralityLintError) {
+            const msg = `Rules provider "${provider.id}" failed neutrality lint — escalating`;
             logger.error("context-v2", msg, { storyId: request.storyId, error: errMsg });
             throw err;
           }

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -308,7 +308,8 @@ export class ContextOrchestrator {
       }
     }
 
-    // Step 2: parallel fetch with timeout — failures return empty, never throw.
+    // Step 2: parallel fetch with timeout — failures return empty, never throw,
+    // except a "static" (rules) provider, which escalates (see catch below).
     // Per-provider status is recorded for manifest auditability (Finding 3).
     const fetchResults = await Promise.all(
       activeProviders.map(async (provider) => {
@@ -336,6 +337,15 @@ export class ContextOrchestrator {
           const durationMs = _orchestratorDeps.now() - providerStart;
           const errMsg = errorMessage(err);
           const status = errMsg.includes("timed out") ? ("timeout" as const) : ("failed" as const);
+
+          // A rules-store failure is a silent fail-open otherwise — see
+          // IContextProvider.fetch (types.ts) for the documented exception.
+          if (provider.kind === "static") {
+            const msg = `Rules provider "${provider.id}" ${status} — aborting rather than proceeding ruleless`;
+            logger.error("context-v2", msg, { storyId: request.storyId, error: errMsg });
+            throw err;
+          }
+
           logger.warn("context-v2", `Provider "${provider.id}" ${status} — skipping`, {
             storyId: request.storyId,
             error: errMsg,

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -555,13 +555,15 @@ export interface IContextProvider {
    * Fetch context chunks for the given request.
    * Must not throw — return empty chunks array on failure and log internally.
    *
-   * Exception: a `kind: "static"` provider (the canonical rules store) MAY
-   * throw to signal a fail-closed condition — e.g. StaticRulesProvider
-   * re-throws NeutralityLintError. The orchestrator treats that specific
-   * case as fatal to assemble() (see orchestrator.ts fetch loop) instead of
-   * the usual soft-skip, because silently proceeding with zero rules is
-   * worse than aborting the v2 bundle and falling back to the v1 context
-   * path. Every other kind must still honor the "never throw" contract.
+   * Exception: StaticRulesProvider deliberately throws NeutralityLintError
+   * to signal a fail-closed condition (the canonical rules store failed
+   * lint). The orchestrator escalates specifically on that error type (not
+   * on `kind: "static"` generally — see orchestrator.ts fetch loop) instead
+   * of the usual soft-skip, aborting assemble() rather than silently
+   * proceeding with zero rules. Callers of assemble() (runV2Path in
+   * pipeline/stages/context.ts) fall back to the v1 context path on that
+   * escalation specifically. Every other error must still honor the "never
+   * throw" contract.
    *
    * Concurrency contract: fetch() must be safe under concurrent invocation with
    * distinct ContextRequest values. The orchestrator calls providers in parallel

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -555,6 +555,14 @@ export interface IContextProvider {
    * Fetch context chunks for the given request.
    * Must not throw — return empty chunks array on failure and log internally.
    *
+   * Exception: a `kind: "static"` provider (the canonical rules store) MAY
+   * throw to signal a fail-closed condition — e.g. StaticRulesProvider
+   * re-throws NeutralityLintError. The orchestrator treats that specific
+   * case as fatal to assemble() (see orchestrator.ts fetch loop) instead of
+   * the usual soft-skip, because silently proceeding with zero rules is
+   * worse than aborting the v2 bundle and falling back to the v1 context
+   * path. Every other kind must still honor the "never throw" contract.
+   *
    * Concurrency contract: fetch() must be safe under concurrent invocation with
    * distinct ContextRequest values. The orchestrator calls providers in parallel
    * within a single assemble pass, and a future plugin cache (Finding 5) will

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -30,6 +30,7 @@ export {
 export { estimateTokens } from "../optimizer/types";
 export { ContextOrchestrator } from "./engine";
 export type { AdapterFailure } from "./engine/types";
+export { NeutralityLintError } from "./rules/canonical-loader";
 
 export {
   generateTestCoverageSummary,

--- a/src/context/rules/canonical-loader.ts
+++ b/src/context/rules/canonical-loader.ts
@@ -74,25 +74,87 @@ export const _canonicalLoaderDeps = {
 // Neutrality linter
 // ─────────────────────────────────────────────────────────────────────────────
 
-interface BannedPattern {
-  id: string;
-  regex: RegExp;
-  description: string;
+interface NeutralizeStep {
+  /** Global regex applied across the full file content (not just one line). */
+  pattern: RegExp;
+  replacement: string;
 }
 
-const BANNED_PATTERNS: BannedPattern[] = [
-  { id: "xml-tag", regex: /<system-reminder>|<ide_diagnostics>/i, description: "agent-specific XML tag" },
-  { id: "claude-reference", regex: /CLAUDE\.md/, description: "agent-specific file reference CLAUDE.md" },
-  { id: "codex-reference", regex: /AGENTS\.md/, description: "agent-specific file reference AGENTS.md" },
-  { id: "gemini-reference", regex: /GEMINI\.md/, description: "agent-specific file reference GEMINI.md" },
-  { id: "agent-directory", regex: /\.claude\/|\.codex\/|\.gemini\//, description: "agent-specific directory path" },
+interface NeutralityRule {
+  id: string;
+  /** Per-line test regex used by the linter — no /g flag (see lintForNeutrality). */
+  regex: RegExp;
+  description: string;
+  /**
+   * How `nax rules migrate` / `neutralizeContent` auto-fixes a match. Absent
+   * for patterns with no safe automatic fix.
+   */
+  neutralizeSteps?: NeutralizeStep[];
+}
+
+/**
+ * Single source of truth for what the neutrality linter bans AND how
+ * `nax rules migrate` auto-fixes it. Previously `lintForNeutrality` (here)
+ * and `neutralizeContent` (src/cli/rules.ts) maintained two independent
+ * pattern tables that had drifted — migrate didn't neutralize AGENTS.md /
+ * GEMINI.md / .codex/ / .gemini/ / <ide_diagnostics> references, and its
+ * tool-phrasing match was case-sensitive on the first letter while the
+ * linter's was not — so migrated content could still fail lint.
+ */
+export const NEUTRALITY_RULES: NeutralityRule[] = [
+  {
+    id: "xml-tag",
+    regex: /<system-reminder>|<ide_diagnostics>/i,
+    description: "agent-specific XML tag",
+    neutralizeSteps: [
+      { pattern: /<system-reminder>[\s\S]*?<\/system-reminder>/gi, replacement: "" },
+      { pattern: /<system-reminder>/gi, replacement: "" },
+      { pattern: /<ide_diagnostics>[\s\S]*?<\/ide_diagnostics>/gi, replacement: "" },
+      { pattern: /<ide_diagnostics>/gi, replacement: "" },
+    ],
+  },
+  {
+    id: "claude-reference",
+    regex: /CLAUDE\.md/,
+    description: "agent-specific file reference CLAUDE.md",
+    neutralizeSteps: [{ pattern: /CLAUDE\.md/g, replacement: "project conventions file" }],
+  },
+  {
+    id: "codex-reference",
+    regex: /AGENTS\.md/,
+    description: "agent-specific file reference AGENTS.md",
+    neutralizeSteps: [{ pattern: /AGENTS\.md/g, replacement: "project conventions file" }],
+  },
+  {
+    id: "gemini-reference",
+    regex: /GEMINI\.md/,
+    description: "agent-specific file reference GEMINI.md",
+    neutralizeSteps: [{ pattern: /GEMINI\.md/g, replacement: "project conventions file" }],
+  },
+  {
+    id: "agent-directory",
+    regex: /\.claude\/|\.codex\/|\.gemini\//,
+    description: "agent-specific directory path",
+    neutralizeSteps: [{ pattern: /\.claude\/|\.codex\/|\.gemini\//g, replacement: ".nax/rules/" }],
+  },
   {
     id: "tool-phrasing",
     regex: /\bthe [A-Za-z][A-Za-z0-9_-]* tool\b/i,
     description: "agent-specific tool-name phrasing",
+    neutralizeSteps: [{ pattern: /\bthe ([A-Za-z][A-Za-z0-9_-]*) tool\b/gi, replacement: "the $1 capability" }],
   },
-  { id: "important-shouting", regex: /\bIMPORTANT:/, description: "shouting-style IMPORTANT:" },
-  { id: "emoji", regex: /\p{Extended_Pictographic}/u, description: "emoji character" },
+  {
+    id: "important-shouting",
+    regex: /\bIMPORTANT:/,
+    description: "shouting-style IMPORTANT:",
+    neutralizeSteps: [{ pattern: /\bIMPORTANT:/g, replacement: "Note:" }],
+  },
+  {
+    id: "emoji",
+    regex: /\p{Extended_Pictographic}/u,
+    description: "emoji character",
+    neutralizeSteps: [{ pattern: /\p{Extended_Pictographic}/gu, replacement: "" }],
+  },
 ];
 
 const FRONTMATTER_PRIORITY_DEFAULT = 100;
@@ -134,7 +196,7 @@ export function lintForNeutrality(content: string, fileName: string): Neutrality
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? "";
     const allowList = parseRuleAllowMarker(line);
-    for (const { id, regex, description } of BANNED_PATTERNS) {
+    for (const { id, regex, description } of NEUTRALITY_RULES) {
       if (allowList.has(id)) continue;
       if (regex.test(line)) {
         violations.push({

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -16,7 +16,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createDefaultOrchestrator, createRunCallCounter } from "../../context/engine";
+import { NeutralityLintError, createDefaultOrchestrator, createRunCallCounter } from "../../context/engine";
 import type { ContextRequest, IContextProvider } from "../../context/engine";
 import { estimateAvailableBudgetTokens } from "../../context/engine/available-budget";
 import { writeContextManifest } from "../../context/engine/manifest-store";
@@ -201,6 +201,20 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
       buildMs: bundle.manifest.buildMs,
     });
   } catch (err) {
+    if (err instanceof NeutralityLintError) {
+      // The canonical rules store failed neutrality lint. Proceeding with v2
+      // enabled but zero rules chunks is a silent fail-open — fall back to
+      // the v1 path (reads CLAUDE.md / .nax/context.md directly, unaffected
+      // by this specific failure) so the story still gets SOME grounding
+      // content instead of none. See IContextProvider.fetch (types.ts).
+      logger.error("context", "Canonical rules failed neutrality lint — falling back to v1 context", {
+        storyId: ctx.story.id,
+        error: errorMessage(err),
+      });
+      await runV1Path(ctx);
+      return;
+    }
+
     // Soft failure — v2 context is not required for agent to proceed
     logger.warn("context", "v2 orchestrator failed — proceeding without v2 context", {
       storyId: ctx.story.id,

--- a/test/unit/cli/rules.test.ts
+++ b/test/unit/cli/rules.test.ts
@@ -9,6 +9,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { NaxError } from "@/errors";
+import { lintForNeutrality } from "../../../src/context/rules/canonical-loader";
 import { withTempDir } from "@test/helpers";
 import {
   neutralizeContent,
@@ -112,6 +113,29 @@ describe("neutralizeContent", () => {
     const { content } = neutralizeContent("\n\n## Style\n\nContent.\n\n");
     expect(content.startsWith("\n")).toBe(false);
     expect(content.endsWith("\n")).toBe(false);
+  });
+
+  test("round-trips clean against the lint table for every banned pattern (migrate<->lint parity)", () => {
+    // Previously neutralizeContent and the linter's BANNED_PATTERNS were two
+    // independent tables that had drifted: migrate never touched AGENTS.md /
+    // GEMINI.md / .codex/ / .gemini/ / <ide_diagnostics>, and its tool-phrasing
+    // match was case-sensitive on the first letter while the linter's was not
+    // — so migrated content could still fail `nax rules lint`. Both now read
+    // from the same NEUTRALITY_RULES table, so this must produce zero
+    // violations for every pattern the linter checks.
+    const dirty = [
+      "<system-reminder>internal</system-reminder>",
+      "<ide_diagnostics>errors</ide_diagnostics>",
+      "See CLAUDE.md, AGENTS.md, and GEMINI.md.",
+      "Rules live in .claude/, .codex/, and .gemini/.",
+      "use the grep tool to search (lowercase, was previously missed)",
+      "IMPORTANT: read this.",
+      "Ship it 🚀",
+    ].join("\n");
+
+    const { content, replacements } = neutralizeContent(dirty);
+    expect(replacements).toBeGreaterThan(0);
+    expect(lintForNeutrality(content, "test.md")).toEqual([]);
   });
 });
 

--- a/test/unit/commands/curator.test.ts
+++ b/test/unit/commands/curator.test.ts
@@ -379,6 +379,117 @@ describe("curatorCommit", () => {
     });
   });
 
+  describe("target path containment", () => {
+    test("rejects a proposal whose ### heading escapes .nax/ via path traversal", async () => {
+      const projectDir = join(tmpDir, "project");
+      mkdirSync(join(projectDir, ".nax", "rules"), { recursive: true });
+      _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
+
+      setupRun(
+        [
+          "# Curator Proposals",
+          "## add — Add suggestions",
+          "### ../../../etc/whatever.md",
+          "- [x] [MED] H1: escape attempt — stories: US-001",
+          "  _Evidence: n/a_",
+        ].join("\n"),
+      );
+
+      let writeCalled = false;
+      _deps.appendFile = mock(async () => {
+        writeCalled = true;
+      });
+      _deps.writeFile = mock(async () => {
+        writeCalled = true;
+      });
+
+      await expect(curatorCommit({ runId })).rejects.toThrow(/resolves outside/);
+      expect(writeCalled).toBe(false);
+    });
+
+    test("allows a proposal targeting .nax/features/<id>/context.md (not just .nax/rules/)", async () => {
+      const projectDir = join(tmpDir, "project");
+      mkdirSync(join(projectDir, ".nax", "features", "feat-1"), { recursive: true });
+      _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
+
+      setupRun(
+        [
+          "# Curator Proposals",
+          "## add — Add suggestions",
+          "### .nax/features/feat-1/context.md",
+          "- [x] [MED] H2: legit feature-scoped target — stories: US-001",
+          "  _Evidence: n/a_",
+        ].join("\n"),
+      );
+
+      let appendCalled = false;
+      _deps.appendFile = mock(async (p: string, content: string) => {
+        appendCalled = true;
+        await Bun.write(p, content);
+      });
+
+      await curatorCommit({ runId });
+      expect(appendCalled).toBe(true);
+    });
+  });
+
+  describe("content neutrality lint before append", () => {
+    test("rejects a rules-store add proposal whose content fails the neutrality linter", async () => {
+      const projectDir = join(tmpDir, "project");
+      mkdirSync(join(projectDir, ".nax", "rules"), { recursive: true });
+      _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
+
+      // The description text lands verbatim in the appended HTML comment
+      // (buildAddContent) — an emoji here would otherwise break the
+      // canonical rules store the next time it loads.
+      setupRun(
+        [
+          "# Curator Proposals",
+          "## add — Add suggestions",
+          "### .nax/rules/curator-suggestions.md",
+          "- [x] [HIGH] H1: ship it 🚀 always — stories: US-001",
+          "  _Evidence: n/a_",
+        ].join("\n"),
+      );
+
+      let writeCalled = false;
+      _deps.appendFile = mock(async () => {
+        writeCalled = true;
+      });
+
+      await expect(curatorCommit({ runId })).rejects.toThrow(/neutrality linter/);
+      expect(writeCalled).toBe(false);
+    });
+
+    test("does NOT lint add proposals targeting .nax/features/<id>/context.md", async () => {
+      // Feature context.md isn't the canonical rules store the orchestrator
+      // fails closed on — lint scope is intentionally narrower than
+      // path-containment scope.
+      const projectDir = join(tmpDir, "project");
+      mkdirSync(join(projectDir, ".nax", "features", "feat-1"), { recursive: true });
+      _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
+
+      setupRun(
+        [
+          "# Curator Proposals",
+          "## add — Add suggestions",
+          "### .nax/features/feat-1/context.md",
+          "- [x] [HIGH] H1: ship it 🚀 always — stories: US-001",
+          "  _Evidence: n/a_",
+        ].join("\n"),
+      );
+
+      let appendCalled = false;
+      _deps.appendFile = mock(async (p: string, content: string) => {
+        appendCalled = true;
+        await Bun.write(p, content);
+      });
+
+      await curatorCommit({ runId });
+      expect(appendCalled).toBe(true);
+    });
+  });
+
   describe("drops before adds ordering", () => {
     test("applies drop proposals before add proposals", async () => {
       const projectDir = join(tmpDir, "project");

--- a/test/unit/commands/curator.test.ts
+++ b/test/unit/commands/curator.test.ts
@@ -380,7 +380,7 @@ describe("curatorCommit", () => {
   });
 
   describe("target path containment", () => {
-    test("rejects a proposal whose ### heading escapes .nax/ via path traversal", async () => {
+    test("skips (does not write) a proposal whose ### heading escapes the allowed targets via path traversal", async () => {
       const projectDir = join(tmpDir, "project");
       mkdirSync(join(projectDir, ".nax", "rules"), { recursive: true });
       _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
@@ -403,7 +403,35 @@ describe("curatorCommit", () => {
         writeCalled = true;
       });
 
-      await expect(curatorCommit({ runId })).rejects.toThrow(/resolves outside/);
+      await curatorCommit({ runId });
+      expect(writeCalled).toBe(false);
+      const out = capturedOutput.join("\n");
+      expect(out).toMatch(/\[skip\].*not an allowed curator target/);
+    });
+
+    test("skips a proposal targeting a shape outside .nax/rules/ or .nax/features/*/context.md", async () => {
+      // e.g. .nax/config.json — inside .nax/ but not one of the two shapes
+      // curator actually writes.
+      const projectDir = join(tmpDir, "project");
+      mkdirSync(join(projectDir, ".nax"), { recursive: true });
+      _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
+
+      setupRun(
+        [
+          "# Curator Proposals",
+          "## add — Add suggestions",
+          "### .nax/config.json",
+          "- [x] [MED] H1: not a rules or context target — stories: US-001",
+          "  _Evidence: n/a_",
+        ].join("\n"),
+      );
+
+      let writeCalled = false;
+      _deps.appendFile = mock(async () => {
+        writeCalled = true;
+      });
+
+      await curatorCommit({ runId });
       expect(writeCalled).toBe(false);
     });
 
@@ -434,7 +462,7 @@ describe("curatorCommit", () => {
   });
 
   describe("content neutrality lint before append", () => {
-    test("rejects a rules-store add proposal whose content fails the neutrality linter", async () => {
+    test("skips (does not append) a rules-store add proposal whose content fails the neutrality linter", async () => {
       const projectDir = join(tmpDir, "project");
       mkdirSync(join(projectDir, ".nax", "rules"), { recursive: true });
       _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
@@ -457,8 +485,40 @@ describe("curatorCommit", () => {
         writeCalled = true;
       });
 
-      await expect(curatorCommit({ runId })).rejects.toThrow(/neutrality linter/);
+      await curatorCommit({ runId });
       expect(writeCalled).toBe(false);
+      const out = capturedOutput.join("\n");
+      expect(out).toMatch(/\[skip\].*neutrality linter/);
+    });
+
+    test("one proposal failing lint does not block other valid proposals in the same commit", async () => {
+      const projectDir = join(tmpDir, "project");
+      mkdirSync(join(projectDir, ".nax", "rules"), { recursive: true });
+      mkdirSync(join(projectDir, ".nax", "features", "feat-1"), { recursive: true });
+      _deps.resolveProject = mock((_opts?) => makeResolvedProject(projectDir));
+
+      setupRun(
+        [
+          "# Curator Proposals",
+          "## add — Add suggestions",
+          "### .nax/rules/curator-suggestions.md",
+          "- [x] [HIGH] H1: ship it 🚀 always — stories: US-001",
+          "  _Evidence: n/a_",
+          "### .nax/features/feat-1/context.md",
+          "- [x] [MED] H2: a valid unrelated proposal — stories: US-002",
+          "  _Evidence: n/a_",
+        ].join("\n"),
+      );
+
+      const appendedPaths: string[] = [];
+      _deps.appendFile = mock(async (p: string, content: string) => {
+        appendedPaths.push(p);
+        await Bun.write(p, content);
+      });
+
+      await curatorCommit({ runId });
+      expect(appendedPaths.some((p) => p.endsWith("feat-1/context.md"))).toBe(true);
+      expect(appendedPaths.some((p) => p.endsWith("curator-suggestions.md"))).toBe(false);
     });
 
     test("does NOT lint add proposals targeting .nax/features/<id>/context.md", async () => {

--- a/test/unit/context/engine/orchestrator.test.ts
+++ b/test/unit/context/engine/orchestrator.test.ts
@@ -140,6 +140,24 @@ describe("ContextOrchestrator.assemble()", () => {
     expect(bundle.chunks.some((c) => c.id === "good:1")).toBe(true);
   });
 
+  test("static (rules) provider failure aborts assembly instead of silently dropping rules", async () => {
+    // A "static"-kind provider (the canonical rules store) is special: its
+    // failure means the run would proceed with zero rules chunks, silently.
+    // Unlike a generic provider timeout, this must abort assemble() so
+    // callers (stage-assembler.ts / pipeline/stages/context.ts) fall back to
+    // the v1 context path instead of continuing ruleless in v2.
+    const failingRules: IContextProvider = {
+      id: "static-rules",
+      kind: "static",
+      fetch: async () => { throw new Error("simulated neutrality lint failure"); },
+    };
+    const goodProvider = makeProvider("good", makeChunkResult({ id: "good:1" }));
+    const orch = new ContextOrchestrator([failingRules, goodProvider]);
+    await expect(
+      orch.assemble({ ...BASE_REQUEST, providerIds: [...(BASE_REQUEST.providerIds ?? []), "static-rules"] }),
+    ).rejects.toThrow("simulated neutrality lint failure");
+  });
+
   test("providerIds filter restricts which providers fetch", async () => {
     const p1 = makeProvider("p1", makeChunkResult({ id: "p1:chunk" }));
     const p2 = makeProvider("p2", makeChunkResult({ id: "p2:chunk" }));

--- a/test/unit/context/engine/orchestrator.test.ts
+++ b/test/unit/context/engine/orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import { ContextOrchestrator, _orchestratorDeps } from "../../../../src/context/engine/orchestrator";
 import { QUERY_NEIGHBOR_DESCRIPTOR, QUERY_FEATURE_CONTEXT_DESCRIPTOR } from "../../../../src/context/engine/pull-tools";
+import { NeutralityLintError } from "@/context";
 import type { ContextRequest, IContextProvider, ContextProviderResult } from "../../../../src/context/engine/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -140,22 +141,41 @@ describe("ContextOrchestrator.assemble()", () => {
     expect(bundle.chunks.some((c) => c.id === "good:1")).toBe(true);
   });
 
-  test("static (rules) provider failure aborts assembly instead of silently dropping rules", async () => {
-    // A "static"-kind provider (the canonical rules store) is special: its
-    // failure means the run would proceed with zero rules chunks, silently.
-    // Unlike a generic provider timeout, this must abort assemble() so
-    // callers (stage-assembler.ts / pipeline/stages/context.ts) fall back to
-    // the v1 context path instead of continuing ruleless in v2.
+  test("NeutralityLintError from a rules provider aborts assembly instead of silently dropping rules", async () => {
+    // A neutrality-lint failure is special: proceeding means the run gets
+    // zero rules chunks, silently. This must abort assemble() so callers
+    // (stage-assembler.ts / pipeline/stages/context.ts) can fall back to the
+    // v1 context path instead of continuing ruleless in v2.
     const failingRules: IContextProvider = {
       id: "static-rules",
       kind: "static",
-      fetch: async () => { throw new Error("simulated neutrality lint failure"); },
+      fetch: async () => {
+        throw new NeutralityLintError([{ file: "x.md", lineNumber: 1, line: "IMPORTANT:", ruleId: "important-shouting", pattern: "shouting-style IMPORTANT:" }]);
+      },
     };
     const goodProvider = makeProvider("good", makeChunkResult({ id: "good:1" }));
     const orch = new ContextOrchestrator([failingRules, goodProvider]);
     await expect(
       orch.assemble({ ...BASE_REQUEST, providerIds: [...(BASE_REQUEST.providerIds ?? []), "static-rules"] }),
-    ).rejects.toThrow("simulated neutrality lint failure");
+    ).rejects.toThrow(NeutralityLintError);
+  });
+
+  test("a non-lint error (e.g. timeout) from a static-kind provider still soft-skips like any other provider", async () => {
+    // Escalation is scoped to NeutralityLintError specifically, not to
+    // `kind: "static"` generally — a static provider timeout or transient
+    // I/O error should degrade gracefully, not take down the whole bundle.
+    const flakyRules: IContextProvider = {
+      id: "static-rules",
+      kind: "static",
+      fetch: async () => { throw new Error("simulated I/O error"); },
+    };
+    const goodProvider = makeProvider("good", makeChunkResult({ id: "good:1" }));
+    const orch = new ContextOrchestrator([flakyRules, goodProvider]);
+    const bundle = await orch.assemble({
+      ...BASE_REQUEST,
+      providerIds: [...(BASE_REQUEST.providerIds ?? []), "static-rules"],
+    });
+    expect(bundle.chunks.some((c) => c.id === "good:1")).toBe(true);
   });
 
   test("providerIds filter restricts which providers fetch", async () => {

--- a/test/unit/pipeline/stages/context-rules-fallback.test.ts
+++ b/test/unit/pipeline/stages/context-rules-fallback.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Context Stage — rules-integrity fallback (gap-analysis finding 1)
+ *
+ * When the canonical rules store fails the neutrality linter, orchestrator.ts
+ * escalates (re-throws NeutralityLintError instead of soft-skipping). This
+ * verifies runV2Path's catch actually falls back to the v1 context path on
+ * that specific error — not just logs and leaves ctx.contextMarkdown unset,
+ * which would be a silent no-context proceed, strictly worse than the
+ * original bug.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { NeutralityLintError } from "@/context";
+import type { PipelineContext } from "@/pipeline";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+// _contextStageDeps is test-only and not re-exported from the pipeline/stages barrel.
+import { contextStage, _contextStageDeps } from "../../../../src/pipeline/stages/context";
+
+let origCreateOrchestrator: typeof _contextStageDeps.createOrchestrator;
+let origReadDigest: typeof _contextStageDeps.readDigest;
+let origWriteDigest: typeof _contextStageDeps.writeDigest;
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = makeTempDir("nax-ctx-rules-fallback-test-");
+  origCreateOrchestrator = _contextStageDeps.createOrchestrator;
+  origReadDigest = _contextStageDeps.readDigest;
+  origWriteDigest = _contextStageDeps.writeDigest;
+  _contextStageDeps.readDigest = async () => "";
+  _contextStageDeps.writeDigest = async () => {};
+});
+
+afterEach(() => {
+  _contextStageDeps.createOrchestrator = origCreateOrchestrator;
+  _contextStageDeps.readDigest = origReadDigest;
+  _contextStageDeps.writeDigest = origWriteDigest;
+  cleanupTempDir(tmpDir);
+});
+
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    config: {
+      context: {
+        v2: { enabled: true },
+        featureEngine: { budgetTokens: 8_000 },
+      },
+    } as unknown as PipelineContext["config"],
+    rootConfig: {} as PipelineContext["rootConfig"],
+    prd: { userStories: [] } as unknown as PipelineContext["prd"],
+    story: { id: "US-001", workdir: "" } as PipelineContext["story"],
+    stories: [],
+    routing: {} as PipelineContext["routing"],
+    projectDir: tmpDir,
+    workdir: tmpDir,
+    hooks: {} as PipelineContext["hooks"],
+    sessionScratchDir: join(tmpDir, "sessions", "sess-001"),
+    sessionId: "sess-001",
+    ...overrides,
+  } as PipelineContext;
+}
+
+describe("context stage — rules-integrity fallback", () => {
+  test("falls back to the v1 path (contextMarkdown gets set) when assemble() throws NeutralityLintError", async () => {
+    _contextStageDeps.createOrchestrator = () =>
+      ({
+        async assemble() {
+          throw new NeutralityLintError([
+            { file: "curator-suggestions.md", lineNumber: 1, line: "IMPORTANT:", ruleId: "important-shouting", pattern: "shouting-style IMPORTANT:" },
+          ]);
+        },
+        rebuildForAgent: () => {
+          throw new Error("not used in this test");
+        },
+      }) as unknown as ReturnType<typeof _contextStageDeps.createOrchestrator>;
+
+    const ctx = makeCtx();
+    await contextStage.execute(ctx);
+
+    // v1's runV1Path always sets contextMarkdown (possibly to "" on soft
+    // failure) — its presence is the observable signal the fallback ran,
+    // as opposed to the pre-fix behavior where neither path populated it.
+    expect(ctx.contextMarkdown).toBeDefined();
+    // v2 must not be left half-populated from the failed attempt.
+    expect(ctx.contextBundle).toBeUndefined();
+  });
+
+  test("a non-lint v2 failure still soft-skips (contextMarkdown NOT forced via v1 fallback)", async () => {
+    _contextStageDeps.createOrchestrator = () =>
+      ({
+        async assemble() {
+          throw new Error("simulated unrelated provider failure");
+        },
+        rebuildForAgent: () => {
+          throw new Error("not used in this test");
+        },
+      }) as unknown as ReturnType<typeof _contextStageDeps.createOrchestrator>;
+
+    const ctx = makeCtx();
+    await contextStage.execute(ctx);
+
+    // Existing behavior for non-lint failures is unchanged: soft warn, no
+    // v1 fallback forced.
+    expect(ctx.contextMarkdown).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes finding 1 from the [Context Engine v2 gap analysis (2026-08-02)](.) — the report's highest-leverage Tier-1 item.

**The bug:** `src/context/engine/providers/static-rules.ts` deliberately re-throws `NeutralityLintError` when the canonical `.nax/rules/` store fails the neutrality linter ("linter violations must not silently fall back"). But `orchestrator.ts`'s provider-fetch loop caught **every** provider throw uniformly, logged a `warn`, and continued with zero rules chunks — so the entire rules store could silently vanish from every prompt with no hard signal, the opposite of the fail-closed intent. Two producers routinely fed it lint-failing content:
- `nax rules migrate` and the lint command disagreed on banned patterns (migrate never neutralized `AGENTS.md`/`GEMINI.md`/`.codex/`/`.gemini/`/`<ide_diagnostics>`, and its tool-phrasing match was case-sensitive where the linter's wasn't).
- `nax curator commit` appended unvalidated run-finding text with no path containment on its `### <path>` heading.

## Fix

1. **orchestrator.ts** — escalates specifically on `err instanceof NeutralityLintError` (logs at error level, re-throws), aborting v2 assembly. `pipeline/stages/context.ts`'s `runV2Path` catch now calls `runV1Path(ctx)` as a real fallback on that error.
2. **canonical-loader.ts + cli/rules.ts** — `neutralizeContent` and the lint command's banned-pattern table now read from one shared `NEUTRALITY_RULES` table, closing the drift (proven by a new round-trip test).
3. **curator.ts** — every proposal target path is validated against an allow-list (`.nax/rules/*.md`, `.nax/features/<id>/context.md`) before any writes; add/advisory content targeting the rules store is linted before append. Invalid/failing proposals are skipped (logged), not aborting the whole commit.

## Review

An independent code-reviewer pass on the first commit (`ca196f1f`) found the escalation's stated safety property didn't hold — v1/v2 are an if/else at the config level, so "falls back to v1" was false; the actual effect was leaving `ctx.contextMarkdown` unset, a **strictly larger** fail-open than the original bug — and that `provider.kind === "static"` was too broad a trigger (would fire on plain timeouts, and is spoofable by third-party plugins). Both fixed in the second commit (`087172ac`):
- Escalation trigger narrowed to `NeutralityLintError` specifically.
- `runV2Path`'s catch now genuinely calls `runV1Path(ctx)` — verified by a new pipeline-level test asserting `ctx.contextMarkdown` gets populated.
- Curator's path containment narrowed from "anywhere under `.nax/`" to the exact two shapes curator writes, checked against the *resolved* path (immune to a `..`-segment bypass).
- Curator's lint failure changed from abort-the-whole-commit to skip-just-that-proposal, since free-text run-finding descriptions can trip "the X tool" or an emoji easily and that shouldn't block unrelated proposals in the same batch.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (biome + all custom checks)
- [x] `bun run test` — 11,095 unit / 1,092 integration / 24 UI, 0 failures
- [x] New regression tests: NeutralityLintError escalates and aborts assemble(); a non-lint static-provider failure still soft-skips; runV2Path's catch actually falls back to v1 (`ctx.contextMarkdown` populated) vs. non-lint failures (unaffected); migrate↔lint round-trip parity; curator path-traversal/shape-allowlist rejection; curator content-lint skip-not-abort with a co-existing valid proposal still applied