### PR TITLE
feat(plan-fidelity): warn when a spec-declared Context Files entry is dropped

### DIFF
--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -7,7 +7,12 @@ export { planRefineOp, _planRefineDeps, normalizeCreatedContextFiles } from "./p
 export type { PlanRefineInput } from "./plan-refine";
 export { makeSelfHealStep, runSelfHealChain } from "./self-heal";
 export type { SelfHealStep, SelfHealSpec } from "./self-heal";
-export { applyPlanFidelity, backfillModifiedFiles, backfillOutOfScope } from "./plan-fidelity";
+export {
+  applyPlanFidelity,
+  backfillModifiedFiles,
+  backfillOutOfScope,
+  warnOnDroppedContextFiles,
+} from "./plan-fidelity";
 export { decomposeOp } from "./decompose";
 export type { DecomposeOpInput, DecomposeOpOutput } from "./decompose";
 export { buildHopCallback, _buildHopCallbackDeps } from "./build-hop-callback";

--- a/src/operations/plan-fidelity.ts
+++ b/src/operations/plan-fidelity.ts
@@ -15,6 +15,7 @@ import {
   findMissingOutOfScope,
   findSpecDriftViolations,
   getContextFiles,
+  isSafeRelativePath,
 } from "../prd";
 import type { PRD } from "../prd/types";
 
@@ -86,6 +87,11 @@ export function backfillModifiedFiles(prd: PRD, specContent: string, featureName
   return applied;
 }
 
+/** Strip a leading `./` so `./src/a.ts` and `src/a.ts` compare equal. */
+function normalizeContextPath(path: string): string {
+  return path.startsWith("./") ? path.slice(2) : path;
+}
+
 /**
  * Warn when a spec-declared `### Context Files` entry is absent from the story
  * it was attributed to (#1466). Observability only — no PRD mutation.
@@ -98,30 +104,59 @@ export function backfillModifiedFiles(prd: PRD, specContent: string, featureName
  * that does not exist yet — so this only makes the drop frequency measurable,
  * exactly as #1466's suggested first step, rather than backfilling a fallback
  * the way `backfillOutOfScope` / `backfillModifiedFiles` do.
+ *
+ * `declaredCount` / `presentCount` ride along with every drop warning so a
+ * reader can tell "evicted at the 5-file cap" (`presentCount === 5`) from
+ * "planner ignored the spec" (`presentCount` far below the cap) — exactly the
+ * distinction a future priority rule needs data on.
  */
 export function warnOnDroppedContextFiles(prd: PRD, specContent: string, featureName: string): void {
-  const declared = extractSpecContextFiles(specContent);
-  if (declared.length === 0) return;
+  const extracted = extractSpecContextFiles(specContent);
+  if (extracted.length === 0) return;
 
-  const byStory = new Map<string, typeof declared>();
+  const invalidPaths = extracted.filter((entry) => !isSafeRelativePath(entry.path));
+  if (invalidPaths.length > 0) {
+    getSafeLogger()?.warn("plan", "Spec Context Files entries declare an absolute or traversing path — ignored", {
+      featureName,
+      rejectedCount: invalidPaths.length,
+      rejected: invalidPaths.map((entry) => ({ storyId: entry.storyId, path: entry.path })),
+    });
+  }
+
+  const declared = extracted.filter((entry) => isSafeRelativePath(entry.path));
+  const storyIds = new Set(prd.userStories.map((story) => story.id));
+  const orphans = declared.filter((entry) => !entry.storyId || !storyIds.has(entry.storyId));
+  if (orphans.length > 0) {
+    getSafeLogger()?.warn("plan", "Spec Context Files entries name no story in the PRD — dropped, not applied", {
+      featureName,
+      orphanCount: orphans.length,
+      orphans: orphans.map((entry) => ({ storyId: entry.storyId, path: entry.path })),
+    });
+  }
+
+  // First-seen-wins per story: a spec that lists the same path twice for one
+  // story must not double-count it as two drops.
+  const byStory = new Map<string, Map<string, string>>();
   for (const entry of declared) {
-    if (!entry.storyId) continue;
-    const list = byStory.get(entry.storyId) ?? [];
-    list.push(entry);
-    byStory.set(entry.storyId, list);
+    if (!entry.storyId || !storyIds.has(entry.storyId)) continue;
+    const byPath = byStory.get(entry.storyId) ?? new Map<string, string>();
+    if (!byPath.has(entry.path)) byPath.set(entry.path, entry.path);
+    byStory.set(entry.storyId, byPath);
   }
 
   for (const story of prd.userStories) {
     const storyDeclared = byStory.get(story.id);
-    if (!storyDeclared || storyDeclared.length === 0) continue;
-    const present = new Set(getContextFiles(story));
-    const dropped = storyDeclared.filter((entry) => !present.has(entry.path));
+    if (!storyDeclared || storyDeclared.size === 0) continue;
+    const present = new Set(getContextFiles(story).map(normalizeContextPath));
+    const dropped = [...storyDeclared.keys()].filter((path) => !present.has(normalizeContextPath(path)));
     if (dropped.length === 0) continue;
     getSafeLogger()?.warn("plan", "Spec Context Files entries absent from the resulting story — not backfilled", {
       featureName,
       storyId: story.id,
+      declaredCount: storyDeclared.size,
+      presentCount: present.size,
       droppedCount: dropped.length,
-      dropped: dropped.map((entry) => entry.path),
+      dropped,
     });
   }
 }

--- a/src/operations/plan-fidelity.ts
+++ b/src/operations/plan-fidelity.ts
@@ -11,8 +11,10 @@ import {
   applyModifiedFiles,
   applyOutOfScopeFallback,
   demoteStoryScopedOutOfScope,
+  extractSpecContextFiles,
   findMissingOutOfScope,
   findSpecDriftViolations,
+  getContextFiles,
 } from "../prd";
 import type { PRD } from "../prd/types";
 
@@ -85,14 +87,59 @@ export function backfillModifiedFiles(prd: PRD, specContent: string, featureName
 }
 
 /**
+ * Warn when a spec-declared `### Context Files` entry is absent from the story
+ * it was attributed to (#1466). Observability only — no PRD mutation.
+ *
+ * Unlike out-of-scope and `### Modifies`, `contextFiles` is intentionally
+ * planner-chosen: the LLM reasons about what it needs to read, and injection is
+ * capped at `FILE_INJECTION_MAX_FILES` (`src/context/builder.ts`). A dropped
+ * entry may be a correct eviction under that cap rather than a bug, and
+ * reconciling spec-declared vs. planner-inferred reads needs a priority rule
+ * that does not exist yet — so this only makes the drop frequency measurable,
+ * exactly as #1466's suggested first step, rather than backfilling a fallback
+ * the way `backfillOutOfScope` / `backfillModifiedFiles` do.
+ */
+export function warnOnDroppedContextFiles(prd: PRD, specContent: string, featureName: string): void {
+  const declared = extractSpecContextFiles(specContent);
+  if (declared.length === 0) return;
+
+  const byStory = new Map<string, typeof declared>();
+  for (const entry of declared) {
+    if (!entry.storyId) continue;
+    const list = byStory.get(entry.storyId) ?? [];
+    list.push(entry);
+    byStory.set(entry.storyId, list);
+  }
+
+  for (const story of prd.userStories) {
+    const storyDeclared = byStory.get(story.id);
+    if (!storyDeclared || storyDeclared.length === 0) continue;
+    const present = new Set(getContextFiles(story));
+    const dropped = storyDeclared.filter((entry) => !present.has(entry.path));
+    if (dropped.length === 0) continue;
+    getSafeLogger()?.warn("plan", "Spec Context Files entries absent from the resulting story — not backfilled", {
+      featureName,
+      storyId: story.id,
+      droppedCount: dropped.length,
+      dropped: dropped.map((entry) => entry.path),
+    });
+  }
+}
+
+/**
  * Every deterministic spec→PRD fidelity repair, in the order they must run.
  *
  * One entry point so the four plan strategies (single, refine, pipeline, debate)
  * cannot drift on which repairs they apply — the class of bug that let
  * `### Modifies` reach only some paths would otherwise recur per-field.
+ *
+ * `warnOnDroppedContextFiles` runs last — it is observability, not a repair,
+ * so it inspects the fully-repaired PRD without changing what is returned.
  */
 export function applyPlanFidelity(prd: PRD, specContent: string, featureName: string): PRD {
-  return backfillModifiedFiles(backfillOutOfScope(prd, specContent, featureName), specContent, featureName);
+  const scoped = backfillModifiedFiles(backfillOutOfScope(prd, specContent, featureName), specContent, featureName);
+  warnOnDroppedContextFiles(scoped, specContent, featureName);
+  return scoped;
 }
 
 /**

--- a/src/prd/context-files-extract.ts
+++ b/src/prd/context-files-extract.ts
@@ -1,0 +1,45 @@
+/**
+ * `### Context Files` *extraction* — the spec's reads a story should see before
+ * implementing (#1466).
+ *
+ * Unlike `### Modifies`, `contextFiles` is intentionally something the planner
+ * chooses: the LLM reasons about what it needs to read, and `FILE_INJECTION_MAX_FILES`
+ * caps injected reads to 5. A spec-declared entry that loses its slot under that
+ * cap is a legitimate eviction, not a bug — so this module extracts the spec's
+ * declared list purely so a caller can detect drift (see `warnOnDroppedContextFiles`
+ * in `../operations/plan-fidelity`), never to carry or backfill a PRD field the
+ * way `./modifies-extract` does.
+ *
+ * Grammar, fencing, and `**US-00N**` grouping are shared with `### Modifies` —
+ * see `extractGroupedPathSection` in `./markdown-scan`.
+ */
+
+import { type GroupedPathEntry, extractGroupedPathSection } from "./markdown-scan";
+
+/** One `### Context Files` bullet, with the story its group lead-in attributed it to. */
+export type SpecContextFile = GroupedPathEntry;
+
+/**
+ * Upper bound on extracted entries across the whole spec. A well-formed spec
+ * lists at most a handful of context files per story; this only guards against
+ * a runaway document, not the per-story 5-file injection cap.
+ */
+export const MAX_SPEC_CONTEXT_FILES = 200;
+
+/**
+ * `### Context Files`, `### Context Files (per story)` …
+ *
+ * The trailing `\b` admits the parenthetical suffix real specs use, mirroring
+ * `MODIFIES_HEADING` in `./modifies-extract`.
+ */
+const CONTEXT_FILES_HEADING = /^(#{1,6})\s*context\s*files\b/i;
+
+/**
+ * Every `### Context Files` entry the spec declares, in document order.
+ *
+ * Unattributed entries are returned with `storyId: null` — deciding what to do
+ * with one is the caller's business.
+ */
+export function extractSpecContextFiles(specContent: string): SpecContextFile[] {
+  return extractGroupedPathSection(specContent, CONTEXT_FILES_HEADING, MAX_SPEC_CONTEXT_FILES);
+}

--- a/src/prd/context-files-extract.ts
+++ b/src/prd/context-files-extract.ts
@@ -27,10 +27,18 @@ export type SpecContextFile = GroupedPathEntry;
 export const MAX_SPEC_CONTEXT_FILES = 200;
 
 /**
- * `### Context Files`, `### Context Files (per story)` …
+ * `### Context Files`, `#### Context Files (per story)` …
  *
  * The trailing `\b` admits the parenthetical suffix real specs use, mirroring
  * `MODIFIES_HEADING` in `./modifies-extract`.
+ *
+ * Deliberately narrow, matching only an ATX heading (`#{1,6} Context Files`).
+ * A bold pseudo-heading (`**Context Files:**`) or an inline list item
+ * (`- Context Files: \`a.ts\`, \`b.ts\``) are NOT matched — both appear in a
+ * handful of older specs in this repo, predating spec-writing's current
+ * template. Widening the regex to catch them risks false-matching prose that
+ * merely mentions "context files" in a sentence; the current heading-only
+ * match trades those specs' coverage for that safety.
  */
 const CONTEXT_FILES_HEADING = /^(#{1,6})\s*context\s*files\b/i;
 

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -40,6 +40,8 @@ export type { SpecModifiedFile } from "./modifies-extract";
 export { MAX_MODIFIED_FILES, extractSpecModifiedFiles } from "./modifies-extract";
 export type { ApplyModifiedFilesResult } from "./modifies";
 export { applyModifiedFiles } from "./modifies";
+export type { SpecContextFile } from "./context-files-extract";
+export { MAX_SPEC_CONTEXT_FILES, extractSpecContextFiles } from "./context-files-extract";
 export type { FailureCategory } from "../tdd/types";
 export { validateInjectedStory, deriveNextStoryId } from "./inject";
 

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -39,7 +39,7 @@ export {
 export type { SpecModifiedFile } from "./modifies-extract";
 export { MAX_MODIFIED_FILES, extractSpecModifiedFiles } from "./modifies-extract";
 export type { ApplyModifiedFilesResult } from "./modifies";
-export { applyModifiedFiles } from "./modifies";
+export { applyModifiedFiles, isSafeRelativePath } from "./modifies";
 export type { SpecContextFile } from "./context-files-extract";
 export { MAX_SPEC_CONTEXT_FILES, extractSpecContextFiles } from "./context-files-extract";
 export type { FailureCategory } from "../tdd/types";

--- a/src/prd/markdown-scan.ts
+++ b/src/prd/markdown-scan.ts
@@ -63,3 +63,158 @@ export function fencedLineIndices(lines: readonly string[]): Set<number> {
   }
   return fenced;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// **US-00N**-grouped path sections
+//
+// `### Modifies` and `### Context Files` are both written by spec-writing to
+// the SAME shape: a heading, then one `**US-00N**` group lead-in per story,
+// then bulleted `` `path` `` entries with an optional trailing reason. Two
+// independent copies of this grammar would silently drift on what counts as
+// a path, a group boundary, or a section end — so both parsers route through
+// `extractGroupedPathSection` below.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One bullet from a `**US-00N**`-grouped section: a path plus its stated reason. */
+export interface GroupedPathEntry {
+  /** Owning story from the nearest `**US-00N**` group above — null when none. */
+  readonly storyId: string | null;
+  readonly path: string;
+  /** The spec's stated reason, verbatim. Empty when the author listed a bare path. */
+  readonly reason: string;
+}
+
+/** A `**US-001**` group lead-in on its own line — the ownership marker. */
+const GROUP_LEAD_IN = /^\s*\*\*\s*(US-\d+)\s*\*\*\s*:?\s*$/i;
+
+/** A heading naming a story — `#### US-001`, the alternative group form. */
+const STORY_HEADING = /^#{1,6}\s.*\b(US-\d+)\b/i;
+
+/** The dash separating a path from its reason: em, en, or hyphen. */
+const PATH_REASON_SEPARATOR = /^\s*[—–-]\s*/;
+
+/** A leading backticked span — the canonical way a spec writes the path. */
+const BACKTICKED_PATH = /^`([^`]+)`/;
+
+/** Minimum evidence that an unbackticked token is a path and not the first word of a sentence. */
+const PATH_SHAPED = /[/.]/;
+
+/**
+ * Lines belonging to a section starting at `startIndex`.
+ *
+ * Ends at the next heading whose level is the same as or shallower than the
+ * section heading's, so neighbouring sections at the same nesting are never
+ * absorbed. The `level === 1` guard is a safety rail: when the section
+ * heading is H1 every other section nests under it, and folding the whole
+ * document in would fabricate authorisations from unrelated prose.
+ *
+ * A story heading is deliberately NOT exempted from the boundary. A DEEPER one
+ * (`#### US-001` under `### Modifies`) already survives — it fails the level
+ * test and is collected, then read as a group lead-in. Exempting a heading at
+ * the section's own level would only ever swallow a sibling section.
+ */
+export function sectionLines(
+  lines: readonly string[],
+  startIndex: number,
+  level: number,
+  fenced: Set<number>,
+): string[] {
+  const collected: string[] = [];
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    if (fenced.has(i)) continue;
+    const heading = lines[i].match(ANY_HEADING);
+    if (heading && (heading[1].length <= level || level === 1)) break;
+    collected.push(lines[i]);
+  }
+  return collected;
+}
+
+/**
+ * Split one bullet's folded text into a path and the reason behind it.
+ *
+ * A leading backticked span is taken as the path verbatim — the author marked it
+ * explicitly, so nothing further is inferred. Without backticks the first
+ * whitespace-delimited token is accepted only when it is **path-shaped** (holds
+ * a `/` or a `.`), which is what stops a stray prose bullet inside the section —
+ * "- see the notes below" — from being written into the PRD as a file named
+ * `see`. Returns null in that case, dropping the bullet.
+ */
+function parsePathEntry(text: string): { path: string; reason: string } | null {
+  const backticked = text.match(BACKTICKED_PATH);
+  if (backticked) {
+    const path = backticked[1].trim();
+    if (!path) return null;
+    return { path, reason: text.slice(backticked[0].length).replace(PATH_REASON_SEPARATOR, "").trim() };
+  }
+
+  const candidate = text.match(/^\S+/)?.[0]?.trim() ?? "";
+  if (!candidate || !PATH_SHAPED.test(candidate)) return null;
+  return { path: candidate, reason: text.replace(/^\S+/, "").replace(PATH_REASON_SEPARATOR, "").trim() };
+}
+
+/** One pass over a section body, tracking the group lead-in currently in force. */
+function collectGroupedPathEntries(body: readonly string[]): GroupedPathEntry[] {
+  const entries: GroupedPathEntry[] = [];
+  let storyId: string | null = null;
+  let current: string[] = [];
+
+  const flush = () => {
+    const parsed = current.length > 0 ? parsePathEntry(current.join(" ").replace(/\s+/g, " ").trim()) : null;
+    if (parsed) entries.push({ storyId, ...parsed });
+    current = [];
+  };
+
+  for (const line of body) {
+    const group = line.match(GROUP_LEAD_IN) ?? line.match(STORY_HEADING);
+    if (group) {
+      flush();
+      storyId = group[1].toUpperCase();
+      continue;
+    }
+    if (line.trim().length === 0) {
+      flush();
+      continue;
+    }
+    if (LIST_ITEM_START.test(line)) {
+      flush();
+      current.push(stripBullet(line));
+      continue;
+    }
+    // A continuation line only folds into an OPEN bullet; prose sitting under the
+    // heading before any bullet is a lead-in sentence, not an authorisation.
+    if (current.length > 0) current.push(line.trim());
+  }
+  flush();
+  return entries;
+}
+
+/**
+ * Every entry a `**US-00N**`-grouped section declares, in document order.
+ *
+ * `headingPattern` identifies the section (e.g. `### Modifies`, `### Context
+ * Files`); `maxEntries` bounds total extraction so a runaway spec cannot
+ * produce an unbounded list. Fenced lines are skipped entirely — spec-kit
+ * specs document their own markdown by example, so a literal fenced block
+ * containing the heading text would otherwise fabricate entries.
+ *
+ * Unattributed entries are returned with `storyId: null` — deciding what to
+ * do with one is the caller's business.
+ */
+export function extractGroupedPathSection(
+  specContent: string,
+  headingPattern: RegExp,
+  maxEntries: number,
+): GroupedPathEntry[] {
+  if (!specContent.trim()) return [];
+  const lines = specContent.split("\n");
+  const fenced = fencedLineIndices(lines);
+
+  const entries: GroupedPathEntry[] = [];
+  for (let i = 0; i < lines.length && entries.length < maxEntries; i++) {
+    if (fenced.has(i)) continue;
+    const heading = stripEmphasis(lines[i]).match(headingPattern);
+    if (!heading) continue;
+    entries.push(...collectGroupedPathEntries(sectionLines(lines, i, heading[1].length, fenced)));
+  }
+  return entries.slice(0, maxEntries);
+}

--- a/src/prd/markdown-scan.ts
+++ b/src/prd/markdown-scan.ts
@@ -111,14 +111,11 @@ const PATH_SHAPED = /[/.]/;
  * A story heading is deliberately NOT exempted from the boundary. A DEEPER one
  * (`#### US-001` under `### Modifies`) already survives — it fails the level
  * test and is collected, then read as a group lead-in. Exempting a heading at
- * the section's own level would only ever swallow a sibling section.
+ * the section's own level would only ever swallow a sibling section: `## US-002:
+ * Second story` following `## Modifies` would be read as a group, and every
+ * bullet beneath it would become a fabricated authorisation.
  */
-export function sectionLines(
-  lines: readonly string[],
-  startIndex: number,
-  level: number,
-  fenced: Set<number>,
-): string[] {
+function sectionLines(lines: readonly string[], startIndex: number, level: number, fenced: Set<number>): string[] {
   const collected: string[] = [];
   for (let i = startIndex + 1; i < lines.length; i++) {
     if (fenced.has(i)) continue;
@@ -138,6 +135,11 @@ export function sectionLines(
  * a `/` or a `.`), which is what stops a stray prose bullet inside the section —
  * "- see the notes below" — from being written into the PRD as a file named
  * `see`. Returns null in that case, dropping the bullet.
+ *
+ * The cost of the rule is a bare extensionless filename (`Makefile`) written
+ * without backticks, which is rejected. That is the right trade: spec-writing
+ * tells authors to backtick paths, and fabricating an entry is worse than
+ * declining an ambiguous one.
  */
 function parsePathEntry(text: string): { path: string; reason: string } | null {
   const backticked = text.match(BACKTICKED_PATH);
@@ -152,10 +154,43 @@ function parsePathEntry(text: string): { path: string; reason: string } | null {
   return { path: candidate, reason: text.replace(/^\S+/, "").replace(PATH_REASON_SEPARATOR, "").trim() };
 }
 
-/** One pass over a section body, tracking the group lead-in currently in force. */
-function collectGroupedPathEntries(body: readonly string[]): GroupedPathEntry[] {
+/**
+ * Nearest ancestor `### US-00N: ...` heading strictly shallower than the
+ * section heading at `headingIndex` — the section's ambient story when the
+ * section itself is nested under a per-story heading rather than declaring
+ * its own `**US-00N**` group lead-ins (e.g. `#### Context Files` written
+ * directly under `### US-001: ...`, the shape spec-writing's own template
+ * produces — see #1466).
+ *
+ * Stops at the FIRST shallower heading found, story or not: a section
+ * nested two levels under a non-story ancestor (`## Stories` → `### Design
+ * notes` → `#### Context Files`) has no story to inherit, and climbing
+ * further up would misattribute it to an unrelated ancestor.
+ */
+function enclosingStoryId(
+  lines: readonly string[],
+  headingIndex: number,
+  level: number,
+  fenced: Set<number>,
+): string | null {
+  for (let i = headingIndex - 1; i >= 0; i--) {
+    if (fenced.has(i)) continue;
+    const heading = lines[i].match(ANY_HEADING);
+    if (!heading || heading[1].length >= level) continue;
+    return lines[i].match(STORY_HEADING)?.[1]?.toUpperCase() ?? null;
+  }
+  return null;
+}
+
+/**
+ * One pass over a section body, tracking the group lead-in currently in
+ * force. `defaultStoryId` seeds attribution for a section with no explicit
+ * `**US-00N**` lead-ins of its own (see `enclosingStoryId`); an explicit
+ * lead-in inside the body still overrides it from that point on.
+ */
+function collectGroupedPathEntries(body: readonly string[], defaultStoryId: string | null = null): GroupedPathEntry[] {
   const entries: GroupedPathEntry[] = [];
-  let storyId: string | null = null;
+  let storyId: string | null = defaultStoryId;
   let current: string[] = [];
 
   const flush = () => {
@@ -189,13 +224,23 @@ function collectGroupedPathEntries(body: readonly string[]): GroupedPathEntry[] 
 }
 
 /**
- * Every entry a `**US-00N**`-grouped section declares, in document order.
+ * Every entry a `**US-00N**`-grouped OR per-story-nested section declares,
+ * in document order.
  *
  * `headingPattern` identifies the section (e.g. `### Modifies`, `### Context
  * Files`); `maxEntries` bounds total extraction so a runaway spec cannot
  * produce an unbounded list. Fenced lines are skipped entirely — spec-kit
  * specs document their own markdown by example, so a literal fenced block
  * containing the heading text would otherwise fabricate entries.
+ *
+ * Two attribution shapes are supported, since real specs use both:
+ *   1. A single section with `**US-00N**` group lead-ins per story
+ *      (`### Modifies` — always this shape in this repo's specs).
+ *   2. A section repeated once per story, nested directly under that
+ *      story's own heading (`### US-001: ...` → `#### Context Files` — the
+ *      shape spec-writing's own template produces for `Context Files`).
+ *      `enclosingStoryId` resolves the ambient story for this case; an
+ *      explicit `**US-00N**` lead-in inside the body still overrides it.
  *
  * Unattributed entries are returned with `storyId: null` — deciding what to
  * do with one is the caller's business.
@@ -214,7 +259,9 @@ export function extractGroupedPathSection(
     if (fenced.has(i)) continue;
     const heading = stripEmphasis(lines[i]).match(headingPattern);
     if (!heading) continue;
-    entries.push(...collectGroupedPathEntries(sectionLines(lines, i, heading[1].length, fenced)));
+    const level = heading[1].length;
+    const defaultStoryId = enclosingStoryId(lines, i, level, fenced);
+    entries.push(...collectGroupedPathEntries(sectionLines(lines, i, level, fenced), defaultStoryId));
   }
   return entries.slice(0, maxEntries);
 }

--- a/src/prd/modifies-extract.ts
+++ b/src/prd/modifies-extract.ts
@@ -40,16 +40,10 @@
  * never sees a `PRD`. Pure and deterministic — no I/O, no LLM.
  */
 
-import { ANY_HEADING, LIST_ITEM_START, fencedLineIndices, stripBullet, stripEmphasis } from "./markdown-scan";
+import { type GroupedPathEntry, extractGroupedPathSection } from "./markdown-scan";
 
 /** One `### Modifies` bullet, with the story its group lead-in attributed it to. */
-export interface SpecModifiedFile {
-  /** Owning story from the nearest `**US-00N**` group above — null when none. */
-  readonly storyId: string | null;
-  readonly path: string;
-  /** The spec's stated reason, verbatim. Empty when the author listed a bare path. */
-  readonly reason: string;
-}
+export type SpecModifiedFile = GroupedPathEntry;
 
 /**
  * Upper bound on extracted entries. A spec authorising more than this many
@@ -68,135 +62,15 @@ export const MAX_MODIFIED_FILES = 25;
  */
 const MODIFIES_HEADING = /^(#{1,6})\s*modifi(?:es|ed\s+files)\b/i;
 
-/** A `**US-001**` group lead-in on its own line — the ownership marker. */
-const GROUP_LEAD_IN = /^\s*\*\*\s*(US-\d+)\s*\*\*\s*:?\s*$/i;
-
-/** A heading naming a story — `#### US-001`, the alternative group form. */
-const STORY_HEADING = /^#{1,6}\s.*\b(US-\d+)\b/i;
-
-/** The dash separating a path from its reason: em, en, or hyphen. */
-const PATH_REASON_SEPARATOR = /^\s*[—–-]\s*/;
-
-/** A leading backticked span — the canonical way a spec writes the path. */
-const BACKTICKED_PATH = /^`([^`]+)`/;
-
-/** Minimum evidence that an unbackticked token is a path and not the first word of a sentence. */
-const PATH_SHAPED = /[/.]/;
-
-/**
- * Lines belonging to the `Modifies` section starting at `startIndex`.
- *
- * Ends at the next heading whose level is the same as or shallower than the
- * section heading's, so the neighbouring `### Creates` / `### Seams` blocks are
- * never absorbed. The `level === 1` guard is a safety rail: when the section
- * heading is H1 every other section nests under it, and folding the whole
- * document in would fabricate authorisations from unrelated prose.
- *
- * A story heading is deliberately NOT exempted from the boundary. A DEEPER one
- * (`#### US-001` under `### Modifies`) already survives — it fails the level
- * test and is collected, then read as a group lead-in. Exempting a heading at
- * the section's own level would only ever swallow a sibling section: `## US-002:
- * Second story` following `## Modifies` would be read as a group, and every
- * bullet beneath it would become a fabricated authorisation.
- */
-function sectionLines(lines: readonly string[], startIndex: number, level: number, fenced: Set<number>): string[] {
-  const collected: string[] = [];
-  for (let i = startIndex + 1; i < lines.length; i++) {
-    if (fenced.has(i)) continue;
-    const heading = lines[i].match(ANY_HEADING);
-    if (heading && (heading[1].length <= level || level === 1)) break;
-    collected.push(lines[i]);
-  }
-  return collected;
-}
-
-/**
- * Split one bullet's folded text into a path and the reason behind it.
- *
- * A leading backticked span is taken as the path verbatim — the author marked it
- * explicitly, so nothing further is inferred. Without backticks the first
- * whitespace-delimited token is accepted only when it is **path-shaped** (holds
- * a `/` or a `.`), which is what stops a stray prose bullet inside the section —
- * "- see the notes below" — from being written into the PRD as a file named
- * `see` and rendered to the implementer as a file it may change. Returns null in
- * that case, dropping the bullet.
- *
- * The cost of the rule is a bare extensionless filename (`Makefile`) written
- * without backticks, which is rejected. That is the right trade: spec-writing
- * tells authors to backtick paths, and fabricating an authorisation is worse
- * than declining an ambiguous one.
- */
-function parseEntry(text: string): { path: string; reason: string } | null {
-  const backticked = text.match(BACKTICKED_PATH);
-  if (backticked) {
-    const path = backticked[1].trim();
-    if (!path) return null;
-    return { path, reason: text.slice(backticked[0].length).replace(PATH_REASON_SEPARATOR, "").trim() };
-  }
-
-  const candidate = text.match(/^\S+/)?.[0]?.trim() ?? "";
-  if (!candidate || !PATH_SHAPED.test(candidate)) return null;
-  return { path: candidate, reason: text.replace(/^\S+/, "").replace(PATH_REASON_SEPARATOR, "").trim() };
-}
-
 /**
  * Every `### Modifies` entry the spec declares, in document order.
  *
- * Fenced lines are skipped entirely: spec-kit specs document their own markdown
- * by example, so a literal ` ```markdown / ### Modifies ` block would otherwise
- * fabricate an authorisation that is written into the PRD and rendered to an
- * implementer as fact.
+ * Grammar, fencing, and grouping are shared with `### Context Files`
+ * extraction — see `extractGroupedPathSection` in `./markdown-scan`.
  *
  * Unattributed entries are returned with `storyId: null` rather than guessed at
  * — deciding what to do with one is the caller's business (see `./modifies`).
  */
 export function extractSpecModifiedFiles(specContent: string): SpecModifiedFile[] {
-  if (!specContent.trim()) return [];
-  const lines = specContent.split("\n");
-  const fenced = fencedLineIndices(lines);
-
-  const entries: SpecModifiedFile[] = [];
-  for (let i = 0; i < lines.length && entries.length < MAX_MODIFIED_FILES; i++) {
-    if (fenced.has(i)) continue;
-    const heading = stripEmphasis(lines[i]).match(MODIFIES_HEADING);
-    if (!heading) continue;
-    entries.push(...collectSection(sectionLines(lines, i, heading[1].length, fenced)));
-  }
-  return entries.slice(0, MAX_MODIFIED_FILES);
-}
-
-/** One pass over a section body, tracking the group lead-in currently in force. */
-function collectSection(body: readonly string[]): SpecModifiedFile[] {
-  const entries: SpecModifiedFile[] = [];
-  let storyId: string | null = null;
-  let current: string[] = [];
-
-  const flush = () => {
-    const parsed = current.length > 0 ? parseEntry(current.join(" ").replace(/\s+/g, " ").trim()) : null;
-    if (parsed) entries.push({ storyId, ...parsed });
-    current = [];
-  };
-
-  for (const line of body) {
-    const group = line.match(GROUP_LEAD_IN) ?? line.match(STORY_HEADING);
-    if (group) {
-      flush();
-      storyId = group[1].toUpperCase();
-      continue;
-    }
-    if (line.trim().length === 0) {
-      flush();
-      continue;
-    }
-    if (LIST_ITEM_START.test(line)) {
-      flush();
-      current.push(stripBullet(line));
-      continue;
-    }
-    // A continuation line only folds into an OPEN bullet; prose sitting under the
-    // heading before any bullet is a lead-in sentence, not an authorisation.
-    if (current.length > 0) current.push(line.trim());
-  }
-  flush();
-  return entries;
+  return extractGroupedPathSection(specContent, MODIFIES_HEADING, MAX_MODIFIED_FILES);
 }

--- a/src/prd/modifies.ts
+++ b/src/prd/modifies.ts
@@ -47,7 +47,7 @@ export interface ApplyModifiedFilesResult {
  * missing authorisation for no PRD at all. `schema.ts` still throws on the same
  * shape when a hand-edited `prd.json` is loaded.
  */
-function isSafeRelativePath(path: string): boolean {
+export function isSafeRelativePath(path: string): boolean {
   return !path.startsWith("/") && !path.includes("..");
 }
 

--- a/test/unit/operations/plan-fidelity.test.ts
+++ b/test/unit/operations/plan-fidelity.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
-import { applyPlanFidelity, backfillModifiedFiles, backfillOutOfScope } from "@/operations";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { addSink, initLogger, resetLogger } from "@/logger";
+import type { LogEntry } from "@/logger";
+import { applyPlanFidelity, backfillModifiedFiles, backfillOutOfScope, warnOnDroppedContextFiles } from "@/operations";
 import { makePRD, makeStory } from "@test/helpers";
 
 const SPEC = [
@@ -48,6 +50,100 @@ describe("backfillModifiedFiles", () => {
   test("returns the input reference when the spec declares no Modifies section", () => {
     const input = twoStoryPrd();
     expect(backfillModifiedFiles(input, "# Feature\n\n## Design", "feat")).toBe(input);
+  });
+});
+
+describe("warnOnDroppedContextFiles — #1466", () => {
+  let entries: LogEntry[];
+
+  beforeEach(() => {
+    resetLogger();
+    initLogger({ level: "debug" });
+    entries = [];
+    addSink((entry) => entries.push(entry));
+  });
+
+  afterEach(() => {
+    resetLogger();
+  });
+
+  const CONTEXT_FILES_SPEC = [
+    "### Context Files",
+    "",
+    "**US-001**",
+    "- `src/a.ts` — read this",
+    "- `src/b.ts` — and this",
+    "",
+    "**US-002**",
+    "- `src/c.ts` — this too",
+  ].join("\n");
+
+  test("warns once per story with a spec-declared Context Files entry missing from contextFiles", () => {
+    const prd = makePRD({
+      userStories: [
+        makeStory({ id: "US-001", contextFiles: ["src/a.ts"] }), // src/b.ts dropped
+        makeStory({ id: "US-002", contextFiles: ["src/c.ts"] }), // fully present
+      ],
+    });
+
+    warnOnDroppedContextFiles(prd, CONTEXT_FILES_SPEC, "feat");
+
+    const warnings = entries.filter((e) => e.level === "warn" && e.stage === "plan");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].data).toMatchObject({
+      featureName: "feat",
+      storyId: "US-001",
+      droppedCount: 1,
+      dropped: ["src/b.ts"],
+    });
+  });
+
+  test("does not mutate the PRD", () => {
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: ["src/a.ts"] })] });
+    const before = JSON.stringify(prd);
+
+    warnOnDroppedContextFiles(prd, CONTEXT_FILES_SPEC, "feat");
+
+    expect(JSON.stringify(prd)).toBe(before);
+  });
+
+  test("emits nothing when every spec-declared entry survives", () => {
+    const prd = makePRD({
+      userStories: [
+        makeStory({ id: "US-001", contextFiles: ["src/a.ts", "src/b.ts"] }),
+        makeStory({ id: "US-002", contextFiles: ["src/c.ts"] }),
+      ],
+    });
+
+    warnOnDroppedContextFiles(prd, CONTEXT_FILES_SPEC, "feat");
+
+    expect(entries.filter((e) => e.level === "warn" && e.stage === "plan")).toHaveLength(0);
+  });
+
+  test("emits nothing when the spec declares no Context Files section", () => {
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: [] })] });
+
+    warnOnDroppedContextFiles(prd, "# Feature\n\n## Design", "feat");
+
+    expect(entries.filter((e) => e.level === "warn" && e.stage === "plan")).toHaveLength(0);
+  });
+
+  test("ignores entries naming a story the PRD does not contain", () => {
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: [] })] });
+    const spec = ["### Context Files", "", "**US-404**", "- `src/ghost.ts` — owned by nobody here"].join("\n");
+
+    warnOnDroppedContextFiles(prd, spec, "feat");
+
+    expect(entries.filter((e) => e.level === "warn" && e.stage === "plan")).toHaveLength(0);
+  });
+
+  test("applyPlanFidelity surfaces the warning without changing the returned PRD's contextFiles", () => {
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: ["src/a.ts"] })] });
+
+    const result = applyPlanFidelity(prd, CONTEXT_FILES_SPEC, "feat");
+
+    expect(result.userStories[0].contextFiles).toEqual(["src/a.ts"]);
+    expect(entries.some((e) => e.level === "warn" && e.stage === "plan" && e.data?.storyId === "US-001")).toBe(true);
   });
 });
 

--- a/test/unit/operations/plan-fidelity.test.ts
+++ b/test/unit/operations/plan-fidelity.test.ts
@@ -128,13 +128,16 @@ describe("warnOnDroppedContextFiles — #1466", () => {
     expect(entries.filter((e) => e.level === "warn" && e.stage === "plan")).toHaveLength(0);
   });
 
-  test("ignores entries naming a story the PRD does not contain", () => {
+  test("reports an entry naming a story the PRD does not contain as an orphan, not a per-story drop", () => {
     const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: [] })] });
     const spec = ["### Context Files", "", "**US-404**", "- `src/ghost.ts` — owned by nobody here"].join("\n");
 
     warnOnDroppedContextFiles(prd, spec, "feat");
 
-    expect(entries.filter((e) => e.level === "warn" && e.stage === "plan")).toHaveLength(0);
+    const warnings = entries.filter((e) => e.level === "warn" && e.stage === "plan");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("name no story in the PRD");
+    expect(warnings[0].data).toMatchObject({ orphanCount: 1, orphans: [{ storyId: "US-404", path: "src/ghost.ts" }] });
   });
 
   test("applyPlanFidelity surfaces the warning without changing the returned PRD's contextFiles", () => {
@@ -144,6 +147,70 @@ describe("warnOnDroppedContextFiles — #1466", () => {
 
     expect(result.userStories[0].contextFiles).toEqual(["src/a.ts"]);
     expect(entries.some((e) => e.level === "warn" && e.stage === "plan" && e.data?.storyId === "US-001")).toBe(true);
+  });
+
+  test("resolves a contextFiles entry stored as a {path, factId} object, not just a plain string", () => {
+    const prd = makePRD({
+      userStories: [makeStory({ id: "US-001", contextFiles: [{ path: "src/a.ts", factId: "fact-1" }] })],
+    });
+
+    warnOnDroppedContextFiles(prd, CONTEXT_FILES_SPEC, "feat");
+
+    const warning = entries.find((e) => e.level === "warn" && e.stage === "plan" && e.data?.storyId === "US-001");
+    expect(warning?.data).toMatchObject({ dropped: ["src/b.ts"] });
+  });
+
+  test("normalizes a leading ./ so it does not read as a drop", () => {
+    const spec = ["### Context Files", "", "**US-001**", "- `src/a.ts` — a", "- `src/b.ts` — b"].join("\n");
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: ["./src/a.ts", "./src/b.ts"] })] });
+
+    warnOnDroppedContextFiles(prd, spec, "feat");
+
+    expect(entries.filter((e) => e.level === "warn" && e.stage === "plan")).toHaveLength(0);
+  });
+
+  test("dedupes a spec-declared path listed twice for the same story instead of double-counting the drop", () => {
+    const spec = ["### Context Files", "", "**US-001**", "- `src/b.ts` — first", "- `src/b.ts` — again"].join("\n");
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: [] })] });
+
+    warnOnDroppedContextFiles(prd, spec, "feat");
+
+    const warning = entries.find((e) => e.level === "warn" && e.stage === "plan" && e.data?.storyId === "US-001");
+    expect(warning?.data).toMatchObject({ declaredCount: 1, droppedCount: 1, dropped: ["src/b.ts"] });
+  });
+
+  test("emits a separate warning per story when more than one drops an entry", () => {
+    const prd = makePRD({
+      userStories: [
+        makeStory({ id: "US-001", contextFiles: [] }), // src/a.ts, src/b.ts dropped
+        makeStory({ id: "US-002", contextFiles: [] }), // src/c.ts dropped
+      ],
+    });
+
+    warnOnDroppedContextFiles(prd, CONTEXT_FILES_SPEC, "feat");
+
+    const warnings = entries.filter((e) => e.level === "warn" && e.stage === "plan" && e.message.includes("absent"));
+    expect(warnings.map((w) => w.data?.storyId).sort()).toEqual(["US-001", "US-002"]);
+  });
+
+  test("ignores an absolute or traversing path instead of counting it as a drop", () => {
+    const spec = [
+      "### Context Files",
+      "",
+      "**US-001**",
+      "- `/etc/passwd` — absolute",
+      "- `../outside.ts` — traversing",
+    ].join("\n");
+    const prd = makePRD({ userStories: [makeStory({ id: "US-001", contextFiles: [] })] });
+
+    warnOnDroppedContextFiles(prd, spec, "feat");
+
+    const dropWarnings = entries.filter((e) => e.level === "warn" && e.stage === "plan" && e.message.includes("absent"));
+    expect(dropWarnings).toHaveLength(0);
+    const rejectedWarning = entries.find(
+      (e) => e.level === "warn" && e.stage === "plan" && e.message.includes("absolute or traversing"),
+    );
+    expect(rejectedWarning?.data).toMatchObject({ rejectedCount: 2 });
   });
 });
 

--- a/test/unit/prd/context-files-extract.test.ts
+++ b/test/unit/prd/context-files-extract.test.ts
@@ -104,4 +104,84 @@ describe("extractSpecContextFiles", () => {
 
     expect(extractSpecContextFiles(spec)).toHaveLength(MAX_SPEC_CONTEXT_FILES);
   });
+
+  // #1466 regression: this is spec-writing's OWN template shape (verified against
+  // docs/specs/SPEC-plan-strategy-refactor.md) — a `#### Context Files` heading
+  // nested directly under `### US-00N: ...`, with no `**US-00N**` group lead-in
+  // at all. Before the enclosingStoryId fix every entry here came back
+  // storyId: null and warnOnDroppedContextFiles silently ignored all of them.
+  test("attributes entries to the enclosing `### US-00N: ...` heading when the section is nested per-story", () => {
+    const spec = [
+      "### US-001: Strategy contract and context builder",
+      "",
+      "Some prose describing the story.",
+      "",
+      "#### Context Files",
+      "- `src/cli/plan.ts` — lines 112-157",
+      "- `src/cli/plan-helpers.ts` — buildPackageSummary",
+      "",
+      "### US-002: `SinglePlanStrategy`",
+      "",
+      "#### Context Files",
+      "- `src/plan/strategies/single.ts` — the file being created",
+    ].join("\n");
+
+    const entries = extractSpecContextFiles(spec);
+
+    expect(entries).toEqual([
+      { storyId: "US-001", path: "src/cli/plan.ts", reason: "lines 112-157" },
+      { storyId: "US-001", path: "src/cli/plan-helpers.ts", reason: "buildPackageSummary" },
+      { storyId: "US-002", path: "src/plan/strategies/single.ts", reason: "the file being created" },
+    ]);
+  });
+
+  test("an explicit `**US-00N**` lead-in inside a nested section overrides the enclosing story", () => {
+    const spec = [
+      "### US-001: Outer story",
+      "",
+      "#### Context Files",
+      "- `src/outer.ts` — belongs to the enclosing heading",
+      "",
+      "**US-999**",
+      "- `src/override.ts` — explicitly reattributed",
+    ].join("\n");
+
+    const entries = extractSpecContextFiles(spec);
+
+    expect(entries).toEqual([
+      { storyId: "US-001", path: "src/outer.ts", reason: "belongs to the enclosing heading" },
+      { storyId: "US-999", path: "src/override.ts", reason: "explicitly reattributed" },
+    ]);
+  });
+
+  test("does not climb past the nearest non-story ancestor heading", () => {
+    const spec = [
+      "## Stories",
+      "",
+      "### Design notes",
+      "",
+      "#### Context Files",
+      "- `src/unowned.ts` — nested under a non-story ancestor",
+    ].join("\n");
+
+    const entries = extractSpecContextFiles(spec);
+
+    expect(entries).toEqual([{ storyId: null, path: "src/unowned.ts", reason: "nested under a non-story ancestor" }]);
+  });
+
+  test("resolves the enclosing story independently for each nested occurrence, in document order", () => {
+    const spec = [
+      "### US-001: First",
+      "#### Context Files",
+      "- `src/a.ts` — a",
+      "### US-002: Second",
+      "#### Context Files",
+      "- `src/b.ts` — b",
+      "### US-003: Third",
+      "#### Context Files",
+      "- `src/c.ts` — c",
+    ].join("\n");
+
+    expect(extractSpecContextFiles(spec).map((e) => e.storyId)).toEqual(["US-001", "US-002", "US-003"]);
+  });
 });

--- a/test/unit/prd/context-files-extract.test.ts
+++ b/test/unit/prd/context-files-extract.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { MAX_SPEC_CONTEXT_FILES, extractSpecContextFiles } from "@/prd";
+
+/** The canonical shape spec-kit's spec-writing guide produces. */
+const CANONICAL_SPEC = [
+  "# Feature",
+  "",
+  "## Stories",
+  "",
+  "1. **US-001: Budget arithmetic** — no dependencies.",
+  "2. **US-002: Truncation** — no dependencies.",
+  "",
+  "### Context Files",
+  "",
+  "**US-001**",
+  "- `src/context/engine/available-budget.ts` — the ceiling estimator being corrected",
+  "- `src/context/engine/orchestrator.ts` — effective-budget computation and pack call site",
+  "",
+  "**US-002**",
+  "- `src/context/rules/canonical-loader.ts` — applyCanonicalRulesBudget and the priority sort",
+  "",
+  "### Creates",
+  "",
+  "**US-001**",
+  "- `test/unit/context/engine/available-budget.test.ts` — first tests for an untested module",
+].join("\n");
+
+describe("extractSpecContextFiles", () => {
+  test("extracts one entry per bullet, attributed to its `**US-00N**` group", () => {
+    const entries = extractSpecContextFiles(CANONICAL_SPEC);
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({
+      storyId: "US-001",
+      path: "src/context/engine/available-budget.ts",
+      reason: "the ceiling estimator being corrected",
+    });
+    expect(entries[1].path).toBe("src/context/engine/orchestrator.ts");
+    expect(entries[2]).toEqual({
+      storyId: "US-002",
+      path: "src/context/rules/canonical-loader.ts",
+      reason: "applyCanonicalRulesBudget and the priority sort",
+    });
+  });
+
+  test("stops at the next sibling heading, so `### Creates` is not absorbed", () => {
+    const entries = extractSpecContextFiles(CANONICAL_SPEC);
+
+    expect(entries.some((e) => e.path.includes("available-budget.test.ts"))).toBe(false);
+  });
+
+  test("accepts a parenthetical heading suffix", () => {
+    const spec = ["### Context Files (per story)", "", "**US-003**", "- `src/a.ts` — reason a"].join("\n");
+
+    const entries = extractSpecContextFiles(spec);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].storyId).toBe("US-003");
+  });
+
+  test("ignores a `### Context Files` block written inside a fenced code example", () => {
+    const spec = [
+      "# Spec about specs",
+      "",
+      "Authors write the block like this:",
+      "",
+      "```markdown",
+      "### Context Files",
+      "",
+      "**US-001**",
+      "- `src/fabricated.ts` — this is documentation, not a real declaration",
+      "```",
+      "",
+      "## Design",
+    ].join("\n");
+
+    expect(extractSpecContextFiles(spec)).toEqual([]);
+  });
+
+  test("returns an unattributed entry with a null storyId rather than guessing", () => {
+    const spec = ["## Context Files", "", "- `src/orphan.ts` — nobody declared which story owns this"].join("\n");
+
+    const entries = extractSpecContextFiles(spec);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].storyId).toBeNull();
+    expect(entries[0].path).toBe("src/orphan.ts");
+  });
+
+  test("records a bare path with an empty reason rather than dropping the entry", () => {
+    const spec = ["### Context Files", "", "**US-001**", "- `src/bare.ts`"].join("\n");
+
+    expect(extractSpecContextFiles(spec)).toEqual([{ storyId: "US-001", path: "src/bare.ts", reason: "" }]);
+  });
+
+  test("returns an empty list for a spec with no Context Files section", () => {
+    expect(extractSpecContextFiles("# Feature\n\n## Design\n\n- nothing here")).toEqual([]);
+    expect(extractSpecContextFiles("")).toEqual([]);
+  });
+
+  test("caps runaway sections at MAX_SPEC_CONTEXT_FILES", () => {
+    const bullets = Array.from({ length: MAX_SPEC_CONTEXT_FILES + 10 }, (_, i) => `- \`src/f${i}.ts\` — reason ${i}`);
+    const spec = ["### Context Files", "", "**US-001**", ...bullets].join("\n");
+
+    expect(extractSpecContextFiles(spec)).toHaveLength(MAX_SPEC_CONTEXT_FILES);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the observability-first step #1466 asked for, without touching the open policy question.

- `FILE_INJECTION_MAX_FILES = 5` (`src/context/builder.ts`) can silently evict a spec-declared `### Context Files` entry once the planner's own additions (or the `### Modifies` file) push a story past the cap. Today that eviction is invisible.
- `warnOnDroppedContextFiles` (`src/operations/plan-fidelity.ts`) compares each spec's declared `### Context Files` entries against the resulting story's `contextFiles` and logs a structured warning for anything missing. **No PRD mutation, no fallback backfill** — `contextFiles` is intentionally planner-chosen, and reconciling a drop needs a priority rule (spec-declared vs. planner-inferred reads) that doesn't exist yet. This only makes the drop frequency measurable, per the issue's suggested first step.
- Wired into `applyPlanFidelity`, so all four plan strategies (single, refine, pipeline, debate) get it uniformly — same entry point as the existing out-of-scope and `### Modifies` repairs.
- `extractSpecContextFiles` (new: `src/prd/context-files-extract.ts`) reuses the `### Modifies` parser's `**US-00N**`-grouped bullet grammar. Promoted the shared mechanics into `extractGroupedPathSection` in `src/prd/markdown-scan.ts` so the two parsers can't independently drift on what counts as a path, a group boundary, or a section end. `modifies-extract.ts` is now a thin wrapper around the same primitive — its existing 25 tests pass unchanged, confirming the refactor is behavior-preserving.

### Fixed after an independent review

The first pass of this warning was inert on the dominant real-world spec shape: spec-writing's own template nests `#### Context Files` directly under `### US-001: ...`, with no `**US-00N**` group lead-in at all (verified against `docs/specs/SPEC-plan-strategy-refactor.md` and others). Every entry came back `storyId: null` and was silently skipped — the drop metric would have read ~zero regardless of reality. Fixed with `enclosingStoryId`: when a section has no explicit group lead-in, it resolves the nearest strictly-shallower ancestor `### US-00N` heading as the default story (an explicit `**US-00N**` lead-in inside the body still overrides it). Confirmed backward compatible — `### Modifies` never nests this way in this repo, and all 25 existing `modifies.test.ts` cases still pass.

The same review also found and fixed:
- Absolute/traversing spec paths were counted as drops (an authoring slip, not an eviction) — now filtered via `isSafeRelativePath` before diffing.
- Orphaned entries (naming no story, or a story absent from the PRD) were silently discarded — now warned about, mirroring `backfillModifiedFiles`.
- A duplicate spec-declared path for one story double-counted as two drops — now deduped.
- Path comparison didn't normalize a leading `./` — now does.
- The warning now carries `declaredCount`/`presentCount` alongside `droppedCount` so a reader can tell "evicted at the 5-file cap" from "planner ignored the spec".
- `sectionLines` had leaked as a public export with no external caller and shadowed a differently-behaved private function of the same name in `out-of-scope-extract.ts` — unexported.

Closes #1466 (first step only — the priority-rule / cap-size policy question the issue raises is still open and needs a decision before any repair logic lands).

## Test plan
- [x] `bun test test/unit/prd/context-files-extract.test.ts` — extractor grammar coverage, including a regression test built from the real nested-heading spec shape that the review caught
- [x] `bun test test/unit/prd/modifies.test.ts` — all 25 existing tests pass unchanged against the refactored shared extractor
- [x] `bun test test/unit/operations/plan-fidelity.test.ts` — `warnOnDroppedContextFiles` suite: drop detection, `{path, factId}` object entries, dedup, path normalization, orphan/invalid-path reporting, multi-story warnings, wired through `applyPlanFidelity`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:bail` — full suite (11492 unit + 1092 integration + 24 UI), 0 failures