### PR TITLE
feat(context): record pull-tool invocations and thread the run counter (gap finding 7)

### DIFF
--- a/src/context/engine/index.ts
+++ b/src/context/engine/index.ts
@@ -45,7 +45,7 @@ export {
   handleQueryNeighbor,
   handleQueryFeatureContext,
 } from "./pull-tools";
-export type { RunCallCounter } from "./pull-tools";
+export type { PullCallRecord, RunCallCounter } from "./pull-tools";
 
 export { getAgentProfile, AGENT_PROFILES, CONSERVATIVE_DEFAULT_PROFILE } from "./agent-profiles";
 export type { AgentCapabilities, AgentProfile } from "./agent-profiles";

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -131,13 +131,35 @@ export const PULL_TOOL_REGISTRY: Record<string, ToolDescriptor> = {
  * One RunCallCounter is created per nax run and passed to every PullToolBudget
  * instance so they all draw from the same pool.
  */
+/**
+ * One recorded pull-tool invocation. Shape is fixed by
+ * SPEC-context-engine-v2.md:245 (ContextManifest.pullCalls).
+ */
+export interface PullCallRecord {
+  /** Tool name, e.g. "query_neighbor" */
+  tool: string;
+  /** The tool's primary argument — the file path or filter the agent asked for */
+  query: string;
+  /** ISO timestamp of the invocation */
+  at: string;
+  /** Estimated tokens in the (possibly truncated) response */
+  tokensReturned: number;
+  /** Ids of the chunks the provider returned for this call */
+  chunkIds: string[];
+}
+
 export interface RunCallCounter {
   count: number;
+  /**
+   * Per-invocation records (AC-18). Shares the counter's lifetime, so it is
+   * run-scoped exactly as `count` is and needs no separate threading.
+   */
+  calls: PullCallRecord[];
 }
 
 /** Create a fresh RunCallCounter for the start of a run. */
 export function createRunCallCounter(): RunCallCounter {
-  return { count: 0 };
+  return { count: 0, calls: [] };
 }
 
 /**
@@ -176,6 +198,14 @@ export class PullToolBudget {
     }
     this.sessionCalls += 1;
     this.runCounter.count += 1;
+  }
+
+  /**
+   * Record a completed invocation. Called by handlers AFTER the response is
+   * known, so `consume()`'s throw path can never leave a phantom record.
+   */
+  record(entry: PullCallRecord): void {
+    this.runCounter.calls.push(entry);
   }
 
   isSessionExhausted(): boolean {
@@ -243,6 +273,14 @@ export async function handleQueryNeighbor(
   const maxChars = maxTokensPerCall * 4;
   const truncated = content.length > maxChars;
   const finalContent = truncated ? content.slice(0, maxChars) : content;
+
+  budget.record({
+    tool: "query_neighbor",
+    query: input.filePath,
+    at: new Date().toISOString(),
+    tokensReturned: Math.ceil(finalContent.length / 4),
+    chunkIds: result.chunks.map((c) => c.id),
+  });
 
   const logger = _pullToolsDeps.getLogger();
   const logData: Record<string, unknown> = {
@@ -328,6 +366,14 @@ export async function handleQueryFeatureContext(
 
   const maxChars = maxTokensPerCall * 4;
   const finalContent = content.length > maxChars ? content.slice(0, maxChars) : content;
+
+  budget.record({
+    tool: "query_feature_context",
+    query: input.filter ?? "",
+    at: new Date().toISOString(),
+    tokensReturned: Math.ceil(finalContent.length / 4),
+    chunkIds: result.chunks.map((c) => c.id),
+  });
 
   const logger = _pullToolsDeps.getLogger();
   logger.info("pull-tool", "invoked", {

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -128,7 +128,7 @@ export const PULL_TOOL_REGISTRY: Record<string, ToolDescriptor> = {
 
 /**
  * Shared mutable counter for the per-run call ceiling.
- * One RunCallCounter is created per nax run and passed to every PullToolBudget
+ * One RunCallCounter is created per story attempt (not per run, despite the name) and passed to every PullToolBudget
  * instance so they all draw from the same pool.
  */
 /**
@@ -152,7 +152,8 @@ export interface RunCallCounter {
   count: number;
   /**
    * Per-invocation records (AC-18). Shares the counter's lifetime, so it is
-   * run-scoped exactly as `count` is and needs no separate threading.
+   * scoped exactly as `count` is and needs no separate threading. Bounded by
+   * `maxCallsPerRun`, since `record()` is only reachable after `consume()`.
    */
   calls: PullCallRecord[];
 }

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -7,6 +7,7 @@
 import path from "node:path";
 import { resolveDefaultAgent } from "../agents";
 import { resolveModelForAgent } from "../config/schema";
+import type { PullCallRecord } from "../context/engine";
 import { loadContextManifests } from "../context/engine/manifest-store";
 import { computePollutionMetrics } from "../context/engine/pollution";
 import type { PipelineContext } from "../pipeline/types";
@@ -45,6 +46,7 @@ async function deriveContextMetrics(
   projectDir: string,
   storyId: string,
   featureId: string,
+  pullCalls?: PullCallRecord[],
 ): Promise<StoryMetrics["context"] | undefined> {
   const stored = await loadContextManifests(projectDir, storyId, featureId);
   if (stored.length === 0) return undefined;
@@ -93,7 +95,12 @@ async function deriveContextMetrics(
   // above); a manifest set with no providers never reaches this line.
   const floorOverage = computeFloorOverage(stored);
 
-  return { providers, ...(hasPollution && { pollution }), floorOverage };
+  return {
+    providers,
+    ...(hasPollution && { pollution }),
+    floorOverage,
+    ...(pullCalls?.length ? { pullCalls } : {}),
+  };
 }
 
 /**
@@ -177,7 +184,9 @@ export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: 
 
   const featureId = ctx.prd.feature;
   const contextMetrics =
-    ctx.projectDir && featureId ? await deriveContextMetrics(ctx.projectDir, story.id, featureId) : undefined;
+    ctx.projectDir && featureId
+      ? await deriveContextMetrics(ctx.projectDir, story.id, featureId, ctx.contextToolRunCounter?.calls)
+      : undefined;
 
   return {
     storyId: story.id,

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -164,6 +164,13 @@ export interface StoryMetrics {
   context?: {
     providers: Record<string, ContextProviderMetrics>;
     /**
+     * Pull-tool invocations for this story (spec AC-18). Sourced from the
+     * run-scoped counter threaded through CallContext, so it reflects what the
+     * agent actually asked for rather than what was offered. Absent when the
+     * story made no pull calls.
+     */
+    pullCalls?: import("../context/engine").PullCallRecord[];
+    /**
      * Aggregate pollution indicators (Amendment A AC-48).
      * Populated post-story when effectiveness annotation and staleness detection run.
      * Absent when no manifests were found or no effectiveness data exists.

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -138,15 +138,10 @@ export function buildHopCallback(
   // contextToolRunCounter — which until now was declared but never populated by
   // any production caller, so the run-level cap reset per hop too (call.ts).
   const sessionToolBudgets = createSessionToolBudgets();
-  // Same defect, different cause, for the RUN-level cap: BuildHopCallbackContext
-  // declares contextToolRunCounter but no production site populates it (the
-  // hopCtx literal in call.ts omits it), so tool-runtime's
-  // createRunCallCounter() fallback minted a fresh counter per hop and
-  // pull.maxCallsPerRun never bound. Hoisting the fallback here makes it hold
-  // across the hops of one callback. It is NOT yet a true per-run cap — that
-  // needs contextToolRunCounter threaded through CallContext, which cannot land
-  // in this change because call.ts is at its grandfathered file-size ceiling
-  // and the ratchet forbids growing it. Tracked as a follow-up.
+  // The counter is now threaded from the context stage through CallContext and
+  // hopCtx (call.ts), so a real one arrives here. The fallback covers callers
+  // that construct a hop context directly — tests, and any op invoked outside
+  // the pipeline. Hoisted out of the closure either way so it survives hops.
   const runCounterForHops = contextToolRunCounter ?? createRunCallCounter();
 
   return async (

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -37,6 +37,12 @@ import type {
 /** Injectable deps for testability — mirrors _agentManagerDeps pattern. */
 export const _callOpDeps = {
   sleep: (ms: number, signal?: AbortSignal) => cancellableDelay(ms, signal),
+  /**
+   * Seam over buildHopCallback so tests can observe the hopCtx literal this
+   * function assembles. Without it nothing pins what callOp forwards — the
+   * contextToolRunCounter threading was silently absent for exactly that reason.
+   */
+  buildHopCallback,
   readFileOutput: async (path: string) =>
     Bun.file(path)
       .text()
@@ -206,6 +212,9 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     projectDir: ctx.runtime.projectDir,
     featureName: ctx.featureName ?? "",
     workdir: ctx.packageDir,
+    // Run-scoped pull counter: keeps pull.maxCallsPerRun a real per-run ceiling
+    // instead of resetting each hop, and carries AC-18's invocation records.
+    ...(ctx.contextToolRunCounter ? { contextToolRunCounter: ctx.contextToolRunCounter } : {}),
     effectiveTier,
     defaultAgent,
     pipelineStage: op.stage,
@@ -353,7 +362,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   // without losing the middleware envelope. dispatchAgent roots the chain at
   // the resolved agent, which may differ from ctx.agentName when op.model
   // pins a specific `{ agent, model }`.
-  const executeHop = buildHopCallback(
+  const executeHop = _callOpDeps.buildHopCallback(
     {
       ...hopCtx,
       hopBody: effectiveHopBody as NonNullable<import("./build-hop-callback").BuildHopCallbackContext["hopBody"]>,

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -212,8 +212,12 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     projectDir: ctx.runtime.projectDir,
     featureName: ctx.featureName ?? "",
     workdir: ctx.packageDir,
-    // Run-scoped pull counter: keeps pull.maxCallsPerRun a real per-run ceiling
-    // instead of resetting each hop, and carries AC-18's invocation records.
+    // Pull counter for this story attempt. Forwarding it stops
+    // pull.maxCallsPerRun resetting on every hop, and carries AC-18's
+    // invocation records through to metrics. NOTE: despite the config key's
+    // name the ceiling is per story ATTEMPT, not per run — PipelineContext is
+    // constructed fresh per iteration (iteration-runner.ts) and per parallel
+    // story (parallel-worker.ts), so each gets its own counter.
     ...(ctx.contextToolRunCounter ? { contextToolRunCounter: ctx.contextToolRunCounter } : {}),
     effectiveTier,
     defaultAgent,

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -16,6 +16,12 @@ export interface CallContext {
   readonly runtime: NaxRuntime;
   readonly packageView: PackageView;
   readonly packageDir: string;
+  /**
+   * Run-scoped pull-tool counter, created by the context stage. Threaded so
+   * `pull.maxCallsPerRun` is enforced once per run instead of resetting on
+   * every hop, and so AC-18's per-invocation records survive to metrics.
+   */
+  readonly contextToolRunCounter?: import("../context/engine").RunCallCounter;
   readonly storyId?: string;
   readonly featureName?: string;
   /**

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -17,9 +17,10 @@ export interface CallContext {
   readonly packageView: PackageView;
   readonly packageDir: string;
   /**
-   * Run-scoped pull-tool counter, created by the context stage. Threaded so
-   * `pull.maxCallsPerRun` is enforced once per run instead of resetting on
-   * every hop, and so AC-18's per-invocation records survive to metrics.
+   * Pull-tool counter for this story attempt, created by the context stage.
+   * Threaded so `pull.maxCallsPerRun` stops resetting on every hop, and so
+   * AC-18's per-invocation records survive to metrics. The ceiling is per
+   * story attempt despite the key's name — see the note in call.ts.
    */
   readonly contextToolRunCounter?: import("../context/engine").RunCallCounter;
   readonly storyId?: string;

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -90,6 +90,7 @@ export const executionStage: PipelineStage = {
       runtime: ctx.runtime,
       packageView,
       packageDir: ctx.workdir,
+      ...(ctx.contextToolRunCounter ? { contextToolRunCounter: ctx.contextToolRunCounter } : {}),
       agentName: resolved.agentName,
       storyId: ctx.story.id,
       featureName: ctx.prd.feature,

--- a/test/unit/context/engine/pull-tools.test.ts
+++ b/test/unit/context/engine/pull-tools.test.ts
@@ -7,23 +7,23 @@
  * Feature context reads are intercepted via _featureContextV2Deps injection.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { NaxError } from "../../../../src/errors";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { NaxConfig } from "../../../../src/config/types";
 import { _codeNeighborDeps } from "../../../../src/context/engine/providers/code-neighbor";
 import { _featureContextV2Deps } from "../../../../src/context/engine/providers/feature-context";
 import {
-  QUERY_NEIGHBOR_DESCRIPTOR,
-  QUERY_FEATURE_CONTEXT_DESCRIPTOR,
   PULL_TOOL_REGISTRY,
   PullToolBudget,
-  createRunCallCounter,
-  handleQueryNeighbor,
-  handleQueryFeatureContext,
+  QUERY_FEATURE_CONTEXT_DESCRIPTOR,
+  QUERY_NEIGHBOR_DESCRIPTOR,
   _pullToolsDeps,
+  createRunCallCounter,
+  handleQueryFeatureContext,
+  handleQueryNeighbor,
 } from "../../../../src/context/engine/pull-tools";
-import { makeLogger } from "../../../../test/helpers";
-import type { NaxConfig } from "../../../../src/config/types";
+import { NaxError } from "../../../../src/errors";
 import type { UserStory } from "../../../../src/prd";
+import { makeLogger } from "../../../../test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Saved originals for dep injection
@@ -46,9 +46,10 @@ beforeEach(() => {
   _codeNeighborDeps.readFile = async () => "";
   _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
   // Default: feature context returns null (no context.md)
-  _featureContextV2Deps.createV1Provider = () => ({
-    getContext: async () => null,
-  }) as ReturnType<typeof origCreateV1Provider>;
+  _featureContextV2Deps.createV1Provider = () =>
+    ({
+      getContext: async () => null,
+    }) as ReturnType<typeof origCreateV1Provider>;
   // Default: no-op logger (real logger is used)
   _pullToolsDeps.getLogger = () => makeLogger() as any;
 });
@@ -163,6 +164,60 @@ describe("PullToolBudget", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // handleQueryNeighbor
 // ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap finding 7 / spec AC-18: pull-tool invocations were never recorded.
+// SPEC-context-engine-v2.md:245 declares ContextManifest.pullCalls and AC-18
+// declares StoryMetrics.context.pullCalls; `grep -rn pullCalls src/` returned
+// zero hits, so the Phase-4 exit gate ("budget respected, cost within
+// envelope") was unevaluable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("pull-call recording", () => {
+  function makeBudget(sessionLimit = 5, runLimit = 50, counter = createRunCallCounter()) {
+    return { budget: new PullToolBudget(sessionLimit, runLimit, counter), counter };
+  }
+
+  test("records one entry per invocation with the spec'd shape", async () => {
+    const { budget, counter } = makeBudget();
+    _codeNeighborDeps.fileExists = async () => false;
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+
+    await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", budget, 100, undefined, "US-001");
+
+    expect(counter.calls).toHaveLength(1);
+    const c = counter.calls[0];
+    expect(c?.tool).toBe("query_neighbor");
+    expect(c?.query).toBe("src/a.ts");
+    expect(typeof c?.at).toBe("string");
+    expect(typeof c?.tokensReturned).toBe("number");
+    expect(Array.isArray(c?.chunkIds)).toBe(true);
+  });
+
+  test("accumulates across calls on the shared run counter", async () => {
+    const { budget, counter } = makeBudget();
+    _codeNeighborDeps.fileExists = async () => false;
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+
+    await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", budget, 100);
+    await handleQueryNeighbor({ filePath: "src/b.ts" }, "/repo", budget, 100);
+
+    expect(counter.calls.map((c) => c.query)).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(counter.count).toBe(2);
+  });
+
+  test("records nothing when the budget rejects the call", async () => {
+    const { budget, counter } = makeBudget(0, 50);
+    let threw = false;
+    try {
+      await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", budget, 100);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    expect(counter.calls).toHaveLength(0);
+  });
+});
 
 describe("handleQueryNeighbor", () => {
   function makeBudget(sessionLimit = 5, runLimit = 50) {
@@ -331,7 +386,9 @@ describe("handleQueryFeatureContext", () => {
     expect(await handleQueryFeatureContext({}, STORY, CONFIG, "/repo", makeBudget())).toBe("");
 
     mockV1Provider("## Conventions\nUse async/await.\n\n## Security\nNever log tokens.");
-    expect(await handleQueryFeatureContext({ filter: "nonexistent-keyword-xyz" }, STORY, CONFIG, "/repo", makeBudget())).toBe("");
+    expect(
+      await handleQueryFeatureContext({ filter: "nonexistent-keyword-xyz" }, STORY, CONFIG, "/repo", makeBudget()),
+    ).toBe("");
   });
 
   test("filter returns matching sections (case-insensitive)", async () => {
@@ -348,13 +405,7 @@ describe("handleQueryFeatureContext", () => {
 
   test("filter with no ## headings returns full content (flat context.md)", async () => {
     mockV1Provider("Flat content without any headings.\nSome conventions here.");
-    const result = await handleQueryFeatureContext(
-      { filter: "conventions" },
-      STORY,
-      CONFIG,
-      "/repo",
-      makeBudget(),
-    );
+    const result = await handleQueryFeatureContext({ filter: "conventions" }, STORY, CONFIG, "/repo", makeBudget());
     // No ## headings — section-filter not possible; full content returned
     expect(result).toContain("Flat content");
     expect(result).toContain("conventions");
@@ -364,14 +415,7 @@ describe("handleQueryFeatureContext", () => {
     const longContent = "## Section\n" + "x".repeat(500);
     mockV1Provider(longContent);
     const maxTokensPerCall = 20; // tiny cap → 80 chars max
-    const result = await handleQueryFeatureContext(
-      {},
-      STORY,
-      CONFIG,
-      "/repo",
-      makeBudget(),
-      maxTokensPerCall,
-    );
+    const result = await handleQueryFeatureContext({}, STORY, CONFIG, "/repo", makeBudget(), maxTokensPerCall);
     expect(result.length).toBeLessThanOrEqual(maxTokensPerCall * 4);
   });
 

--- a/test/unit/metrics/tracker-context-metrics.test.ts
+++ b/test/unit/metrics/tracker-context-metrics.test.ts
@@ -7,11 +7,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import { _manifestStoreDeps } from "../../../src/context/engine/manifest-store";
+import type { ContextManifest } from "../../../src/context/engine/types";
 import { collectStoryMetrics } from "../../../src/metrics/tracker";
 import type { PipelineContext } from "../../../src/pipeline/types";
-import type { ContextManifest } from "../../../src/context/engine/types";
-import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import type { PRD, UserStory } from "../../../src/prd";
 import { makeStory } from "../../helpers";
 import { makeMockRuntime } from "../../helpers/runtime";
@@ -182,7 +182,14 @@ describe("collectStoryMetrics — AC-18 context.providers", () => {
     mockManifests({
       [`${FEATURE}/execution`]: makeManifest({
         providerResults: [
-          { providerId: "plugin-rag", status: "failed", chunkCount: 0, durationMs: 20, tokensProduced: 0, error: "oops" },
+          {
+            providerId: "plugin-rag",
+            status: "failed",
+            chunkCount: 0,
+            durationMs: 20,
+            tokensProduced: 0,
+            error: "oops",
+          },
         ],
         includedChunks: [],
       }),
@@ -214,8 +221,8 @@ describe("collectStoryMetrics — AC-18 context.providers", () => {
     const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
     const p = metrics.context?.providers["static-rules"];
     expect(p?.chunksProduced).toBe(4); // 2 + 2
-    expect(p?.chunksKept).toBe(3);     // 2 + 1
-    expect(p?.wallClockMs).toBe(75);   // 40 + 35
+    expect(p?.chunksKept).toBe(3); // 2 + 1
+    expect(p?.wallClockMs).toBe(75); // 40 + 35
     expect(p?.tokensProduced).toBe(400); // 200 + 200
   });
 
@@ -348,5 +355,60 @@ describe("collectStoryMetrics — US-003 context.floorOverage (AC-2, AC-3)", () 
     const ctx = makeCtx();
     const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
     expect(metrics.context?.floorOverage?.overageTokens).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Spec AC-18: StoryMetrics.context.pullCalls tracks invocations. Sourced from
+// the run-scoped counter threaded through CallContext, so it reflects what the
+// agent actually asked for rather than what was offered.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("collectStoryMetrics — context.pullCalls (AC-18)", () => {
+  const CALL = {
+    tool: "query_neighbor",
+    query: "src/a.ts",
+    at: "2026-08-03T00:00:00.000Z",
+    tokensReturned: 42,
+    chunkIds: ["code-neighbor:a:001"],
+  };
+
+  function ctxWithCalls(calls: unknown[]) {
+    const ctx = makeCtx() as unknown as { contextToolRunCounter?: unknown };
+    ctx.contextToolRunCounter = { count: calls.length, calls };
+    return ctx as never;
+  }
+
+  test("surfaces the recorded invocations on the story's context metrics", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        stage: "execution",
+        providerResults: [
+          { providerId: "code-neighbor", status: "ok", chunkCount: 1, durationMs: 10, tokensProduced: 100 },
+        ],
+        includedChunks: ["code-neighbor:a:001"],
+      }),
+    });
+
+    const metrics = await collectStoryMetrics(ctxWithCalls([CALL]), new Date().toISOString());
+
+    expect(metrics.context?.pullCalls).toHaveLength(1);
+    expect(metrics.context?.pullCalls?.[0]).toMatchObject({ tool: "query_neighbor", query: "src/a.ts" });
+  });
+
+  test("omits pullCalls entirely when the story made none", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        stage: "execution",
+        providerResults: [
+          { providerId: "code-neighbor", status: "ok", chunkCount: 1, durationMs: 10, tokensProduced: 100 },
+        ],
+        includedChunks: ["code-neighbor:a:001"],
+      }),
+    });
+
+    const metrics = await collectStoryMetrics(ctxWithCalls([]), new Date().toISOString());
+
+    expect(metrics.context?.pullCalls).toBeUndefined();
   });
 });

--- a/test/unit/operations/build-hop-callback-stale-retry.test.ts
+++ b/test/unit/operations/build-hop-callback-stale-retry.test.ts
@@ -100,6 +100,30 @@ function makeCtx(sessionMgr: ReturnType<typeof makeSessionManager>) {
 // outside the returned closure. Created inside, every retry / fallback /
 // escalation hop got a fresh registry and maxCallsPerSession reset to zero.
 // Nothing else in the suite pins this placement.
+// Gap finding 7 / AC-18: BuildHopCallbackContext declared contextToolRunCounter
+// but no production site populated it — call.ts's hopCtx literal omitted it,
+// and could not gain the line because the file sat at its grandfathered
+// size ceiling (cleared by #1460). So the run cap reset every hop and pull
+// invocations were never recorded anywhere.
+describe("buildHopCallback — run counter threading", () => {
+  test("forwards the run counter it was given, instead of minting a fresh one", async () => {
+    const seen: unknown[] = [];
+    _buildHopCallbackDeps.createContextToolRuntime = (opts: { runCounter?: unknown }) => {
+      seen.push(opts.runCounter);
+      return undefined as never;
+    };
+    const counter = { count: 7, calls: [] };
+    const sessionMgr = makeSessionManager({});
+    const ctx = { ...makeCtx(sessionMgr), contextToolRunCounter: counter } as never;
+    const cb = buildHopCallback(ctx, undefined, STUB_RUN_OPTIONS);
+
+    const bundle = { pushMarkdown: "", pullTools: [], digest: "", manifest: {} } as never;
+    await cb("claude", bundle, { kind: "primary", attempt: 1 }, STUB_RUN_OPTIONS);
+
+    expect(seen[0]).toBe(counter);
+  });
+});
+
 describe("buildHopCallback — session-scoped pull budget registry", () => {
   test("every hop receives the same sessionBudgets instance", async () => {
     const seen: unknown[] = [];

--- a/test/unit/operations/call-run-counter.test.ts
+++ b/test/unit/operations/call-run-counter.test.ts
@@ -1,10 +1,10 @@
 /**
  * callOp — run-scoped pull-tool counter threading.
  *
- * Split into its own file rather than appended to call.test.ts, which is
- * grandfathered at 972 lines against an 800 limit; the ratchet forbids growth.
- * Matches the existing call-*.test.ts topical split (call-correlation,
- * call-fail-timeout, call-op-retry, ...).
+ * Own file rather than appended to call.test.ts, matching the existing
+ * call-*.test.ts topical split (call-correlation, call-fail-timeout,
+ * call-op-retry, ...). call.test.ts is 736 lines against an 800 limit, so the
+ * split is by convention, not because the ratchet forced it.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -38,7 +38,6 @@ const runEchoOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONF
 
 describe("callOp — contextToolRunCounter threading", () => {
   test("forwards ctx.contextToolRunCounter into the hop context", async () => {
-    const { _callOpDeps } = await import("@/operations");
     const orig = _callOpDeps.buildHopCallback;
     let seen: unknown;
     let stubCalled = false;

--- a/test/unit/operations/call-run-counter.test.ts
+++ b/test/unit/operations/call-run-counter.test.ts
@@ -1,0 +1,73 @@
+/**
+ * callOp — run-scoped pull-tool counter threading.
+ *
+ * Split into its own file rather than appended to call.test.ts, which is
+ * grandfathered at 972 lines against an 800 limit; the ratchet forbids growth.
+ * Matches the existing call-*.test.ts topical split (call-correlation,
+ * call-fail-timeout, call-op-retry, ...).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { type DEFAULT_CONFIG, pickSelector } from "@/config";
+import { _callOpDeps, callOp } from "@/operations";
+import type { RunOperation } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+import { makeMockAgentManager, makeSessionManager, makeTestRuntime } from "@test/helpers";
+
+const testSel = pickSelector("test", "routing");
+
+const runEchoOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  kind: "run",
+  name: "run-echo-counter-test",
+  stage: "run",
+  config: testSel,
+  session: { role: "implementer", lifetime: "fresh" },
+  build: (input) => ({
+    role: { id: "role", content: "You echo text.", overridable: false },
+    task: { id: "task", content: input.text, overridable: false },
+  }),
+  parse: (output) => output.trim(),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap finding 7 / AC-18. BuildHopCallbackContext declared contextToolRunCounter
+// but callOp's hopCtx literal never set it, so the run-level pull cap reset on
+// every hop and no invocation was ever recorded. The line could not be added
+// until #1460 took call.ts back under the file-size limit.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("callOp — contextToolRunCounter threading", () => {
+  test("forwards ctx.contextToolRunCounter into the hop context", async () => {
+    const { _callOpDeps } = await import("@/operations");
+    const orig = _callOpDeps.buildHopCallback;
+    let seen: unknown;
+    let stubCalled = false;
+    _callOpDeps.buildHopCallback = ((hopCtx: { contextToolRunCounter?: unknown }) => {
+      stubCalled = true;
+      seen = hopCtx.contextToolRunCounter;
+      return async () => ({ result: { success: true, exitCode: 0, output: "ok" }, bundle: undefined });
+    }) as typeof _callOpDeps.buildHopCallback;
+
+    const counter = { count: 3, calls: [] };
+    const agentManager = makeMockAgentManager({});
+    const localRuntime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager({}) });
+    try {
+      await callOp(
+        {
+          runtime: localRuntime,
+          packageView: localRuntime.packages.repo(),
+          packageDir: "/tmp",
+          agentName: "claude",
+          contextToolRunCounter: counter,
+        } as never,
+        runEchoOp,
+        { text: "hi" },
+      ).catch(() => undefined);
+    } finally {
+      _callOpDeps.buildHopCallback = orig;
+      await localRuntime.close();
+    }
+
+    expect({ stubCalled, seen }).toEqual({ stubCalled: true, seen: counter });
+  });
+});

--- a/test/unit/pipeline/stages/execution-phase-telemetry.test.ts
+++ b/test/unit/pipeline/stages/execution-phase-telemetry.test.ts
@@ -11,9 +11,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { executionStage, _executionDeps } from "@/pipeline";
-import type { PipelineContext } from "@/pipeline/types";
 import type { CallContext } from "@/operations/types";
+import { _executionDeps, executionStage } from "@/pipeline";
+import type { PipelineContext } from "@/pipeline/types";
 import { makeAgentAdapter, makeMockAgentManager, makeNaxConfig, makeStory } from "@test/helpers";
 
 function makePipelineContext(overrides: Partial<PipelineContext> = {}): PipelineContext {
@@ -90,7 +90,9 @@ afterEach(() => {
 
 describe("execution stage — phaseTelemetry derivation (US-003 ACs 1-4)", () => {
   test("AC1/AC2: three-session-tdd derives sessionModel=three-session and forwards testStrategy unchanged", async () => {
-    const ctx = makePipelineContext({ routing: { ...makePipelineContext().routing, testStrategy: "three-session-tdd" } });
+    const ctx = makePipelineContext({
+      routing: { ...makePipelineContext().routing, testStrategy: "three-session-tdd" },
+    });
     await executionStage.execute(ctx);
     expect(capturedCallCtx?.phaseTelemetry?.sessionModel).toBe("three-session");
     expect(capturedCallCtx?.phaseTelemetry?.testStrategy).toBe("three-session-tdd");
@@ -116,5 +118,33 @@ describe("execution stage — phaseTelemetry derivation (US-003 ACs 1-4)", () =>
     const ctx = makePipelineContext({ routing: { ...makePipelineContext().routing, modelTier: "powerful" } });
     await executionStage.execute(ctx);
     expect(capturedCallCtx?.phaseTelemetry?.tier).toBe("fast");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap finding 7 / AC-18. This one line in the callCtx literal is the only edge
+// connecting the counter the context stage creates to the call path that uses
+// it. Delete it and the whole pull-telemetry feature is inert in production —
+// metrics permanently absent, the cap back to per-hop — while every other test
+// in the suite stays green. That is the same declared-but-never-populated
+// pattern the feature exists to fix, so it gets its own guard.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("execution stage — contextToolRunCounter threading (AC-18)", () => {
+  test("forwards the SAME counter object from PipelineContext onto CallContext", async () => {
+    const counter = { count: 0, calls: [] };
+    const ctx = makePipelineContext();
+    (ctx as unknown as { contextToolRunCounter: unknown }).contextToolRunCounter = counter;
+
+    await executionStage.execute(ctx);
+
+    // Identity, not equality: a copy would leave collectStoryMetrics reading an
+    // empty array while every unit test still passed.
+    expect(capturedCallCtx?.contextToolRunCounter).toBe(counter);
+  });
+
+  test("omits the field entirely when the context stage never created a counter", async () => {
+    await executionStage.execute(makePipelineContext());
+    expect(capturedCallCtx?.contextToolRunCounter).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes gap-analysis finding 7. Spec `SPEC-context-engine-v2.md:245` declares `ContextManifest.pullCalls` and AC-18 declares `StoryMetrics.context.pullCalls`; `grep -rn pullCalls src/` returned **zero hits**, so the Phase-4 exit gate ("budget respected, cost within envelope") was unevaluable.

## Two defects, one root cause

`BuildHopCallbackContext` declared `contextToolRunCounter` but `callOp`'s `hopCtx` literal never set it. So:

- `pull.maxCallsPerRun` reset on every retry / fallback / escalation hop, leaving the ceiling effectively unbounded (noted in #1455)
- there was nowhere for invocation records to accumulate

That line could not be added until #1460 took `call.ts` back under the 600-line limit — it had been grandfathered at exactly its own size, so the ratchet forbade any growth.

## What ships

`RunCallCounter` gains `calls: PullCallRecord[]` in the spec'd shape `{ tool, query, at, tokensReturned, chunkIds }`. Recording lives on `PullToolBudget.record()`, called by both handlers **after** the response is known, so `consume()`'s throw path can never leave a phantom record for a rejected call. The counter is threaded context stage → `CallContext` → `hopCtx` → tool runtime, and `collectStoryMetrics` reads it back off the same object.

Adds a `_callOpDeps.buildHopCallback` seam so the `hopCtx` literal is observable. It earned itself immediately: the first version of the threading line landed in `completeOptions` rather than `hopCtx` — `call.ts` has three literals sharing a `workdir: ctx.packageDir` line — and the test caught it.

## Review round: the PR reproduced its own root-cause pattern one layer up

`execution.ts`'s `callCtx` literal is the **only** edge connecting the counter the context stage creates to the call path that consumes it, and nothing tested it. Deleting that line left **2996 tests green** while the entire feature was inert in production: metrics permanently absent, cap back to per-hop. That is precisely the declared-but-never-populated shape this work exists to fix.

My "each link is independently mutation-verified" claim covered four of five links. This was the missing one. It now has a guard asserting object **identity** (a copy would leave `collectStoryMetrics` reading an empty array with every test still passing), mutation-verified.

## The counter is per story attempt, not per run

`PipelineContext` is constructed fresh per iteration (`iteration-runner.ts`) and per parallel story (`parallel-worker.ts`), so `context.ts`'s `if (!ctx.contextToolRunCounter)` guard is always true and a new counter is minted each time. `pull.maxCallsPerRun` is therefore enforced **N times per run** — which matters, because it is the cost-control lever.

Four comments across three files asserted a run-level scope the code does not have. All corrected to state the real scope and flag the config key's name as the misnomer. **Renaming the key is a breaking config change and is left as a follow-up.** This PR still strictly improves the ceiling: per-hop → per-story-attempt.

Also removed the now-false note in `build-hop-callback.ts` claiming the threading "cannot land in this change… tracked as a follow-up" — that follow-up is this PR.

## Verification

- **Full suite green** (unit + integration + ui); typecheck and lint clean, all ratchets at baseline.
- **All five links mutation-verified:** reverting the `hopCtx` line, the `execution.ts` link, the tracker emit, `budget.record()`, or the hop-callback forward each fails a *different* test.
- Memory is bounded by construction: `record()` is only reachable after a successful `consume()`, which throws at `maxCallsPerRun`, so `calls.length ≤ 50` by default for the counter's whole life.

## Scope notes

- **`ContextManifest.pullCalls` (spec `:245`) is deliberately not implemented.** The manifest is written by the context stage *before* the agent hop where pull calls happen, so filling it would need a post-hoc rewrite of the persisted file. AC-18's `StoryMetrics` half is what this PR delivers; the manifest half is an undeclared spec deviation worth its own decision.
- `pullCalls` is dropped when no context manifest was persisted (`deriveContextMetrics` early-returns on `stored.length === 0`). Usually co-present, but the coupling is incidental.
- Failed stories lose pull telemetry entirely — `collectStoryMetrics` only runs in the completion stage. The most diagnostically valuable case (budget burned *and* the story failed) reports nothing. Worth a follow-up issue.
- Two touched test files carry incidental biome import-reordering.
