### PR TITLE
feat(context): make the per-provider fetch timeout configurable (gap finding 16)

### DIFF
--- a/src/config/runtime-types-context.ts
+++ b/src/config/runtime-types-context.ts
@@ -77,6 +77,8 @@ export interface ContextV2Config {
    * Phase 0 default: 0.1 (near-zero impact).
    */
   minScore: number;
+  /** Per-provider fetch timeout in ms (spec AC-5). Default 5000. */
+  providerTimeoutMs: number;
   /** Pull tool configuration (Phase 4+) */
   pull: ContextV2PullConfig;
   /** Canonical rules store configuration (Phase 5.1+) */
@@ -88,7 +90,7 @@ export interface ContextV2Config {
    * Set via per-package config (<repoRoot>/.nax/mono/<packageDir>/config.json).
    * Keys are stage names; value overrides the default stage budgetTokens.
    */
-  stages: Record<string, { budgetTokens?: number; extraProviderIds?: string[] }>;
+  stages: Record<string, { budgetTokens?: number; extraProviderIds?: string[]; providerTimeoutMs?: number }>;
   /**
    * Determinism mode (AC-24).
    * When true, providers declaring `deterministic: false` are excluded from assembly.

--- a/src/config/schemas-context.ts
+++ b/src/config/schemas-context.ts
@@ -90,6 +90,8 @@ const ContextPluginProviderConfigSchema = z.object({
 const ContextV2StageOverrideSchema = z.object({
   budgetTokens: z.number().int().positive().optional(),
   extraProviderIds: z.array(z.string().min(1)).default([]),
+  /** Per-stage override of the engine-wide providerTimeoutMs (spec :330). */
+  providerTimeoutMs: z.number().int().min(1000).optional(),
 });
 
 // Context Engine config (Phase 6: selective on; operators opt in per project)
@@ -107,6 +109,12 @@ export const ContextV2ConfigSchema = z
      * Post-GA: tuned upward once effectiveness signal data is available.
      */
     minScore: z.number().min(0).max(1).default(0.1),
+    /**
+     * Per-provider fetch timeout in ms (spec :841, AC-5). A provider that
+     * exceeds it is dropped with a warning; the stage still assembles.
+     * Was hardcoded at 5000 in the orchestrator before this key existed.
+     */
+    providerTimeoutMs: z.number().int().min(1000).default(5000),
     /** Pull tool configuration (Phase 4+) */
     pull: ContextV2PullConfigSchema,
     /** Canonical rules store configuration (Phase 5.1+) */
@@ -213,6 +221,7 @@ export const ContextV2ConfigSchema = z
   .default(() => ({
     enabled: false,
     minScore: 0.1,
+    providerTimeoutMs: 5000,
     pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5, maxCallsPerRun: 50 },
     rules: { allowLegacyClaudeMd: false, budgetTokens: 8192 },
     pluginProviders: [],

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -316,6 +316,7 @@ export const NaxConfigSchema = z
       v2: {
         enabled: false,
         minScore: 0.1,
+        providerTimeoutMs: 5000,
         pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5, maxCallsPerRun: 50 },
         rules: { allowLegacyClaudeMd: false, budgetTokens: 8192 },
         pluginProviders: [],

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -279,7 +279,7 @@ export class ContextOrchestrator {
       activeProviders.map(async (provider) => {
         const providerStart = _orchestratorDeps.now();
         try {
-          const result = await fetchWithTimeout(provider, request);
+          const result = await fetchWithTimeout(provider, request, request.providerTimeoutMs);
           const durationMs = _orchestratorDeps.now() - providerStart;
           const status = result.chunks.length === 0 ? ("empty" as const) : ("ok" as const);
           const tokensProduced = result.chunks.reduce((sum, c) => sum + c.tokens, 0);

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -194,6 +194,9 @@ export async function assembleForStage(
       storyScratchDirs,
       priorStageDigest: options.priorStageDigest ?? ctx.contextBundle?.digest,
       minScore: ctx.config.context.v2.minScore,
+      ...((stageOverrides?.providerTimeoutMs ?? ctx.config.context?.v2?.providerTimeoutMs) !== undefined && {
+        providerTimeoutMs: stageOverrides?.providerTimeoutMs ?? ctx.config.context?.v2?.providerTimeoutMs,
+      }),
       pullConfig: ctx.config.context.v2.pull
         ? {
             enabled: ctx.config.context.v2.pull.enabled,

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -416,6 +416,13 @@ export interface ContextRequest {
    */
   minScore?: number;
   /**
+   * Per-provider fetch timeout in ms. A provider exceeding it is dropped; the
+   * orchestrator warns but does not fail the stage (spec AC-5). Sourced from
+   * `config.context.v2.stages[stage].providerTimeoutMs` falling back to
+   * `config.context.v2.providerTimeoutMs` (default 5000). Absent = engine default.
+   */
+  providerTimeoutMs?: number;
+  /**
    * Files this story touches (from PRD contextFiles or story.relevantFiles).
    * Used by GitHistoryProvider and CodeNeighborProvider (Phase 3).
    */

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -149,6 +149,11 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
     budgetTokens: stageOverrides?.budgetTokens ?? ctx.config.context.featureEngine?.budgetTokens ?? 8_000,
     extraProviderIds: stageOverrides?.extraProviderIds ?? [],
     minScore: ctx.config.context.v2.minScore,
+    // Per-stage override wins, then the engine-wide key; absent leaves the
+    // orchestrator's own default in place.
+    ...((stageOverrides?.providerTimeoutMs ?? ctx.config.context.v2.providerTimeoutMs) !== undefined && {
+      providerTimeoutMs: stageOverrides?.providerTimeoutMs ?? ctx.config.context.v2.providerTimeoutMs,
+    }),
     storyScratchDirs,
     priorStageDigest,
     ...(touchedFiles.length > 0 && { touchedFiles }),

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -384,6 +384,28 @@ describe("assembleForStage — ADR-009 / .naxignore threading", () => {
     _stageAssemblerDeps.createOrchestrator = origCreate;
   });
 
+  test("threads the engine-wide providerTimeoutMs from config into the request", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    const ctx = makeCtx();
+    (ctx.config as unknown as { context: { v2: Record<string, unknown> } }).context.v2.providerTimeoutMs = 9000;
+    await assembleForStage(ctx, "execution");
+
+    expect(mock.ref.captured?.providerTimeoutMs).toBe(9000);
+  });
+
+  test("a per-stage providerTimeoutMs override wins over the engine-wide value", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    const ctx = makeCtx({ stages: { execution: { providerTimeoutMs: 2000 } } });
+    (ctx.config as unknown as { context: { v2: Record<string, unknown> } }).context.v2.providerTimeoutMs = 9000;
+    await assembleForStage(ctx, "execution");
+
+    expect(mock.ref.captured?.providerTimeoutMs).toBe(2000);
+  });
+
   test("threads resolvedTestPatterns from the pipeline context into the request", async () => {
     const mock = makeMockOrchestrator();
     _stageAssemblerDeps.createOrchestrator = () =>

--- a/test/unit/context/provider-timeout-abort.test.ts
+++ b/test/unit/context/provider-timeout-abort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { fetchWithTimeout } from "../../../src/context/engine/orchestrator";
+import { ContextOrchestrator, fetchWithTimeout } from "../../../src/context/engine/orchestrator";
 
 describe("fetchWithTimeout", () => {
   test("aborts the losing provider fetch when the timeout wins and does not throw unhandled", async () => {
@@ -21,5 +21,48 @@ describe("fetchWithTimeout", () => {
     // Give the abort event a tick to fire
     await new Promise((r) => setTimeout(r, 5));
     expect(aborted).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap finding 16: the per-provider timeout is spec'd as configuration
+// (SPEC-context-engine-v2.md:841, `providerTimeoutMs`, min 1000 default 5000)
+// and consumed per-stage (:330), but the orchestrator hardcoded a 5s constant.
+// fetchWithTimeout always accepted a timeoutMs argument — nothing ever passed a
+// configured one.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ContextOrchestrator — configurable provider timeout", () => {
+  function slowProvider(delayMs: number) {
+    return {
+      id: "slow",
+      kind: "retrieved" as const,
+      fetch: async () => {
+        await new Promise((r) => setTimeout(r, delayMs));
+        return { chunks: [{ id: "slow:1", kind: "retrieved", scope: "retrieved", role: ["all"], content: "x", tokens: 1, rawScore: 1 }], pullTools: [] };
+      },
+    };
+  }
+
+  const REQ = {
+    storyId: "US-001",
+    repoRoot: "/p",
+    packageDir: "/p",
+    stage: "execution",
+    role: "implementer",
+    budgetTokens: 8000,
+    providerIds: ["slow"],
+  };
+
+  test("drops a provider that exceeds request.providerTimeoutMs", async () => {
+    const orch = new ContextOrchestrator([slowProvider(80) as never]);
+    const bundle = await orch.assemble({ ...REQ, providerTimeoutMs: 10 } as never);
+    expect(bundle.manifest.includedChunks).toHaveLength(0);
+  });
+
+  test("keeps a provider that finishes within request.providerTimeoutMs", async () => {
+    const orch = new ContextOrchestrator([slowProvider(10) as never]);
+    const bundle = await orch.assemble({ ...REQ, providerTimeoutMs: 400 } as never);
+    expect(bundle.manifest.includedChunks).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes the `providerTimeoutMs` half of gap-analysis finding 16.

## What was wrong

`SPEC-context-engine-v2.md` declares `providerTimeoutMs` as configuration (`:841` — `z.number().int().min(1000).default(5000)`), consumes it per-stage (`:330`), and AC-5 specifies that a provider exceeding it is dropped with a warning rather than failing the stage. In practice the orchestrator hardcoded `PROVIDER_FETCH_TIMEOUT_MS = 5_000` and no config key existed at all.

`fetchWithTimeout` already accepted a `timeoutMs` argument — nothing ever passed a configured one.

## What this does

Adds `context.v2.providerTimeoutMs` (min 1000, default 5000) plus a per-stage override under `context.v2.stages.<stage>.providerTimeoutMs`, threaded onto `ContextRequest` exactly as `minScore` already is, and passed through by the orchestrator.

Resolution order, applied in both request builders (`stages/context.ts` and `stage-assembler.ts`):

```
stages.<stage>.providerTimeoutMs  ->  context.v2.providerTimeoutMs  ->  orchestrator default (5000)
```

A repo that sets neither is byte-identical to before.

## Verification

- **1884 pass / 0 fail** across `test/unit/{context,config,pipeline}`; typecheck and full `bun run lint` clean, all ratchets at baseline.
- **Mutation-verified at both levels**, because a config key that never reaches its consumer is exactly the failure mode worth guarding here:
  - reverting the orchestrator pass-through → the timeout-behaviour test fails
  - reverting the `stage-assembler` wiring → both override tests fail
- End-to-end default confirmed: `NaxConfigSchema.parse({}).context.v2.providerTimeoutMs === 5000`.

## Scope: this PR is one item, not the three that were planned

The batch was going to include two more observability items. Both were checked before coding and neither is shippable yet:

**`pullCalls` (spec `:245`, AC-18) — blocked.** Recording pull calls needs the run counter to reach the tool runtime, which requires one extra line in the `hopCtx` literal in `src/operations/call.ts`. That file is **628 lines against a baseline of exactly 628** with a 600-line limit, so `check:file-sizes` forbids the growth. It needs splitting first. Adding the manifest field without the wiring would ship a field that is always empty.

**`context.fallback.triggered` (AC-41) — premise is false.** The gap report says the data "exists only as `StoryMetrics.fallback.hops`". It does not: `ctx.agentFallbacks` is declared (`pipeline/types.ts:260`) and read (`metrics/tracker.ts:211`), but **nothing in `src/` ever assigns it**, so `StoryMetrics.fallback` is always absent. Emitting the event first requires wiring `AgentResult.agentFallbacks` → `ctx.agentFallbacks` (two similar but distinct types). That is a separate, larger change and the gap report needs correcting either way.
