### PR TITLE
fix(execution): monorepo path anchors (#1451) and carve-out gate regressions reaching the fix cycle (#1452)

### DIFF
--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -16,7 +16,7 @@
  * addX(input: I) overload of StoryOrchestratorBuilder.
  */
 
-import { join } from "node:path";
+import { join, normalize, resolve, sep } from "node:path";
 import type { NaxConfig } from "../config";
 import { isThreeSessionStrategy, qualityConfigSelector } from "../config";
 import type { TestStrategy } from "../config/schema-types";
@@ -52,6 +52,50 @@ import { type ExecutionPlan, type RectificationPhaseOptions, StoryOrchestratorBu
  */
 export function requiresInitialRefCapture(strategy: TestStrategy): boolean {
   return isThreeSessionStrategy(strategy);
+}
+
+/**
+ * Resolve the `(repoRoot, packageDir)` anchor pair for a story.
+ *
+ * `CallContext.packageDir` is populated from `PipelineContext.workdir`, which
+ * `iteration-runner.ts` builds as `join(<repo root>, story.workdir)` — it is ALREADY
+ * the package directory, not the repo root (the repo root is `PipelineContext.projectDir`).
+ * Joining `story.workdir` onto it a second time yielded `<repo>/apps/api/apps/api`, so in
+ * every monorepo story BOTH anchors handed to `validateMockStructureFiles` pointed at a
+ * path that does not exist — rejecting real test files as nonexistent — and
+ * `resolveTestFilePatterns` looked for `.nax/mono/<pkg>/config.json` under the package
+ * instead of the repo, silently falling back to root patterns (#1451).
+ *
+ * Deriving the root by stripping the suffix (rather than reading `projectDir`) keeps this
+ * correct under worktree/parallel execution, where the package lives inside the worktree
+ * but `projectDir` still names the primary checkout.
+ *
+ * Both input shapes are accepted so ad-hoc callers that pass a repo root keep working:
+ * when `ctxPackageDir` ends with `story.workdir` it is read as the package dir and the
+ * root is derived; otherwise it is read as the repo root and `story.workdir` is joined.
+ * The shapes are only ambiguous for a repo root whose own trailing segments happen to
+ * equal `story.workdir`, which production never produces.
+ *
+ * Pure function — no FS access. Exported for unit testing.
+ */
+export function resolveStoryPathAnchors(
+  ctxPackageDir: string,
+  storyWorkdir?: string,
+): { repoRoot: string; packageDir: string } {
+  const rel = (storyWorkdir ?? "").trim();
+  // `normalize` keeps a trailing separator ("apps/api/"), which `join` then preserves —
+  // enough to make the suffix comparison below miss. Compare on bare segments instead.
+  const segments = rel.split(/[\\/]+/).filter((segment) => segment !== "" && segment !== ".");
+  const normalizedRel = segments.join(sep);
+  const depth = segments.length;
+  if (depth === 0) {
+    return { repoRoot: ctxPackageDir, packageDir: ctxPackageDir };
+  }
+  const candidateRoot = resolve(ctxPackageDir, ...Array<string>(depth).fill(".."));
+  if (join(candidateRoot, normalizedRel) === normalize(ctxPackageDir)) {
+    return { repoRoot: candidateRoot, packageDir: normalize(ctxPackageDir) };
+  }
+  return { repoRoot: ctxPackageDir, packageDir: join(ctxPackageDir, normalizedRel) };
 }
 
 /**
@@ -175,9 +219,7 @@ export async function buildPlanForStrategy(
 
   // Path anchors shared by both the main-rectification postValidate and the nbf postValidate.
   // Computed once here; used in both closures below to avoid duplicate async FS reads.
-  // ctx.packageDir = repo root (absolute); story.workdir = relative sub-path to package.
-  const repoRoot = ctx.packageDir;
-  const packageDir = join(repoRoot, story.workdir ?? "");
+  const { repoRoot, packageDir } = resolveStoryPathAnchors(ctx.packageDir, story.workdir);
   const resolvedTestPatterns = await resolveTestFilePatterns(config, repoRoot, story.workdir);
 
   // Rectification: requires both config gate and typed inputs.

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -54,6 +54,12 @@ export function requiresInitialRefCapture(strategy: TestStrategy): boolean {
   return isThreeSessionStrategy(strategy);
 }
 
+/** Normalized path with any trailing separator removed; a bare root ("/") is left alone. */
+function stripTrailingSep(p: string): string {
+  const normalized = normalize(p);
+  return normalized.length > 1 && normalized.endsWith(sep) ? normalized.slice(0, -1) : normalized;
+}
+
 /**
  * Resolve the `(repoRoot, packageDir)` anchor pair for a story.
  *
@@ -82,20 +88,21 @@ export function resolveStoryPathAnchors(
   ctxPackageDir: string,
   storyWorkdir?: string,
 ): { repoRoot: string; packageDir: string } {
-  const rel = (storyWorkdir ?? "").trim();
-  // `normalize` keeps a trailing separator ("apps/api/"), which `join` then preserves —
-  // enough to make the suffix comparison below miss. Compare on bare segments instead.
-  const segments = rel.split(/[\\/]+/).filter((segment) => segment !== "" && segment !== ".");
+  // Both sides of the suffix comparison below must be in the same canonical form.
+  // `normalize` preserves a trailing separator and `join` propagates it, so a base of
+  // "<repo>/apps/api/" would compare unequal to "<repo>/apps/api" and fall through to the
+  // repo-root branch — reinstating the very double-join this function exists to prevent.
+  const base = stripTrailingSep(ctxPackageDir);
+  const segments = (storyWorkdir ?? "").split(/[\\/]+/).filter((segment) => segment !== "" && segment !== ".");
   const normalizedRel = segments.join(sep);
-  const depth = segments.length;
-  if (depth === 0) {
-    return { repoRoot: ctxPackageDir, packageDir: ctxPackageDir };
+  if (segments.length === 0) {
+    return { repoRoot: base, packageDir: base };
   }
-  const candidateRoot = resolve(ctxPackageDir, ...Array<string>(depth).fill(".."));
-  if (join(candidateRoot, normalizedRel) === normalize(ctxPackageDir)) {
-    return { repoRoot: candidateRoot, packageDir: normalize(ctxPackageDir) };
+  const candidateRoot = resolve(base, ...Array<string>(segments.length).fill(".."));
+  if (join(candidateRoot, normalizedRel) === base) {
+    return { repoRoot: candidateRoot, packageDir: base };
   }
-  return { repoRoot: ctxPackageDir, packageDir: join(ctxPackageDir, normalizedRel) };
+  return { repoRoot: base, packageDir: join(base, normalizedRel) };
 }
 
 /**

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -85,7 +85,7 @@ export {
 } from "./story-orchestrator-logging";
 export { assemblePlanInputs, assemblePlanInputsFromCtx, type PlanInputs } from "./plan-inputs";
 export { runNonBlockingFix } from "./non-blocking-fix";
-export { buildPlanForStrategy } from "./build-plan-for-strategy";
+export { buildPlanForStrategy, resolveStoryPathAnchors } from "./build-plan-for-strategy";
 export {
   CheckpointWriter,
   createCheckpointWriter,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -62,6 +62,7 @@ export {
   orderGateLast,
   gateFailureKeys,
   describeGateRegression,
+  selectRegressedGateFindings,
   createNbfFlakeTriageTransaction,
   refreshReviewInputForDispatch,
   withIncreasingFailuresBail,

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -176,7 +176,9 @@ export class ExecutionPlan {
     const gateName = this.state.fullSuiteGate?.slot.op.name;
     const preRectGateFailureKeys = gateName ? gateFailureKeys(phaseOutputs[gateName]) : new Set<string>();
 
-    const rectResult = await runRectification(this.ctx, this.state, phaseCosts, phaseOutputs);
+    const rectResult = await runRectification(this.ctx, this.state, phaseCosts, phaseOutputs, {
+      gateBaselineKeys: preRectGateFailureKeys,
+    });
 
     // Resume the canonical loop after rectification resolves. The strategy-specific
     // revalidation set (STRATEGY_TO_REVALIDATION_PHASES) intentionally narrow — e.g.
@@ -228,6 +230,7 @@ export class ExecutionPlan {
             );
             const secondRect = await runRectification(this.ctx, this.state, phaseCosts, phaseOutputs, {
               skipGateTriage: true,
+              gateBaselineKeys: preRectGateFailureKeys,
             });
             if (secondRect.rectificationExhausted) {
               logger?.warn("story-orchestrator", "Second rectification pass exhausted — terminal failure", {

--- a/src/execution/story-orchestrator/index.ts
+++ b/src/execution/story-orchestrator/index.ts
@@ -10,6 +10,7 @@ export {
   orderGateLast,
   phasePassed,
   phasesToRevalidate,
+  selectRegressedGateFindings,
   type GateRegressionDetail,
   type GateRegressionInput,
 } from "./phase-eval";

--- a/src/execution/story-orchestrator/phase-eval.ts
+++ b/src/execution/story-orchestrator/phase-eval.ts
@@ -135,6 +135,36 @@ export function gateFindingKey(finding: Finding): string {
 const KEYLESS_GATE_FAILURE_KEY = "::";
 
 /**
+ * The subset of a gate's findings that `describeGateRegression` would call regressed:
+ * failures absent from the verifier-time baseline, plus keyless (timeout /
+ * execution-failure) failures the key diff is blind to.
+ *
+ * Used by the rectification validate sweep so the findings it feeds the fix cycle are
+ * exactly the ones the terminal keep-decision will later judge (#1452). Before this, the
+ * verifier-SSOT carve-out discarded the gate's findings wholesale, so a regression
+ * introduced BY rectification never entered the cycle's work queue — and the story was
+ * then failed on it by the staleness guard, having never been given a chance to fix it.
+ *
+ * Quarantined flakes and findings already relabelled `flaky-test` are excluded, matching
+ * `gatherRectificationFindings` and the memo exclusion in `describeGateRegression` (#1383).
+ *
+ * Pure function. Exported for unit testing.
+ */
+export function selectRegressedGateFindings(
+  findings: readonly Finding[],
+  baselineKeys: ReadonlySet<string>,
+  quarantineMemo?: QuarantineMemo,
+): Finding[] {
+  return findings.filter((finding) => {
+    if (finding.category === "flaky-test") return false;
+    if (isQuarantinedFlake(finding, quarantineMemo)) return false;
+    const key = gateFindingKey(finding);
+    if (key === KEYLESS_GATE_FAILURE_KEY) return true;
+    return !baselineKeys.has(key);
+  });
+}
+
+/**
  * True when this finding is a test failure the run has already quarantined as a flake.
  *
  * Mirrors the exclusion `describeGateRegression` applies before assigning blame, so a

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -4,7 +4,7 @@ import type { CallContext, Operation, RunOperation } from "@/operations";
 import { countOscillationOutcomes, recordOscillations } from "../oscillation-store";
 import { triageNbfGate } from "./nbf-flake-triage";
 import { extractPhaseFindings, orderGateLast, phasesToRevalidate } from "./phase-eval";
-import { isQuarantinedFlake, phaseExplicitlyPassed, phasePassed } from "./phase-eval";
+import { isQuarantinedFlake, phaseExplicitlyPassed, phasePassed, selectRegressedGateFindings } from "./phase-eval";
 import { _storyOrchestratorDeps, runPhase, withIncreasingFailuresBail } from "./run-phase";
 import type { AnySlot, InternalBuildState, InternalPhase, RectificationOverrides, RectificationResult } from "./types";
 import { EXHAUSTED_EXIT_REASONS } from "./types";
@@ -343,7 +343,31 @@ export async function runRectification(
       let shortCircuited = false;
       for (const phase of phases) {
         await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
-        if (shouldSkipPhaseForRectification({ phase, state, phaseOutputs, nbfPath })) continue;
+        if (shouldSkipPhaseForRectification({ phase, state, phaseOutputs, nbfPath })) {
+          // Carve-out fired: the verifier explicitly passed, so this story is not failed
+          // by the gate here. It still must not swallow a regression rectification just
+          // introduced — that set is precisely what the staleness guard in
+          // `ExecutionPlan.run` will fail the story on, so hand it to the cycle instead of
+          // discarding it and failing later with no repair attempted (#1452).
+          //
+          // Findings only: the short-circuit below stays skipped, preserving the carve-out's
+          // other half — downstream phases still run, since a verifier-passed story should
+          // not have its reviews withheld over a gate the verifier already judged.
+          const carvedOutFindings = selectRegressedGateFindings(
+            extractPhaseFindings(phaseOutputs[phase.slot.op.name]),
+            overrides?.gateBaselineKeys ?? new Set<string>(),
+            ctx.runtime.quarantineMemo,
+          );
+          if (carvedOutFindings.length > 0) {
+            getSafeLogger()?.warn("story-orchestrator", "Gate regressed under the verifier-SSOT carve-out", {
+              storyId: ctx.storyId,
+              phase: phase.slot.op.name,
+              regressedCount: carvedOutFindings.length,
+            });
+          }
+          findings.push(...carvedOutFindings);
+          continue;
+        }
         const output = phaseOutputs[phase.slot.op.name];
         const nbfFlakeTriage = overrides?.nbfFlakeTriage;
         if (nbfPath && phase.kind === "full-suite-gate" && nbfFlakeTriage) {

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -221,6 +221,18 @@ export interface RectificationOverrides {
   initialFindings?: readonly Finding[];
   /** Transaction-local, read-only gate triage for the ADR-024 NBF path (#1404). */
   nbfFlakeTriage?: NbfFlakeTriageTransaction;
+  /**
+   * Gate failure keys as of the verifier-time baseline (`gateFailureKeys(phaseOutputs[gate])`
+   * captured before rectification).
+   *
+   * Read by the validate sweep when the verifier-SSOT carve-out fires on a red gate: failures
+   * present in this baseline stay exempt (the verifier already judged them unrelated), while
+   * failures absent from it — i.e. regressions rectification itself introduced — are fed to
+   * the fix cycle instead of being discarded (#1452). Omitting it means "no baseline known",
+   * so every failure counts as a regression: the safe direction, since findings reach the
+   * cycle rather than vanish.
+   */
+  gateBaselineKeys?: ReadonlySet<string>;
   /** Strategy set instead of state.rectification.strategies (scope filtering). */
   strategies?: FixStrategy<Finding, unknown, unknown, unknown>[];
   /** Phase kinds removed from validationPhases (e.g. the LLM reviews). */

--- a/test/unit/execution/_revalidation-fixtures.ts
+++ b/test/unit/execution/_revalidation-fixtures.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared fixtures for the rectification revalidation tests.
+ *
+ * Split out when `story-orchestrator-revalidation.test.ts` crossed the 800-line test
+ * limit: the phase ops and finding shapes are identical across the phase-selection
+ * suite and the verifier-SSOT carve-out suite, and duplicating them would leave two
+ * definitions to keep in sync.
+ *
+ * Not a `.test.ts` file — the runner only collects tests, so this holds no assertions.
+ */
+import { type DEFAULT_CONFIG, pickSelector } from "@/config";
+import type { Finding } from "@/findings/types";
+import type { RunOperation } from "@/operations";
+
+const testSel = pickSelector("test-revalidation-sel", "execution");
+
+export const mockImplementerOp: RunOperation<{ story: string }, { success: boolean }, typeof DEFAULT_CONFIG> = {
+  kind: "run",
+  name: "implementer",
+  stage: "run",
+  // biome-ignore lint/suspicious/noExplicitAny: test double for a heterogeneous op config slice
+  config: testSel as any,
+  session: { role: "implementer", lifetime: "warm" },
+  build: () => ({
+    role: { id: "r", content: "impl", overridable: false },
+    task: { id: "t", content: "", overridable: false },
+  }),
+  parse: () => ({ success: true }),
+};
+
+export function makePhaseOp(
+  name: string,
+  stage: string,
+  role: string,
+): RunOperation<{ story: string }, { success: boolean; findings: Finding[] }, typeof DEFAULT_CONFIG> {
+  return {
+    kind: "run",
+    name,
+    // biome-ignore lint/suspicious/noExplicitAny: test double for a heterogeneous op stage
+    stage: stage as any,
+    // biome-ignore lint/suspicious/noExplicitAny: test double for a heterogeneous op config slice
+    config: testSel as any,
+    // biome-ignore lint/suspicious/noExplicitAny: test double for a heterogeneous session role
+    session: { role: role as any, lifetime: "fresh" },
+    build: () => ({
+      role: { id: "r", content: name, overridable: false },
+      task: { id: "t", content: "", overridable: false },
+    }),
+    parse: () => ({ success: false, findings: [] }),
+  };
+}
+
+export const mockVerifierOp = makePhaseOp("verifier", "verify", "verifier");
+export const mockFullSuiteGateOp = makePhaseOp("full-suite-gate", "verify", "verifier");
+export const mockVerifyScopedOp = makePhaseOp("verify-scoped", "verify", "verifier");
+export const mockLintCheckOp = makePhaseOp("lint-check", "verify", "verifier");
+export const mockTypecheckCheckOp = makePhaseOp("typecheck-check", "verify", "verifier");
+export const mockSemanticReviewOp = makePhaseOp("semantic-review", "review", "reviewer-semantic");
+export const mockAdversarialReviewOp = makePhaseOp("adversarial-review", "review", "reviewer-adversarial");
+
+export const ADVISORY = {
+  source: "adversarial-review",
+  severity: "warning",
+  category: "style",
+  message: "advisory — seeds the nbf pass",
+} as unknown as Finding;
+
+/** The regression a rectification pass introduces: a test-runner failure with a stable identity. */
+export const GATE_FAILURE = {
+  source: "test-runner",
+  severity: "error",
+  category: "",
+  message: "the regression the nbf pass introduced",
+  file: "test/integration/tdd/story-orchestrator-verdict.test.ts",
+  rule: "verifier session fails",
+} as unknown as Finding;
+
+/** Identity key for {@link GATE_FAILURE}, matching `gateFindingKey`. */
+export const GATE_FAILURE_KEY = `${GATE_FAILURE.file}::${GATE_FAILURE.rule}`;
+
+export const LINT_FINDING: Finding = {
+  source: "lint",
+  tool: "biome",
+  severity: "error",
+  message: "Unused variable",
+  file: "src/foo.ts",
+  line: 5,
+  category: "",
+};

--- a/test/unit/execution/build-plan-story-path-anchors.test.ts
+++ b/test/unit/execution/build-plan-story-path-anchors.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #1451 — `story.workdir` was joined onto a path that already ended in it.
+ *
+ * `CallContext.packageDir` comes from `PipelineContext.workdir`, which
+ * `iteration-runner.ts` builds as `join(<repo root>, story.workdir)`. The old code
+ * treated it as the repo root and joined `story.workdir` again, so in every monorepo
+ * story both anchors handed to `validateMockStructureFiles` named a non-existent
+ * directory and `resolveTestFilePatterns` missed `.nax/mono/<pkg>/config.json`.
+ *
+ * The end-to-end assertions below drive the REAL `validateMockStructureFiles` and
+ * `resolveTestFilePatterns` against a temp monorepo, so they fail on the old anchors
+ * regardless of how the pair is computed.
+ */
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { resolveStoryPathAnchors } from "@/execution";
+import { validateMockStructureFiles } from "@/operations";
+import { resolveTestFilePatterns } from "@/test-runners";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+describe("resolveStoryPathAnchors (#1451)", () => {
+  test("package-dir shape: derives the repo root by stripping story.workdir", () => {
+    expect(resolveStoryPathAnchors("/repo/apps/api", "apps/api")).toEqual({
+      repoRoot: "/repo",
+      packageDir: "/repo/apps/api",
+    });
+  });
+
+  test("package-dir shape: single-segment workdir", () => {
+    expect(resolveStoryPathAnchors("/repo/packages", "packages")).toEqual({
+      repoRoot: "/repo",
+      packageDir: "/repo/packages",
+    });
+  });
+
+  test("repo-root shape is still accepted — story.workdir is joined as before", () => {
+    expect(resolveStoryPathAnchors("/repo", "apps/api")).toEqual({
+      repoRoot: "/repo",
+      packageDir: "/repo/apps/api",
+    });
+  });
+
+  test("empty / absent story.workdir collapses both anchors (single-package repo)", () => {
+    expect(resolveStoryPathAnchors("/repo", undefined)).toEqual({ repoRoot: "/repo", packageDir: "/repo" });
+    expect(resolveStoryPathAnchors("/repo", "")).toEqual({ repoRoot: "/repo", packageDir: "/repo" });
+    expect(resolveStoryPathAnchors("/repo", ".")).toEqual({ repoRoot: "/repo", packageDir: "/repo" });
+  });
+
+  test("tolerates a trailing separator and a ./ prefix on story.workdir", () => {
+    expect(resolveStoryPathAnchors("/repo/apps/api", "./apps/api/")).toEqual({
+      repoRoot: "/repo",
+      packageDir: "/repo/apps/api",
+    });
+  });
+});
+
+describe("#1451 end-to-end — real resolver and validator against a temp monorepo", () => {
+  /** Repo with a per-package pattern override and one real test file. */
+  async function makeMonorepo(): Promise<string> {
+    const root = await makeTempDir("nax-1451-");
+    await Bun.write(
+      join(root, ".nax/config.json"),
+      JSON.stringify({ execution: { smartTestRunner: { testFilePatterns: ["test/**/*.spec.ts"] } } }),
+    );
+    await Bun.write(
+      join(root, ".nax/mono/apps/api/config.json"),
+      JSON.stringify({ execution: { smartTestRunner: { testFilePatterns: ["tests/**/*.py"] } } }),
+    );
+    await Bun.write(join(root, "apps/api/tests/test_lifespan.py"), "# test\n");
+    return root;
+  }
+
+  test("per-package testFilePatterns are found (old anchors fell back to root patterns)", async () => {
+    const root = await makeMonorepo();
+    try {
+      const { repoRoot } = resolveStoryPathAnchors(join(root, "apps/api"), "apps/api");
+      const resolved = await resolveTestFilePatterns({} as never, repoRoot, "apps/api");
+      expect(resolved.globs).toEqual(["tests/**/*.py"]);
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test.each([
+    ["repo-relative", "apps/api/tests/test_lifespan.py"],
+    ["package-relative", "tests/test_lifespan.py"],
+  ])("a mock_structure declaration for an existing file is accepted (%s path)", async (_label, declared) => {
+    const root = await makeMonorepo();
+    try {
+      const { repoRoot, packageDir } = resolveStoryPathAnchors(join(root, "apps/api"), "apps/api");
+      const resolved = await resolveTestFilePatterns({} as never, repoRoot, "apps/api");
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [{ reason: "mock_structure", file: declared, files: [declared], reasonDetail: "mock moved" } as never],
+        resolved,
+        packageDir,
+        { repoRoot },
+      );
+
+      expect(invalid).toHaveLength(0);
+      expect(valid).toHaveLength(1);
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+
+  test("a declaration for a file that genuinely does not exist is still rejected", async () => {
+    const root = await makeMonorepo();
+    try {
+      const { repoRoot, packageDir } = resolveStoryPathAnchors(join(root, "apps/api"), "apps/api");
+      const resolved = await resolveTestFilePatterns({} as never, repoRoot, "apps/api");
+
+      const declared = "tests/test_absent.py";
+      const { valid, invalid } = await validateMockStructureFiles(
+        [{ reason: "mock_structure", file: declared, files: [declared], reasonDetail: "x" } as never],
+        resolved,
+        packageDir,
+        { repoRoot },
+      );
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+    } finally {
+      await cleanupTempDir(root);
+    }
+  });
+});

--- a/test/unit/execution/build-plan-story-path-anchors.test.ts
+++ b/test/unit/execution/build-plan-story-path-anchors.test.ts
@@ -52,6 +52,22 @@ describe("resolveStoryPathAnchors (#1451)", () => {
       packageDir: "/repo/apps/api",
     });
   });
+
+  test("a trailing separator on the package dir does not defeat suffix detection", () => {
+    // Both sides of the comparison must be canonical — otherwise this falls through to the
+    // repo-root branch and reinstates the #1451 double-join.
+    expect(resolveStoryPathAnchors("/repo/apps/api/", "apps/api")).toEqual({
+      repoRoot: "/repo",
+      packageDir: "/repo/apps/api",
+    });
+  });
+
+  test("normalizes redundant segments in the package dir", () => {
+    expect(resolveStoryPathAnchors("/repo/./apps/api", "apps/api")).toEqual({
+      repoRoot: "/repo",
+      packageDir: "/repo/apps/api",
+    });
+  });
 });
 
 describe("#1451 end-to-end — real resolver and validator against a temp monorepo", () => {

--- a/test/unit/execution/story-orchestrator-revalidation-carveout.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation-carveout.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Verifier-SSOT carve-out — rectification revalidation.
+ *
+ * Split from `story-orchestrator-revalidation.test.ts` (800-line test limit); shares its
+ * phase-op and finding fixtures via `_revalidation-fixtures.ts`.
+ *
+ * Covers #1401 (the nbf sweep must not inherit a stale verifier pass) and #1452 (a gate
+ * failure absent from the verifier-time baseline must reach the fix cycle rather than be
+ * discarded and then failed on by the staleness guard).
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _storyOrchestratorDeps, runRectification } from "@/execution";
+import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
+import type { Finding } from "@/findings/types";
+import type { CallContext } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+import { makeTestRuntime } from "@test/helpers";
+import {
+  ADVISORY,
+  GATE_FAILURE,
+  GATE_FAILURE_KEY,
+  LINT_FINDING,
+  mockAdversarialReviewOp,
+  mockFullSuiteGateOp,
+  mockImplementerOp,
+  mockLintCheckOp,
+  mockSemanticReviewOp,
+  mockTypecheckCheckOp,
+  mockVerifierOp,
+  mockVerifyScopedOp,
+} from "./_revalidation-fixtures";
+
+let origCallOp: typeof _storyOrchestratorDeps.callOp;
+let origRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
+let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
+let runtime: NaxRuntime;
+
+function makeCtx(): CallContext {
+  runtime = makeTestRuntime();
+  return {
+    runtime,
+    packageView: runtime.packages.repo(),
+    packageDir: "/tmp",
+    agentName: "claude",
+    storyId: "US-revalidation",
+  } as CallContext;
+}
+
+beforeEach(() => {
+  origCallOp = _storyOrchestratorDeps.callOp;
+  origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+  origCaptureGitRef = _storyOrchestratorDeps.captureGitRef;
+  _storyOrchestratorDeps.captureGitRef = mock(async () => "HEAD");
+});
+
+afterEach(async () => {
+  _storyOrchestratorDeps.callOp = origCallOp;
+  _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+  _storyOrchestratorDeps.captureGitRef = origCaptureGitRef;
+  await runtime?.close();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1401 — the nbf revalidation must not inherit a STALE verifier pass.
+//
+// `phasesToRevalidate` places full-suite-gate before the verifier in the sweep,
+// so when the carve-out is evaluated `phaseOutputs[verifier]` still holds the
+// PRE-rectification pass. On the nbf path that stale green made the carve-out
+// discard the very regression the pass had just introduced, which (a) let the
+// cycle exit "resolved" so `regressionAttempts` was never spent, and (b) skipped
+// the halt-on-failure short-circuit so the verifier session still ran against a
+// red gate. `runNonBlockingFix` then read the same gate output RAW and restored.
+//
+// The carve-out exists so a story is not rolled back over regressions it did not
+// cause. nbf never fails a story — it only chooses keep-vs-discard of its own
+// edits — so the policy has nothing to protect there and only forfeits the repair.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verifier-SSOT carve-out — nbf revalidation must not inherit a stale verifier pass (#1401)", () => {
+  /** Gate + verifier + the cheap checks: the minimum to reproduce the stale read. */
+  function makeRectifyState(strategies: unknown[] = []): Parameters<typeof runRectification>[1] {
+    return {
+      fullSuiteGate: { kind: "full-suite-gate", slot: { op: mockFullSuiteGateOp, input: { story: "US-1401" } } },
+      verifier: { kind: "verifier", slot: { op: mockVerifierOp, input: { story: "US-1401" } } },
+      lintCheck: { kind: "lint-check", slot: { op: mockLintCheckOp, input: { story: "US-1401" } } },
+      typecheckCheck: { kind: "typecheck-check", slot: { op: mockTypecheckCheckOp, input: { story: "US-1401" } } },
+      rectification: { maxAttempts: 3, strategies, abortOnIncreasingFailures: false },
+    } as unknown as Parameters<typeof runRectification>[1];
+  }
+
+  /** Mirrors ExecutionPlan's nbf wiring: seeded advisories + verifierGuard extra phase. */
+  function nbfOverrides(extra: Record<string, unknown> = {}) {
+    return {
+      initialFindings: [ADVISORY],
+      extraRevalidationKinds: ["verifier"],
+      // 1 + review.nonBlockingFix.regressionAttempts (default 1).
+      maxAttempts: 2,
+      ...extra,
+    } as unknown as Parameters<typeof runRectification>[4];
+  }
+
+  /** Pre-rectification state: the story was green, verifier included. */
+  const greenBefore = (): Record<string, unknown> => ({
+    verifier: { success: true, passed: true, findings: [] },
+    "full-suite-gate": { success: true, passed: true, findings: [] },
+  });
+
+  /** Re-runs during validate: only the gate is red. */
+  function failGateOnly(): void {
+    _storyOrchestratorDeps.callOp = mock(async (_c: unknown, op: { name: string }) => {
+      if (op.name === "full-suite-gate") return { success: false, passed: false, findings: [GATE_FAILURE] };
+      return { success: true, passed: true, findings: [] };
+    }) as typeof _storyOrchestratorDeps.callOp;
+  }
+
+  /** Capture the FixCycle runRectification builds, without running it. */
+  async function captureNbfCycle(
+    ctx: CallContext,
+    state: Parameters<typeof runRectification>[1],
+    phaseOutputs: Record<string, unknown>,
+    overrides: Parameters<typeof runRectification>[4],
+  ): Promise<{ cycle: FixCycle<Finding>; cycleCtx: FixCycleContext }> {
+    let cycle: FixCycle<Finding> | null = null;
+    let cycleCtx: FixCycleContext | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (c: FixCycle<Finding>, cc: FixCycleContext) => {
+      cycle = c;
+      cycleCtx = cc;
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as FixCycleExitReason, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    await runRectification(ctx, state, {}, phaseOutputs, overrides);
+    failGateOnly();
+    return { cycle: cycle as unknown as FixCycle<Finding>, cycleCtx: cycleCtx as unknown as FixCycleContext };
+  }
+
+  test("nbf path: a gate regression surfaces as a finding instead of being discarded by the stale verifier pass", async () => {
+    const ctx = makeCtx();
+    const phaseOutputs = greenBefore();
+    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
+
+    const result = await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    // The gate's failure must reach the cycle — this is what makes the next
+    // iteration happen at all, i.e. what makes `regressionAttempts` spendable.
+    expect(result.findings.some((f) => f.source === "test-runner")).toBe(true);
+    // And the halt-on-failure contract must hold: nothing downstream of a red
+    // gate may run, so the expensive verifier session is never dispatched.
+    expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(true);
+  });
+
+  test("nbf path: the verifier is NOT dispatched after the gate goes red (no session spent on a doomed pass)", async () => {
+    const ctx = makeCtx();
+    const phaseOutputs = greenBefore();
+    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
+
+    const dispatched: string[] = [];
+    const failing = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = (async (c: unknown, op: { name: string }, i: unknown) => {
+      dispatched.push(op.name);
+      return (failing as (c: unknown, op: unknown, i: unknown) => Promise<unknown>)(c, op, i);
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    expect(dispatched).toContain("full-suite-gate");
+    expect(dispatched).not.toContain("verifier");
+  });
+
+  /**
+   * #1452 — the carve-out is now split by the verifier-time baseline.
+   *
+   * The verifier judged the PRE-rectification tree, so its pass can only exempt failures
+   * that already existed then. A failure absent from `gateBaselineKeys` was introduced BY
+   * rectification, is exactly what `ExecutionPlan.run`'s staleness guard will fail the story
+   * on, and therefore has to reach the fix cycle instead of being discarded.
+   */
+  async function captureMainPathCarveOut(
+    baselineKeys?: ReadonlySet<string>,
+  ): Promise<{ findings: readonly Finding[]; shortCircuited: boolean }> {
+    const ctx = makeCtx();
+    // Seed via gatherRectificationFindings: lint red pre-rectification, verifier green.
+    const phaseOutputs: Record<string, unknown> = {
+      verifier: { success: true, passed: true, findings: [] },
+      "lint-check": { success: false, passed: false, findings: [LINT_FINDING] },
+    };
+    let cycle: FixCycle<Finding> | null = null;
+    let cycleCtx: FixCycleContext | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (c: FixCycle<Finding>, cc: FixCycleContext) => {
+      cycle = c;
+      cycleCtx = cc;
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as FixCycleExitReason, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    await runRectification(
+      ctx,
+      makeRectifyState(),
+      {},
+      phaseOutputs,
+      baselineKeys ? { gateBaselineKeys: baselineKeys } : undefined,
+    );
+    failGateOnly();
+
+    const result = await (cycle as unknown as FixCycle<Finding>).validate(cycleCtx as unknown as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["autofix-implementer"],
+    });
+    return {
+      findings: result.findings,
+      shortCircuited: (result as { shortCircuited?: boolean }).shortCircuited === true,
+    };
+  }
+
+  test("main path: a gate failure already in the verifier-time baseline stays exempt (#1452)", async () => {
+    const baseline = new Set([GATE_FAILURE_KEY]);
+    const { findings, shortCircuited } = await captureMainPathCarveOut(baseline);
+
+    // The verifier already judged this failure unrelated — unchanged behaviour.
+    expect(findings.some((f) => f.source === "test-runner")).toBe(false);
+    expect(shortCircuited).toBe(false);
+  });
+
+  test("main path: a gate failure ABSENT from the baseline reaches the cycle instead of being swallowed (#1452)", async () => {
+    const { findings, shortCircuited } = await captureMainPathCarveOut(new Set(["some/other.test.ts::unrelated"]));
+
+    // Introduced by rectification -> must be fixable, not silently dropped.
+    expect(findings.filter((f) => f.source === "test-runner")).toHaveLength(1);
+    // The carve-out's other half is preserved: downstream phases still run.
+    expect(shortCircuited).toBe(false);
+  });
+
+  test("main path: an omitted baseline is treated as 'no baseline known' — findings reach the cycle (#1452)", async () => {
+    const { findings } = await captureMainPathCarveOut();
+
+    expect(findings.filter((f) => f.source === "test-runner")).toHaveLength(1);
+  });
+
+  // #1383 parity. `describeGateRegression` excludes already-quarantined keys from the
+  // blame set, so a known flake firing inside the revalidation window must KEEP the pass.
+  // Turning the carve-out off exposed the sweep to that same gate output, so the sweep has
+  // to apply the same exclusion — otherwise the flake seeds a fix attempt (and a test-code
+  // edit via full-suite-rectify) and the pass is discarded, reversing #1383.
+  test("nbf path: a failure the run already quarantined does NOT seed a fix attempt", async () => {
+    const ctx = makeCtx();
+    ctx.runtime.quarantineMemo.add(GATE_FAILURE_KEY);
+
+    const phaseOutputs = greenBefore();
+    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
+
+    const result = await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
+
+    // No blame ⇒ no finding ⇒ the cycle resolves and `keptTreeRegressed` (which excludes
+    // the same key) keeps the pass, exactly as it did before #1401.
+    expect(result.findings.some((f) => f.source === "test-runner")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1401 — the consequence the two tests above buy: `review.nonBlockingFix
+// .regressionAttempts` becomes spendable. `runNonBlockingFix` passes
+// `1 + regressionAttempts` as the cycle's maxAttemptsTotal; while the gate
+// regression was discarded the cycle always exited "resolved" on iteration 1, so
+// the budget could never be reached on any verifier-bearing (three-session) plan.
+// This drives the REAL runFixCycle to prove the second attempt now happens.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("nbf regressionAttempts is actually spendable once the gate regression surfaces (#1401)", () => {
+  test("a gate that stays red drives a SECOND fix attempt instead of exiting 'resolved' after one", async () => {
+    const ctx = makeCtx();
+
+    const attempts: string[] = [];
+    _storyOrchestratorDeps.callOp = mock(async (_c: unknown, op: { name: string }) => {
+      if (op.name === "implementer") {
+        attempts.push("fix");
+        return { success: true };
+      }
+      // The nbf edit broke the suite and the repair does not clear it, so the gate
+      // stays red across both iterations — the worst case for the budget.
+      if (op.name === "full-suite-gate") return { success: false, passed: false, findings: [GATE_FAILURE] };
+      return { success: true, passed: true, findings: [] };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const strategy = {
+      name: "autofix-implementer",
+      appliesTo: (f: Finding) => f.source === "adversarial-review" || f.source === "test-runner",
+      fixOp: mockImplementerOp,
+      buildInput: () => ({ story: "US-1401" }),
+      maxAttempts: 2,
+    };
+
+    const state = {
+      fullSuiteGate: { kind: "full-suite-gate", slot: { op: mockFullSuiteGateOp, input: { story: "US-1401" } } },
+      verifier: { kind: "verifier", slot: { op: mockVerifierOp, input: { story: "US-1401" } } },
+      lintCheck: { kind: "lint-check", slot: { op: mockLintCheckOp, input: { story: "US-1401" } } },
+      rectification: { maxAttempts: 3, strategies: [strategy], abortOnIncreasingFailures: false },
+    } as unknown as Parameters<typeof runRectification>[1];
+
+    await runRectification(
+      ctx,
+      state,
+      {},
+      // Pre-rectification: green, verifier included — the stale pass that used to
+      // exempt the gate for the whole sweep.
+      { verifier: { success: true, passed: true, findings: [] } },
+      {
+        initialFindings: [ADVISORY],
+        extraRevalidationKinds: ["verifier"],
+        // 1 + review.nonBlockingFix.regressionAttempts (default 1).
+        maxAttempts: 2,
+      } as unknown as Parameters<typeof runRectification>[4],
+    );
+
+    // Iteration 1 fixes the advisory; the gate then goes red and that finding now
+    // reaches the cycle, so iteration 2 dispatches the repair attempt.
+    expect(attempts).toHaveLength(2);
+  });
+});

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -14,87 +14,26 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { type DEFAULT_CONFIG, pickSelector } from "@/config";
 import { StoryOrchestratorBuilder, _storyOrchestratorDeps, orderGateLast, runRectification } from "@/execution";
 import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
 import type { Finding } from "@/findings/types";
-import type { CallContext, RunOperation } from "@/operations";
+import type { CallContext } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
 import { makeTestRuntime } from "@test/helpers";
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Test fixtures
-// ─────────────────────────────────────────────────────────────────────────────
-
-const testSel = pickSelector("test-revalidation-sel", "execution");
-
-const mockImplementerOp: RunOperation<{ story: string }, { success: boolean }, typeof DEFAULT_CONFIG> = {
-  kind: "run",
-  name: "implementer",
-  stage: "run",
-  config: testSel as any,
-  session: { role: "implementer", lifetime: "warm" },
-  build: () => ({
-    role: { id: "r", content: "impl", overridable: false },
-    task: { id: "t", content: "", overridable: false },
-  }),
-  parse: () => ({ success: true }),
-};
-
-function makePhaseOp(
-  name: string,
-  stage: string,
-  role: string,
-): RunOperation<{ story: string }, { success: boolean; findings: Finding[] }, typeof DEFAULT_CONFIG> {
-  return {
-    kind: "run",
-    name,
-    stage: stage as any,
-    config: testSel as any,
-    session: { role: role as any, lifetime: "fresh" },
-    build: () => ({
-      role: { id: "r", content: name, overridable: false },
-      task: { id: "t", content: "", overridable: false },
-    }),
-    parse: () => ({ success: false, findings: [] }),
-  };
-}
-
-const mockVerifierOp = makePhaseOp("verifier", "verify", "verifier");
-const mockFullSuiteGateOp = makePhaseOp("full-suite-gate", "verify", "verifier");
-const mockVerifyScopedOp = makePhaseOp("verify-scoped", "verify", "verifier");
-const mockLintCheckOp = makePhaseOp("lint-check", "verify", "verifier");
-const mockTypecheckCheckOp = makePhaseOp("typecheck-check", "verify", "verifier");
-const mockSemanticReviewOp = makePhaseOp("semantic-review", "review", "reviewer-semantic");
-const mockAdversarialReviewOp = makePhaseOp("adversarial-review", "review", "reviewer-adversarial");
-
-// #1401 nbf fixtures — shared by both nbf describes below.
-const ADVISORY = {
-  source: "adversarial-review",
-  severity: "warning",
-  category: "style",
-  message: "advisory — seeds the nbf pass",
-} as unknown as Finding;
-
-/** The regression an nbf pass introduces: a test-runner failure with a stable identity. */
-const GATE_FAILURE = {
-  source: "test-runner",
-  severity: "error",
-  category: "",
-  message: "the regression the nbf pass introduced",
-  file: "test/integration/tdd/story-orchestrator-verdict.test.ts",
-  rule: "verifier session fails",
-} as unknown as Finding;
-
-const LINT_FINDING: Finding = {
-  source: "lint",
-  tool: "biome",
-  severity: "error",
-  message: "Unused variable",
-  file: "src/foo.ts",
-  line: 5,
-  category: "",
-};
+import {
+  ADVISORY,
+  GATE_FAILURE,
+  GATE_FAILURE_KEY,
+  LINT_FINDING,
+  mockAdversarialReviewOp,
+  mockFullSuiteGateOp,
+  mockImplementerOp,
+  mockLintCheckOp,
+  mockSemanticReviewOp,
+  mockTypecheckCheckOp,
+  mockVerifierOp,
+  mockVerifyScopedOp,
+} from "./_revalidation-fixtures";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared state
@@ -534,7 +473,7 @@ describe("terminal lite-validate — gate runs LAST as final arbiter (Q1/Q3)", (
     expect(order.indexOf("full-suite-gate")).toBeLessThan(order.indexOf("verifier"));
   });
 
-  test("lite mode: verifier-SSOT carve-out — a red gate is dispatched (last) but its finding is discarded when the verifier passed", async () => {
+  test("lite mode: verifier-SSOT carve-out — a red gate is dispatched (last) and does not short-circuit, but a regression still reaches the cycle", async () => {
     const ctx = makeCtx();
     // Only the gate fails; the verifier (and everything cheaper) passes.
     const { capturedCycle, capturedCtx, order } = await captureWithOrderedTracker(ctx, new Set(["full-suite-gate"]));
@@ -547,11 +486,12 @@ describe("terminal lite-validate — gate runs LAST as final arbiter (Q1/Q3)", (
 
     // The gate still RUNS (last) — it validates the just-applied fix (Q1) ...
     expect(order[order.length - 1]).toBe("full-suite-gate");
-    // ... but because the verifier passed, shouldSkipPhaseForRectification discards
-    // the gate's finding (unrelated-regression policy). So the cycle is not blocked:
-    // no findings surface and it does NOT short-circuit on the gate failure.
-    expect(result.findings).toHaveLength(0);
+    // ... and because the verifier passed, shouldSkipPhaseForRectification still keeps the
+    // gate from short-circuiting the sweep (unrelated-regression policy).
     expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(false);
+    // No verifier-time baseline was supplied, so the failure counts as introduced by
+    // rectification and is handed to the fix cycle rather than discarded (#1452).
+    expect(result.findings).toHaveLength(1);
   });
 });
 
@@ -571,220 +511,5 @@ describe("orderGateLast — pure ordering helper", () => {
   test("is a no-op when there is no full-suite-gate phase", () => {
     const input = [mk("lint-check"), mk("typecheck-check"), mk("semantic-review")];
     expect(orderGateLast(input).map((p) => p.kind)).toEqual(["lint-check", "typecheck-check", "semantic-review"]);
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// #1401 — the nbf revalidation must not inherit a STALE verifier pass.
-//
-// `phasesToRevalidate` places full-suite-gate before the verifier in the sweep,
-// so when the carve-out is evaluated `phaseOutputs[verifier]` still holds the
-// PRE-rectification pass. On the nbf path that stale green made the carve-out
-// discard the very regression the pass had just introduced, which (a) let the
-// cycle exit "resolved" so `regressionAttempts` was never spent, and (b) skipped
-// the halt-on-failure short-circuit so the verifier session still ran against a
-// red gate. `runNonBlockingFix` then read the same gate output RAW and restored.
-//
-// The carve-out exists so a story is not rolled back over regressions it did not
-// cause. nbf never fails a story — it only chooses keep-vs-discard of its own
-// edits — so the policy has nothing to protect there and only forfeits the repair.
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("verifier-SSOT carve-out — nbf revalidation must not inherit a stale verifier pass (#1401)", () => {
-  /** Gate + verifier + the cheap checks: the minimum to reproduce the stale read. */
-  function makeRectifyState(strategies: unknown[] = []): Parameters<typeof runRectification>[1] {
-    return {
-      fullSuiteGate: { kind: "full-suite-gate", slot: { op: mockFullSuiteGateOp, input: { story: "US-1401" } } },
-      verifier: { kind: "verifier", slot: { op: mockVerifierOp, input: { story: "US-1401" } } },
-      lintCheck: { kind: "lint-check", slot: { op: mockLintCheckOp, input: { story: "US-1401" } } },
-      typecheckCheck: { kind: "typecheck-check", slot: { op: mockTypecheckCheckOp, input: { story: "US-1401" } } },
-      rectification: { maxAttempts: 3, strategies, abortOnIncreasingFailures: false },
-    } as unknown as Parameters<typeof runRectification>[1];
-  }
-
-  /** Mirrors ExecutionPlan's nbf wiring: seeded advisories + verifierGuard extra phase. */
-  function nbfOverrides(extra: Record<string, unknown> = {}) {
-    return {
-      initialFindings: [ADVISORY],
-      extraRevalidationKinds: ["verifier"],
-      // 1 + review.nonBlockingFix.regressionAttempts (default 1).
-      maxAttempts: 2,
-      ...extra,
-    } as unknown as Parameters<typeof runRectification>[4];
-  }
-
-  /** Pre-rectification state: the story was green, verifier included. */
-  const greenBefore = (): Record<string, unknown> => ({
-    verifier: { success: true, passed: true, findings: [] },
-    "full-suite-gate": { success: true, passed: true, findings: [] },
-  });
-
-  /** Re-runs during validate: only the gate is red. */
-  function failGateOnly(): void {
-    _storyOrchestratorDeps.callOp = mock(async (_c: unknown, op: { name: string }) => {
-      if (op.name === "full-suite-gate") return { success: false, passed: false, findings: [GATE_FAILURE] };
-      return { success: true, passed: true, findings: [] };
-    }) as typeof _storyOrchestratorDeps.callOp;
-  }
-
-  /** Capture the FixCycle runRectification builds, without running it. */
-  async function captureNbfCycle(
-    ctx: CallContext,
-    state: Parameters<typeof runRectification>[1],
-    phaseOutputs: Record<string, unknown>,
-    overrides: Parameters<typeof runRectification>[4],
-  ): Promise<{ cycle: FixCycle<Finding>; cycleCtx: FixCycleContext }> {
-    let cycle: FixCycle<Finding> | null = null;
-    let cycleCtx: FixCycleContext | null = null;
-    _storyOrchestratorDeps.runFixCycle = mock(async (c: FixCycle<Finding>, cc: FixCycleContext) => {
-      cycle = c;
-      cycleCtx = cc;
-      return { iterations: [], finalFindings: [], exitReason: "resolved" as FixCycleExitReason, costUsd: 0 };
-    }) as typeof _storyOrchestratorDeps.runFixCycle;
-
-    await runRectification(ctx, state, {}, phaseOutputs, overrides);
-    failGateOnly();
-    return { cycle: cycle as unknown as FixCycle<Finding>, cycleCtx: cycleCtx as unknown as FixCycleContext };
-  }
-
-  test("nbf path: a gate regression surfaces as a finding instead of being discarded by the stale verifier pass", async () => {
-    const ctx = makeCtx();
-    const phaseOutputs = greenBefore();
-    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
-
-    const result = await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
-
-    // The gate's failure must reach the cycle — this is what makes the next
-    // iteration happen at all, i.e. what makes `regressionAttempts` spendable.
-    expect(result.findings.some((f) => f.source === "test-runner")).toBe(true);
-    // And the halt-on-failure contract must hold: nothing downstream of a red
-    // gate may run, so the expensive verifier session is never dispatched.
-    expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(true);
-  });
-
-  test("nbf path: the verifier is NOT dispatched after the gate goes red (no session spent on a doomed pass)", async () => {
-    const ctx = makeCtx();
-    const phaseOutputs = greenBefore();
-    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
-
-    const dispatched: string[] = [];
-    const failing = _storyOrchestratorDeps.callOp;
-    _storyOrchestratorDeps.callOp = (async (c: unknown, op: { name: string }, i: unknown) => {
-      dispatched.push(op.name);
-      return (failing as (c: unknown, op: unknown, i: unknown) => Promise<unknown>)(c, op, i);
-    }) as typeof _storyOrchestratorDeps.callOp;
-
-    await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
-
-    expect(dispatched).toContain("full-suite-gate");
-    expect(dispatched).not.toContain("verifier");
-  });
-
-  test("control — the main (non-nbf) path keeps the carve-out: a red gate is still discarded when the verifier passed", async () => {
-    const ctx = makeCtx();
-    // Seed via gatherRectificationFindings: lint red pre-rectification, verifier green.
-    const phaseOutputs: Record<string, unknown> = {
-      verifier: { success: true, passed: true, findings: [] },
-      "lint-check": { success: false, passed: false, findings: [LINT_FINDING] },
-    };
-    let cycle: FixCycle<Finding> | null = null;
-    let cycleCtx: FixCycleContext | null = null;
-    _storyOrchestratorDeps.runFixCycle = mock(async (c: FixCycle<Finding>, cc: FixCycleContext) => {
-      cycle = c;
-      cycleCtx = cc;
-      return { iterations: [], finalFindings: [], exitReason: "resolved" as FixCycleExitReason, costUsd: 0 };
-    }) as typeof _storyOrchestratorDeps.runFixCycle;
-
-    await runRectification(ctx, makeRectifyState(), {}, phaseOutputs);
-    failGateOnly();
-
-    const result = await (cycle as unknown as FixCycle<Finding>).validate(cycleCtx as unknown as FixCycleContext, {
-      mode: "full",
-      strategiesRun: ["autofix-implementer"],
-    });
-
-    // Unchanged main-path semantics: the verifier's pass still exempts the gate.
-    expect(result.findings.some((f) => f.source === "test-runner")).toBe(false);
-    expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(false);
-  });
-
-  // #1383 parity. `describeGateRegression` excludes already-quarantined keys from the
-  // blame set, so a known flake firing inside the revalidation window must KEEP the pass.
-  // Turning the carve-out off exposed the sweep to that same gate output, so the sweep has
-  // to apply the same exclusion — otherwise the flake seeds a fix attempt (and a test-code
-  // edit via full-suite-rectify) and the pass is discarded, reversing #1383.
-  test("nbf path: a failure the run already quarantined does NOT seed a fix attempt", async () => {
-    const ctx = makeCtx();
-    ctx.runtime.quarantineMemo.add(`${GATE_FAILURE.file}::${GATE_FAILURE.rule}`);
-
-    const phaseOutputs = greenBefore();
-    const { cycle, cycleCtx } = await captureNbfCycle(ctx, makeRectifyState(), phaseOutputs, nbfOverrides());
-
-    const result = await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["autofix-implementer"] });
-
-    // No blame ⇒ no finding ⇒ the cycle resolves and `keptTreeRegressed` (which excludes
-    // the same key) keeps the pass, exactly as it did before #1401.
-    expect(result.findings.some((f) => f.source === "test-runner")).toBe(false);
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// #1401 — the consequence the two tests above buy: `review.nonBlockingFix
-// .regressionAttempts` becomes spendable. `runNonBlockingFix` passes
-// `1 + regressionAttempts` as the cycle's maxAttemptsTotal; while the gate
-// regression was discarded the cycle always exited "resolved" on iteration 1, so
-// the budget could never be reached on any verifier-bearing (three-session) plan.
-// This drives the REAL runFixCycle to prove the second attempt now happens.
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("nbf regressionAttempts is actually spendable once the gate regression surfaces (#1401)", () => {
-  test("a gate that stays red drives a SECOND fix attempt instead of exiting 'resolved' after one", async () => {
-    const ctx = makeCtx();
-
-    const attempts: string[] = [];
-    _storyOrchestratorDeps.callOp = mock(async (_c: unknown, op: { name: string }) => {
-      if (op.name === "implementer") {
-        attempts.push("fix");
-        return { success: true };
-      }
-      // The nbf edit broke the suite and the repair does not clear it, so the gate
-      // stays red across both iterations — the worst case for the budget.
-      if (op.name === "full-suite-gate") return { success: false, passed: false, findings: [GATE_FAILURE] };
-      return { success: true, passed: true, findings: [] };
-    }) as typeof _storyOrchestratorDeps.callOp;
-
-    const strategy = {
-      name: "autofix-implementer",
-      appliesTo: (f: Finding) => f.source === "adversarial-review" || f.source === "test-runner",
-      fixOp: mockImplementerOp,
-      buildInput: () => ({ story: "US-1401" }),
-      maxAttempts: 2,
-    };
-
-    const state = {
-      fullSuiteGate: { kind: "full-suite-gate", slot: { op: mockFullSuiteGateOp, input: { story: "US-1401" } } },
-      verifier: { kind: "verifier", slot: { op: mockVerifierOp, input: { story: "US-1401" } } },
-      lintCheck: { kind: "lint-check", slot: { op: mockLintCheckOp, input: { story: "US-1401" } } },
-      rectification: { maxAttempts: 3, strategies: [strategy], abortOnIncreasingFailures: false },
-    } as unknown as Parameters<typeof runRectification>[1];
-
-    await runRectification(
-      ctx,
-      state,
-      {},
-      // Pre-rectification: green, verifier included — the stale pass that used to
-      // exempt the gate for the whole sweep.
-      { verifier: { success: true, passed: true, findings: [] } },
-      {
-        initialFindings: [ADVISORY],
-        extraRevalidationKinds: ["verifier"],
-        // 1 + review.nonBlockingFix.regressionAttempts (default 1).
-        maxAttempts: 2,
-      } as unknown as Parameters<typeof runRectification>[4],
-    );
-
-    // Iteration 1 fixes the advisory; the gate then goes red and that finding now
-    // reaches the cycle, so iteration 2 dispatches the repair attempt.
-    expect(attempts).toHaveLength(2);
   });
 });

--- a/test/unit/execution/story-orchestrator/regressed-gate-findings.test.ts
+++ b/test/unit/execution/story-orchestrator/regressed-gate-findings.test.ts
@@ -1,0 +1,66 @@
+/**
+ * #1452 — `selectRegressedGateFindings` must agree with `describeGateRegression`.
+ *
+ * The rectification validate sweep feeds the fix cycle whatever this selector returns
+ * when the verifier-SSOT carve-out fires. If it disagreed with the keep-decision that
+ * later judges the same gate output, the cycle would either chase failures the story is
+ * exempt from, or (as before #1452) miss the ones it will be failed on.
+ */
+import { describe, expect, test } from "bun:test";
+import { describeGateRegression, selectRegressedGateFindings } from "@/execution";
+import type { Finding } from "@/findings/types";
+
+const finding = (file: string, rule: string, category = ""): Finding =>
+  ({ source: "test-runner", severity: "error", category, message: `${file} failed`, file, rule }) as unknown as Finding;
+
+const key = (f: Finding): string => `${f.file}::${f.rule}`;
+
+describe("selectRegressedGateFindings (#1452)", () => {
+  const preExisting = finding("tests/old.py", "test_a");
+  const introduced = finding("tests/new.py", "test_b");
+
+  test("keeps failures absent from the baseline", () => {
+    const selected = selectRegressedGateFindings([preExisting, introduced], new Set([key(preExisting)]));
+    expect(selected).toEqual([introduced]);
+  });
+
+  test("drops every failure when all are in the baseline", () => {
+    const baseline = new Set([key(preExisting), key(introduced)]);
+    expect(selectRegressedGateFindings([preExisting, introduced], baseline)).toEqual([]);
+  });
+
+  test("an empty baseline makes every failure a regression", () => {
+    expect(selectRegressedGateFindings([preExisting, introduced], new Set())).toEqual([preExisting, introduced]);
+  });
+
+  test("keyless failures (timeout / execution-failure) are always regressions", () => {
+    const keyless = { source: "test-runner", severity: "error", category: "", message: "gate timed out" } as Finding;
+    expect(selectRegressedGateFindings([keyless], new Set(["::"]))).toEqual([keyless]);
+  });
+
+  test("quarantined flakes are excluded — #1383 parity", () => {
+    const flake = finding("tests/flaky.py", "test_c");
+    const selected = selectRegressedGateFindings([flake, introduced], new Set(), new Set([key(flake)]));
+    expect(selected).toEqual([introduced]);
+  });
+
+  test("findings already relabelled flaky-test are excluded", () => {
+    const relabelled = finding("tests/flaky.py", "test_c", "flaky-test");
+    expect(selectRegressedGateFindings([relabelled, introduced], new Set())).toEqual([introduced]);
+  });
+
+  test("agrees with describeGateRegression on whether the gate regressed", () => {
+    const baseline = new Set([key(preExisting)]);
+    for (const findings of [[preExisting], [preExisting, introduced], [introduced], []]) {
+      const gateOutput = { success: findings.length === 0, passed: findings.length === 0, findings };
+      const viaDescribe = describeGateRegression({
+        gateOutput,
+        baselineKeys: baseline,
+        gateName: "full-suite-gate",
+        storyId: "US-1452",
+      }).regressed;
+      const viaSelector = selectRegressedGateFindings(findings, baseline).length > 0;
+      expect(viaSelector).toBe(viaDescribe);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1451, fixes #1452.

Both were found while diagnosing a story failure in a downstream monorepo consumer, then confirmed against **512 local run logs** spanning five projects (anonymized below as A–E; A is this repo).

## #1451 — `story.workdir` joined twice

`CallContext.packageDir` is populated from `PipelineContext.workdir`, which `iteration-runner.ts:167-175` builds as `join(<repo root>, story.workdir)` — it is already the **package** directory (the repo root is `projectDir`). `buildPlanForStrategy` treated it as the root and joined `story.workdir` again, so for every monorepo story:

- both anchors passed to `validateMockStructureFiles` named `<repo>/apps/api/apps/api`, rejecting existing test files as nonexistent — the `#1386` repo-relative second anchor cannot help when *both* anchors are wrong;
- `resolveTestFilePatterns` looked for `.nax/mono/<pkg>/config.json` under the package instead of the repo, silently falling back to root patterns.

| project | `story.workdir` | `mock_structure` declared | rejected |
|---|---|---|---|
| A (this repo) | empty (267/267 stories) | 6 | **0** |
| B | empty (45/45) | 6 | **0** |
| C | mixed | 1 | 0 |
| D | `packages/*` | 9 | **5 (56%)** |
| E | `apps/*`, `packages/*` | 55 | **41 (75%)** |

Zero rejections wherever `story.workdir` is empty — the implementer → test-writer mock handoff was effectively dead in monorepos.

**Fix:** `resolveStoryPathAnchors` derives the root by stripping the `story.workdir` suffix. Stripping (rather than reading `projectDir`) stays correct under worktree execution, where the package lives in the worktree but `projectDir` still names the primary checkout. The repo-root input shape is still accepted so ad-hoc callers keep working.

## #1452 — verifier-SSOT carve-out swallowed a red gate

When the verifier explicitly passed, the carve-out made the revalidation sweep **run** `full-suite-gate`, then discard its findings and skip the halt-on-failure short-circuit. The cycle reported `outcome: "resolved", findingsAfter: 0` on a red gate; the post-rectification resume re-ran the same gate outside the carve-out and `#1240`'s staleness guard failed the story — on failures the cycle was never shown.

```
revalidation full-suite-gate failures:                    288
  short-circuited, findings kept (correct):                89
  swallowed -> cycle declared "resolved" / 0 findings:      50

what happened after those 50:
   22  story PASSED            (carve-out benign — red was not story-caused)
   19  story FAILED (stale-verifier guard)
    3  story FAILED (other)
    6  continued
```

Present in every project including this repo itself — not monorepo-specific. Roughly 44% benign / 44% harmful, so this is a dual-use seam, not a pure bug.

**Fix:** split the carve-out by the verifier-time baseline — the same discriminator the terminal keep-decision already computes (`preRectGateFailureKeys`, now threaded through as `gateBaselineKeys`):

- failures **in** the baseline stay exempt — the verifier judged the pre-rectification tree, and this is the 22-of-50 benign population, unchanged;
- failures **absent** from it were introduced by rectification, are exactly what the staleness guard will fail the story on, and now reach the fix cycle.

The short-circuit stays skipped either way, so a verifier-passed story still gets its downstream reviews. `selectRegressedGateFindings` has a test asserting it agrees with `describeGateRegression` case-for-case, so the sweep and the keep-decision cannot drift.

Scope kept deliberately narrow: the **seed** path (`gatherRectificationFindings`) applies the same carve-out and is left alone — changing it would alter which stories enter rectification at all, a wider blast radius than the evidence supports.

## Review notes

Self-review checked the one hazard this change could introduce — a finding with no claiming strategy exits the cycle `no-strategy` and fails an otherwise-green story (`#1327`). It is closed on every path:

- the carve-out only fires when a verifier exists ⇒ `isThreeSession` ⇒ with the gate phase present, `full-suite-rectify` is registered;
- real gate findings carry `category: "failed-test"` / `"execution-failed"` (`findings/adapters/test-failure.ts`, `test-runner.ts`), which `claimsFailingTest` matches;
- when a mock handoff is pending, `full-suite-rectify` defers and `autofix-test-writer`'s `sink.mockHandoffs.length > 0` blanket clause claims instead — complementary, no gap.

The third commit fixes a latent defect review found in the new helper itself: a trailing separator on the package dir defeated suffix detection and reinstated the double-join.

`story-orchestrator-revalidation.test.ts` crossed the 800-line test limit, so it is split into a carve-out file plus a shared `_revalidation-fixtures.ts` rather than duplicating the phase-op fixtures. Test count is preserved (19 → 21; one test replaced by three).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean, all 9 gates, no baseline movement
- [x] `bun run test` — 11115 unit / 1092 integration / 24 ui, **0 fail**
- [x] `bun run test:coverage` — 83.72% lines, 85.79% functions (floor 80%)
- [x] `scripts/check-runtime-cleanup.sh` — clean
- [x] New `#1451` coverage drives the real `resolveTestFilePatterns` + `validateMockStructureFiles` against a temp monorepo, so it fails on the old anchors regardless of how the pair is computed
- [ ] Not yet exercised by a real `nax run` against a monorepo — worth watching the first such run after merge for `mock_structure` acceptance and for the new `"Gate regressed under the verifier-SSOT carve-out"` warn
