### PR TITLE
feat(prd): carry spec `### Modifies` blocks into the PRD and implementer prompt

### DIFF
--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -7,7 +7,7 @@ export { planRefineOp, _planRefineDeps, normalizeCreatedContextFiles } from "./p
 export type { PlanRefineInput } from "./plan-refine";
 export { makeSelfHealStep, runSelfHealChain } from "./self-heal";
 export type { SelfHealStep, SelfHealSpec } from "./self-heal";
-export { backfillOutOfScope } from "./plan-fidelity";
+export { applyPlanFidelity, backfillModifiedFiles, backfillOutOfScope } from "./plan-fidelity";
 export { decomposeOp } from "./decompose";
 export type { DecomposeOpInput, DecomposeOpOutput } from "./decompose";
 export { buildHopCallback, _buildHopCallbackDeps } from "./build-hop-callback";

--- a/src/operations/plan-fidelity.ts
+++ b/src/operations/plan-fidelity.ts
@@ -8,6 +8,7 @@
  */
 import { getSafeLogger } from "../logger";
 import {
+  applyModifiedFiles,
   applyOutOfScopeFallback,
   demoteStoryScopedOutOfScope,
   findMissingOutOfScope,
@@ -48,6 +49,50 @@ export function backfillOutOfScope(prd: PRD, specContent: string, featureName: s
     missing,
   });
   return applyOutOfScopeFallback(scoped, specContent);
+}
+
+/**
+ * Carry the spec's `### Modifies` entries onto the stories that declared them.
+ *
+ * Unlike the out-of-scope backfill there is nothing to reconcile: the planner is
+ * never asked for this field, because the value is the spec's verbatim
+ * specificity — which test, which assertion, what the new invariant is — and a
+ * paraphrase ("update affected engine tests") is the exact loss #1450 records.
+ * So this is a pure carry, not a repair.
+ *
+ * Orphans (an entry naming no story, or one absent from the PRD) are warned
+ * about and dropped rather than broadcast. Attaching an unowned authorisation to
+ * every story would tell four implementers they may rewrite a test that only one
+ * of them should touch.
+ */
+export function backfillModifiedFiles(prd: PRD, specContent: string, featureName: string): PRD {
+  const { prd: applied, orphans, invalidPaths } = applyModifiedFiles(prd, specContent);
+  if (invalidPaths.length > 0) {
+    getSafeLogger()?.warn("plan", "Spec Modifies entries declare an absolute or traversing path — rejected", {
+      featureName,
+      rejectedCount: invalidPaths.length,
+      rejected: invalidPaths.map((entry) => ({ storyId: entry.storyId, path: entry.path })),
+    });
+  }
+  if (orphans.length > 0) {
+    getSafeLogger()?.warn("plan", "Spec Modifies entries name no story in the PRD — dropped, not applied", {
+      featureName,
+      orphanCount: orphans.length,
+      orphans: orphans.map((entry) => ({ storyId: entry.storyId, path: entry.path })),
+    });
+  }
+  return applied;
+}
+
+/**
+ * Every deterministic spec→PRD fidelity repair, in the order they must run.
+ *
+ * One entry point so the four plan strategies (single, refine, pipeline, debate)
+ * cannot drift on which repairs they apply — the class of bug that let
+ * `### Modifies` reach only some paths would otherwise recur per-field.
+ */
+export function applyPlanFidelity(prd: PRD, specContent: string, featureName: string): PRD {
+  return backfillModifiedFiles(backfillOutOfScope(prd, specContent, featureName), specContent, featureName);
 }
 
 /**

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -15,7 +15,7 @@ import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
 import type { SessionRole } from "../session/types";
 import { errorMessage } from "../utils/errors";
-import { backfillOutOfScope, warnOnSpecDrift } from "./plan-fidelity";
+import { applyPlanFidelity, warnOnSpecDrift } from "./plan-fidelity";
 import { type SelfHealStep, makeSelfHealStep, runSelfHealChain } from "./self-heal";
 import type { RunOperation } from "./types";
 
@@ -407,7 +407,7 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
     }
     // Last line of defence after the out-of-scope self-heal turn: anything the
     // repair turn still missed is restored verbatim from the spec.
-    const scoped = backfillOutOfScope(validated, input.specContent, input.featureName);
+    const scoped = applyPlanFidelity(validated, input.specContent, input.featureName);
     return await normalizeCreatedContextFiles(scoped, input.workdir, ctx.fileExists);
   },
   recover: async (input, ctx) => {

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -6,7 +6,7 @@ import { validatePlanOutput } from "../prd/schema";
 import type { PRD } from "../prd/types";
 import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
-import { backfillOutOfScope } from "./plan-fidelity";
+import { applyPlanFidelity } from "./plan-fidelity";
 import type { RunOperation } from "./types";
 
 export interface PlanInteractiveInput {
@@ -76,7 +76,7 @@ export const planInteractiveOp: RunOperation<PlanInteractiveInput, PRD, PlanConf
     if (!parsed.userStories || parsed.userStories.length === 0) return null;
     // Feature-level exclusions have one home, so a drop is repairable rather
     // than merely reportable — backfill instead of warning-and-continuing.
-    return backfillOutOfScope(parsed, input.specContent, input.featureName);
+    return applyPlanFidelity(parsed, input.specContent, input.featureName);
   },
   recover: async (input, ctx) => {
     const content = await ctx.readFile(input.outputPath);

--- a/src/plan/strategies/debate.ts
+++ b/src/plan/strategies/debate.ts
@@ -1,6 +1,6 @@
 import type { DebateStageConfig } from "@/debate/types";
 import { NaxError } from "@/errors";
-import { backfillOutOfScope, callOp, planInteractiveOp } from "@/operations";
+import { applyPlanFidelity, callOp, planInteractiveOp } from "@/operations";
 import type { CallContext, PlanInteractiveInput } from "@/operations";
 import { validatePlanOutput } from "@/prd";
 import type { PRD } from "@/prd/types";
@@ -83,7 +83,7 @@ export class DebatePlanStrategy implements IPlanStrategy {
         // Debate synthesis merges debater candidates and can drop a feature-level
         // exclusion. Repairable rather than merely reportable — an exclusion has
         // exactly one home, so restore it. spec-review --prd remains the gate.
-        const scoped = backfillOutOfScope(prd, ctx.specContent, ctx.options.feature);
+        const scoped = applyPlanFidelity(prd, ctx.specContent, ctx.options.feature);
         const withProject = { ...scoped, project: ctx.projectName } satisfies PRD;
         return _debatePlanDeps.writeOrRecoverPrd(ctx, withProject);
       }

--- a/src/plan/strategies/pipeline.ts
+++ b/src/plan/strategies/pipeline.ts
@@ -1,7 +1,7 @@
 import { renderManifestSection } from "@/debate";
 import type { FactsManifest } from "@/debate/facts-manifest";
 import { NaxError } from "@/errors";
-import { backfillOutOfScope, callOp, groundOp, planDraftOp } from "@/operations";
+import { applyPlanFidelity, callOp, groundOp, planDraftOp } from "@/operations";
 import type { CallContext, PlanDraftInput } from "@/operations";
 import { runPlanCritic } from "../critic";
 import { finalizePrdRouting } from "./finalize-routing";
@@ -87,7 +87,7 @@ export class PipelinePlanStrategy implements IPlanStrategy {
 
       // The critic can drop feature-level exclusions the draft carried; this path
       // has no op verify, so restore them here for parity with single/refine.
-      const scoped = backfillOutOfScope(verdict.prd, ctx.specContent, ctx.options.feature);
+      const scoped = applyPlanFidelity(verdict.prd, ctx.specContent, ctx.options.feature);
       const prdToWrite = finalizePrdRouting(
         { ...scoped, project: ctx.projectName },
         ctx.config.routing?.agents,

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -36,6 +36,10 @@ export {
   propagateOutOfScopeToStories,
   stripPropagatedOutOfScope,
 } from "./out-of-scope";
+export type { SpecModifiedFile } from "./modifies-extract";
+export { MAX_MODIFIED_FILES, extractSpecModifiedFiles } from "./modifies-extract";
+export type { ApplyModifiedFilesResult } from "./modifies";
+export { applyModifiedFiles } from "./modifies";
 export type { FailureCategory } from "../tdd/types";
 export { validateInjectedStory, deriveNextStoryId } from "./inject";
 

--- a/src/prd/markdown-scan.ts
+++ b/src/prd/markdown-scan.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared markdown scanning primitives for spec parsing.
+ *
+ * `./out-of-scope-extract` and `./modifies-extract` both walk a spec's raw lines
+ * looking for a named section and folding its bullets into items. The mechanics
+ * they share — what counts as a heading, what counts as a bullet, and which
+ * lines sit inside a fenced code block — live here so the two parsers cannot
+ * drift on the question that matters most: whether a construct written *inside*
+ * a fence is real.
+ *
+ * Fence handling in particular is not a detail. spec-kit specs routinely
+ * document their own markdown by example, so a literal ` ```markdown / ###
+ * Modifies ` block appears in specs *about* specs. A parser that treats it as a
+ * real declaration fabricates a directive that is then written into the PRD and
+ * rendered to an implementer as fact.
+ *
+ * Pure and deterministic — no I/O, no PRD types, no LLM.
+ */
+
+/** Any markdown ATX heading, captured so section nesting can be compared. */
+export const ANY_HEADING = /^(#{1,6})\s/;
+
+/** A list item — used both to split bullets and to bound folded prose. */
+export const LIST_ITEM_START = /^\s*(?:[-*+•‣◦⁃∙]|\d+\.)\s+/;
+
+/** A fenced code block delimiter (``` or ~~~), with optional info string. */
+export const FENCE = /^\s*(?:```|~~~)/;
+
+/**
+ * Strip inline emphasis/backticks so heading matching is not defeated by
+ * formatting. `## **Out of Scope**` and `## \`Out of Scope\`` are the same
+ * heading as `## Out of Scope` — treating them differently silently drops the
+ * entire section, which is the exact failure these parsers exist to prevent.
+ */
+export function stripEmphasis(text: string): string {
+  return text.replace(/\*\*/g, "").replace(/[*`_]/g, "");
+}
+
+/** Strip a leading `-`/`*`/`1.` bullet marker. */
+export function stripBullet(line: string): string {
+  return line.replace(LIST_ITEM_START, "").trim();
+}
+
+/**
+ * Indices of every line inside a fenced code block.
+ *
+ * Fenced content is illustrative — a spec documenting markdown (which spec-kit
+ * specs routinely do) contains a literal `## Out of Scope` example. Treating it
+ * as a real declaration fabricates an entry that is then backfilled into the
+ * PRD, pushed onto a story, and rendered to the implementer as a hard
+ * instruction. Every scan over raw lines must consult this.
+ */
+export function fencedLineIndices(lines: readonly string[]): Set<number> {
+  const fenced = new Set<number>();
+  let inFence = false;
+  for (const [i, line] of lines.entries()) {
+    if (FENCE.test(line)) {
+      fenced.add(i);
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) fenced.add(i);
+  }
+  return fenced;
+}

--- a/src/prd/modifies-extract.ts
+++ b/src/prd/modifies-extract.ts
@@ -80,6 +80,9 @@ const PATH_REASON_SEPARATOR = /^\s*[—–-]\s*/;
 /** A leading backticked span — the canonical way a spec writes the path. */
 const BACKTICKED_PATH = /^`([^`]+)`/;
 
+/** Minimum evidence that an unbackticked token is a path and not the first word of a sentence. */
+const PATH_SHAPED = /[/.]/;
+
 /**
  * Lines belonging to the `Modifies` section starting at `startIndex`.
  *
@@ -88,14 +91,20 @@ const BACKTICKED_PATH = /^`([^`]+)`/;
  * never absorbed. The `level === 1` guard is a safety rail: when the section
  * heading is H1 every other section nests under it, and folding the whole
  * document in would fabricate authorisations from unrelated prose.
+ *
+ * A story heading is deliberately NOT exempted from the boundary. A DEEPER one
+ * (`#### US-001` under `### Modifies`) already survives — it fails the level
+ * test and is collected, then read as a group lead-in. Exempting a heading at
+ * the section's own level would only ever swallow a sibling section: `## US-002:
+ * Second story` following `## Modifies` would be read as a group, and every
+ * bullet beneath it would become a fabricated authorisation.
  */
 function sectionLines(lines: readonly string[], startIndex: number, level: number, fenced: Set<number>): string[] {
   const collected: string[] = [];
   for (let i = startIndex + 1; i < lines.length; i++) {
     if (fenced.has(i)) continue;
     const heading = lines[i].match(ANY_HEADING);
-    // A story heading is a group lead-in, not a section boundary — keep it.
-    if (heading && !STORY_HEADING.test(lines[i]) && (heading[1].length <= level || level === 1)) break;
+    if (heading && (heading[1].length <= level || level === 1)) break;
     collected.push(lines[i]);
   }
   return collected;
@@ -104,20 +113,30 @@ function sectionLines(lines: readonly string[], startIndex: number, level: numbe
 /**
  * Split one bullet's folded text into a path and the reason behind it.
  *
- * The path is the leading backticked span when present, else the first
- * whitespace-delimited token — so an author who omits backticks still gets a
- * usable entry rather than a silent drop. Returns null when nothing path-shaped
- * leads the item, which is how a stray prose bullet inside the section is
- * rejected instead of being written into the PRD as a file path.
+ * A leading backticked span is taken as the path verbatim — the author marked it
+ * explicitly, so nothing further is inferred. Without backticks the first
+ * whitespace-delimited token is accepted only when it is **path-shaped** (holds
+ * a `/` or a `.`), which is what stops a stray prose bullet inside the section —
+ * "- see the notes below" — from being written into the PRD as a file named
+ * `see` and rendered to the implementer as a file it may change. Returns null in
+ * that case, dropping the bullet.
+ *
+ * The cost of the rule is a bare extensionless filename (`Makefile`) written
+ * without backticks, which is rejected. That is the right trade: spec-writing
+ * tells authors to backtick paths, and fabricating an authorisation is worse
+ * than declining an ambiguous one.
  */
 function parseEntry(text: string): { path: string; reason: string } | null {
   const backticked = text.match(BACKTICKED_PATH);
-  const [path, rest] = backticked
-    ? [backticked[1].trim(), text.slice(backticked[0].length)]
-    : [(text.match(/^\S+/)?.[0] ?? "").trim(), text.replace(/^\S+/, "")];
+  if (backticked) {
+    const path = backticked[1].trim();
+    if (!path) return null;
+    return { path, reason: text.slice(backticked[0].length).replace(PATH_REASON_SEPARATOR, "").trim() };
+  }
 
-  if (!path) return null;
-  return { path, reason: rest.replace(PATH_REASON_SEPARATOR, "").trim() };
+  const candidate = text.match(/^\S+/)?.[0]?.trim() ?? "";
+  if (!candidate || !PATH_SHAPED.test(candidate)) return null;
+  return { path: candidate, reason: text.replace(/^\S+/, "").replace(PATH_REASON_SEPARATOR, "").trim() };
 }
 
 /**

--- a/src/prd/modifies-extract.ts
+++ b/src/prd/modifies-extract.ts
@@ -1,0 +1,183 @@
+/**
+ * `### Modifies` *extraction* — the markdown side of modification authority.
+ *
+ * A spec's `### Modifies` block is the channel that authorises an implementer to
+ * update an EXISTING file its own correct change necessarily breaks — most often
+ * a test whose closed-world assertion no longer holds under the new behaviour.
+ * spec-review treats a missing entry as a blocker precisely because the
+ * implementer's other option, when a correct implementation fails an existing
+ * assertion, is to revert until the assertion passes.
+ *
+ * ## Why this is parsed, not prompted
+ *
+ * The field is never asked of the planner (#1450). `outOfScope` asks first on
+ * purpose — a planner paraphrase is usually better-worded prose. Here the value
+ * IS the specificity: which test, which assertion, what the new invariant is.
+ * A paraphrase ("update affected engine tests") is exactly the loss this module
+ * exists to prevent, so the spec's words are taken verbatim and the planner is
+ * left out of the loop entirely.
+ *
+ * ## Grammar
+ *
+ * Narrower than the out-of-scope grammar by design — this heading is emitted by
+ * spec-writing to a fixed shape, so there is no setext, table, or prose-paragraph
+ * fallback to support:
+ *
+ * ```
+ * ### Modifies
+ *
+ * **US-001**
+ * - `path/to/file.ts` — reason, folded across continuation lines
+ * ```
+ *
+ * Ownership comes from the nearest `**US-00N**` group lead-in above a bullet —
+ * NOT from the nearest heading, which is how `./out-of-scope-extract` attributes
+ * its story-scoped items. The two sections sit in different territory: `Modifies`
+ * lives between `## Stories` and `## Acceptance Criteria`, where no per-story
+ * headings exist yet.
+ *
+ * Reconciling extracted entries against a PRD lives in `./modifies`; this file
+ * never sees a `PRD`. Pure and deterministic — no I/O, no LLM.
+ */
+
+import { ANY_HEADING, LIST_ITEM_START, fencedLineIndices, stripBullet, stripEmphasis } from "./markdown-scan";
+
+/** One `### Modifies` bullet, with the story its group lead-in attributed it to. */
+export interface SpecModifiedFile {
+  /** Owning story from the nearest `**US-00N**` group above — null when none. */
+  readonly storyId: string | null;
+  readonly path: string;
+  /** The spec's stated reason, verbatim. Empty when the author listed a bare path. */
+  readonly reason: string;
+}
+
+/**
+ * Upper bound on extracted entries. A spec authorising more than this many
+ * existing-file changes has a scope problem, not a modification list; truncating
+ * keeps every downstream story prompt bounded.
+ */
+export const MAX_MODIFIED_FILES = 25;
+
+/**
+ * `### Modifies`, `## Modified Files (per story)`, `### Modifies:` …
+ *
+ * The trailing `\b` (rather than an end anchor) is what admits the parenthetical
+ * suffix real specs use — `### Creates (per story)` and `### Context Files (per
+ * story)` both appear in this repo's own specs, so the sibling heading must
+ * tolerate the same shape.
+ */
+const MODIFIES_HEADING = /^(#{1,6})\s*modifi(?:es|ed\s+files)\b/i;
+
+/** A `**US-001**` group lead-in on its own line — the ownership marker. */
+const GROUP_LEAD_IN = /^\s*\*\*\s*(US-\d+)\s*\*\*\s*:?\s*$/i;
+
+/** A heading naming a story — `#### US-001`, the alternative group form. */
+const STORY_HEADING = /^#{1,6}\s.*\b(US-\d+)\b/i;
+
+/** The dash separating a path from its reason: em, en, or hyphen. */
+const PATH_REASON_SEPARATOR = /^\s*[—–-]\s*/;
+
+/** A leading backticked span — the canonical way a spec writes the path. */
+const BACKTICKED_PATH = /^`([^`]+)`/;
+
+/**
+ * Lines belonging to the `Modifies` section starting at `startIndex`.
+ *
+ * Ends at the next heading whose level is the same as or shallower than the
+ * section heading's, so the neighbouring `### Creates` / `### Seams` blocks are
+ * never absorbed. The `level === 1` guard is a safety rail: when the section
+ * heading is H1 every other section nests under it, and folding the whole
+ * document in would fabricate authorisations from unrelated prose.
+ */
+function sectionLines(lines: readonly string[], startIndex: number, level: number, fenced: Set<number>): string[] {
+  const collected: string[] = [];
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    if (fenced.has(i)) continue;
+    const heading = lines[i].match(ANY_HEADING);
+    // A story heading is a group lead-in, not a section boundary — keep it.
+    if (heading && !STORY_HEADING.test(lines[i]) && (heading[1].length <= level || level === 1)) break;
+    collected.push(lines[i]);
+  }
+  return collected;
+}
+
+/**
+ * Split one bullet's folded text into a path and the reason behind it.
+ *
+ * The path is the leading backticked span when present, else the first
+ * whitespace-delimited token — so an author who omits backticks still gets a
+ * usable entry rather than a silent drop. Returns null when nothing path-shaped
+ * leads the item, which is how a stray prose bullet inside the section is
+ * rejected instead of being written into the PRD as a file path.
+ */
+function parseEntry(text: string): { path: string; reason: string } | null {
+  const backticked = text.match(BACKTICKED_PATH);
+  const [path, rest] = backticked
+    ? [backticked[1].trim(), text.slice(backticked[0].length)]
+    : [(text.match(/^\S+/)?.[0] ?? "").trim(), text.replace(/^\S+/, "")];
+
+  if (!path) return null;
+  return { path, reason: rest.replace(PATH_REASON_SEPARATOR, "").trim() };
+}
+
+/**
+ * Every `### Modifies` entry the spec declares, in document order.
+ *
+ * Fenced lines are skipped entirely: spec-kit specs document their own markdown
+ * by example, so a literal ` ```markdown / ### Modifies ` block would otherwise
+ * fabricate an authorisation that is written into the PRD and rendered to an
+ * implementer as fact.
+ *
+ * Unattributed entries are returned with `storyId: null` rather than guessed at
+ * — deciding what to do with one is the caller's business (see `./modifies`).
+ */
+export function extractSpecModifiedFiles(specContent: string): SpecModifiedFile[] {
+  if (!specContent.trim()) return [];
+  const lines = specContent.split("\n");
+  const fenced = fencedLineIndices(lines);
+
+  const entries: SpecModifiedFile[] = [];
+  for (let i = 0; i < lines.length && entries.length < MAX_MODIFIED_FILES; i++) {
+    if (fenced.has(i)) continue;
+    const heading = stripEmphasis(lines[i]).match(MODIFIES_HEADING);
+    if (!heading) continue;
+    entries.push(...collectSection(sectionLines(lines, i, heading[1].length, fenced)));
+  }
+  return entries.slice(0, MAX_MODIFIED_FILES);
+}
+
+/** One pass over a section body, tracking the group lead-in currently in force. */
+function collectSection(body: readonly string[]): SpecModifiedFile[] {
+  const entries: SpecModifiedFile[] = [];
+  let storyId: string | null = null;
+  let current: string[] = [];
+
+  const flush = () => {
+    const parsed = current.length > 0 ? parseEntry(current.join(" ").replace(/\s+/g, " ").trim()) : null;
+    if (parsed) entries.push({ storyId, ...parsed });
+    current = [];
+  };
+
+  for (const line of body) {
+    const group = line.match(GROUP_LEAD_IN) ?? line.match(STORY_HEADING);
+    if (group) {
+      flush();
+      storyId = group[1].toUpperCase();
+      continue;
+    }
+    if (line.trim().length === 0) {
+      flush();
+      continue;
+    }
+    if (LIST_ITEM_START.test(line)) {
+      flush();
+      current.push(stripBullet(line));
+      continue;
+    }
+    // A continuation line only folds into an OPEN bullet; prose sitting under the
+    // heading before any bullet is a lead-in sentence, not an authorisation.
+    if (current.length > 0) current.push(line.trim());
+  }
+  flush();
+  return entries;
+}

--- a/src/prd/modifies.ts
+++ b/src/prd/modifies.ts
@@ -51,10 +51,21 @@ function isSafeRelativePath(path: string): boolean {
   return !path.startsWith("/") && !path.includes("..");
 }
 
-/** Merge new entries into a story's existing list, first-seen path winning. */
+/**
+ * Merge spec entries into whatever the story already carried, deduplicating on
+ * path.
+ *
+ * Spec entries are ordered first, so on a collision the **spec's** reason wins.
+ * That is the module's whole premise: the spec is the authority and its wording
+ * is carried verbatim. Letting a `prd.json` value survive would mean an edited
+ * spec silently failed to update the authorisation it owns.
+ *
+ * Within one side, first-seen wins — a spec that lists the same path twice keeps
+ * the first reason rather than the last.
+ */
 function mergeEntries(existing: readonly ModifiedFileEntry[], incoming: readonly ModifiedFileEntry[]) {
   const byPath = new Map<string, ModifiedFileEntry>();
-  for (const entry of [...existing, ...incoming]) {
+  for (const entry of [...incoming, ...existing]) {
     if (!byPath.has(entry.path)) byPath.set(entry.path, entry);
   }
   return [...byPath.values()];

--- a/src/prd/modifies.ts
+++ b/src/prd/modifies.ts
@@ -1,0 +1,101 @@
+/**
+ * `### Modifies` preservation — deterministic modification-authority repair.
+ *
+ * Attaches what `./modifies-extract` read out of the spec onto the stories that
+ * declared it. The implementer, rectifier, and reviewers only ever receive a
+ * `UserStory` — never the spec, never the PRD envelope — so an authorisation
+ * that does not reach the story object does not exist as far as they are
+ * concerned. That is the whole of #1450.
+ *
+ * Unlike `./out-of-scope`, there is no feature-level tier and no propagation:
+ * authority to rewrite an existing test belongs to exactly the story that owns
+ * the breaking change. Broadcasting it would tell every other implementer it may
+ * rewrite a test that is not its business.
+ *
+ * Pure and deterministic — no I/O, no LLM.
+ */
+
+import { type SpecModifiedFile, extractSpecModifiedFiles } from "./modifies-extract";
+import type { ModifiedFileEntry, PRD, UserStory } from "./types";
+
+/** Outcome of {@link applyModifiedFiles}: the updated PRD plus what it could not place. */
+export interface ApplyModifiedFilesResult {
+  /** The input reference itself when nothing was attached, so callers can detect a no-op. */
+  readonly prd: PRD;
+  /**
+   * Entries that named no story, or named one absent from the PRD. Dropped
+   * rather than broadcast — the caller is expected to warn, since a silently
+   * discarded authorisation reproduces the deadlock this feature prevents.
+   */
+  readonly orphans: SpecModifiedFile[];
+  /** Entries rejected by {@link isSafeRelativePath}. Reported separately: an unowned entry is an authoring slip, an escaping path is not. */
+  readonly invalidPaths: SpecModifiedFile[];
+}
+
+/**
+ * The same path policy `./schema.ts` enforces on `contextFiles` / `expectedFiles`:
+ * repo-relative, no traversal.
+ *
+ * It has to be re-applied here because of call ordering. `validatePlanOutput`
+ * runs in the plan op's `parse`, but this carry runs in its `verify` — strictly
+ * afterwards — so an entry injected from the spec would reach `prd.json`, and the
+ * implementer's authorisation block, without ever passing the validator that
+ * rejects absolute and `..` paths everywhere else.
+ *
+ * Rejection is a drop-and-warn rather than a throw: this is a fidelity carry, not
+ * a gate, and failing an entire plan over one malformed spec bullet trades a
+ * missing authorisation for no PRD at all. `schema.ts` still throws on the same
+ * shape when a hand-edited `prd.json` is loaded.
+ */
+function isSafeRelativePath(path: string): boolean {
+  return !path.startsWith("/") && !path.includes("..");
+}
+
+/** Merge new entries into a story's existing list, first-seen path winning. */
+function mergeEntries(existing: readonly ModifiedFileEntry[], incoming: readonly ModifiedFileEntry[]) {
+  const byPath = new Map<string, ModifiedFileEntry>();
+  for (const entry of [...existing, ...incoming]) {
+    if (!byPath.has(entry.path)) byPath.set(entry.path, entry);
+  }
+  return [...byPath.values()];
+}
+
+/**
+ * Attach every spec-declared `### Modifies` entry to its owning story.
+ *
+ * Returns the input PRD unchanged (same reference) when the spec declares
+ * nothing, or when every entry is an orphan — attaching nothing must not look
+ * like a rewrite to callers that compare references.
+ */
+export function applyModifiedFiles(prd: PRD, specContent: string): ApplyModifiedFilesResult {
+  const declared = extractSpecModifiedFiles(specContent);
+  if (declared.length === 0) return { prd, orphans: [], invalidPaths: [] };
+
+  const storyIds = new Set(prd.userStories.map((story) => story.id));
+  const byStory = new Map<string, ModifiedFileEntry[]>();
+  const orphans: SpecModifiedFile[] = [];
+  const invalidPaths: SpecModifiedFile[] = [];
+
+  for (const entry of declared) {
+    // Checked before ownership: an escaping path is rejected whether or not a
+    // story claims it, so a valid group lead-in cannot launder one through.
+    if (!isSafeRelativePath(entry.path)) {
+      invalidPaths.push(entry);
+      continue;
+    }
+    if (!entry.storyId || !storyIds.has(entry.storyId)) {
+      orphans.push(entry);
+      continue;
+    }
+    const entries = byStory.get(entry.storyId) ?? [];
+    entries.push({ path: entry.path, reason: entry.reason });
+    byStory.set(entry.storyId, entries);
+  }
+  if (byStory.size === 0) return { prd, orphans, invalidPaths };
+
+  const userStories: UserStory[] = prd.userStories.map((story) => {
+    const incoming = byStory.get(story.id);
+    return incoming ? { ...story, modifiedFiles: mergeEntries(story.modifiedFiles ?? [], incoming) } : story;
+  });
+  return { prd: { ...prd, userStories }, orphans, invalidPaths };
+}

--- a/src/prd/out-of-scope-extract.ts
+++ b/src/prd/out-of-scope-extract.ts
@@ -22,6 +22,8 @@
  * backticks stripped, lowercased) and by substring, never by equality.
  */
 
+import { ANY_HEADING, FENCE, LIST_ITEM_START, fencedLineIndices, stripBullet, stripEmphasis } from "./markdown-scan";
+
 /** An extracted item plus the line its declaration started on. */
 interface PlacedItem {
   readonly lineIndex: number;
@@ -48,12 +50,6 @@ const OUT_OF_SCOPE_TITLE = /^(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?|not[\s-]i
 /** `## Out of Scope`, `### Non-Goals`, `## Not in scope`, `## Out-of-scope`, … */
 const OUT_OF_SCOPE_HEADING = /^(#{1,6})\s*(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?|not[\s-]in[\s-]scope)\b/i;
 
-/** Any markdown ATX heading, captured so section nesting can be compared. */
-const ANY_HEADING = /^(#{1,6})\s/;
-
-/** A fenced code block delimiter (``` or ~~~), with optional info string. */
-const FENCE = /^\s*(?:```|~~~)/;
-
 /** A markdown table separator row: `|---|:--:|`. Carries no content. */
 const TABLE_SEPARATOR = /^\s*\|?[\s:|-]+\|[\s:|-]*$/;
 
@@ -75,16 +71,6 @@ const STORY_ID_HEADING = /^#{1,6}\s.*\b(US-\d+)\b/i;
 
 /** A setext underline — `===` (H1) or `---` (H2) beneath a title line. */
 const SETEXT_UNDERLINE = /^\s*(?:=+|-+)\s*$/;
-
-/**
- * Strip inline emphasis/backticks so heading matching is not defeated by
- * formatting. `## **Out of Scope**` and `## \`Out of Scope\`` are the same
- * heading as `## Out of Scope` — treating them differently silently drops the
- * entire section, which is the exact failure this module exists to prevent.
- */
-function stripEmphasis(text: string): string {
-  return text.replace(/\*\*/g, "").replace(/[*`_]/g, "");
-}
 
 /**
  * Heading level when `line` opens an out-of-scope section, else null.
@@ -120,17 +106,9 @@ function isSetextUnderline(lines: string[], index: number): boolean {
  */
 export const INLINE_MARKER = /^\s*(?:[-*]\s*)?\*\*\s*(?:out[\s-]?of[\s-]?scope|non[\s-]?goals?)[^*]*\*\*\s*:?\s*/i;
 
-/** A list item — used both to split bullets and to bound folded prose. */
-const LIST_ITEM_START = /^\s*(?:[-*+\u2022\u2023\u25E6\u2043\u2219]|\d+\.)\s+/;
-
 /** Collapse whitespace, strip backticks, lowercase — the comparison form. */
 export function canonical(text: string): string {
   return text.replace(/`/g, "").replace(/\s+/g, " ").trim().toLowerCase();
-}
-
-/** Strip a leading `-`/`*`/`1.` bullet marker. */
-function stripBullet(line: string): string {
-  return line.replace(LIST_ITEM_START, "").trim();
 }
 
 /**
@@ -240,29 +218,6 @@ function itemsFromSection(body: string[]): string[] {
   }
   flush();
   return items;
-}
-
-/**
- * Indices of every line inside a fenced code block.
- *
- * Fenced content is illustrative — a spec documenting markdown (which spec-kit
- * specs routinely do) contains a literal `## Out of Scope` example. Treating it
- * as a real declaration fabricates an exclusion that is then backfilled into the
- * PRD, pushed onto every story, and rendered to the implementer as a hard
- * boundary. Every scan over raw lines must consult this.
- */
-function fencedLineIndices(lines: string[]): Set<number> {
-  const fenced = new Set<number>();
-  let inFence = false;
-  for (const [i, line] of lines.entries()) {
-    if (FENCE.test(line)) {
-      fenced.add(i);
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) fenced.add(i);
-  }
-  return fenced;
 }
 
 /**

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -10,7 +10,7 @@ import { NaxError } from "../errors";
 import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas } from "../utils/llm-json";
 export { extractJsonFromMarkdown };
 import { normalizeOutOfScopeList } from "./out-of-scope";
-import type { ContextFileEntry, PRD, UserStory } from "./types";
+import type { ContextFileEntry, ModifiedFileEntry, PRD, UserStory } from "./types";
 import { validateStoryId } from "./validate";
 
 // ---------------------------------------------------------------------------
@@ -336,6 +336,40 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
     }
   }
 
+  // modifiedFiles — optional list of EXISTING files this story is authorised to
+  // change, each with the spec's reason. Same path rules as contextFiles.
+  // Populated deterministically from the spec's `### Modifies` section rather
+  // than by the planner (see ./modifies-extract), but validated here all the
+  // same: a prd.json edited by hand reaches this path too.
+  const rawModifiedFiles = s.modifiedFiles;
+  const modifiedFiles: ModifiedFileEntry[] = [];
+  if (Array.isArray(rawModifiedFiles)) {
+    for (const f of rawModifiedFiles as unknown[]) {
+      if (typeof f !== "object" || f === null) continue; // non-object entries silently filtered
+      const obj = f as Record<string, unknown>;
+      if (typeof obj.path !== "string") continue;
+      const path = obj.path.trim();
+      if (path === "") continue;
+      if (path.startsWith("/")) {
+        throw new NaxError(
+          `[schema] story[${index}].modifiedFiles entry must be relative (no absolute paths): "${path}"`,
+          "SCHEMA_VALIDATION_FAILED",
+          { stage: "schema", index, filePath: path },
+        );
+      }
+      if (path.includes("..")) {
+        throw new NaxError(
+          `[schema] story[${index}].modifiedFiles entry must not contain '..': "${path}"`,
+          "SCHEMA_VALIDATION_FAILED",
+          { stage: "schema", index, filePath: path },
+        );
+      }
+      // An empty reason is legitimate — the spec author listed a bare path, and
+      // an authorisation without a rationale still clears the deadlock.
+      modifiedFiles.push({ path, reason: typeof obj.reason === "string" ? obj.reason.trim() : "" });
+    }
+  }
+
   // verifiedBy — optional citation anchor (Phase 2)
   const VALID_VERIFIED_BY_KINDS = ["test", "symbol", "file"] as const;
   type VerifiedByKind = (typeof VALID_VERIFIED_BY_KINDS)[number];
@@ -386,6 +420,7 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
     ...(workdir !== undefined ? { workdir } : {}),
     ...(contextFiles.length > 0 ? { contextFiles } : {}),
     ...(expectedFiles.length > 0 ? { expectedFiles } : {}),
+    ...(modifiedFiles.length > 0 ? { modifiedFiles } : {}),
     ...(suggestedCriteria !== undefined ? { suggestedCriteria } : {}),
     ...(storyOutOfScope !== undefined ? { outOfScope: storyOutOfScope } : {}),
     ...(verifiedBy !== undefined ? { verifiedBy } : {}),

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -14,6 +14,17 @@ export interface ContextFileEntry {
   factId?: string;
 }
 
+/**
+ * An existing file a story is authorised to change, and the spec's stated
+ * reason. `reason` carries the spec's wording verbatim and may be empty when the
+ * author listed a bare path — an authorisation without a rationale is still an
+ * authorisation, and dropping it would reinstate the deadlock it prevents.
+ */
+export interface ModifiedFileEntry {
+  path: string;
+  reason: string;
+}
+
 /** User story status */
 export type StoryStatus =
   | "pending"
@@ -166,6 +177,19 @@ export interface UserStory {
   intent?: boolean;
   /** Files that must exist after execution (pre-flight gate) */
   expectedFiles?: string[];
+  /**
+   * Existing files this story is explicitly authorised to change, with the
+   * spec's own reason for each. Extracted deterministically from the spec's
+   * `### Modifies` section (see `./modifies-extract`) — never asked of the
+   * planner, because the value here is the verbatim specificity (which test,
+   * which assertion, what the new invariant is) that a paraphrase destroys.
+   *
+   * Distinct from `contextFiles` (read) and `expectedFiles` (create): this is
+   * the authorisation an implementer needs when its own correct change makes an
+   * existing assertion fail. Without it the implementer's remaining option is to
+   * revert until the assertion passes.
+   */
+  modifiedFiles?: ModifiedFileEntry[];
   /** Prior error messages from failed attempts */
   priorErrors?: string[];
   /** Structured failure context for escalated tiers */

--- a/src/prompts/sections/index.ts
+++ b/src/prompts/sections/index.ts
@@ -9,6 +9,7 @@ export { buildIsolationSection } from "./isolation";
 export { buildRoleTaskSection } from "./role-task";
 export { buildBatchStorySection, buildStoryReminderSection, buildStorySection } from "./story";
 export { buildOutOfScopeLines, buildReviewOutOfScopeBlock } from "./out-of-scope";
+export { buildModifiedFilesLines } from "./modified-files";
 export { buildVerdictSection } from "./verdict";
 export { buildConventionsSection } from "./conventions";
 export { buildTddLanguageSection } from "./tdd-conventions";

--- a/src/prompts/sections/modified-files.ts
+++ b/src/prompts/sections/modified-files.ts
@@ -1,0 +1,44 @@
+/**
+ * Modified-Files Section
+ *
+ * Renders `story.modifiedFiles` — the existing files the spec explicitly
+ * authorises this story to change, extracted from its `### Modifies` block
+ * (src/prd/modifies-extract.ts).
+ *
+ * This block exists to break one specific deadlock. When a story's own correct
+ * change makes an existing assertion fail, an implementer with no authorisation
+ * has exactly two moves: leave the suite red, or revert its change until the old
+ * assertion passes again. nax has been observed taking the second (#1450). The
+ * spec author's reason is carried verbatim precisely because the useful content
+ * is the specifics — which test, which assertion, what the new invariant is.
+ *
+ * Rendered as its own labelled block rather than folded into the description,
+ * for the same reason the out-of-scope block is: an authorisation read as a task
+ * becomes busywork, and this list is permission, never instruction.
+ */
+
+import type { ModifiedFileEntry } from "@/prd/types";
+
+/**
+ * Imperative block for a story-implementing role. Returned as lines so callers
+ * can spread it into an existing section array; `[]` when the story carries no
+ * authorisations.
+ *
+ * An entry whose `reason` is empty renders as a bare path — the spec author
+ * listed one without a rationale, and a permission with no stated reason is
+ * still a permission.
+ */
+export function buildModifiedFilesLines(entries: readonly ModifiedFileEntry[] | undefined): string[] {
+  if (!entries || entries.length === 0) return [];
+  return [
+    "",
+    "**Existing files this story is authorised to modify:**",
+    ...entries.map((entry) => (entry.reason ? `- \`${entry.path}\` — ${entry.reason}` : `- \`${entry.path}\``)),
+    "",
+    "These files already exist and this story's change is expected to break them. You are permitted to",
+    "update them to match the new behaviour. If an assertion in one of them fails against an",
+    "implementation you believe is correct, update the assertion — do NOT revert your change to make the",
+    "old assertion pass. This list is permission, not a task: touch these files only if your change",
+    "actually requires it.",
+  ];
+}

--- a/src/prompts/sections/story.ts
+++ b/src/prompts/sections/story.ts
@@ -5,6 +5,7 @@
  */
 
 import type { UserStory } from "../../prd/types";
+import { buildModifiedFilesLines } from "./modified-files";
 import { buildOutOfScopeLines } from "./out-of-scope";
 
 /**
@@ -14,6 +15,16 @@ import { buildOutOfScopeLines } from "./out-of-scope";
  */
 function outOfScopeLines(story: UserStory): string[] {
   return buildOutOfScopeLines(story.outOfScope);
+}
+
+/**
+ * Existing files the spec authorises this story to change (see
+ * src/prd/modifies.ts). Ordered after the exclusions so the two boundary blocks
+ * read together: what this story must not do, then what it is permitted to
+ * touch despite the file already existing.
+ */
+function modifiedFilesLines(story: UserStory): string[] {
+  return buildModifiedFilesLines(story.modifiedFiles);
 }
 
 export function buildBatchStorySection(stories: UserStory[]): string {
@@ -27,6 +38,7 @@ export function buildBatchStorySection(stories: UserStory[]): string {
       "**Acceptance Criteria:**",
       criteria,
       ...outOfScopeLines(story),
+      ...modifiedFilesLines(story),
     ].join("\n");
   });
 
@@ -65,6 +77,7 @@ export function buildStoryReminderSection(story: UserStory): string {
     "**Acceptance Criteria:**",
     criteria,
     ...outOfScopeLines(story),
+    ...modifiedFilesLines(story),
     "",
     "<!-- END USER-SUPPLIED DATA -->",
   ].join("\n");
@@ -88,6 +101,7 @@ export function buildStorySection(story: UserStory): string {
     "**Acceptance Criteria:**",
     criteria,
     ...outOfScopeLines(story),
+    ...modifiedFilesLines(story),
     "",
     "<!-- END USER-SUPPLIED DATA -->",
   ].join("\n");

--- a/test/unit/operations/plan-fidelity.test.ts
+++ b/test/unit/operations/plan-fidelity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { applyPlanFidelity, backfillModifiedFiles, backfillOutOfScope } from "@/operations";
+import { makePRD, makeStory } from "@test/helpers";
+
+const SPEC = [
+  "# Feature",
+  "",
+  "## Out of Scope",
+  "",
+  "- An interactive Ink TUI",
+  "",
+  "## Stories",
+  "",
+  "1. **US-001: First** — no dependencies.",
+  "2. **US-002: Second** — no dependencies.",
+  "",
+  "### Modifies",
+  "",
+  "**US-001**",
+  "- `test/unit/engine/orchestrator.test.ts` — the identity no longer holds under the new accounting",
+].join("\n");
+
+const twoStoryPrd = () => makePRD({ userStories: [makeStory({ id: "US-001" }), makeStory({ id: "US-002" })] });
+
+describe("backfillModifiedFiles", () => {
+  test("attaches a spec-declared entry to its owning story only", () => {
+    const result = backfillModifiedFiles(twoStoryPrd(), SPEC, "feat");
+
+    expect(result.userStories[0].modifiedFiles).toEqual([
+      {
+        path: "test/unit/engine/orchestrator.test.ts",
+        reason: "the identity no longer holds under the new accounting",
+      },
+    ]);
+    expect(result.userStories[1].modifiedFiles).toBeUndefined();
+  });
+
+  test("drops an entry naming a story the PRD does not contain", () => {
+    const spec = ["### Modifies", "", "**US-404**", "- `src/ghost.ts` — owned by nobody here"].join("\n");
+    const input = twoStoryPrd();
+
+    const result = backfillModifiedFiles(input, spec, "feat");
+
+    expect(result).toBe(input);
+    expect(result.userStories.every((s) => s.modifiedFiles === undefined)).toBe(true);
+  });
+
+  test("returns the input reference when the spec declares no Modifies section", () => {
+    const input = twoStoryPrd();
+    expect(backfillModifiedFiles(input, "# Feature\n\n## Design", "feat")).toBe(input);
+  });
+});
+
+describe("applyPlanFidelity", () => {
+  test("applies the out-of-scope backfill and the Modifies carry in one pass", () => {
+    const result = applyPlanFidelity(twoStoryPrd(), SPEC, "feat");
+
+    expect(result.outOfScope).toEqual(["An interactive Ink TUI"]);
+    expect(result.userStories[0].modifiedFiles).toHaveLength(1);
+  });
+
+  test("matches backfillOutOfScope for a spec that declares no Modifies", () => {
+    const specWithoutModifies = SPEC.split("### Modifies")[0];
+    const viaFidelity = applyPlanFidelity(twoStoryPrd(), specWithoutModifies, "feat");
+    const viaOutOfScope = backfillOutOfScope(twoStoryPrd(), specWithoutModifies, "feat");
+
+    expect(viaFidelity.outOfScope).toEqual(viaOutOfScope.outOfScope);
+    expect(viaFidelity.userStories.every((s) => s.modifiedFiles === undefined)).toBe(true);
+  });
+});

--- a/test/unit/prd/modifies.test.ts
+++ b/test/unit/prd/modifies.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+import { MAX_MODIFIED_FILES, applyModifiedFiles, extractSpecModifiedFiles } from "@/prd";
+import { makePRD, makeStory } from "@test/helpers";
+
+/** The canonical shape spec-kit's spec-writing guide produces. */
+const CANONICAL_SPEC = [
+  "# Feature",
+  "",
+  "## Stories",
+  "",
+  "1. **US-001: Budget arithmetic** — no dependencies.",
+  "2. **US-002: Truncation** — no dependencies.",
+  "",
+  "### Creates",
+  "",
+  "**US-001**",
+  "- `test/unit/context/engine/available-budget.test.ts` — first tests for an untested module",
+  "",
+  "### Modifies",
+  "",
+  "**US-001**",
+  '- `test/unit/context/engine/orchestrator.test.ts` — the test named "chunkTokens covers exactly the',
+  '  included chunks" (`:99-110`) asserts `summed === usedTokens - digestTokens`. US-001 owns updating',
+  "  it to the new invariant.",
+  "",
+  "**US-002**",
+  "- `test/unit/context/rules/canonical-loader.test.ts` — the truncation test asserts a best-fit skip",
+  "",
+  "### Seams",
+  "",
+  "- **US-001** something else entirely",
+].join("\n");
+
+describe("extractSpecModifiedFiles", () => {
+  test("extracts one entry per bullet, attributed to its `**US-00N**` group", () => {
+    const entries = extractSpecModifiedFiles(CANONICAL_SPEC);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].storyId).toBe("US-001");
+    expect(entries[0].path).toBe("test/unit/context/engine/orchestrator.test.ts");
+    expect(entries[1].storyId).toBe("US-002");
+    expect(entries[1].path).toBe("test/unit/context/rules/canonical-loader.test.ts");
+  });
+
+  test("folds wrapped continuation lines into the reason verbatim", () => {
+    const [first] = extractSpecModifiedFiles(CANONICAL_SPEC);
+
+    expect(first.reason).toContain("chunkTokens covers exactly the included chunks");
+    expect(first.reason).toContain("US-001 owns updating it to the new invariant.");
+    // The path itself must not survive into the reason — it has its own field.
+    expect(first.reason.startsWith("test/unit/")).toBe(false);
+  });
+
+  test("stops at the next sibling heading, so neighbouring sections are not absorbed", () => {
+    const entries = extractSpecModifiedFiles(CANONICAL_SPEC);
+
+    expect(entries.some((e) => e.path.includes("available-budget"))).toBe(false);
+    expect(entries.some((e) => e.reason.includes("something else entirely"))).toBe(false);
+  });
+
+  test("ignores a `### Modifies` block written inside a fenced code example", () => {
+    const spec = [
+      "# Spec about specs",
+      "",
+      "Authors write the block like this:",
+      "",
+      "```markdown",
+      "### Modifies",
+      "",
+      "**US-001**",
+      "- `src/fabricated.ts` — this is documentation, not a real authorisation",
+      "```",
+      "",
+      "## Design",
+    ].join("\n");
+
+    expect(extractSpecModifiedFiles(spec)).toEqual([]);
+  });
+
+  test("returns an unattributed entry with a null storyId rather than guessing", () => {
+    const spec = ["## Modifies", "", "- `src/orphan.ts` — nobody declared which story owns this"].join("\n");
+
+    const entries = extractSpecModifiedFiles(spec);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].storyId).toBeNull();
+    expect(entries[0].path).toBe("src/orphan.ts");
+  });
+
+  test("accepts a parenthetical heading suffix and the `Modified Files` spelling", () => {
+    const spec = [
+      "### Modified Files (per story)",
+      "",
+      "**US-003**",
+      "- `src/a.ts` — reason a",
+    ].join("\n");
+
+    const entries = extractSpecModifiedFiles(spec);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].storyId).toBe("US-003");
+  });
+
+  test("records a bare path with an empty reason rather than dropping the authorisation", () => {
+    const spec = ["### Modifies", "", "**US-001**", "- `src/bare.ts`"].join("\n");
+
+    expect(extractSpecModifiedFiles(spec)).toEqual([{ storyId: "US-001", path: "src/bare.ts", reason: "" }]);
+  });
+
+  test("returns an empty list for a spec with no Modifies section", () => {
+    expect(extractSpecModifiedFiles("# Feature\n\n## Design\n\n- nothing here")).toEqual([]);
+    expect(extractSpecModifiedFiles("")).toEqual([]);
+  });
+
+  test("caps runaway sections at MAX_MODIFIED_FILES", () => {
+    const bullets = Array.from({ length: MAX_MODIFIED_FILES + 10 }, (_, i) => `- \`src/f${i}.ts\` — reason ${i}`);
+    const spec = ["### Modifies", "", "**US-001**", ...bullets].join("\n");
+
+    expect(extractSpecModifiedFiles(spec)).toHaveLength(MAX_MODIFIED_FILES);
+  });
+});
+
+describe("applyModifiedFiles", () => {
+  const prdWithTwoStories = () =>
+    makePRD({
+      userStories: [makeStory({ id: "US-001" }), makeStory({ id: "US-002" })],
+    });
+
+  test("attaches each entry to the story that declared it, and to no other", () => {
+    const { prd } = applyModifiedFiles(prdWithTwoStories(), CANONICAL_SPEC);
+
+    const [first, second] = prd.userStories;
+    expect(first.modifiedFiles).toEqual([
+      { path: "test/unit/context/engine/orchestrator.test.ts", reason: expect.stringContaining("chunkTokens") },
+    ]);
+    expect(second.modifiedFiles).toEqual([
+      { path: "test/unit/context/rules/canonical-loader.test.ts", reason: expect.stringContaining("best-fit skip") },
+    ]);
+  });
+
+  test("reports an unattributed entry as an orphan and attaches it nowhere", () => {
+    const spec = ["### Modifies", "", "- `src/orphan.ts` — no owning group"].join("\n");
+
+    const { prd, orphans } = applyModifiedFiles(prdWithTwoStories(), spec);
+
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].path).toBe("src/orphan.ts");
+    expect(prd.userStories.every((s) => s.modifiedFiles === undefined)).toBe(true);
+  });
+
+  test("reports an entry naming a story absent from the PRD as an orphan", () => {
+    const spec = ["### Modifies", "", "**US-999**", "- `src/ghost.ts` — owned by a story that does not exist"].join(
+      "\n",
+    );
+
+    const { prd, orphans } = applyModifiedFiles(prdWithTwoStories(), spec);
+
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].storyId).toBe("US-999");
+    expect(prd.userStories.every((s) => s.modifiedFiles === undefined)).toBe(true);
+  });
+
+  test("deduplicates repeated paths within one story, keeping the first reason", () => {
+    const spec = [
+      "### Modifies",
+      "",
+      "**US-001**",
+      "- `src/dup.ts` — first reason",
+      "- `src/dup.ts` — second reason",
+    ].join("\n");
+
+    const { prd } = applyModifiedFiles(prdWithTwoStories(), spec);
+
+    expect(prd.userStories[0].modifiedFiles).toEqual([{ path: "src/dup.ts", reason: "first reason" }]);
+  });
+
+  // The plan op runs validatePlanOutput in `parse` but this carry in `verify`,
+  // so without a check here an escaping path reaches prd.json and the
+  // implementer's authorisation block without meeting the schema's path policy.
+  test.each([
+    ["an absolute path", "/etc/passwd"],
+    ["a traversing path", "../../../etc/passwd"],
+    ["a traversal buried mid-path", "src/../../secrets.txt"],
+  ])("rejects %s instead of attaching it", (_label, path) => {
+    const input = prdWithTwoStories();
+    const spec = ["### Modifies", "", "**US-001**", `- \`${path}\` — looks legitimate`].join("\n");
+
+    const { prd, invalidPaths, orphans } = applyModifiedFiles(input, spec);
+
+    expect(invalidPaths).toHaveLength(1);
+    expect(invalidPaths[0].path).toBe(path);
+    expect(orphans).toEqual([]);
+    expect(prd).toBe(input);
+    expect(prd.userStories.every((s) => s.modifiedFiles === undefined)).toBe(true);
+  });
+
+  test("rejects an escaping path while still attaching the safe entries beside it", () => {
+    const spec = [
+      "### Modifies",
+      "",
+      "**US-001**",
+      "- `/etc/passwd` — rejected",
+      "- `src/safe.ts` — kept",
+    ].join("\n");
+
+    const { prd, invalidPaths } = applyModifiedFiles(prdWithTwoStories(), spec);
+
+    expect(invalidPaths.map((e) => e.path)).toEqual(["/etc/passwd"]);
+    expect(prd.userStories[0].modifiedFiles).toEqual([{ path: "src/safe.ts", reason: "kept" }]);
+  });
+
+  test("returns the input PRD reference unchanged when the spec declares nothing", () => {
+    const input = prdWithTwoStories();
+    const { prd, orphans } = applyModifiedFiles(input, "# Feature\n\n## Design");
+
+    expect(prd).toBe(input);
+    expect(orphans).toEqual([]);
+  });
+
+  test("returns the input PRD reference unchanged when every entry is an orphan", () => {
+    const input = prdWithTwoStories();
+    const { prd } = applyModifiedFiles(input, "### Modifies\n\n- `src/orphan.ts` — unowned");
+
+    expect(prd).toBe(input);
+  });
+
+  test("preserves modifiedFiles the PRD already carried for an untouched story", () => {
+    const existing = { path: "src/kept.ts", reason: "already there" };
+    const input = makePRD({
+      userStories: [makeStory({ id: "US-001", modifiedFiles: [existing] }), makeStory({ id: "US-002" })],
+    });
+
+    const { prd } = applyModifiedFiles(input, "### Modifies\n\n**US-002**\n- `src/new.ts` — added now");
+
+    expect(prd.userStories[0].modifiedFiles).toEqual([existing]);
+    expect(prd.userStories[1].modifiedFiles).toEqual([{ path: "src/new.ts", reason: "added now" }]);
+  });
+});

--- a/test/unit/prd/modifies.test.ts
+++ b/test/unit/prd/modifies.test.ts
@@ -107,6 +107,50 @@ describe("extractSpecModifiedFiles", () => {
     expect(extractSpecModifiedFiles(spec)).toEqual([{ storyId: "US-001", path: "src/bare.ts", reason: "" }]);
   });
 
+  // A story heading at the section's OWN level is a sibling section, not a group.
+  // Exempting it would read `## US-002` as a group and turn every bullet beneath
+  // it into a fabricated authorisation.
+  test("stops at a same-level story heading instead of swallowing it as a group", () => {
+    const spec = [
+      "## Modifies",
+      "",
+      "**US-001**",
+      "- `src/real.ts` — genuinely authorised",
+      "",
+      "## US-002: Second story",
+      "",
+      "- `src/not-authorised.ts` — this is a story bullet, not a Modifies entry",
+    ].join("\n");
+
+    const entries = extractSpecModifiedFiles(spec);
+
+    expect(entries).toEqual([{ storyId: "US-001", path: "src/real.ts", reason: "genuinely authorised" }]);
+  });
+
+  test("still reads a DEEPER story heading as a group lead-in", () => {
+    const spec = ["### Modifies", "", "#### US-004", "- `src/deep.ts` — grouped by a heading, not bold"].join("\n");
+
+    expect(extractSpecModifiedFiles(spec)).toEqual([
+      { storyId: "US-004", path: "src/deep.ts", reason: "grouped by a heading, not bold" },
+    ]);
+  });
+
+  // Without a path-shape check the first word of a prose bullet becomes a file
+  // the implementer is told it may change.
+  test("drops a prose bullet instead of inventing a path from its first word", () => {
+    const spec = ["### Modifies", "", "**US-001**", "- see the notes below for details"].join("\n");
+
+    expect(extractSpecModifiedFiles(spec)).toEqual([]);
+  });
+
+  test("accepts an unbackticked path-shaped token", () => {
+    const spec = ["### Modifies", "", "**US-001**", "- src/plain.ts — no backticks here"].join("\n");
+
+    expect(extractSpecModifiedFiles(spec)).toEqual([
+      { storyId: "US-001", path: "src/plain.ts", reason: "no backticks here" },
+    ]);
+  });
+
   test("returns an empty list for a spec with no Modifies section", () => {
     expect(extractSpecModifiedFiles("# Feature\n\n## Design\n\n- nothing here")).toEqual([]);
     expect(extractSpecModifiedFiles("")).toEqual([]);
@@ -222,6 +266,19 @@ describe("applyModifiedFiles", () => {
     const { prd } = applyModifiedFiles(input, "### Modifies\n\n- `src/orphan.ts` — unowned");
 
     expect(prd).toBe(input);
+  });
+
+  test("lets the spec's reason win over a stale one already in the PRD", () => {
+    const input = makePRD({
+      userStories: [
+        makeStory({ id: "US-001", modifiedFiles: [{ path: "src/x.ts", reason: "stale reason from a prior plan" }] }),
+        makeStory({ id: "US-002" }),
+      ],
+    });
+
+    const { prd } = applyModifiedFiles(input, "### Modifies\n\n**US-001**\n- `src/x.ts` — the spec's current reason");
+
+    expect(prd.userStories[0].modifiedFiles).toEqual([{ path: "src/x.ts", reason: "the spec's current reason" }]);
   });
 
   test("preserves modifiedFiles the PRD already carried for an untouched story", () => {

--- a/test/unit/prd/schema.test.ts
+++ b/test/unit/prd/schema.test.ts
@@ -397,6 +397,52 @@ describe("validatePlanOutput — expectedFiles parsing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// modifiedFiles (existing files the story may change) — issue #1450
+// ---------------------------------------------------------------------------
+
+describe("validatePlanOutput — modifiedFiles parsing", () => {
+  test("survives the round-trip with path and reason intact", () => {
+    const story = makeStory({
+      modifiedFiles: [{ path: "test/unit/engine/orchestrator.test.ts", reason: "the identity no longer holds" }],
+    });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].modifiedFiles).toEqual([
+      { path: "test/unit/engine/orchestrator.test.ts", reason: "the identity no longer holds" },
+    ]);
+  });
+
+  test("keeps an entry whose reason is missing rather than dropping the authorisation", () => {
+    const story = makeStory({ modifiedFiles: [{ path: "src/bare.ts" } as never] });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].modifiedFiles).toEqual([{ path: "src/bare.ts", reason: "" }]);
+  });
+
+  test("filters entries that are not objects or carry no path", () => {
+    const story = makeStory({
+      modifiedFiles: ["src/str.ts", 42, null, { reason: "no path" }, { path: "  " }, { path: "src/ok.ts" }] as never,
+    });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].modifiedFiles).toEqual([{ path: "src/ok.ts", reason: "" }]);
+  });
+
+  test.each([
+    ["not present on story", makeStory()],
+    ["empty array", makeStory({ modifiedFiles: [] })],
+  ])("omits modifiedFiles when %s", (_label, story) => {
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].modifiedFiles).toBeUndefined();
+  });
+
+  test.each([
+    ["contains '..'", "../../../etc/passwd", /modifiedFiles.*\.\./i],
+    ["is an absolute path", "/etc/passwd", /modifiedFiles.*absolute/i],
+  ])("throws when a modifiedFiles entry %s", (_label, path, pattern) => {
+    const story = makeStory({ modifiedFiles: [{ path, reason: "r" }] });
+    expect(() => validatePlanOutput(makeInput([story]), "feat", "feat/feat")).toThrow(pattern);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // suggestedCriteria validation
 // ---------------------------------------------------------------------------
 

--- a/test/unit/prompts/sections/modified-files.test.ts
+++ b/test/unit/prompts/sections/modified-files.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { buildModifiedFilesLines } from "@/prompts/sections";
+import { buildBatchStorySection, buildStoryReminderSection, buildStorySection } from "@/prompts/sections";
+import { makeStory } from "@test/helpers";
+
+const ENTRY = {
+  path: "test/unit/engine/orchestrator.test.ts",
+  reason: "the identity no longer holds under the corrected accounting",
+};
+
+describe("buildModifiedFilesLines", () => {
+  test.each([
+    ["undefined", undefined],
+    ["an empty list", []],
+  ])("renders nothing for %s", (_label, entries) => {
+    expect(buildModifiedFilesLines(entries)).toEqual([]);
+  });
+
+  test("renders the path and the spec's reason verbatim", () => {
+    const rendered = buildModifiedFilesLines([ENTRY]).join("\n");
+
+    expect(rendered).toContain("**Existing files this story is authorised to modify:**");
+    expect(rendered).toContain(`\`${ENTRY.path}\` — ${ENTRY.reason}`);
+  });
+
+  test("tells the implementer to update the assertion rather than revert its change", () => {
+    const rendered = buildModifiedFilesLines([ENTRY]).join("\n");
+
+    expect(rendered).toContain("do NOT revert your change");
+  });
+
+  test("renders a bare path when the spec gave no reason", () => {
+    const rendered = buildModifiedFilesLines([{ path: "src/bare.ts", reason: "" }]).join("\n");
+
+    expect(rendered).toContain("- `src/bare.ts`");
+    // No dangling separator when there is nothing after it.
+    expect(rendered).not.toContain("src/bare.ts` —");
+  });
+});
+
+describe("story sections carry modifiedFiles to every builder", () => {
+  const story = makeStory({ id: "US-001", acceptanceCriteria: ["it works"], modifiedFiles: [ENTRY] });
+
+  test.each([
+    ["buildStorySection", () => buildStorySection(story)],
+    ["buildStoryReminderSection", () => buildStoryReminderSection(story)],
+    ["buildBatchStorySection", () => buildBatchStorySection([story])],
+  ])("%s renders the authorisation block", (_label, build) => {
+    const rendered = build();
+
+    expect(rendered).toContain("**Existing files this story is authorised to modify:**");
+    expect(rendered).toContain(ENTRY.path);
+  });
+
+  test("omits the block entirely for a story with no authorisations", () => {
+    expect(buildStorySection(makeStory({ id: "US-002" }))).not.toContain("authorised to modify");
+  });
+
+  // Pre-existing shape, pinned here so it is a decision rather than a surprise:
+  // the reminder section short-circuits to a one-line nudge when a story has no
+  // acceptance criteria, which drops the out-of-scope block too. A story with no
+  // ACs is degenerate — nothing to implement, so nothing to authorise.
+  test("reminder section drops the block for a story with no acceptance criteria", () => {
+    const noCriteria = makeStory({ id: "US-003", acceptanceCriteria: [], modifiedFiles: [ENTRY] });
+
+    expect(buildStoryReminderSection(noCriteria)).not.toContain("authorised to modify");
+    expect(buildStorySection(noCriteria)).toContain("authorised to modify");
+  });
+});


### PR DESCRIPTION
## What

Adds `UserStory.modifiedFiles?: Array<{path, reason}>`, extracted deterministically from a spec's `### Modifies` block and rendered to the implementer as an explicit authorisation block.

Closes #1450.

## Why

`### Modifies` is the channel authorising an implementer to update an **existing** file its own correct change necessarily breaks. It had no representation in `prd.json` and no mention in the plan prompt, so `nax plan` compressed it into generic `description` prose or dropped it entirely.

That matters because of what the implementer does next. When a correct implementation makes an existing assertion fail and nothing authorises editing that test, the remaining move is to revert the change until the assertion passes — the behaviour recorded in the issue.

spec-review's Phase 2 treats a missing `Modifies` entry as a **blocker**. The reviewer half of the toolchain mandated an authorisation channel the planner half had no representation for.

### Measured before/after

`docs/specs/SPEC-context-budget-truth.md:140` declares a 90-word US-001 entry naming the test, the failing assertion, and the invariant that replaces it. What reached `prd.json`, in full:

> …account `priorStageDigest` in the manifest; **update affected engine tests**.

On this branch the entire reason survives verbatim into `modifiedFiles` and into the rendered prompt.

## Design

**The planner is never asked for this field.** `outOfScope` asks first on purpose — a planner paraphrase is usually better-worded prose. Here the value *is* the specificity, so extraction is deterministic and post-parse. No plan-prompt or refine-audit changes were needed.

**Ownership comes from bold `**US-00N**` group lead-ins, not headings.** The section sits between `## Stories` and `## Acceptance Criteria`, where no per-story headings exist yet, so `out-of-scope-extract`'s `owningStoryId` does not apply. Orphans are warned and dropped, never broadcast: an unowned authorisation applied to every story tells N implementers they may rewrite a test only one of them should touch.

**`contextFiles` is deliberately untouched.** `src/context/builder.ts:286` slices it to `FILE_INJECTION_MAX_FILES = 5`, so auto-adding a modified file would silently evict a declared context file.

## Changes

- `src/prd/markdown-scan.ts` — fence/heading/bullet primitives lifted out of `out-of-scope-extract.ts` so both parsers agree on what counts as inside a code fence. No logic change.
- `src/prd/modifies-extract.ts` — the parser.
- `src/prd/modifies.ts` — attaches entries to owning stories.
- `src/prd/types.ts`, `src/prd/schema.ts` — the field, its validation, and the story rebuild it has to be threaded through to survive a round-trip.
- `src/operations/plan-fidelity.ts` — `applyPlanFidelity` runs both deterministic repairs, so the four plan strategies cannot drift on which ones they apply.
- `src/prompts/sections/modified-files.ts` — the rendered block, kept out of the description so it reads as permission rather than a task.

## Two findings fixed in-branch

**Path validation (from automated security review).** The plan op runs `validatePlanOutput` — which enforces the relative-path/no-`..` policy — in `parse()`, but this carry runs in `verify()`, strictly afterwards. An escaping path from a spec would have reached `prd.json` and the implementer's authorisation block without meeting the policy every other file list obeys. `applyModifiedFiles` now re-applies it, reporting `invalidPaths` separately from `orphans`. Drop-and-warn rather than throw: a fidelity carry must not fail an entire plan over one malformed bullet.

**Three parser defects (from self-review), in `df1b744`.** A story-heading exemption in the section-boundary check that was only reachable in the harmful direction; a `parseEntry` docstring that claimed a path-shape check the code never performed, so a prose bullet produced a file named `see`; and a merge precedence that let a stale `prd.json` value outrank the spec on the same path.

## Testing

- [x] `bun run test` — 11,404 unit + 1,092 integration + 24 ui, 0 failures
- [x] `bun run typecheck`, `bun run lint`, `bun run build`
- [x] New: `test/unit/prd/modifies.test.ts` (25 cases), `test/unit/prompts/sections/modified-files.test.ts`, `test/unit/operations/plan-fidelity.test.ts` — the last covers `backfillOutOfScope`, which had **no direct test coverage** before this branch.
- [x] Verified end-to-end against the real reproduction spec.

## Notes

- Companion PR in `nax-spec-kit-skills` defines the heading in spec-writing and corrects spec-review's Phase 2, released as 0.3.1. Until now spec-review *required* a heading spec-writing never defined.
- Follow-up **#1466** covers `Context Files` / `Creates`. Deliberately not bundled: measurement shows those mostly survive today (19/20 and 1/1 on a real run), and the single loss traces to the 5-file cap rather than to paraphrase — so deterministic extraction would not fix it, and would delete useful planner additions.