### PR TITLE
fix(context): scope the pull-tool budget to the session (gap finding 7, correctness half)

### DIFF
--- a/scripts/baselines/nax-error-baseline.json
+++ b/scripts/baselines/nax-error-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 112,
-  "updatedAt": "2026-06-19T15:50:21.967Z",
+  "count": 110,
+  "updatedAt": "2026-08-03T03:51:18.569Z",
   "byFile": {
     "src/interaction/init.ts": 1,
     "src/interaction/plugins/auto.ts": 2,
@@ -44,7 +44,6 @@
     "src/logger/logger.ts": 1,
     "src/context/generator.ts": 1,
     "src/context/builder.ts": 1,
-    "src/context/engine/tool-runtime.ts": 2,
     "src/context/engine/providers/plugin-loader.ts": 2,
     "src/pipeline/runner.ts": 1
   }

--- a/src/context/engine/index.ts
+++ b/src/context/engine/index.ts
@@ -52,8 +52,8 @@ export type { AgentRenderOptions } from "./agent-renderer";
 
 export { assembleForStage, getBundleMarkdown } from "./stage-assembler";
 export type { StageAssembleOptions } from "./stage-assembler";
-export { createContextToolRuntime } from "./tool-runtime";
-export type { ContextToolRuntime } from "./tool-runtime";
+export { createContextToolRuntime, createSessionToolBudgets } from "./tool-runtime";
+export type { ContextToolRuntime, SessionToolBudgets } from "./tool-runtime";
 export {
   writeContextManifest,
   writeRebuildManifest,

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -228,10 +228,12 @@ export async function handleQueryNeighbor(
   budget.consume();
 
   const provider = new CodeNeighborProvider(providerOptions ?? {});
+  // One source of truth so the request and the log provably cannot diverge.
+  const resolvedPackageDir = packageDir ?? repoRoot;
   const request: ContextRequest = {
     storyId: storyId ?? "_pull-tool",
     repoRoot,
-    packageDir: packageDir ?? repoRoot,
+    packageDir: resolvedPackageDir,
     stage: "pull-tool",
     role: "implementer",
     budgetTokens: maxTokensPerCall,
@@ -250,7 +252,7 @@ export async function handleQueryNeighbor(
     storyId: storyId ?? "_pull-tool",
     tool: "query_neighbor",
     filePath: input.filePath,
-    packageDir: packageDir ?? repoRoot,
+    packageDir: resolvedPackageDir,
     resultCount: result.chunks.length,
     resultBytes: finalContent.length,
   };

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -216,24 +216,21 @@ export async function handleQueryNeighbor(
   resolvedTestPatterns?: import("@/test-runners").ResolvedTestPatterns,
   storyId?: string,
   providerOptions?: { sourceGlob?: string; maxGlobFiles?: number },
-  /**
-   * Absolute path to the story's package. Defaults to `repoRoot` for
-   * single-package repos. The push path scopes CodeNeighborProvider by package
-   * (monorepo-awareness §7); before this parameter existed the pull path
-   * hardcoded `packageDir: repoRoot`, so a monorepo story pulled neighbours
-   * from the whole repo instead of its own package.
-   */
-  packageDir?: string,
 ): Promise<string> {
   budget.consume();
 
   const provider = new CodeNeighborProvider(providerOptions ?? {});
-  // One source of truth so the request and the log provably cannot diverge.
-  const resolvedPackageDir = packageDir ?? repoRoot;
+  // NOTE: packageDir intentionally equals repoRoot. Callers pass the story's
+  // already-resolved package dir AS repoRoot (build-hop-callback -> call.ts ->
+  // execution.ts -> iteration-runner, which joins story.workdir), so this IS
+  // package-scoped. Two attempts to "scope" it further were both wrong: joining
+  // story.workdir again double-joins in monorepos, and splitting repoRoot from
+  // packageDir redirects the cross-package scan at the main checkout under
+  // storyIsolation: "worktree". Do not "fix" this without a worktree test.
   const request: ContextRequest = {
     storyId: storyId ?? "_pull-tool",
     repoRoot,
-    packageDir: resolvedPackageDir,
+    packageDir: repoRoot,
     stage: "pull-tool",
     role: "implementer",
     budgetTokens: maxTokensPerCall,
@@ -252,7 +249,7 @@ export async function handleQueryNeighbor(
     storyId: storyId ?? "_pull-tool",
     tool: "query_neighbor",
     filePath: input.filePath,
-    packageDir: resolvedPackageDir,
+    packageDir: repoRoot,
     resultCount: result.chunks.length,
     resultBytes: finalContent.length,
   };

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -216,6 +216,14 @@ export async function handleQueryNeighbor(
   resolvedTestPatterns?: import("@/test-runners").ResolvedTestPatterns,
   storyId?: string,
   providerOptions?: { sourceGlob?: string; maxGlobFiles?: number },
+  /**
+   * Absolute path to the story's package. Defaults to `repoRoot` for
+   * single-package repos. The push path scopes CodeNeighborProvider by package
+   * (monorepo-awareness §7); before this parameter existed the pull path
+   * hardcoded `packageDir: repoRoot`, so a monorepo story pulled neighbours
+   * from the whole repo instead of its own package.
+   */
+  packageDir?: string,
 ): Promise<string> {
   budget.consume();
 
@@ -223,7 +231,7 @@ export async function handleQueryNeighbor(
   const request: ContextRequest = {
     storyId: storyId ?? "_pull-tool",
     repoRoot,
-    packageDir: repoRoot,
+    packageDir: packageDir ?? repoRoot,
     stage: "pull-tool",
     role: "implementer",
     budgetTokens: maxTokensPerCall,
@@ -242,6 +250,7 @@ export async function handleQueryNeighbor(
     storyId: storyId ?? "_pull-tool",
     tool: "query_neighbor",
     filePath: input.filePath,
+    packageDir: packageDir ?? repoRoot,
     resultCount: result.chunks.length,
     resultBytes: finalContent.length,
   };

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -6,8 +6,6 @@
  * text-based tool-call protocol in its multi-turn loop.
  */
 
-import { join } from "node:path";
-
 import type { ContextToolRuntimeConfig } from "@/config/selectors";
 import { NaxError } from "@/errors";
 import { getLogger } from "@/logger";
@@ -15,6 +13,7 @@ import type { UserStory } from "@/prd";
 import { resolveTestFilePatterns } from "@/test-runners";
 import type { ResolvedTestPatterns } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
+import { packageDirRelative } from "@/utils/paths";
 import { PullToolBudget, createRunCallCounter, handleQueryFeatureContext, handleQueryNeighbor } from "./pull-tools";
 import type { RunCallCounter } from "./pull-tools";
 import type { ContextBundle, ToolDescriptor } from "./types";
@@ -48,8 +47,14 @@ export function createContextToolRuntime(options: {
   bundle: ContextBundle;
   story: UserStory;
   config: ContextToolRuntimeConfig;
-  /** Absolute path to the repository root (AC-54). Used by all pull tool handlers. */
+  /** Absolute path to the repository root (AC-54) — where `.nax/` lives. */
   repoRoot: string;
+  /**
+   * Absolute path to the story's package. Equals `repoRoot` for single-package
+   * repos. Callers pass the already-joined package dir; this module must never
+   * re-join `story.workdir` onto it (pipeline/types.ts:88-93).
+   */
+  packageDir?: string;
   runCounter?: RunCallCounter;
   /**
    * Session-scoped budget registry. Pass the same instance for every runtime
@@ -59,6 +64,7 @@ export function createContextToolRuntime(options: {
   sessionBudgets?: SessionToolBudgets;
 }): ContextToolRuntime | undefined {
   const { bundle, story, config, repoRoot } = options;
+  const packageDir = options.packageDir ?? repoRoot;
   if (bundle.pullTools.length === 0) return undefined;
 
   const descriptors = descriptorByName(bundle);
@@ -73,7 +79,12 @@ export function createContextToolRuntime(options: {
   let resolvedTestPatternsPromise: Promise<ResolvedTestPatterns | undefined> | null = null;
   async function getResolvedTestPatterns(): Promise<ResolvedTestPatterns | undefined> {
     if (resolvedTestPatternsPromise === null) {
-      resolvedTestPatternsPromise = resolveTestFilePatterns(config, repoRoot, story.workdir || undefined, {
+      // Anchors per ADR-009: absolute repo ROOT plus a package path RELATIVE to
+      // it. Previously `repoRoot` was the already-joined package dir AND
+      // story.workdir was passed alongside, doubling the segment and silently
+      // falling back to DEFAULT_TEST_FILE_PATTERNS.
+      const relPackage = packageDirRelative(repoRoot, packageDir);
+      resolvedTestPatternsPromise = resolveTestFilePatterns(config, repoRoot, relPackage, {
         storyId: story.id,
       }).catch((err) => {
         getLogger().warn("context", "Pull-tool runtime: failed to resolve test patterns", {
@@ -117,9 +128,8 @@ export function createContextToolRuntime(options: {
             patterns,
             story.id,
             config.context?.v2?.providers,
-            // monorepo-awareness §7: scope the pull path to the story's package,
-            // as the push path already does. Equals repoRoot for single-package.
-            story.workdir ? join(repoRoot, story.workdir) : repoRoot,
+            // Already-joined package dir from the caller — never re-joined here.
+            packageDir,
           );
         }
         case "query_feature_context":

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -13,7 +13,6 @@ import type { UserStory } from "@/prd";
 import { resolveTestFilePatterns } from "@/test-runners";
 import type { ResolvedTestPatterns } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
-import { packageDirRelative } from "@/utils/paths";
 import { PullToolBudget, createRunCallCounter, handleQueryFeatureContext, handleQueryNeighbor } from "./pull-tools";
 import type { RunCallCounter } from "./pull-tools";
 import type { ContextBundle, ToolDescriptor } from "./types";
@@ -47,14 +46,8 @@ export function createContextToolRuntime(options: {
   bundle: ContextBundle;
   story: UserStory;
   config: ContextToolRuntimeConfig;
-  /** Absolute path to the repository root (AC-54) — where `.nax/` lives. */
+  /** Absolute path to the repository root (AC-54). Used by all pull tool handlers. */
   repoRoot: string;
-  /**
-   * Absolute path to the story's package. Equals `repoRoot` for single-package
-   * repos. Callers pass the already-joined package dir; this module must never
-   * re-join `story.workdir` onto it (pipeline/types.ts:88-93).
-   */
-  packageDir?: string;
   runCounter?: RunCallCounter;
   /**
    * Session-scoped budget registry. Pass the same instance for every runtime
@@ -64,7 +57,6 @@ export function createContextToolRuntime(options: {
   sessionBudgets?: SessionToolBudgets;
 }): ContextToolRuntime | undefined {
   const { bundle, story, config, repoRoot } = options;
-  const packageDir = options.packageDir ?? repoRoot;
   if (bundle.pullTools.length === 0) return undefined;
 
   const descriptors = descriptorByName(bundle);
@@ -79,12 +71,7 @@ export function createContextToolRuntime(options: {
   let resolvedTestPatternsPromise: Promise<ResolvedTestPatterns | undefined> | null = null;
   async function getResolvedTestPatterns(): Promise<ResolvedTestPatterns | undefined> {
     if (resolvedTestPatternsPromise === null) {
-      // Anchors per ADR-009: absolute repo ROOT plus a package path RELATIVE to
-      // it. Previously `repoRoot` was the already-joined package dir AND
-      // story.workdir was passed alongside, doubling the segment and silently
-      // falling back to DEFAULT_TEST_FILE_PATTERNS.
-      const relPackage = packageDirRelative(repoRoot, packageDir);
-      resolvedTestPatternsPromise = resolveTestFilePatterns(config, repoRoot, relPackage, {
+      resolvedTestPatternsPromise = resolveTestFilePatterns(config, repoRoot, story.workdir || undefined, {
         storyId: story.id,
       }).catch((err) => {
         getLogger().warn("context", "Pull-tool runtime: failed to resolve test patterns", {
@@ -128,8 +115,6 @@ export function createContextToolRuntime(options: {
             patterns,
             story.id,
             config.context?.v2?.providers,
-            // Already-joined package dir from the caller — never re-joined here.
-            packageDir,
           );
         }
         case "query_feature_context":

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -6,7 +6,10 @@
  * text-based tool-call protocol in its multi-turn loop.
  */
 
+import { join } from "node:path";
+
 import type { ContextToolRuntimeConfig } from "@/config/selectors";
+import { NaxError } from "@/errors";
 import { getLogger } from "@/logger";
 import type { UserStory } from "@/prd";
 import { resolveTestFilePatterns } from "@/test-runners";
@@ -20,6 +23,23 @@ export interface ContextToolRuntime {
   callTool(name: string, input: unknown): Promise<string>;
 }
 
+/**
+ * Per-tool budgets for one agent session, keyed by tool name.
+ *
+ * Must be created once per session and shared across every runtime built for
+ * it. `createContextToolRuntime` is called inside the hop closure
+ * (build-hop-callback), so a runtime-local map would reset
+ * `maxCallsPerSession` on every retry / fallback / escalation hop — making the
+ * per-session ceiling effectively unbounded and leaving only the run-level cap
+ * real. Threaded exactly like `runCounter`, for the same reason.
+ */
+export type SessionToolBudgets = Map<string, PullToolBudget>;
+
+/** Create an empty session-scoped budget registry. */
+export function createSessionToolBudgets(): SessionToolBudgets {
+  return new Map<string, PullToolBudget>();
+}
+
 function descriptorByName(bundle: ContextBundle): Map<string, ToolDescriptor> {
   return new Map(bundle.pullTools.map((tool) => [tool.name, tool]));
 }
@@ -31,12 +51,18 @@ export function createContextToolRuntime(options: {
   /** Absolute path to the repository root (AC-54). Used by all pull tool handlers. */
   repoRoot: string;
   runCounter?: RunCallCounter;
+  /**
+   * Session-scoped budget registry. Pass the same instance for every runtime
+   * built within one agent session so per-session ceilings survive hops.
+   * Omitted (tests, one-shot callers) means this runtime gets its own allowance.
+   */
+  sessionBudgets?: SessionToolBudgets;
 }): ContextToolRuntime | undefined {
   const { bundle, story, config, repoRoot } = options;
   if (bundle.pullTools.length === 0) return undefined;
 
   const descriptors = descriptorByName(bundle);
-  const budgets = new Map<string, PullToolBudget>();
+  const budgets = options.sessionBudgets ?? createSessionToolBudgets();
   const runCounter = options.runCounter ?? createRunCallCounter();
   const maxCallsPerRun = config.context?.v2?.pull?.maxCallsPerRun ?? 50;
 
@@ -72,7 +98,12 @@ export function createContextToolRuntime(options: {
     async callTool(name: string, input: unknown): Promise<string> {
       const tool = descriptors.get(name);
       if (!tool) {
-        throw new Error(`Unknown context tool: ${name}`);
+        throw new NaxError(`Unknown context tool: ${name}`, "PULL_TOOL_UNKNOWN", {
+          stage: "pull-tool",
+          storyId: story.id,
+          tool: name,
+          availableTools: [...descriptors.keys()].sort(),
+        });
       }
 
       switch (name) {
@@ -86,6 +117,9 @@ export function createContextToolRuntime(options: {
             patterns,
             story.id,
             config.context?.v2?.providers,
+            // monorepo-awareness §7: scope the pull path to the story's package,
+            // as the push path already does. Equals repoRoot for single-package.
+            story.workdir ? join(repoRoot, story.workdir) : repoRoot,
           );
         }
         case "query_feature_context":
@@ -98,7 +132,11 @@ export function createContextToolRuntime(options: {
             tool.maxTokensPerCall,
           );
         default:
-          throw new Error(`No runtime handler for context tool: ${name}`);
+          throw new NaxError(`No runtime handler for context tool: ${name}`, "PULL_TOOL_NO_HANDLER", {
+            stage: "pull-tool",
+            storyId: story.id,
+            tool: name,
+          });
       }
     },
   };

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -221,13 +221,7 @@ export function buildHopCallback(
           bundle: workingBundle,
           story,
           config,
-          // `workdir` here is ALREADY join(projectDir, story.workdir) — set from
-          // ctx.packageDir in call.ts, which iteration-runner joined. Passing it
-          // as repoRoot made `repoRoot` a lie inside the runtime; pass the real
-          // root and the package dir separately instead. Never re-join
-          // story.workdir onto workdir (pipeline/types.ts:88-93).
-          repoRoot: projectDir ?? workdir,
-          packageDir: workdir,
+          repoRoot: workdir,
           runCounter: runCounterForHops,
           sessionBudgets: sessionToolBudgets,
         })

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -11,7 +11,7 @@ import { SessionFailureError, SessionTurnError } from "../agents/types";
 import type { AgentResult, AgentRunOptions, TurnResult } from "../agents/types";
 import { DEFAULT_CONFIG, resolveModelForAgent } from "../config";
 import type { NaxConfig } from "../config";
-import { ContextOrchestrator, createContextToolRuntime } from "../context/engine";
+import { ContextOrchestrator, createContextToolRuntime, createSessionToolBudgets } from "../context/engine";
 import type { AdapterFailure, ContextBundle, RunCallCounter } from "../context/engine";
 import { writeRebuildManifest } from "../context/engine/manifest-store";
 import { getLogger } from "../logger";
@@ -126,6 +126,13 @@ export function buildHopCallback(
   // this hop's own start time.
   let priorHopStartedAt: number | undefined;
 
+  // Gap finding 7: pull-tool budgets must be scoped to the SESSION, not the hop.
+  // createContextToolRuntime is called inside the closure below (once per hop),
+  // so a runtime-local registry reset maxCallsPerSession on every retry /
+  // fallback / escalation — leaving only the run-level cap real. Created here,
+  // outside the closure, exactly like contextToolRunCounter is threaded in.
+  const sessionToolBudgets = createSessionToolBudgets();
+
   return async (
     agentName,
     hopBundle,
@@ -200,6 +207,7 @@ export function buildHopCallback(
           config,
           repoRoot: workdir,
           runCounter: contextToolRunCounter,
+          sessionBudgets: sessionToolBudgets,
         })
       : undefined;
     const contextPullTools = workingBundle?.pullTools;

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -11,7 +11,12 @@ import { SessionFailureError, SessionTurnError } from "../agents/types";
 import type { AgentResult, AgentRunOptions, TurnResult } from "../agents/types";
 import { DEFAULT_CONFIG, resolveModelForAgent } from "../config";
 import type { NaxConfig } from "../config";
-import { ContextOrchestrator, createContextToolRuntime, createSessionToolBudgets } from "../context/engine";
+import {
+  ContextOrchestrator,
+  createContextToolRuntime,
+  createRunCallCounter,
+  createSessionToolBudgets,
+} from "../context/engine";
 import type { AdapterFailure, ContextBundle, RunCallCounter } from "../context/engine";
 import { writeRebuildManifest } from "../context/engine/manifest-store";
 import { getLogger } from "../logger";
@@ -129,9 +134,20 @@ export function buildHopCallback(
   // Gap finding 7: pull-tool budgets must be scoped to the SESSION, not the hop.
   // createContextToolRuntime is called inside the closure below (once per hop),
   // so a runtime-local registry reset maxCallsPerSession on every retry /
-  // fallback / escalation — leaving only the run-level cap real. Created here,
-  // outside the closure, exactly like contextToolRunCounter is threaded in.
+  // fallback / escalation. Created here, outside the closure, alongside
+  // contextToolRunCounter — which until now was declared but never populated by
+  // any production caller, so the run-level cap reset per hop too (call.ts).
   const sessionToolBudgets = createSessionToolBudgets();
+  // Same defect, different cause, for the RUN-level cap: BuildHopCallbackContext
+  // declares contextToolRunCounter but no production site populates it (the
+  // hopCtx literal in call.ts omits it), so tool-runtime's
+  // createRunCallCounter() fallback minted a fresh counter per hop and
+  // pull.maxCallsPerRun never bound. Hoisting the fallback here makes it hold
+  // across the hops of one callback. It is NOT yet a true per-run cap — that
+  // needs contextToolRunCounter threaded through CallContext, which cannot land
+  // in this change because call.ts is at its grandfathered file-size ceiling
+  // and the ratchet forbids growing it. Tracked as a follow-up.
+  const runCounterForHops = contextToolRunCounter ?? createRunCallCounter();
 
   return async (
     agentName,
@@ -205,8 +221,14 @@ export function buildHopCallback(
           bundle: workingBundle,
           story,
           config,
-          repoRoot: workdir,
-          runCounter: contextToolRunCounter,
+          // `workdir` here is ALREADY join(projectDir, story.workdir) — set from
+          // ctx.packageDir in call.ts, which iteration-runner joined. Passing it
+          // as repoRoot made `repoRoot` a lie inside the runtime; pass the real
+          // root and the package dir separately instead. Never re-join
+          // story.workdir onto workdir (pipeline/types.ts:88-93).
+          repoRoot: projectDir ?? workdir,
+          packageDir: workdir,
+          runCounter: runCounterForHops,
           sessionBudgets: sessionToolBudgets,
         })
       : undefined;

--- a/test/unit/context/engine/pull-tools.test.ts
+++ b/test/unit/context/engine/pull-tools.test.ts
@@ -7,23 +7,23 @@
  * Feature context reads are intercepted via _featureContextV2Deps injection.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { NaxError } from "../../../../src/errors";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { NaxConfig } from "../../../../src/config/types";
 import { _codeNeighborDeps } from "../../../../src/context/engine/providers/code-neighbor";
 import { _featureContextV2Deps } from "../../../../src/context/engine/providers/feature-context";
 import {
-  QUERY_NEIGHBOR_DESCRIPTOR,
-  QUERY_FEATURE_CONTEXT_DESCRIPTOR,
   PULL_TOOL_REGISTRY,
   PullToolBudget,
-  createRunCallCounter,
-  handleQueryNeighbor,
-  handleQueryFeatureContext,
+  QUERY_FEATURE_CONTEXT_DESCRIPTOR,
+  QUERY_NEIGHBOR_DESCRIPTOR,
   _pullToolsDeps,
+  createRunCallCounter,
+  handleQueryFeatureContext,
+  handleQueryNeighbor,
 } from "../../../../src/context/engine/pull-tools";
-import { makeLogger } from "../../../../test/helpers";
-import type { NaxConfig } from "../../../../src/config/types";
+import { NaxError } from "../../../../src/errors";
 import type { UserStory } from "../../../../src/prd";
+import { makeLogger } from "../../../../test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Saved originals for dep injection
@@ -46,9 +46,10 @@ beforeEach(() => {
   _codeNeighborDeps.readFile = async () => "";
   _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
   // Default: feature context returns null (no context.md)
-  _featureContextV2Deps.createV1Provider = () => ({
-    getContext: async () => null,
-  }) as ReturnType<typeof origCreateV1Provider>;
+  _featureContextV2Deps.createV1Provider = () =>
+    ({
+      getContext: async () => null,
+    }) as ReturnType<typeof origCreateV1Provider>;
   // Default: no-op logger (real logger is used)
   _pullToolsDeps.getLogger = () => makeLogger() as any;
 });
@@ -168,6 +169,41 @@ describe("handleQueryNeighbor", () => {
   function makeBudget(sessionLimit = 5, runLimit = 50) {
     return new PullToolBudget(sessionLimit, runLimit, createRunCallCounter());
   }
+
+  // Gap finding 7 — the pull path hardcoded packageDir: repoRoot, ignoring the
+  // monorepo scoping the push path honours.
+  test("scopes the request to the story's package when packageDir is supplied", async () => {
+    const mockLogger = makeLogger();
+    _pullToolsDeps.getLogger = () => mockLogger as any;
+    _codeNeighborDeps.fileExists = async () => false;
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+
+    await handleQueryNeighbor(
+      { filePath: "src/a.ts" },
+      "/repo",
+      makeBudget(),
+      undefined,
+      undefined,
+      "US-001",
+      undefined,
+      "/repo/packages/api",
+    );
+
+    const call = mockLogger.calls.find((c) => c.stage === "pull-tool" && c.message === "invoked");
+    expect(call?.data?.packageDir).toBe("/repo/packages/api");
+  });
+
+  test("falls back to the repo root when no packageDir is supplied (single-package)", async () => {
+    const mockLogger = makeLogger();
+    _pullToolsDeps.getLogger = () => mockLogger as any;
+    _codeNeighborDeps.fileExists = async () => false;
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+
+    await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", makeBudget());
+
+    const call = mockLogger.calls.find((c) => c.stage === "pull-tool" && c.message === "invoked");
+    expect(call?.data?.packageDir).toBe("/repo");
+  });
 
   test("calls budget.consume() before fetching; propagates NaxError from exhausted budget", async () => {
     const budget = makeBudget();
@@ -331,7 +367,9 @@ describe("handleQueryFeatureContext", () => {
     expect(await handleQueryFeatureContext({}, STORY, CONFIG, "/repo", makeBudget())).toBe("");
 
     mockV1Provider("## Conventions\nUse async/await.\n\n## Security\nNever log tokens.");
-    expect(await handleQueryFeatureContext({ filter: "nonexistent-keyword-xyz" }, STORY, CONFIG, "/repo", makeBudget())).toBe("");
+    expect(
+      await handleQueryFeatureContext({ filter: "nonexistent-keyword-xyz" }, STORY, CONFIG, "/repo", makeBudget()),
+    ).toBe("");
   });
 
   test("filter returns matching sections (case-insensitive)", async () => {
@@ -348,13 +386,7 @@ describe("handleQueryFeatureContext", () => {
 
   test("filter with no ## headings returns full content (flat context.md)", async () => {
     mockV1Provider("Flat content without any headings.\nSome conventions here.");
-    const result = await handleQueryFeatureContext(
-      { filter: "conventions" },
-      STORY,
-      CONFIG,
-      "/repo",
-      makeBudget(),
-    );
+    const result = await handleQueryFeatureContext({ filter: "conventions" }, STORY, CONFIG, "/repo", makeBudget());
     // No ## headings — section-filter not possible; full content returned
     expect(result).toContain("Flat content");
     expect(result).toContain("conventions");
@@ -364,14 +396,7 @@ describe("handleQueryFeatureContext", () => {
     const longContent = "## Section\n" + "x".repeat(500);
     mockV1Provider(longContent);
     const maxTokensPerCall = 20; // tiny cap → 80 chars max
-    const result = await handleQueryFeatureContext(
-      {},
-      STORY,
-      CONFIG,
-      "/repo",
-      makeBudget(),
-      maxTokensPerCall,
-    );
+    const result = await handleQueryFeatureContext({}, STORY, CONFIG, "/repo", makeBudget(), maxTokensPerCall);
     expect(result.length).toBeLessThanOrEqual(maxTokensPerCall * 4);
   });
 

--- a/test/unit/context/engine/pull-tools.test.ts
+++ b/test/unit/context/engine/pull-tools.test.ts
@@ -7,23 +7,23 @@
  * Feature context reads are intercepted via _featureContextV2Deps injection.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { NaxConfig } from "../../../../src/config/types";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { NaxError } from "../../../../src/errors";
 import { _codeNeighborDeps } from "../../../../src/context/engine/providers/code-neighbor";
 import { _featureContextV2Deps } from "../../../../src/context/engine/providers/feature-context";
 import {
+  QUERY_NEIGHBOR_DESCRIPTOR,
+  QUERY_FEATURE_CONTEXT_DESCRIPTOR,
   PULL_TOOL_REGISTRY,
   PullToolBudget,
-  QUERY_FEATURE_CONTEXT_DESCRIPTOR,
-  QUERY_NEIGHBOR_DESCRIPTOR,
-  _pullToolsDeps,
   createRunCallCounter,
-  handleQueryFeatureContext,
   handleQueryNeighbor,
+  handleQueryFeatureContext,
+  _pullToolsDeps,
 } from "../../../../src/context/engine/pull-tools";
-import { NaxError } from "../../../../src/errors";
-import type { UserStory } from "../../../../src/prd";
 import { makeLogger } from "../../../../test/helpers";
+import type { NaxConfig } from "../../../../src/config/types";
+import type { UserStory } from "../../../../src/prd";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Saved originals for dep injection
@@ -46,10 +46,9 @@ beforeEach(() => {
   _codeNeighborDeps.readFile = async () => "";
   _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
   // Default: feature context returns null (no context.md)
-  _featureContextV2Deps.createV1Provider = () =>
-    ({
-      getContext: async () => null,
-    }) as ReturnType<typeof origCreateV1Provider>;
+  _featureContextV2Deps.createV1Provider = () => ({
+    getContext: async () => null,
+  }) as ReturnType<typeof origCreateV1Provider>;
   // Default: no-op logger (real logger is used)
   _pullToolsDeps.getLogger = () => makeLogger() as any;
 });
@@ -169,48 +168,6 @@ describe("handleQueryNeighbor", () => {
   function makeBudget(sessionLimit = 5, runLimit = 50) {
     return new PullToolBudget(sessionLimit, runLimit, createRunCallCounter());
   }
-
-  // Gap finding 7 — the pull path hardcoded packageDir: repoRoot. These assert
-  // the scan root the provider actually receives, NOT the log line: the request
-  // and the log are separate statements, so a log-only assertion passes even if
-  // the ContextRequest is left unscoped.
-  test("scans the story's package, not the repo root, when packageDir is supplied", async () => {
-    const scanRoots: string[] = [];
-    _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = (_pattern: unknown, workdir: string) => {
-      scanRoots.push(workdir);
-      return { files: [], truncated: false };
-    };
-
-    await handleQueryNeighbor(
-      { filePath: "src/a.ts" },
-      "/repo",
-      makeBudget(),
-      undefined,
-      undefined,
-      "US-001",
-      undefined,
-      "/repo/packages/api",
-    );
-
-    // The provider also scans the repo root for cross-package reverse deps, so
-    // the discriminating assertion is that the PACKAGE dir is scanned at all —
-    // before the fix, packageDir defaulted to repoRoot and never appeared here.
-    expect(scanRoots).toContain("/repo/packages/api");
-  });
-
-  test("scans the repo root when no packageDir is supplied (single-package)", async () => {
-    const scanRoots: string[] = [];
-    _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = (_pattern: unknown, workdir: string) => {
-      scanRoots.push(workdir);
-      return { files: [], truncated: false };
-    };
-
-    await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", makeBudget());
-
-    expect(scanRoots).toContain("/repo");
-  });
 
   test("calls budget.consume() before fetching; propagates NaxError from exhausted budget", async () => {
     const budget = makeBudget();
@@ -374,9 +331,7 @@ describe("handleQueryFeatureContext", () => {
     expect(await handleQueryFeatureContext({}, STORY, CONFIG, "/repo", makeBudget())).toBe("");
 
     mockV1Provider("## Conventions\nUse async/await.\n\n## Security\nNever log tokens.");
-    expect(
-      await handleQueryFeatureContext({ filter: "nonexistent-keyword-xyz" }, STORY, CONFIG, "/repo", makeBudget()),
-    ).toBe("");
+    expect(await handleQueryFeatureContext({ filter: "nonexistent-keyword-xyz" }, STORY, CONFIG, "/repo", makeBudget())).toBe("");
   });
 
   test("filter returns matching sections (case-insensitive)", async () => {
@@ -393,7 +348,13 @@ describe("handleQueryFeatureContext", () => {
 
   test("filter with no ## headings returns full content (flat context.md)", async () => {
     mockV1Provider("Flat content without any headings.\nSome conventions here.");
-    const result = await handleQueryFeatureContext({ filter: "conventions" }, STORY, CONFIG, "/repo", makeBudget());
+    const result = await handleQueryFeatureContext(
+      { filter: "conventions" },
+      STORY,
+      CONFIG,
+      "/repo",
+      makeBudget(),
+    );
     // No ## headings — section-filter not possible; full content returned
     expect(result).toContain("Flat content");
     expect(result).toContain("conventions");
@@ -403,7 +364,14 @@ describe("handleQueryFeatureContext", () => {
     const longContent = "## Section\n" + "x".repeat(500);
     mockV1Provider(longContent);
     const maxTokensPerCall = 20; // tiny cap → 80 chars max
-    const result = await handleQueryFeatureContext({}, STORY, CONFIG, "/repo", makeBudget(), maxTokensPerCall);
+    const result = await handleQueryFeatureContext(
+      {},
+      STORY,
+      CONFIG,
+      "/repo",
+      makeBudget(),
+      maxTokensPerCall,
+    );
     expect(result.length).toBeLessThanOrEqual(maxTokensPerCall * 4);
   });
 

--- a/test/unit/context/engine/pull-tools.test.ts
+++ b/test/unit/context/engine/pull-tools.test.ts
@@ -170,13 +170,17 @@ describe("handleQueryNeighbor", () => {
     return new PullToolBudget(sessionLimit, runLimit, createRunCallCounter());
   }
 
-  // Gap finding 7 — the pull path hardcoded packageDir: repoRoot, ignoring the
-  // monorepo scoping the push path honours.
-  test("scopes the request to the story's package when packageDir is supplied", async () => {
-    const mockLogger = makeLogger();
-    _pullToolsDeps.getLogger = () => mockLogger as any;
+  // Gap finding 7 — the pull path hardcoded packageDir: repoRoot. These assert
+  // the scan root the provider actually receives, NOT the log line: the request
+  // and the log are separate statements, so a log-only assertion passes even if
+  // the ContextRequest is left unscoped.
+  test("scans the story's package, not the repo root, when packageDir is supplied", async () => {
+    const scanRoots: string[] = [];
     _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+    _codeNeighborDeps.glob = (_pattern: unknown, workdir: string) => {
+      scanRoots.push(workdir);
+      return { files: [], truncated: false };
+    };
 
     await handleQueryNeighbor(
       { filePath: "src/a.ts" },
@@ -189,20 +193,23 @@ describe("handleQueryNeighbor", () => {
       "/repo/packages/api",
     );
 
-    const call = mockLogger.calls.find((c) => c.stage === "pull-tool" && c.message === "invoked");
-    expect(call?.data?.packageDir).toBe("/repo/packages/api");
+    // The provider also scans the repo root for cross-package reverse deps, so
+    // the discriminating assertion is that the PACKAGE dir is scanned at all —
+    // before the fix, packageDir defaulted to repoRoot and never appeared here.
+    expect(scanRoots).toContain("/repo/packages/api");
   });
 
-  test("falls back to the repo root when no packageDir is supplied (single-package)", async () => {
-    const mockLogger = makeLogger();
-    _pullToolsDeps.getLogger = () => mockLogger as any;
+  test("scans the repo root when no packageDir is supplied (single-package)", async () => {
+    const scanRoots: string[] = [];
     _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+    _codeNeighborDeps.glob = (_pattern: unknown, workdir: string) => {
+      scanRoots.push(workdir);
+      return { files: [], truncated: false };
+    };
 
     await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", makeBudget());
 
-    const call = mockLogger.calls.find((c) => c.stage === "pull-tool" && c.message === "invoked");
-    expect(call?.data?.packageDir).toBe("/repo");
+    expect(scanRoots).toContain("/repo");
   });
 
   test("calls budget.consume() before fetching; propagates NaxError from exhausted budget", async () => {

--- a/test/unit/context/engine/tool-runtime.test.ts
+++ b/test/unit/context/engine/tool-runtime.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { contextToolRuntimeConfigSelector } from "../../../../src/config";
 import type { ContextToolRuntimeConfig } from "../../../../src/config/selectors";
-import { createContextToolRuntime, createSessionToolBudgets } from "../../../../src/context/engine";
+import {
+  _codeNeighborDeps,
+  createContextToolRuntime,
+  createSessionToolBudgets,
+} from "../../../../src/context/engine";
 import type { ContextBundle } from "../../../../src/context/engine";
 import { makeNaxConfig } from "../../../helpers/mock-nax-config";
 
@@ -39,8 +43,9 @@ describe("createContextToolRuntime — slice acceptance", () => {
 // Gap finding 7 — the pull budget was per-tool-per-HOP, not per-session.
 // createContextToolRuntime built a fresh `budgets` Map every call, and
 // build-hop-callback constructs the runtime INSIDE the hop closure, so every
-// retry / fallback / escalation hop reset maxCallsPerSession to zero. Only the
-// run-level counter (threaded in as runCounter) was ever real.
+// retry / fallback / escalation hop reset maxCallsPerSession to zero. The
+// run-level counter had the same defect: BuildHopCallbackContext declared
+// contextToolRunCounter but nothing populated it, so it too reset per hop.
 // ─────────────────────────────────────────────────────────────────────────────
 
 function makeBundleWithTool(maxCallsPerSession: number): ContextBundle {
@@ -109,6 +114,47 @@ describe("createContextToolRuntime — session-scoped pull budget", () => {
     const b = createContextToolRuntime({ bundle, story, config: RUNTIME_CONFIG, repoRoot: "/tmp" });
     await b?.callTool("query_feature_context", {});
     // No throw — an isolated runtime still gets its own allowance.
+  });
+
+  test("forwards the caller's packageDir to query_neighbor rather than the repo root", async () => {
+    const scanRoots: string[] = [];
+    const origGlob = _codeNeighborDeps.glob;
+    const origExists = _codeNeighborDeps.fileExists;
+    _codeNeighborDeps.fileExists = async () => false;
+    _codeNeighborDeps.glob = (_pattern: unknown, workdir: string) => {
+      scanRoots.push(workdir);
+      return { files: [], truncated: false };
+    };
+
+    try {
+      const bundle = {
+        pushMarkdown: "",
+        pullTools: [
+          {
+            name: "query_neighbor",
+            description: "t",
+            inputSchema: { type: "object", properties: {} },
+            maxCallsPerSession: 5,
+            maxTokensPerCall: 100,
+          },
+        ],
+        meta: { stage: "test", schemaVersion: 1, totalTokens: 0 },
+      } as unknown as ContextBundle;
+
+      const runtime = createContextToolRuntime({
+        bundle,
+        story,
+        config: RUNTIME_CONFIG,
+        repoRoot: "/repo",
+        packageDir: "/repo/packages/api",
+      });
+      await runtime?.callTool("query_neighbor", { filePath: "src/a.ts" });
+
+      expect(scanRoots).toContain("/repo/packages/api");
+    } finally {
+      _codeNeighborDeps.glob = origGlob;
+      _codeNeighborDeps.fileExists = origExists;
+    }
   });
 
   test("rejects an unknown tool with a NaxError carrying a machine-readable code", async () => {

--- a/test/unit/context/engine/tool-runtime.test.ts
+++ b/test/unit/context/engine/tool-runtime.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { contextToolRuntimeConfigSelector } from "../../../../src/config";
 import type { ContextToolRuntimeConfig } from "../../../../src/config/selectors";
-import {
-  _codeNeighborDeps,
-  createContextToolRuntime,
-  createSessionToolBudgets,
-} from "../../../../src/context/engine";
+import { createContextToolRuntime, createSessionToolBudgets } from "../../../../src/context/engine";
 import type { ContextBundle } from "../../../../src/context/engine";
 import { makeNaxConfig } from "../../../helpers/mock-nax-config";
 
@@ -114,47 +110,6 @@ describe("createContextToolRuntime — session-scoped pull budget", () => {
     const b = createContextToolRuntime({ bundle, story, config: RUNTIME_CONFIG, repoRoot: "/tmp" });
     await b?.callTool("query_feature_context", {});
     // No throw — an isolated runtime still gets its own allowance.
-  });
-
-  test("forwards the caller's packageDir to query_neighbor rather than the repo root", async () => {
-    const scanRoots: string[] = [];
-    const origGlob = _codeNeighborDeps.glob;
-    const origExists = _codeNeighborDeps.fileExists;
-    _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = (_pattern: unknown, workdir: string) => {
-      scanRoots.push(workdir);
-      return { files: [], truncated: false };
-    };
-
-    try {
-      const bundle = {
-        pushMarkdown: "",
-        pullTools: [
-          {
-            name: "query_neighbor",
-            description: "t",
-            inputSchema: { type: "object", properties: {} },
-            maxCallsPerSession: 5,
-            maxTokensPerCall: 100,
-          },
-        ],
-        meta: { stage: "test", schemaVersion: 1, totalTokens: 0 },
-      } as unknown as ContextBundle;
-
-      const runtime = createContextToolRuntime({
-        bundle,
-        story,
-        config: RUNTIME_CONFIG,
-        repoRoot: "/repo",
-        packageDir: "/repo/packages/api",
-      });
-      await runtime?.callTool("query_neighbor", { filePath: "src/a.ts" });
-
-      expect(scanRoots).toContain("/repo/packages/api");
-    } finally {
-      _codeNeighborDeps.glob = origGlob;
-      _codeNeighborDeps.fileExists = origExists;
-    }
   });
 
   test("rejects an unknown tool with a NaxError carrying a machine-readable code", async () => {

--- a/test/unit/context/engine/tool-runtime.test.ts
+++ b/test/unit/context/engine/tool-runtime.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { contextToolRuntimeConfigSelector } from "../../../../src/config";
 import type { ContextToolRuntimeConfig } from "../../../../src/config/selectors";
-import { createContextToolRuntime } from "../../../../src/context/engine";
+import { createContextToolRuntime, createSessionToolBudgets } from "../../../../src/context/engine";
 import type { ContextBundle } from "../../../../src/context/engine";
 import { makeNaxConfig } from "../../../helpers/mock-nax-config";
 
@@ -32,5 +32,99 @@ describe("createContextToolRuntime — slice acceptance", () => {
       repoRoot: "/tmp",
     });
     expect(runtime).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap finding 7 — the pull budget was per-tool-per-HOP, not per-session.
+// createContextToolRuntime built a fresh `budgets` Map every call, and
+// build-hop-callback constructs the runtime INSIDE the hop closure, so every
+// retry / fallback / escalation hop reset maxCallsPerSession to zero. Only the
+// run-level counter (threaded in as runCounter) was ever real.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeBundleWithTool(maxCallsPerSession: number): ContextBundle {
+  return {
+    pushMarkdown: "",
+    pullTools: [
+      {
+        name: "query_feature_context",
+        description: "test tool",
+        inputSchema: { type: "object", properties: {} },
+        maxCallsPerSession,
+        maxTokensPerCall: 100,
+      },
+    ],
+    meta: { stage: "test", schemaVersion: 1, totalTokens: 0 },
+  } as unknown as ContextBundle;
+}
+
+const RUNTIME_CONFIG: ContextToolRuntimeConfig = {
+  context: undefined,
+  execution: undefined,
+  project: undefined,
+  quality: undefined,
+};
+
+describe("createContextToolRuntime — session-scoped pull budget", () => {
+  const story = { id: "S-001", workdir: "" } as Parameters<typeof createContextToolRuntime>[0]["story"];
+
+  test("a session budget registry shared across runtimes keeps consumption across hops", async () => {
+    const sessionBudgets = createSessionToolBudgets();
+    const bundle = makeBundleWithTool(1);
+
+    // Hop 1 — a fresh runtime, as build-hop-callback constructs per hop.
+    const hop1 = createContextToolRuntime({
+      bundle,
+      story,
+      config: RUNTIME_CONFIG,
+      repoRoot: "/tmp",
+      sessionBudgets,
+    });
+    await hop1?.callTool("query_feature_context", {});
+
+    // Hop 2 — another fresh runtime sharing the same session registry.
+    const hop2 = createContextToolRuntime({
+      bundle,
+      story,
+      config: RUNTIME_CONFIG,
+      repoRoot: "/tmp",
+      sessionBudgets,
+    });
+
+    let threw: unknown;
+    try {
+      await hop2?.callTool("query_feature_context", {});
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toMatchObject({ code: "PULL_TOOL_BUDGET_EXHAUSTED" });
+  });
+
+  test("omitting the registry keeps each runtime independent (previous behaviour)", async () => {
+    const bundle = makeBundleWithTool(1);
+    const a = createContextToolRuntime({ bundle, story, config: RUNTIME_CONFIG, repoRoot: "/tmp" });
+    await a?.callTool("query_feature_context", {});
+
+    const b = createContextToolRuntime({ bundle, story, config: RUNTIME_CONFIG, repoRoot: "/tmp" });
+    await b?.callTool("query_feature_context", {});
+    // No throw — an isolated runtime still gets its own allowance.
+  });
+
+  test("rejects an unknown tool with a NaxError carrying a machine-readable code", async () => {
+    const runtime = createContextToolRuntime({
+      bundle: makeBundleWithTool(5),
+      story,
+      config: RUNTIME_CONFIG,
+      repoRoot: "/tmp",
+    });
+
+    let threw: unknown;
+    try {
+      await runtime?.callTool("no_such_tool", {});
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toMatchObject({ code: "PULL_TOOL_UNKNOWN" });
   });
 });

--- a/test/unit/operations/build-hop-callback-stale-retry.test.ts
+++ b/test/unit/operations/build-hop-callback-stale-retry.test.ts
@@ -12,9 +12,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { buildHopCallback, _buildHopCallbackDeps } from "@/operations";
 import type { SessionHandle, TurnResult } from "@/agents/types";
 import type { AdapterFailure } from "@/context/engine";
+import { _buildHopCallbackDeps, buildHopCallback } from "@/operations";
 import { makeMockAgentManager, makeNaxConfig, makeSessionManager, makeStory } from "@test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -96,6 +96,30 @@ function makeCtx(sessionMgr: ReturnType<typeof makeSessionManager>) {
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Gap finding 7 — the pull budget registry must be created ONCE per callback,
+// outside the returned closure. Created inside, every retry / fallback /
+// escalation hop got a fresh registry and maxCallsPerSession reset to zero.
+// Nothing else in the suite pins this placement.
+describe("buildHopCallback — session-scoped pull budget registry", () => {
+  test("every hop receives the same sessionBudgets instance", async () => {
+    const seen: unknown[] = [];
+    _buildHopCallbackDeps.createContextToolRuntime = (opts: { sessionBudgets?: unknown }) => {
+      seen.push(opts.sessionBudgets);
+      return undefined as any;
+    };
+    const sessionMgr = makeSessionManager({});
+    const cb = buildHopCallback(makeCtx(sessionMgr), undefined, STUB_RUN_OPTIONS);
+
+    const bundle = { pushMarkdown: "", pullTools: [], digest: "", manifest: {} } as any;
+    await cb("claude", bundle, { kind: "primary", attempt: 1 }, STUB_RUN_OPTIONS);
+    await cb("claude", bundle, { kind: "stale-retry", attempt: 2 }, STUB_RUN_OPTIONS);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBeDefined();
+    expect(seen[0]).toBe(seen[1]);
+  });
+});
+
 describe("buildHopCallback — stale-retry session reuse", () => {
   test("stale-retry: getLiveHandle called; openSession and closeSession skipped", async () => {
     const getLiveHandle = mock((_name: string) => STUB_HANDLE);
@@ -150,12 +174,7 @@ describe("buildHopCallback — stale-retry session reuse", () => {
     const sessionMgr = makeSessionManager({ getLiveHandle, openSession, closeSession });
 
     const cb = buildHopCallback(makeCtx(sessionMgr), undefined, STUB_RUN_OPTIONS);
-    const result = await cb(
-      "codex",
-      undefined,
-      { kind: "swap", failure: SWAP_FAILURE },
-      STUB_RUN_OPTIONS,
-    );
+    const result = await cb("codex", undefined, { kind: "swap", failure: SWAP_FAILURE }, STUB_RUN_OPTIONS);
 
     expect(result.result.success).toBe(true);
     expect(getLiveHandle).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes the **budget-correctness** half of finding 7 in the Context Engine v2 gap analysis. The other half of that finding turned out to rest on a false premise and is **not** fixed here — see "What was dropped, and why" below, which is the more important part of this PR.

## What this fixes

### 1. The per-session pull budget was really per-hop

`createContextToolRuntime` built a fresh `budgets` Map on every call, and `buildHopCallback` constructs the runtime **inside** the per-hop closure — so `PullToolBudget.maxCallsPerSession` reset on every retry, fallback and escalation hop. Adds `createSessionToolBudgets()` and threads a session-scoped registry, created once outside the closure.

### 2. The run-level cap had the same defect, for a different reason

`BuildHopCallbackContext` declares `contextToolRunCounter`, but **no production site populates it** — the `hopCtx` literal in `call.ts` omits it — so `tool-runtime`'s `createRunCallCounter()` fallback minted a fresh counter per hop and `pull.maxCallsPerRun` never bound either.

Hoisting the fallback makes it hold across one callback's hops. A **true per-run cap is deliberately deferred**: it needs `contextToolRunCounter` threaded through `CallContext`, which costs one line in the `hopCtx` literal — and `src/operations/call.ts` sits at **628 lines against a baseline of exactly 628** (limit 600, grandfathered), so `check:file-sizes` forbids any growth. That file needs splitting first. Comments in three places that wrongly claimed the run cap was already real are corrected.

### 3. Plain `Error` → `NaxError`

Unknown / unhandled tool names now throw `NaxError` with `PULL_TOOL_UNKNOWN` / `PULL_TOOL_NO_HANDLER` and structured context, per the error-handling rule. `check:nax-error` baseline lowered 112 → 110.

## What was dropped, and why

Finding 7 also claims `handleQueryNeighbor` hardcoding `packageDir: repoRoot` means "monorepo scoping the push path honors is ignored on pull". **That premise is false.** Callers pass the story's already-resolved package dir *as* `repoRoot` (`build-hop-callback` ← `call.ts` ← `execution.ts` ← `iteration-runner`, which joins `story.workdir`), so the original line was already package-scoped and correct.

Two attempts to "fix" it each introduced a new defect:

| Attempt | Result |
|---|---|
| `join(repoRoot, story.workdir)` | Double-joined in monorepos → `/repo/packages/api/packages/api`. `CodeNeighborProvider` found nothing and `query_neighbor` **silently returned empty** for every monorepo story. |
| Split `repoRoot = projectDir` from `packageDir = workdir` | Correct outside worktrees, wrong inside them. Under `storyIsolation: "worktree"`, `projectDir` is the **main** checkout while the agent edits the worktree, so `discoverWorkspacePackages(request.repoRoot)` reads source the agent is not editing. It also **activates** cross-package scanning for single-package worktree runs, where the `packageDir === repoRoot` short-circuit previously suppressed it. |

Neither attempt was pinnable by a test at the seam that mattered, and the "fixed for free" `resolveTestFilePatterns` anchor claim does not hold in worktree mode either.

So this PR reverts to the original behaviour and leaves a comment at the call site recording both failed attempts, so the next reader doesn't try a third. **The gap report needs correcting** — I'll do that separately.

The one thing kept from that half is `packageDir` on the invocation log, which `monorepo-awareness.md` §9 requires for cross-package work.

## Verification

- **1776 pass / 0 fail** across `test/unit/context/` + `test/unit/operations/`; typecheck and full `bun run lint` clean, all 8 ratchets at baseline.
- **Every surviving test is mutation-verified** — an independent review confirmed each fails when its production line is reverted:
  - session registry shared across runtimes → fails when the registry is removed
  - two hops receive the same `sessionBudgets` identity → fails when `createSessionToolBudgets()` moves back inside the closure
  - `PULL_TOOL_UNKNOWN` → fails when the `NaxError` conversion is reverted

Full-suite verification was **not** run: two nax runs are live on this machine and the 11k-test suite risks destabilising them under Bun's JSC. Worth a CI run.

## Review history

Two review rounds. Round 1 returned "do not merge" on the double-join (Critical). Round 2 verified that fix but found the worktree regression, that the fix line was itself untested, and that one new test was **vacuous** — the provider always scans `repoRoot`, so the assertion could never fail. That third finding is why the whole `packageDir` half is gone rather than patched again.

## Known-open, deliberately not in scope

- `pullCalls` telemetry in `ContextManifest` / `StoryMetrics` (the observability half of finding 7) — needs `manifest-builder.ts`, `metrics/types.ts` and `orchestrator.ts`, all of which a concurrent in-flight run is editing.
- True per-run pull cap — blocked on splitting `call.ts` (above).
- `handleQueryNeighbor` has 7 positional params against the ≤3 convention (pre-existing; this PR no longer adds an 8th).
- `sessionBudgets` is optional and a caller that forgets it silently gets the old per-hop behaviour. One production caller today.
