### PR TITLE
fix(cost): strip the effort suffix before the rate-card lookup, and record effort as its own dimension

### DIFF
--- a/src/agents/cost/calculate.ts
+++ b/src/agents/cost/calculate.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ModelTier } from "../../config/schema";
+import { parseModelSpec } from "../acp/model-spec";
 import { COST_RATES, MODEL_PRICING } from "./pricing";
 import type { CostEstimate, ModelCostRates, TokenUsage } from "./types";
 
@@ -122,7 +123,12 @@ export function addTokenUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
  * @returns Estimated cost in USD
  */
 export function estimateCostFromTokenUsage(usage: TokenUsage, model: string): number {
-  const pricing = MODEL_PRICING[model];
+  // #1464: nax profiles name codex models with a reasoning-effort suffix
+  // ("gpt-5.6-luna[high]"); MODEL_PRICING is keyed on the bare id, so a rate
+  // card can never be hit unless the suffix is stripped first. Parsing a bare
+  // id is a no-op, so this is safe to apply unconditionally.
+  const { model: bareModel } = parseModelSpec(model);
+  const pricing = MODEL_PRICING[bareModel];
 
   if (!pricing) {
     // Fallback: use average rate for unknown models
@@ -167,5 +173,8 @@ export function estimateCostFromTokenUsage(usage: TokenUsage, model: string): nu
  */
 export function resolvePricingSource(model: string | undefined): "model-rates" | "fallback-rates" | "unknown-model" {
   if (model === undefined || model === "" || model === "unknown") return "unknown-model";
-  return MODEL_PRICING[model] ? "model-rates" : "fallback-rates";
+  // #1464: same normalization as estimateCostFromTokenUsage, so the two stay
+  // in agreement about which rate card produced the number.
+  const { model: bareModel } = parseModelSpec(model);
+  return MODEL_PRICING[bareModel] ? "model-rates" : "fallback-rates";
 }

--- a/src/agents/manager-dispatch.ts
+++ b/src/agents/manager-dispatch.ts
@@ -16,26 +16,35 @@ import { NaxError } from "../errors";
 import type { CompleteDispatchEvent, DispatchErrorEvent, SessionTurnDispatchEvent } from "../runtime/dispatch-events";
 import type { SessionRole } from "../runtime/session-role";
 import { errorMessage } from "../utils/errors";
+import { parseModelSpec } from "./acp/model-spec";
 import type { RunAsSessionOpts } from "./manager-types";
 import type { CompleteOptions, SessionHandle, TurnResult } from "./types";
 
 /**
- * Model attribution fields for a dispatch event (#1433).
+ * Model attribution fields for a dispatch event (#1433, #1464).
  *
- * Both keys are omitted rather than set to `undefined` when unknown: a cost row
+ * All keys are omitted rather than set to `undefined` when unknown: a cost row
  * that says `model: "unknown"` because nothing resolved a model must stay
  * distinguishable from one that was never attributed at all.
  *
  * `modelTier` is absent whenever an explicit `{ agent, model }` pin bypassed
  * tier resolution — reporting a tier there would claim a tier that never
  * selected the model.
+ *
+ * `model` is decomposed via `parseModelSpec` before it is stamped, so the
+ * event always carries the bare model id — never the `model[effort]`
+ * composite nax profiles use to name codex reasoning effort. `effort` carries
+ * the suffix when the spec had one, and is omitted (not `undefined`) when it
+ * did not, for the same reason `modelTier` is omitted rather than nulled.
  */
 function modelAttribution(src: {
   modelDef?: ModelDef;
   modelTier?: ModelTier;
-}): { model?: string; modelTier?: string } {
+}): { model?: string; effort?: string; modelTier?: string } {
+  const spec = src.modelDef?.model !== undefined ? parseModelSpec(src.modelDef.model) : undefined;
   return {
-    ...(src.modelDef?.model !== undefined ? { model: src.modelDef.model } : {}),
+    ...(spec !== undefined ? { model: spec.model } : {}),
+    ...(spec?.effort !== undefined ? { effort: spec.effort } : {}),
     ...(src.modelTier !== undefined ? { modelTier: src.modelTier } : {}),
   };
 }

--- a/src/runtime/cost-aggregator.ts
+++ b/src/runtime/cost-aggregator.ts
@@ -22,6 +22,15 @@ export interface CostEvent {
   /** Tier the model resolved from, when one selected it. Absent for pinned models. */
   readonly modelTier?: string;
   /**
+   * Reasoning effort from nax's `model[effort]` profile-suffix convention
+   * (#1464) — a nax-level convention, not an upstream one. Sparse: only codex
+   * profiles currently carry a suffix, so most rows omit this field entirely
+   * rather than carrying `undefined`. If a future agent expresses reasoning
+   * effort differently, this field needs a defined cross-agent meaning rather
+   * than "whatever was in brackets" before it can represent that agent too.
+   */
+  readonly effort?: string;
+  /**
    * Resolved run-profile chain ("cc-acceptance", "a+b", "default"). Without it a
    * row cannot distinguish a deliberate profile pin from a stage ignoring its
    * configured tier — profiles live outside the run artifacts entirely.

--- a/src/runtime/dispatch-events.ts
+++ b/src/runtime/dispatch-events.ts
@@ -29,6 +29,13 @@ export interface DispatchEventBase {
   /** Tier `model` resolved from, when it came from one. Attribution only. */
   readonly modelTier?: string;
   /**
+   * Reasoning effort from a nax-level `model[effort]` profile suffix
+   * (`parseModelSpec`), when the resolved model spec carried one. Absent for
+   * bare model ids — currently only codex profiles carry a suffix. Attribution
+   * only; subscribers record it, never branch on it.
+   */
+  readonly effort?: string;
+  /**
    * Resolved run-profile chain as a display string ("cc-acceptance", "a+b", or
    * "default"). Profiles repoint agent and model per stage but appear nowhere
    * else in run artifacts, so without this a cost row cannot distinguish a

--- a/src/runtime/middleware/cost.ts
+++ b/src/runtime/middleware/cost.ts
@@ -14,17 +14,28 @@ import type { DispatchErrorEvent, DispatchEvent, IDispatchEventBus, OperationCom
  *     so a row *without* this field must be read as model-unattributed rather
  *     than treating its "unknown" as a value.
  *
- * 2 — current. Guarantees, on every row: `model` (falling back to "unknown"
+ * 2 — Guarantees, on every row: `model` (falling back to "unknown"
  *     only when the dispatch resolved none), `sessionRole`, `pricingSource`,
  *     `schemaVersion`, and `projectKey` when the runtime supplied one.
  *     `modelTier` is present only when a tier selected the model — an explicit
  *     `{ agent, model }` pin reports none rather than a fabricated tier.
  *     Error rows additionally carry `kind: "error"`.
  *
+ * 3 — current (#1464). `model` is now the bare id with any `[effort]` suffix
+ *     stripped, so rate cards keyed on the bare id (e.g. `gpt-5.6-luna`) apply
+ *     to `MODEL_PRICING` lookups that previously could never match the
+ *     composite string. `effort` is present when the resolved model spec named
+ *     a reasoning effort, omitted otherwise.
+ *
+ *     IMPORTANT: v2 rows carry COMPOSITE models (`gpt-5.6-luna[high]`). A
+ *     consumer aggregating across the v2/v3 boundary will see
+ *     `gpt-5.6-luna[high]` and `gpt-5.6-luna` as distinct keys unless it
+ *     normalizes v2 rows itself.
+ *
  * Bump this when adding or changing a field consumers key on, and extend the
  * list above — the constant is how a reader learns what a row guarantees.
  */
-export const COST_ROW_SCHEMA_VERSION = 2;
+export const COST_ROW_SCHEMA_VERSION = 3;
 
 export function attachCostSubscriber(
   bus: IDispatchEventBus,
@@ -59,6 +70,7 @@ export function attachCostSubscriber(
       // resolved model, but that is now a real signal rather than a constant.
       model: event.model ?? "unknown",
       ...(event.modelTier !== undefined ? { modelTier: event.modelTier } : {}),
+      ...(event.effort !== undefined ? { effort: event.effort } : {}),
       ...(event.profile !== undefined ? { profile: event.profile } : {}),
       stage: event.stage,
       // Both already on the event and previously discarded. sessionRole is the

--- a/test/unit/agents/cost/calculate.test.ts
+++ b/test/unit/agents/cost/calculate.test.ts
@@ -109,3 +109,44 @@ describe("resolvePricingSource", () => {
     expect(estimateCostFromTokenUsage(usage, "haiku")).toBeCloseTo(4.8, 5);
   });
 });
+
+// ─── #1464: effort-suffix normalization before the rate-card lookup ─────────
+//
+// nax profiles name codex models with a reasoning-effort suffix, e.g.
+// "claude-sonnet-4[high]". Both pricing functions must decompose that suffix
+// via parseModelSpec before keying MODEL_PRICING, so a rate card added for
+// the bare model id actually takes effect.
+
+describe("effort-suffix normalization (#1464)", () => {
+  test("estimateCostFromTokenUsage prices a suffixed model identically to its bare id", () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    const bare = estimateCostFromTokenUsage(usage, "claude-sonnet-4");
+    const suffixed = estimateCostFromTokenUsage(usage, "claude-sonnet-4[high]");
+    expect(suffixed).toBeCloseTo(bare, 10);
+  });
+
+  test("a suffixed known model prices differently from a suffixed unpriced model", () => {
+    // haiku ($0.8/$4 per 1M) diverges from the generic fallback card ($3/$15
+    // per 1M) — unlike claude-sonnet-4, which happens to match it, so this
+    // proves the real rate card was hit rather than the fallback.
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    const known = estimateCostFromTokenUsage(usage, "haiku[high]");
+    const unpriced = estimateCostFromTokenUsage(usage, "totally-unknown-model[high]");
+    expect(known).not.toBeCloseTo(unpriced, 5);
+  });
+
+  test("resolvePricingSource reports model-rates for a suffixed known model", () => {
+    expect(resolvePricingSource("claude-sonnet-4[high]")).toBe("model-rates");
+  });
+
+  test("resolvePricingSource still reports unknown-model for undefined, empty, and 'unknown'", () => {
+    expect(resolvePricingSource(undefined)).toBe("unknown-model");
+    expect(resolvePricingSource("")).toBe("unknown-model");
+    expect(resolvePricingSource("unknown")).toBe("unknown-model");
+  });
+
+  test("resolvePricingSource reports fallback-rates for a genuinely unknown model, suffixed or not", () => {
+    expect(resolvePricingSource("totally-unknown-model")).toBe("fallback-rates");
+    expect(resolvePricingSource("totally-unknown-model[high]")).toBe("fallback-rates");
+  });
+});

--- a/test/unit/agents/cost/calculate.test.ts
+++ b/test/unit/agents/cost/calculate.test.ts
@@ -149,4 +149,19 @@ describe("effort-suffix normalization (#1464)", () => {
     expect(resolvePricingSource("totally-unknown-model")).toBe("fallback-rates");
     expect(resolvePricingSource("totally-unknown-model[high]")).toBe("fallback-rates");
   });
+
+  // The defect behind #1464's placement decision was these two DISAGREEING: the
+  // number is priced upstream at the adapter from the raw spec, the label is
+  // resolved downstream in the cost middleware. Normalizing in only one of them
+  // yields a row claiming `model-rates` over a number built on the generic card.
+  // Asserting each half separately cannot catch that — this binds them.
+  test("a model reported as model-rates is genuinely NOT priced on the fallback card", () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    const fallbackPrice = estimateCostFromTokenUsage(usage, "totally-unknown-model");
+
+    for (const model of ["haiku[high]", "haiku", "opus[medium]"]) {
+      expect(resolvePricingSource(model)).toBe("model-rates");
+      expect(estimateCostFromTokenUsage(usage, model)).not.toBeCloseTo(fallbackPrice, 5);
+    }
+  });
 });

--- a/test/unit/agents/manager-dispatch-emission.test.ts
+++ b/test/unit/agents/manager-dispatch-emission.test.ts
@@ -531,3 +531,53 @@ describe("dispatch events carry the model (#1433)", () => {
     expect(received[0]?.profile).toBe("cc-acceptance");
   });
 });
+
+// ─── #1464: modelAttribution decomposes the effort suffix ──────────────────
+
+describe("dispatch events decompose the effort suffix (#1464)", () => {
+  test("runAsSession emits the bare model plus effort for a suffixed spec", async () => {
+    const bus = new DispatchEventBus();
+    const manager = new AgentManager(DEFAULT_CONFIG, undefined, {
+      sendPrompt: mock(async () => makeTurnResult("hello")),
+      dispatchEvents: bus,
+    });
+
+    const received: SessionTurnDispatchEvent[] = [];
+    bus.onDispatch((e) => {
+      if (e.kind === "session-turn") received.push(e);
+    });
+
+    const handle: SessionHandle = {
+      id: "nax-test-handle",
+      agentName: "codex",
+      modelDef: { provider: "openai", model: "gpt-5.6-luna[high]" },
+    };
+    await manager.runAsSession("codex", handle, "p", { pipelineStage: "run", storyId: "US-006" });
+
+    expect(received[0]?.model).toBe("gpt-5.6-luna");
+    expect(received[0]?.effort).toBe("high");
+  });
+
+  test("runAsSession omits effort entirely for a bare model spec", async () => {
+    const bus = new DispatchEventBus();
+    const manager = new AgentManager(DEFAULT_CONFIG, undefined, {
+      sendPrompt: mock(async () => makeTurnResult("hello")),
+      dispatchEvents: bus,
+    });
+
+    const received: SessionTurnDispatchEvent[] = [];
+    bus.onDispatch((e) => {
+      if (e.kind === "session-turn") received.push(e);
+    });
+
+    const handle: SessionHandle = {
+      id: "nax-test-handle",
+      agentName: "claude",
+      modelDef: { provider: "anthropic", model: "haiku" },
+    };
+    await manager.runAsSession("claude", handle, "p", { pipelineStage: "run", storyId: "US-007" });
+
+    expect(received[0]?.model).toBe("haiku");
+    expect("effort" in (received[0] ?? {})).toBe(false);
+  });
+});

--- a/test/unit/runtime/middleware/cost.test.ts
+++ b/test/unit/runtime/middleware/cost.test.ts
@@ -499,4 +499,41 @@ describe("attachCostSubscriber", () => {
 
     expect(errors[0].projectKey).toBe("rs-stock");
   });
+
+  // ── #1464: effort as a dispatch dimension + schema v3 ────────────────────
+
+  test("#1464: copies effort onto the cost row when the dispatch carries one", () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const bus = new DispatchEventBus();
+    attachCostSubscriber(bus, agg, "r-001");
+
+    bus.emitDispatch(makeSessionTurnEvent({ model: "gpt-5.6-luna", effort: "high" }));
+
+    expect(recorded[0].model).toBe("gpt-5.6-luna");
+    expect(recorded[0].effort).toBe("high");
+  });
+
+  test("#1464: omits effort when the dispatch carries none", () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const bus = new DispatchEventBus();
+    attachCostSubscriber(bus, agg, "r-001");
+
+    bus.emitDispatch(makeSessionTurnEvent({ model: "haiku", effort: undefined }));
+
+    expect("effort" in recorded[0]).toBe(false);
+  });
+
+  test("#1464: rows carry schemaVersion 3", () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const bus = new DispatchEventBus();
+    attachCostSubscriber(bus, agg, "r-001");
+
+    bus.emitDispatch(makeSessionTurnEvent());
+
+    expect(recorded[0].schemaVersion).toBe(3);
+    expect(COST_ROW_SCHEMA_VERSION).toBe(3);
+  });
 });


### PR DESCRIPTION
## What

Cost rows stored the model as the raw profile string with its reasoning-effort suffix included — `gpt-5.6-luna[high]` — and both pricing lookups keyed `MODEL_PRICING` on that composite. This strips the suffix at the pricing boundary and records `effort` as a separate dimension.

Closes #1464.

## Why

A rate card added for `gpt-5.6-luna` could never be hit: the table is keyed on the bare id, the lookup passed the composite. Measured across 514 post-v0.76.0 rows, `pricingSource: "model-rates"` occurs **zero times** — every non-wire row is priced on the generic $3/$15 Sonnet-shaped card.

That silently pre-broke the follow-up #1434 explicitly deferred ("add real published prices"): a maintainer adding `"gpt-5.6-luna"` to `pricing.ts` would have seen no change at all, and `pricingSource` would have kept reporting `fallback-rates` after the very fix it exists to prompt.

Effort is also a real analytic dimension the ledger could not express. Decomposing by hand over the same corpus, the same model at `high` vs `medium` runs **3.3x output tokens, 2.9x wall-clock, 1.9x cost per row**. "Is `high` on adversarial review earning its keep?" should be a query, not a re-implementation of the suffix regex in every consumer.

## The part the issue missed

`estimatedCostUsd` is **not** computed in the cost middleware. It is computed upstream at the adapter — `adapter-output.ts:192` and `adapter.ts:244` both call `estimateCostFromTokenUsage(usage, modelDef.model)` with the raw composite — and flows via `TurnResult` → `manager-dispatch.ts:74` → `DispatchEvent` → `cost.ts:43` into the row verbatim.

So the **number** is priced upstream from the suffixed string while the **label** (`pricingSource`) is resolved downstream. Fixing only the middleware, which is what the issue proposed considering, would produce rows reporting `model-rates` over a number built on the generic card — the label lying about the number, strictly worse than the original bug, since `pricingSource` exists precisely to make guessed rates visible.

That finding is why the normalization goes **inside the two pricing functions** rather than at the call sites or in `modelAttribution`.

## Changes

- **`src/agents/cost/calculate.ts`** — `estimateCostFromTokenUsage` and `resolvePricingSource` decompose via `parseModelSpec` before keying `MODEL_PRICING`. All three call sites are fixed at once, number and label together, with no call-site coordination. Parsing a bare id is a no-op, so it is idempotent. `resolvePricingSource` still short-circuits `undefined` / `""` / `"unknown"` to `unknown-model` before any parsing.
- **`src/agents/manager-dispatch.ts`** — `modelAttribution` emits the bare model plus optional `effort`, keeping the existing omit-rather-than-null convention that lets an unattributed row stay distinguishable from an unresolved one.
- **`src/runtime/dispatch-events.ts`**, **`src/runtime/cost-aggregator.ts`** — `effort?: string` on `DispatchEventBase` and `CostEvent`. The `CostEvent` doc records that this is a **nax-level** convention, not an upstream one, and that an agent expressing effort differently would need a defined cross-agent meaning rather than "whatever was in brackets".
- **`src/runtime/middleware/cost.ts`** — `effort` copied onto the row; `COST_ROW_SCHEMA_VERSION` 2 → 3 with a new doc entry.

`parseModelSpec` already existed as the SSOT and had exactly one production caller (the acpx spawn path). This gives it the second caller it always should have had.

## Schema note for consumers

**v2 rows carry composite models.** A consumer aggregating across the v2/v3 boundary will see `gpt-5.6-luna[high]` and `gpt-5.6-luna` as distinct keys unless it normalizes v2 rows itself. This is stated in the `COST_ROW_SCHEMA_VERSION` doc block, which is how a reader learns what a row guarantees.

Done now deliberately: the v2 corpus is 514 rows / $188. The same change against months of accumulated data is materially more expensive, and `schemaVersion` exists to mark exactly this boundary.

No in-repo consumer groups cost rows by model — ledger analysis is external tooling — so nothing downstream breaks.

## Testing

- [x] `bun run test` — 11,415 unit + 1,092 integration + 24 ui, 0 failures
- [x] `bun run typecheck`, `bun run lint` (no ratchet regressions), `bun run build`

Coverage added for: a suffixed model pricing identically to its bare id; `model-rates` reported for a suffixed known model; `unknown-model` preserved for `undefined` / `""` / `"unknown"`; `fallback-rates` for a genuinely unknown model either way; `modelAttribution` emitting bare + `effort` and **omitting** `effort` (not nulling it) for a bare spec; and rows carrying `schemaVersion: 3`.

Two notes on test quality:

- The "prices from the real card" fixture deliberately uses `haiku` ($0.8/$4), **not** `claude-sonnet-4` — the latter is priced $3/$15, identical to the generic fallback, so an assertion built on it would pass whether or not the fix worked.
- `f7fb51ae` adds a test binding `pricingSource` to the number it labels. Asserting the two halves separately cannot catch them disagreeing, which is the exact defect the placement decision exists to prevent.

## Out of scope

Adding the actual rate cards for `gpt-5.6-*`, `minimax/*` and `deepseek*` still needs authoritative published prices and stays a separate change. **This is what makes that change able to work.**