### PR TITLE
fix(context): thread stage config, test patterns and naxignore into assemblies (gap findings 5, 6)

### DIFF
--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -210,9 +210,10 @@ export async function assembleForStage(
       // in every stage that assembleForStage() serves (execution, rectify, tdd-*, review-*, etc.).
       planDigestBoost: getStageContextConfig(ctx.routing?.testStrategy ?? "").planDigestBoost,
       // ADR-009 SSOT: forward the test-file patterns the context stage resolved so
-      // CodeNeighborProvider can hint sibling tests here too. Without this the
-      // tdd-test-writer stage — the one that most needs sibling tests — was the
-      // only consumer that never received them.
+      // CodeNeighborProvider can hint sibling tests here too. Only the context
+      // stage set them before, so every bundle assembled here — today the
+      // batch / no-test / single-session execution bundles built by
+      // prompt.ts, the sole caller — silently skipped sibling-test hinting.
       ...(ctx.resolvedTestPatterns && { resolvedTestPatterns: ctx.resolvedTestPatterns }),
       // Forward the run-scoped .naxignore index so user-ignored paths are excluded
       // from the reverse-dep scan and the session-scratch read, as they already are

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -209,6 +209,15 @@ export async function assembleForStage(
       // AC-51: propagate planDigestBoost from the routing test strategy so the boost applies
       // in every stage that assembleForStage() serves (execution, rectify, tdd-*, review-*, etc.).
       planDigestBoost: getStageContextConfig(ctx.routing?.testStrategy ?? "").planDigestBoost,
+      // ADR-009 SSOT: forward the test-file patterns the context stage resolved so
+      // CodeNeighborProvider can hint sibling tests here too. Without this the
+      // tdd-test-writer stage — the one that most needs sibling tests — was the
+      // only consumer that never received them.
+      ...(ctx.resolvedTestPatterns && { resolvedTestPatterns: ctx.resolvedTestPatterns }),
+      // Forward the run-scoped .naxignore index so user-ignored paths are excluded
+      // from the reverse-dep scan and the session-scratch read, as they already are
+      // on the verify/review paths.
+      ...(ctx.naxIgnoreIndex && { naxIgnoreIndex: ctx.naxIgnoreIndex }),
     };
 
     const bundle = await orchestrator.assemble(request);

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -117,6 +117,15 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
       error: errorMessage(err),
     });
   }
+  // Publish onto the pipeline context so later assemblies (assembleForStage:
+  // execution, rectify, tdd-*, review-*) reuse this resolution instead of
+  // skipping sibling-test hinting or repeating the I/O.
+  if (resolvedTestPatterns) ctx.resolvedTestPatterns = resolvedTestPatterns;
+
+  // Honour the per-stage v2 config for this stage exactly as assembleForStage
+  // does. Without this, `v2.stages.context.budgetTokens` and `extraProviderIds`
+  // were inert on the first — and largest — assembly of every story.
+  const stageOverrides = ctx.config.context?.v2?.stages?.context;
 
   const request: ContextRequest = {
     storyId: ctx.story.id,
@@ -127,7 +136,8 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
     packageDir: ctx.workdir,
     stage: "context", // initial assembly; execution stage overrides to "execution"
     role: "implementer",
-    budgetTokens: ctx.config.context.featureEngine?.budgetTokens ?? 8_000,
+    budgetTokens: stageOverrides?.budgetTokens ?? ctx.config.context.featureEngine?.budgetTokens ?? 8_000,
+    extraProviderIds: stageOverrides?.extraProviderIds ?? [],
     minScore: ctx.config.context.v2.minScore,
     storyScratchDirs,
     priorStageDigest,
@@ -149,6 +159,10 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
     // single-session, tdd-simple, no-test, and batch strategies declare planDigestBoost >= 1.5.
     planDigestBoost: getStageContextConfig(ctx.routing?.testStrategy ?? "").planDigestBoost,
     ...(resolvedTestPatterns && { resolvedTestPatterns }),
+    // Same .naxignore index the verify/review paths already honour — without it
+    // the neighbour scan walks user-ignored files and session-scratch re-reads
+    // patterns from disk on every fetch.
+    ...(ctx.naxIgnoreIndex && { naxIgnoreIndex: ctx.naxIgnoreIndex }),
   };
 
   // Phase 7: load any plugin providers (RAG, graph, KB) configured for this project.

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -16,6 +16,8 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { NaxError } from "@/errors";
+import { packageDirRelative } from "@/utils/paths";
 import { NeutralityLintError, createDefaultOrchestrator, createRunCallCounter } from "../../context/engine";
 import type { ContextRequest, IContextProvider } from "../../context/engine";
 import { estimateAvailableBudgetTokens } from "../../context/engine/available-budget";
@@ -108,7 +110,14 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
   // Failure is non-fatal — providers degrade by skipping sibling-test hinting.
   let resolvedTestPatterns: import("../../test-runners/resolver").ResolvedTestPatterns | undefined;
   try {
-    resolvedTestPatterns = await resolveTestFilePatterns(ctx.config, ctx.workdir, ctx.story.workdir || undefined, {
+    // Anchors must match routing.ts:113-115 — resolveTestFilePatterns takes the
+    // absolute project ROOT plus a package path RELATIVE to it. In monorepo mode
+    // ctx.workdir is already join(projectDir, story.workdir), so passing it as the
+    // root together with story.workdir doubles the package segment: the per-package
+    // .nax/mono/<pkg>/config.json lookup misses and detection scans a path that does
+    // not exist, silently falling through to DEFAULT_TEST_FILE_PATTERNS.
+    const root = ctx.projectDir ?? ctx.workdir;
+    resolvedTestPatterns = await resolveTestFilePatterns(ctx.config, root, packageDirRelative(root, ctx.workdir), {
       storyId: ctx.story.id,
     });
   } catch (err) {
@@ -117,9 +126,10 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
       error: errorMessage(err),
     });
   }
-  // Publish onto the pipeline context so later assemblies (assembleForStage:
-  // execution, rectify, tdd-*, review-*) reuse this resolution instead of
-  // skipping sibling-test hinting or repeating the I/O.
+  // Publish onto the pipeline context so later assemblies via assembleForStage
+  // (today the batch / no-test / single-session execution bundles built by
+  // promptStage) reuse this resolution instead of skipping sibling-test hinting
+  // or repeating the I/O.
   if (resolvedTestPatterns) ctx.resolvedTestPatterns = resolvedTestPatterns;
 
   // Honour the per-stage v2 config for this stage exactly as assembleForStage
@@ -227,6 +237,15 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
       });
       await runV1Path(ctx);
       return;
+    }
+
+    // A typo in v2.stages.context.extraProviderIds is a config error, not a
+    // runtime hiccup — fail closed exactly as assembleForStage does
+    // (stage-assembler.ts). Swallowing it here would silently drop v2 context
+    // for the whole story on strategies where promptStage never re-assembles,
+    // contradicting the documented "typos surface immediately" contract.
+    if (err instanceof NaxError && err.code === "CONTEXT_UNKNOWN_PROVIDER_IDS") {
+      throw err;
     }
 
     // Soft failure — v2 context is not required for agent to proceed

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -94,6 +94,14 @@ export interface PipelineContext extends DispatchContext {
   workdir: string;
   /** Run-scoped pre-resolved .naxignore matcher index (repo-root + package-level). */
   naxIgnoreIndex?: import("../utils/path-filters").NaxIgnoreIndex;
+  /**
+   * Story-scoped ADR-009 test-file patterns, resolved once by the context stage
+   * and reused by every later assembly. Carried here rather than re-resolved per
+   * stage so `assembleForStage` performs no extra I/O; absent when the context
+   * stage did not run or pattern resolution failed (providers then degrade by
+   * skipping sibling-test hinting).
+   */
+  resolvedTestPatterns?: import("../test-runners/resolver").ResolvedTestPatterns;
   /** Dependency-preparation context for worktree execution, if one was created. */
   worktreeDependencyContext?: import("../worktree/types").WorktreeDependencyContext;
   /** Absolute path to the prd.json file (used by routing stage to persist initial classification) */

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -227,6 +227,12 @@ function makeCtx(overrides: {
   projectDir?: string;
   /** Override story.workdir (relative sub-package path). */
   storyWorkdir?: string;
+  /** ADR-009 resolved test-file patterns carried on the pipeline context. */
+  resolvedTestPatterns?: unknown;
+  /** Pre-built .naxignore index carried on the pipeline context. */
+  naxIgnoreIndex?: unknown;
+  /** Per-stage v2 overrides (config.context.v2.stages). */
+  stages?: Record<string, { budgetTokens?: number; extraProviderIds?: string[] }>;
 } = {}): PipelineContext {
   return {
     config: {
@@ -235,10 +241,13 @@ function makeCtx(overrides: {
           enabled: true,
           pluginProviders: [],
           deterministic: overrides.deterministic,
+          ...(overrides.stages && { stages: overrides.stages }),
         },
       },
       autoMode: { defaultAgent: "claude" },
     },
+    ...(overrides.resolvedTestPatterns !== undefined && { resolvedTestPatterns: overrides.resolvedTestPatterns }),
+    ...(overrides.naxIgnoreIndex !== undefined && { naxIgnoreIndex: overrides.naxIgnoreIndex }),
     rootConfig: { autoMode: { defaultAgent: "claude" } },
     prd: { feature: "test-feature", userStories: [] },
     story: { id: "US-001", ...(overrides.storyWorkdir && { workdir: overrides.storyWorkdir }) },
@@ -349,6 +358,50 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
     await assembleForStage(makeCtx({ testStrategy: "tdd-simple" }), "execution");
 
     expect(mock.ref.captured?.availableBudgetTokens).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap finding 6 — resolvedTestPatterns / naxIgnoreIndex never reached
+// assembleForStage, so every stage it serves (tdd-test-writer, tdd-implementer,
+// rectify, single-session, batch) lost sibling-test hinting and .naxignore
+// filtering. The context stage set resolvedTestPatterns; nothing else did.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("assembleForStage — ADR-009 / .naxignore threading", () => {
+  const origCreate = _stageAssemblerDeps.createOrchestrator;
+  afterEach(() => {
+    _stageAssemblerDeps.createOrchestrator = origCreate;
+  });
+
+  test("threads resolvedTestPatterns from the pipeline context into the request", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    const patterns = { regex: [/\.test\.ts$/], globs: ["test/**/*.test.ts"], testDirs: ["test"], pathspec: [] };
+
+    await assembleForStage(makeCtx({ resolvedTestPatterns: patterns }), "tdd-test-writer");
+
+    expect(mock.ref.captured?.resolvedTestPatterns).toBe(patterns);
+  });
+
+  test("threads naxIgnoreIndex from the pipeline context into the request", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    const index = { getMatchers: () => [] };
+
+    await assembleForStage(makeCtx({ naxIgnoreIndex: index }), "tdd-implementer");
+
+    expect(mock.ref.captured?.naxIgnoreIndex).toBe(index);
+  });
+
+  test("leaves both undefined when the pipeline context carries neither", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx(), "execution");
+
+    expect(mock.ref.captured?.resolvedTestPatterns).toBeUndefined();
+    expect(mock.ref.captured?.naxIgnoreIndex).toBeUndefined();
   });
 });
 

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -218,22 +218,24 @@ describe("discoverSessionScratchDirsOnDisk — Finding 2", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Minimal PipelineContext for assembleForStage tests */
-function makeCtx(overrides: {
-  deterministic?: boolean;
-  testStrategy?: string;
-  /** Override the agent-spawn workdir (ctx.workdir). Defaults to "/repo". */
-  workdir?: string;
-  /** Override the repo root (ctx.projectDir). Defaults to undefined to suppress manifest writes. */
-  projectDir?: string;
-  /** Override story.workdir (relative sub-package path). */
-  storyWorkdir?: string;
-  /** ADR-009 resolved test-file patterns carried on the pipeline context. */
-  resolvedTestPatterns?: unknown;
-  /** Pre-built .naxignore index carried on the pipeline context. */
-  naxIgnoreIndex?: unknown;
-  /** Per-stage v2 overrides (config.context.v2.stages). */
-  stages?: Record<string, { budgetTokens?: number; extraProviderIds?: string[] }>;
-} = {}): PipelineContext {
+function makeCtx(
+  overrides: {
+    deterministic?: boolean;
+    testStrategy?: string;
+    /** Override the agent-spawn workdir (ctx.workdir). Defaults to "/repo". */
+    workdir?: string;
+    /** Override the repo root (ctx.projectDir). Defaults to undefined to suppress manifest writes. */
+    projectDir?: string;
+    /** Override story.workdir (relative sub-package path). */
+    storyWorkdir?: string;
+    /** ADR-009 resolved test-file patterns carried on the pipeline context. */
+    resolvedTestPatterns?: unknown;
+    /** Pre-built .naxignore index carried on the pipeline context. */
+    naxIgnoreIndex?: unknown;
+    /** Per-stage v2 overrides (config.context.v2.stages). */
+    stages?: Record<string, { budgetTokens?: number; extraProviderIds?: string[] }>;
+  } = {},
+): PipelineContext {
   return {
     config: {
       context: {
@@ -296,7 +298,9 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
     origReadDescriptor = _stageAssemblerDeps.readDescriptor;
     origCreateOrchestrator = _stageAssemblerDeps.createOrchestrator;
     // Suppress disk discovery
-    _stageAssemblerDeps.readdir = async () => { throw new Error("ENOENT"); };
+    _stageAssemblerDeps.readdir = async () => {
+      throw new Error("ENOENT");
+    };
     _stageAssemblerDeps.readDescriptor = async () => null;
   });
 
@@ -308,7 +312,8 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
 
   test("AC-24: passes deterministic:true when config flag is set", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
 
     await assembleForStage(makeCtx({ deterministic: true }), "execution");
 
@@ -317,7 +322,8 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
 
   test("AC-24: passes deterministic:false when config flag is unset", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
 
     await assembleForStage(makeCtx({ deterministic: false }), "execution");
 
@@ -326,7 +332,8 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
 
   test("AC-51: passes planDigestBoost from routing testStrategy (tdd-simple → 1.5)", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
 
     await assembleForStage(makeCtx({ testStrategy: "tdd-simple" }), "execution");
 
@@ -335,7 +342,8 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
 
   test("AC-51: planDigestBoost is undefined for three-session-tdd (uses multi-session digest)", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
 
     await assembleForStage(makeCtx({ testStrategy: "three-session-tdd" }), "tdd-implementer");
 
@@ -344,7 +352,8 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
 
   test("AC-51: planDigestBoost 1.5 for no-test strategy", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
 
     await assembleForStage(makeCtx({ testStrategy: "no-test" }), "execution");
 
@@ -353,7 +362,8 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
 
   test("threads availableBudgetTokens from stage assembly call site", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
 
     await assembleForStage(makeCtx({ testStrategy: "tdd-simple" }), "execution");
 
@@ -376,7 +386,8 @@ describe("assembleForStage — ADR-009 / .naxignore threading", () => {
 
   test("threads resolvedTestPatterns from the pipeline context into the request", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
     const patterns = { regex: [/\.test\.ts$/], globs: ["test/**/*.test.ts"], testDirs: ["test"], pathspec: [] };
 
     await assembleForStage(makeCtx({ resolvedTestPatterns: patterns }), "tdd-test-writer");
@@ -386,7 +397,8 @@ describe("assembleForStage — ADR-009 / .naxignore threading", () => {
 
   test("threads naxIgnoreIndex from the pipeline context into the request", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
     const index = { getMatchers: () => [] };
 
     await assembleForStage(makeCtx({ naxIgnoreIndex: index }), "tdd-implementer");
@@ -396,7 +408,8 @@ describe("assembleForStage — ADR-009 / .naxignore threading", () => {
 
   test("leaves both undefined when the pipeline context carries neither", async () => {
     const mock = makeMockOrchestrator();
-    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
 
     await assembleForStage(makeCtx(), "execution");
 
@@ -423,7 +436,9 @@ describe("assembleForStage — Issue #556 monorepo workdir contamination", () =>
     origReaddir = _stageAssemblerDeps.readdir;
     origReadDescriptor = _stageAssemblerDeps.readDescriptor;
     origCreateOrchestrator = _stageAssemblerDeps.createOrchestrator;
-    _stageAssemblerDeps.readdir = async () => { throw new Error("ENOENT"); };
+    _stageAssemblerDeps.readdir = async () => {
+      throw new Error("ENOENT");
+    };
     _stageAssemblerDeps.readDescriptor = async () => null;
   });
 

--- a/test/unit/pipeline/stages/context-digest.test.ts
+++ b/test/unit/pipeline/stages/context-digest.test.ts
@@ -259,3 +259,86 @@ describe("context stage — Phase 2 digest threading", () => {
     expect(capturedRequest?.availableBudgetTokens).toBeGreaterThan(0);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap finding 5 — the context stage read featureEngine.budgetTokens and never
+// consulted config.context.v2.stages.context, so the per-stage budget and
+// extraProviderIds were inert on the first (and largest) assembly of a story.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("contextStage — v2.stages.context overrides", () => {
+  function ctxWithStages(stage: { budgetTokens?: number; extraProviderIds?: string[] }): PipelineContext {
+    return makeCtx({
+      config: {
+        context: {
+          v2: { enabled: true, stages: { context: stage } },
+          featureEngine: { budgetTokens: 8_000 },
+        },
+      } as unknown as PipelineContext["config"],
+    });
+  }
+
+  test("uses v2.stages.context.budgetTokens in preference to featureEngine.budgetTokens", async () => {
+    _contextStageDeps.readDigest = async () => "";
+    _contextStageDeps.writeDigest = async () => {};
+    let capturedRequest: ContextRequest | undefined;
+    mockOrchestrator(makeBundle(), (req) => {
+      capturedRequest = req;
+    });
+
+    await contextStage.execute(ctxWithStages({ budgetTokens: 12_345 }));
+
+    expect(capturedRequest?.budgetTokens).toBe(12_345);
+  });
+
+  test("falls back to featureEngine.budgetTokens when v2.stages.context is absent", async () => {
+    _contextStageDeps.readDigest = async () => "";
+    _contextStageDeps.writeDigest = async () => {};
+    let capturedRequest: ContextRequest | undefined;
+    mockOrchestrator(makeBundle(), (req) => {
+      capturedRequest = req;
+    });
+
+    await contextStage.execute(makeCtx());
+
+    expect(capturedRequest?.budgetTokens).toBe(8_000);
+  });
+
+  test("threads extraProviderIds from v2.stages.context", async () => {
+    _contextStageDeps.readDigest = async () => "";
+    _contextStageDeps.writeDigest = async () => {};
+    let capturedRequest: ContextRequest | undefined;
+    mockOrchestrator(makeBundle(), (req) => {
+      capturedRequest = req;
+    });
+
+    await contextStage.execute(ctxWithStages({ extraProviderIds: ["rag"] }));
+
+    expect(capturedRequest?.extraProviderIds).toEqual(["rag"]);
+  });
+
+  test("threads naxIgnoreIndex from the pipeline context into the request", async () => {
+    _contextStageDeps.readDigest = async () => "";
+    _contextStageDeps.writeDigest = async () => {};
+    let capturedRequest: ContextRequest | undefined;
+    mockOrchestrator(makeBundle(), (req) => {
+      capturedRequest = req;
+    });
+    const index = { getMatchers: () => [] } as unknown as PipelineContext["naxIgnoreIndex"];
+
+    await contextStage.execute(makeCtx({ naxIgnoreIndex: index }));
+
+    expect(capturedRequest?.naxIgnoreIndex).toBe(index);
+  });
+
+  test("publishes resolved test patterns onto the pipeline context for later stages", async () => {
+    _contextStageDeps.readDigest = async () => "";
+    _contextStageDeps.writeDigest = async () => {};
+    mockOrchestrator(makeBundle());
+
+    const ctx = makeCtx();
+    await contextStage.execute(ctx);
+
+    expect(ctx.resolvedTestPatterns).toBeDefined();
+  });
+});

--- a/test/unit/pipeline/stages/context-digest.test.ts
+++ b/test/unit/pipeline/stages/context-digest.test.ts
@@ -5,11 +5,12 @@
  * the new digest after. Tests use _contextStageDeps injection — no mock.module().
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { contextStage, _contextStageDeps } from "../../../../src/pipeline/stages/context";
-import type { PipelineContext } from "../../../../src/pipeline/types";
+import { NaxError } from "@/errors";
 import type { ContextBundle, ContextRequest } from "../../../../src/context/engine";
+import { _contextStageDeps, contextStage } from "../../../../src/pipeline/stages/context";
+import type { PipelineContext } from "../../../../src/pipeline/types";
 import { cleanupTempDir, makeTempDir } from "../../../helpers/temp";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -208,7 +209,8 @@ describe("context stage — Phase 2 digest threading", () => {
     _contextStageDeps.writeDigest = async (dir) => {
       writeDir = dir;
     };
-    _contextStageDeps.uuid = () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as `${string}-${string}-${string}-${string}-${string}`;
+    _contextStageDeps.uuid = () =>
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as `${string}-${string}-${string}-${string}-${string}`;
     mockOrchestrator(makeBundle("some digest"));
 
     const ctx = makeCtx({ sessionScratchDir: undefined, sessionId: undefined });
@@ -329,6 +331,28 @@ describe("contextStage — v2.stages.context overrides", () => {
     await contextStage.execute(makeCtx({ naxIgnoreIndex: index }));
 
     expect(capturedRequest?.naxIgnoreIndex).toBe(index);
+  });
+
+  test("rethrows CONTEXT_UNKNOWN_PROVIDER_IDS instead of degrading to no v2 context", async () => {
+    _contextStageDeps.readDigest = async () => "";
+    _contextStageDeps.writeDigest = async () => {};
+    _contextStageDeps.createOrchestrator = () =>
+      ({
+        async assemble() {
+          throw new NaxError("Unknown context provider ID(s): rgu", "CONTEXT_UNKNOWN_PROVIDER_IDS", {
+            stage: "context",
+          });
+        },
+        rebuildForAgent: () => makeBundle(),
+      }) as unknown as ReturnType<typeof _contextStageDeps.createOrchestrator>;
+
+    let threw: unknown;
+    try {
+      await contextStage.execute(ctxWithStages({ extraProviderIds: ["rgu"] }));
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toMatchObject({ code: "CONTEXT_UNKNOWN_PROVIDER_IDS" });
   });
 
   test("publishes resolved test patterns onto the pipeline context for later stages", async () => {


### PR DESCRIPTION
Closes findings **5** and **6** of the Context Engine v2 gap analysis — two threading gaps that left v2 configuration inert and starved later stages of context they were designed to receive.

## Finding 5 — the context stage bypassed its own `v2.stages` config

`stages/context.ts` built its `ContextRequest` with `budgetTokens: ctx.config.context.featureEngine?.budgetTokens ?? 8_000` and never consulted `config.context.v2.stages.context`. Only `assembleForStage` honoured stage overrides, so **`v2.stages[].budgetTokens` and `extraProviderIds` were inert on the first — and largest — assembly of every story.**

It now resolves stage overrides with the same shape `stage-assembler.ts` already used. The fallback chain is `stages.context.budgetTokens → featureEngine.budgetTokens → 8_000`, so **a repo that does not configure `v2.stages.context` is byte-identical to before** — covered by a dedicated regression test.

## Finding 6 — `resolvedTestPatterns` and `naxIgnoreIndex` never reached `assembleForStage`

Neither field was present in the request `assembleForStage` builds, so `CodeNeighborProvider` skipped sibling-test hinting and `.naxignore` was ignored in its 500-file reverse-dep scan and the session-scratch read.

`PipelineContext.naxIgnoreIndex` already existed and is populated by `unified-executor` — that half was a one-line threading gap, not missing infrastructure. `resolvedTestPatterns` had no carrier at all, so one was added to `PipelineContext`: the context stage publishes the resolution it already performs, and later assemblies reuse it rather than repeating the I/O per stage.

Both use conditional spreads, so a context carrying neither field produces a request identical to today's — asserted by a test.

## Review follow-ups (second commit)

An independent review of the first commit found two Important issues, both verified against the code before fixing:

1. **Monorepo resolver anchors were wrong.** `resolveTestFilePatterns` takes `(config, absolute project ROOT, package path RELATIVE to it)`, but was called with `(config, ctx.workdir, ctx.story.workdir)` — and in monorepo mode `ctx.workdir` is *already* `join(projectDir, story.workdir)`. The package segment was doubled, so the per-package `.nax/mono/<pkg>/config.json` lookup missed and detection scanned a non-existent directory, silently falling through to `DEFAULT_TEST_FILE_PATTERNS`. Pre-existing, but the first commit promoted that value from stage-local to run-wide, so it is fixed here using the `routing.ts:113-115` anchor pair.

2. **Unknown provider IDs failed open.** `assembleForStage` deliberately rethrows `NaxError(CONTEXT_UNKNOWN_PROVIDER_IDS)`; the context stage's catch-all swallowed it into a warn. Since this PR makes `extraProviderIds` configurable on that stage, a single typo would silently drop v2 context for an entire story on strategies where `promptStage` never re-assembles — contradicting the "typos surface immediately" contract in `docs/guides/context-engine.md` and the fail-closed config rule. Now rethrown.

A comment claiming the fix restored patterns to the `tdd-*` stages was also corrected: `assembleForStage`'s only caller today is `promptStage`, with `stage ∈ {batch, no-test, single-session}`.

## Verification

- **10 tests added.** `1137 pass / 0 fail` across `test/unit/context/` + `test/unit/pipeline/`.
- **Mutation-verified, not just green.** Reverting the `src/` changes fails exactly the 6 new behavioural tests; reverting the fail-closed guard alone fails exactly that test. The one test that passes either way is the deliberate no-config-fallback regression guard.
- `bun run typecheck` and full `bun run lint` clean, every ratchet at baseline. (An earlier pass tripped `check:deep-relatives` at 2848 vs baseline 2846; both new imports were moved to the `@/` alias.)

Full-suite verification was deliberately **not** run: two nax runs were live on the machine, and Bun's JSC is documented in this repo's own rules as SIGABRT-prone under sustained load. Targeted suites only — worth a full run in CI.

## Notes for the reviewer

Two smaller items the review raised were left as follow-ups rather than scope-creeping this PR:

- `SessionScratchProvider` uses `naxIgnoreIndex?.getMatchers(packageDir) ?? <disk fallback>`. `getMatchers` returns `[]` (truthy) for an unindexed key, so now that the context stage supplies an index, the disk fallback no longer fires. In worktree mode `packageDir` is a worktree path that `buildNaxIgnoreIndex` never keyed, so it degrades to repo-root matchers. Narrow blast radius (scratch-file filtering); wants a `.length > 0` guard.
- `docs/guides/context-engine.md:266` already claimed `v2.stages.*` overrides only `budgetTokens`, which was stale before this PR and remains worth updating alongside the new two-key precedence.
