### PR TITLE
refactor(operations): split pure resolvers out of call.ts to clear the file-size block

### DIFF
--- a/scripts/baselines/file-sizes-baseline.json
+++ b/scripts/baselines/file-sizes-baseline.json
@@ -1,13 +1,12 @@
 {
-  "updatedAt": "2026-08-02T02:59:58.753Z",
+  "updatedAt": "2026-08-03T10:11:18.793Z",
   "byFile": {
     "src/agents/acp/adapter.ts": 629,
     "src/agents/acp/spawn-client.ts": 734,
-    "src/agents/manager.ts": 792,
+    "src/agents/manager.ts": 790,
     "src/config/runtime-types.ts": 606,
     "src/context/engine/providers/code-neighbor.ts": 613,
     "src/execution/unified-executor.ts": 689,
-    "src/operations/call.ts": 628,
     "src/prompts/builders/rectifier-builder.ts": 902,
     "src/session/manager.ts": 707,
     "test/unit/cli/plan.test.ts": 1087,

--- a/src/operations/call-resolvers.ts
+++ b/src/operations/call-resolvers.ts
@@ -1,0 +1,120 @@
+/**
+ * callOp resolvers — pure helpers extracted from call.ts.
+ *
+ * These normalise an Operation's declarative fields (model, timeout, retry,
+ * config selector) into concrete values, plus two small factories. They hold no
+ * state, touch no I/O, and never reference callOp's internals — which is why
+ * they can live apart from the ~450-line dispatch function.
+ *
+ * Split out because call.ts sat at its grandfathered file-size ceiling (628
+ * lines against a 600 limit), so the ratchet forbade any growth — blocking
+ * unrelated work that needed a single line in the hopCtx literal.
+ */
+
+import type { AgentRunOutcome } from "../agents";
+import { resolveRetryPreset } from "../agents/retry";
+import type { RetryPreset, RetryStrategy } from "../agents/retry";
+import { pickSelector } from "../config";
+import type { ConfigSelector, ConfiguredModel, NaxConfig } from "../config";
+import { NaxError } from "../errors";
+import type { UserStory } from "../prd";
+import type { BuildContext, Operation } from "./types";
+
+/** Hard ceiling for injected RetryStrategy instances that may not self-terminate. */
+export const MAX_COMPLETE_RETRY_ATTEMPTS = 20;
+
+/**
+ * Generates a per-invocation correlation id (≤16 chars, /^[0-9a-z]+-[0-9a-z]+$/).
+ * Exported for unit-testing uniqueness and format guarantees.
+ */
+export function newCorrelationId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function normalizeRunOutcome(outcome: AgentRunOutcome): AgentRunOutcome {
+  return outcome;
+}
+
+export function normalizeSelector<C>(
+  s: ConfigSelector<C> | readonly (keyof NaxConfig)[],
+  opName: string,
+): ConfigSelector<C> {
+  if (Array.isArray(s)) {
+    return pickSelector(`anonymous:${opName}`, ...(s as readonly (keyof NaxConfig)[])) as unknown as ConfigSelector<C>;
+  }
+  return s as ConfigSelector<C>;
+}
+
+export function resolveOpModel<I, O, C>(
+  op: Operation<I, O, C>,
+  input: I,
+  buildCtx: BuildContext<C>,
+): ConfiguredModel | undefined {
+  const m = (op as { model?: ConfiguredModel | ((i: I, ctx: BuildContext<C>) => ConfiguredModel | undefined) }).model;
+  if (typeof m === "function") return m(input, buildCtx);
+  return m;
+}
+
+export function resolveTimeoutMs<I, O, C>(
+  op: Operation<I, O, C>,
+  input: I,
+  buildCtx: BuildContext<C>,
+): number | undefined {
+  const timeoutMs = op.timeoutMs?.(input, buildCtx);
+  if (timeoutMs === undefined) return undefined;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new NaxError(`callOp[${op.name}]: invalid timeoutMs (${String(timeoutMs)})`, "CALL_OP_INVALID_TIMEOUT", {
+      stage: op.stage,
+      timeoutMs,
+    });
+  }
+  return timeoutMs;
+}
+
+export function resolveOpRetry<I, O, C>(
+  op: Operation<I, O, C>,
+  input: I,
+  buildCtx: BuildContext<C>,
+): RetryStrategy | null {
+  const retry = (
+    op as {
+      retry?: RetryPreset | RetryStrategy | ((i: I, ctx: BuildContext<C>) => RetryPreset | RetryStrategy | undefined);
+    }
+  ).retry;
+  if (!retry) return null;
+  if (typeof retry === "function") {
+    const resolved = retry(input, buildCtx);
+    if (!resolved) return null;
+    if ("shouldRetry" in resolved) return resolved as RetryStrategy;
+    return resolveRetryPreset(resolved as RetryPreset);
+  }
+  if ("shouldRetry" in retry) return retry as RetryStrategy;
+  return resolveRetryPreset(retry as RetryPreset);
+}
+
+/**
+ * Synthesize a minimal UserStory for callOp use cases that don't carry a real
+ * one (CLI ad-hoc calls, debate runners, simple op invocations). Only the `id`
+ * field is read by buildHopCallback's active code paths when no context bundle
+ * is provided — the other fields are zero-value placeholders.
+ *
+ * Uses `satisfies` (not `as`) so any future required field on UserStory breaks
+ * compile here, forcing an explicit decision rather than silently producing an
+ * empty default. If a downstream provider starts reading e.g. `acceptanceCriteria`
+ * for these stub stories, that's a bug — the synthesis path shouldn't run for
+ * any op that consumes story data beyond `id`.
+ */
+export function synthesizeStory(storyId: string | undefined): UserStory {
+  return {
+    id: storyId ?? "",
+    title: "",
+    description: "",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+  } satisfies UserStory;
+}

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -13,6 +13,16 @@ import { composeSections, join } from "../prompts/compose";
 import { cancellableDelay } from "../utils/bun-deps";
 import { errorMessage } from "../utils/errors";
 import { buildHopCallback } from "./build-hop-callback";
+import {
+  MAX_COMPLETE_RETRY_ATTEMPTS,
+  newCorrelationId,
+  normalizeRunOutcome,
+  normalizeSelector,
+  resolveOpModel,
+  resolveOpRetry,
+  resolveTimeoutMs,
+  synthesizeStory,
+} from "./call-resolvers";
 import { classifyEmptyOutputFailure } from "./turn-failure-classification";
 import type {
   BuildContext,
@@ -32,94 +42,6 @@ export const _callOpDeps = {
       .text()
       .catch(() => null),
 };
-
-/** Hard ceiling for injected RetryStrategy instances that may not self-terminate. */
-const MAX_COMPLETE_RETRY_ATTEMPTS = 20;
-
-/**
- * Generates a per-invocation correlation id (≤16 chars, /^[0-9a-z]+-[0-9a-z]+$/).
- * Exported for unit-testing uniqueness and format guarantees.
- */
-export function newCorrelationId(): string {
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function normalizeRunOutcome(outcome: AgentRunOutcome): AgentRunOutcome {
-  return outcome;
-}
-
-function normalizeSelector<C>(s: ConfigSelector<C> | readonly (keyof NaxConfig)[], opName: string): ConfigSelector<C> {
-  if (Array.isArray(s)) {
-    return pickSelector(`anonymous:${opName}`, ...(s as readonly (keyof NaxConfig)[])) as unknown as ConfigSelector<C>;
-  }
-  return s as ConfigSelector<C>;
-}
-
-function resolveOpModel<I, O, C>(
-  op: Operation<I, O, C>,
-  input: I,
-  buildCtx: BuildContext<C>,
-): ConfiguredModel | undefined {
-  const m = (op as { model?: ConfiguredModel | ((i: I, ctx: BuildContext<C>) => ConfiguredModel | undefined) }).model;
-  if (typeof m === "function") return m(input, buildCtx);
-  return m;
-}
-
-function resolveTimeoutMs<I, O, C>(op: Operation<I, O, C>, input: I, buildCtx: BuildContext<C>): number | undefined {
-  const timeoutMs = op.timeoutMs?.(input, buildCtx);
-  if (timeoutMs === undefined) return undefined;
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    throw new NaxError(`callOp[${op.name}]: invalid timeoutMs (${String(timeoutMs)})`, "CALL_OP_INVALID_TIMEOUT", {
-      stage: op.stage,
-      timeoutMs,
-    });
-  }
-  return timeoutMs;
-}
-
-function resolveOpRetry<I, O, C>(op: Operation<I, O, C>, input: I, buildCtx: BuildContext<C>): RetryStrategy | null {
-  const retry = (
-    op as {
-      retry?: RetryPreset | RetryStrategy | ((i: I, ctx: BuildContext<C>) => RetryPreset | RetryStrategy | undefined);
-    }
-  ).retry;
-  if (!retry) return null;
-  if (typeof retry === "function") {
-    const resolved = retry(input, buildCtx);
-    if (!resolved) return null;
-    if ("shouldRetry" in resolved) return resolved as RetryStrategy;
-    return resolveRetryPreset(resolved as RetryPreset);
-  }
-  if ("shouldRetry" in retry) return retry as RetryStrategy;
-  return resolveRetryPreset(retry as RetryPreset);
-}
-
-/**
- * Synthesize a minimal UserStory for callOp use cases that don't carry a real
- * one (CLI ad-hoc calls, debate runners, simple op invocations). Only the `id`
- * field is read by buildHopCallback's active code paths when no context bundle
- * is provided — the other fields are zero-value placeholders.
- *
- * Uses `satisfies` (not `as`) so any future required field on UserStory breaks
- * compile here, forcing an explicit decision rather than silently producing an
- * empty default. If a downstream provider starts reading e.g. `acceptanceCriteria`
- * for these stub stories, that's a bug — the synthesis path shouldn't run for
- * any op that consumes story data beyond `id`.
- */
-function synthesizeStory(storyId: string | undefined): UserStory {
-  return {
-    id: storyId ?? "",
-    title: "",
-    description: "",
-    acceptanceCriteria: [],
-    tags: [],
-    dependencies: [],
-    status: "pending",
-    passes: false,
-    escalations: [],
-    attempts: 0,
-  } satisfies UserStory;
-}
 
 export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, input: I): Promise<O> {
   // Deterministic ops bypass all LLM dispatch, cost tracking, and session management.

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,4 +1,5 @@
-export { callOp, newCorrelationId, _callOpDeps, _runPostParseForTest } from "./call";
+export { callOp, _callOpDeps, _runPostParseForTest } from "./call";
+export { newCorrelationId } from "./call-resolvers";
 export { classifyEmptyOutputFailure } from "./turn-failure-classification";
 export { planInteractiveOp } from "./plan";
 export type { PlanInteractiveInput } from "./plan";


### PR DESCRIPTION
`src/operations/call.ts` sat at **628 lines against a 600-line limit**, grandfathered at exactly its own size. `check:file-sizes` therefore forbade **any** growth, which blocked two unrelated pieces of work that each needed a single line in the `hopCtx` literal:

- threading `contextToolRunCounter` so `pull.maxCallsPerRun` is a real per-run cap rather than resetting every hop (noted in #1455)
- `pullCalls` telemetry, spec'd at `SPEC-context-engine-v2.md:245` and AC-18 (noted in #1458)

## What moved

The pure helper block ahead of `callOp` becomes `src/operations/call-resolvers.ts`: `newCorrelationId`, `normalizeRunOutcome`, `normalizeSelector`, `resolveOpModel`, `resolveTimeoutMs`, `resolveOpRetry`, `synthesizeStory`, `MAX_COMPLETE_RETRY_ATTEMPTS`.

They normalise an `Operation`'s declarative fields (model, timeout, retry, config selector) into concrete values. They hold no state, touch no I/O, and never reference `callOp`'s internals — which is why they can live apart from the ~450-line dispatch function rather than being an arbitrary slice taken to satisfy a line count.

`callOp` itself is untouched.

## Result

| | before | after |
|:--|--:|--:|
| `call.ts` | 628 | **550** |
| status | grandfathered at its ceiling | **under the 600 limit** |
| baseline entries | 13 | 12 |

`call.ts` is removed from `scripts/baselines/file-sizes-baseline.json` entirely, so it cannot silently creep back over the limit — the ratchet now enforces the real limit on this file rather than a frozen exception.

## Verification

- **Full suite green** — unit + integration + ui. Typecheck and full `bun run lint` clean, all ratchets at baseline.
- **Proved the blocker is actually gone, not merely reduced:** adding the previously-forbidden `contextToolRunCounter` line to `hopCtx` puts `call.ts` at 551 lines and `check:file-sizes` passes. (Probe reverted; that line belongs to the follow-up work, not this PR.)
- **Proved this is a move, not a rewrite:** each of the 7 extracted functions was diffed against its `origin/main` body. All 7 are identical modulo biome's line-wrapping of three signatures, which `export ` pushed past the line-width limit (wrapping adds trailing commas in the parameter lists). No logic changed.

## Compatibility

Every external consumer imports through `src/operations/index.ts`, which now re-exports `newCorrelationId` from the new module. No call site changed.
