### PR TITLE
fix(nax-finish): survive an unparseable reviewer reply

### DIFF
--- a/docs/superpowers/plans/2026-08-06-nax-finish-verdict-recovery.md
+++ b/docs/superpowers/plans/2026-08-06-nax-finish-verdict-recovery.md
@@ -63,18 +63,20 @@ Create `test/unit/flows/nax-finish/verdict.test.ts`:
 import { describe, expect, test } from "bun:test";
 import { parseFixVerdict, parseReviewVerdict } from "@flows/nax-finish/verdict";
 
-// The real 927-byte reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3
-// on rs-stock/pipeline-run-chat-context. Not a synthetic "not json" string: the point is
-// that a chatty reviewer emits no brace at all, which defeats every extractJsonObject tier.
+// The real reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3 on
+// rs-stock, with private identifiers replaced by generic equivalents — the shape
+// (long, chatty, no brace anywhere) is authentic, only the names are not. Not a
+// synthetic "not json" string: the point is that a chatty reviewer emits no brace at
+// all, which defeats every extractJsonObject tier.
 const REAL_UNPARSEABLE =
   "Good, not a concern — self-contained change with a matching doc comment. " +
-  "Let's check the Python test files briefly for pipeline.py resolver, and the " +
-  "`apps/api/_pipeline_adapter.py` registration for unused import warnings etc." +
+  "Let's check the test files briefly for the request-routing resolver, and the " +
+  "`src/server/request_handler.py` registration for unused import warnings etc." +
   "Good, that exists as expected. Now let's check the gate-blocked probing logic once " +
-  "more and the `measureForNode`/`findGateBlocker` for edge cases against the AC that " +
+  "more and the `computeNodeMetrics`/`locateBlockingGate` for edge cases against the AC that " +
   '"does not render the gate\'s own output payload" — seems fine. I have enough for ' +
-  "findings.Reported two findings: a HIGH-confidence correctness regression (screen/" +
-  "backtest chat context now emits `Strategy: undefined | Universe: undefined`).";
+  "findings.Reported two findings: a HIGH-confidence correctness regression (the " +
+  "dashboard summary panel now emits `Label: undefined | Category: undefined`).";
 
 const FINDING = { severity: "HIGH", title: "t", problem: "p", fix: "f" };
 
@@ -766,7 +768,7 @@ gh pr create --base main --title "fix(nax-finish): survive an unparseable review
 A reviewer returning prose instead of JSON threw inside `parseVerdict`, failing the
 acp node and killing the whole flow — exit 1, no result file, no notification.
 
-Observed on `rs-stock/pipeline-run-chat-context` (flow run
+Observed on `rs-stock` (flow run
 `2026-08-05T154112386Z-nax-finish-600cf3f3`): the run itself was clean, 4/4 stories,
 but the flow died at `review_quality` after 128s and ~4.2M tokens, losing the quality
 review, the quality gates and the PR.
@@ -792,9 +794,9 @@ The `reprompt` branch is checked before the findings-empty branch. A reprompt ve
 carries zero findings, so the reverse order would route an unread review to `clean` and
 open a PR having verified nothing — a silent false green, worse than the crash.
 
-The regression fixture is the real 927-byte reply from the run above, not a synthetic
-string: the point is that a chatty reviewer emits no brace at all, defeating every
-`extractJsonObject` tier.
+The regression fixture is the real reply from the run above, with private identifiers
+replaced by generic equivalents, not a synthetic string: the point is that a chatty
+reviewer emits no brace at all, defeating every `extractJsonObject` tier.
 
 ## Test plan
 

--- a/docs/superpowers/plans/2026-08-06-nax-finish-verdict-recovery.md
+++ b/docs/superpowers/plans/2026-08-06-nax-finish-verdict-recovery.md
@@ -1,0 +1,825 @@
+# nax-finish Verdict Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the `nax-finish` flow from dying on a reviewer reply that isn't JSON — reprompt once, then escalate through the flow's existing human-needed sink.
+
+**Architecture:** Extract verdict parsing and review routing out of `nax-finish.flow.ts` into a new `flows/nax-finish/verdict.ts`. Split the single `parseVerdict` into a strict-but-recoverable `parseReviewVerdict` (for the two review nodes, whose JSON is load-bearing) and a never-throwing `parseFixVerdict` (for the four fix nodes, whose parsed value nothing reads). An unparseable review returns `route: "reprompt"` instead of throwing; `routeReview` loops back to the review node once, then converts to `escalate`.
+
+**Tech Stack:** Bun 1.3.7+, TypeScript strict, `bun:test`, Biome. The flow module is loaded by `acpx` in its own Node process.
+
+## Global Constraints
+
+- **`flows/` must never import from `src/`** — not via the `@/*` alias, not relatively. Only `flows/` is published. Use `FinishError` from `./errors`, never `NaxError`.
+- **No `Bun.*` APIs anywhere under `flows/`** — enforced by `bun run check:flows-no-bun`. The flow runs in acpx's Node process.
+- **600-line hard limit** for source files, **800** for test files. Enforced by `bun run check:file-sizes`, which runs as part of `bun run lint`.
+- **Functions ≤30 lines, ≤3 positional params.**
+- **No `any` in public APIs.** TypeScript strict.
+- **Conventional commits**, one concern per commit.
+- Test imports use the `@flows/...` alias (e.g. `@flows/nax-finish/verdict`), matching the existing files in `test/unit/flows/nax-finish/`.
+
+## Baseline facts (verified on this branch, `feat/nax-finish-verdict-recovery` @ `origin/main`)
+
+| Anchor | Location |
+|:--|:--|
+| `const MAX_FIX_ATTEMPTS = 3;` | `nax-finish.flow.ts:74` |
+| `routeReview` docstring | `nax-finish.flow.ts:130-135` |
+| `function routeReview(` | `nax-finish.flow.ts:136` |
+| `function parseVerdict(` | `nax-finish.flow.ts:257` |
+| flow file length | 568 lines |
+
+`nax-finish.flow.ts` is **568 lines here** but **599 on `feat/finish-pr-body`**, which is in flight and adds 45 lines to this same file. Do not be surprised by the discrepancy; the extraction is sized so the file passes the limit either way.
+
+## File Structure
+
+| File | Responsibility |
+|:--|:--|
+| `flows/nax-finish/verdict.ts` | **new** — turning a reviewer's reply into a route: both parsers, both loop caps, `repromptCount`, `routeReview` |
+| `flows/nax-finish/types.ts` | widen `ReviewVerdict.route` with `"reprompt"` |
+| `flows/nax-finish/review-prompts.ts` | `retry` flag on `buildReviewPrompt` |
+| `flows/nax-finish/nax-finish.flow.ts` | delete the moved code, import it back, wire the two parsers per node, add two switch cases, pass `retry` |
+| `test/unit/flows/nax-finish/verdict.test.ts` | **new** — parsers, counter, routing |
+| `test/unit/flows/nax-finish/flow-graph.test.ts` | extend — reprompt edges |
+| `test/unit/flows/nax-finish/review-prompts.test.ts` | extend — retry prompt |
+
+---
+
+### Task 1: Widen `ReviewVerdict.route` and create `verdict.ts` with the two parsers
+
+**Files:**
+- Modify: `flows/nax-finish/types.ts:17-26`
+- Create: `flows/nax-finish/verdict.ts`
+- Test: `test/unit/flows/nax-finish/verdict.test.ts`
+
+**Interfaces:**
+- Consumes: `ReviewVerdict`, `Finding` from `./types`; `extractJsonObject` from `acpx/flows`.
+- Produces: `parseReviewVerdict(text: string): ReviewVerdict`, `parseFixVerdict(text: string): ReviewVerdict`, `MAX_REPROMPT_ATTEMPTS: number`, `MAX_FIX_ATTEMPTS: number`, `RAW_TAIL_LIMIT: number`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/flows/nax-finish/verdict.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { parseFixVerdict, parseReviewVerdict } from "@flows/nax-finish/verdict";
+
+// The real 927-byte reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3
+// on rs-stock/pipeline-run-chat-context. Not a synthetic "not json" string: the point is
+// that a chatty reviewer emits no brace at all, which defeats every extractJsonObject tier.
+const REAL_UNPARSEABLE =
+  "Good, not a concern — self-contained change with a matching doc comment. " +
+  "Let's check the Python test files briefly for pipeline.py resolver, and the " +
+  "`apps/api/_pipeline_adapter.py` registration for unused import warnings etc." +
+  "Good, that exists as expected. Now let's check the gate-blocked probing logic once " +
+  "more and the `measureForNode`/`findGateBlocker` for edge cases against the AC that " +
+  '"does not render the gate\'s own output payload" — seems fine. I have enough for ' +
+  "findings.Reported two findings: a HIGH-confidence correctness regression (screen/" +
+  "backtest chat context now emits `Strategy: undefined | Universe: undefined`).";
+
+const FINDING = { severity: "HIGH", title: "t", problem: "p", fix: "f" };
+
+describe("parseReviewVerdict", () => {
+  test("parses a bare JSON object", () => {
+    const v = parseReviewVerdict(JSON.stringify({ route: "proceed", findings: [FINDING] }));
+    expect(v.route).toBe("proceed");
+    expect(v.findings).toHaveLength(1);
+  });
+
+  test("rewrites proceed-with-no-findings to clean", () => {
+    expect(parseReviewVerdict(JSON.stringify({ route: "proceed", findings: [] })).route).toBe("clean");
+  });
+
+  test("honours an explicit escalate route", () => {
+    const v = parseReviewVerdict(JSON.stringify({ route: "escalate", findings: [], escalationReason: "r" }));
+    expect(v.route).toBe("escalate");
+    expect(v.escalationReason).toBe("r");
+  });
+
+  test("still parses fenced JSON", () => {
+    const v = parseReviewVerdict('```json\n{"route":"proceed","findings":[]}\n```');
+    expect(v.route).toBe("clean");
+  });
+
+  test("still parses JSON embedded in prose", () => {
+    const v = parseReviewVerdict(`Here you go:\n{"route":"proceed","findings":[]}\nDone.`);
+    expect(v.route).toBe("clean");
+  });
+
+  test("routes reprompt on the real unparseable reply, with no findings", () => {
+    const v = parseReviewVerdict(REAL_UNPARSEABLE);
+    expect(v.route).toBe("reprompt");
+    expect(v.findings).toEqual([]);
+  });
+
+  test("carries a bounded tail of the raw reply", () => {
+    const v = parseReviewVerdict("x".repeat(2000));
+    expect(v.raw).toBeDefined();
+    expect((v.raw as string).length).toBeLessThanOrEqual(500);
+  });
+
+  test("routes reprompt on empty output", () => {
+    expect(parseReviewVerdict("").route).toBe("reprompt");
+  });
+});
+
+describe("parseFixVerdict", () => {
+  test("parses JSON like the review parser", () => {
+    expect(parseFixVerdict(JSON.stringify({ route: "proceed", findings: [FINDING] })).findings).toHaveLength(1);
+  });
+
+  test("never throws and never routes reprompt on garbage", () => {
+    const v = parseFixVerdict(REAL_UNPARSEABLE);
+    expect(v.route).toBe("proceed");
+    expect(v.findings).toEqual([]);
+  });
+
+  test("never throws on empty output", () => {
+    expect(parseFixVerdict("").route).toBe("proceed");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/unit/flows/nax-finish/verdict.test.ts --timeout=30000`
+Expected: FAIL — cannot resolve module `@flows/nax-finish/verdict`.
+
+- [ ] **Step 3: Widen the route union in `types.ts`**
+
+In `flows/nax-finish/types.ts`, replace the `ReviewVerdict` interface (currently lines 17-26):
+
+```ts
+export interface ReviewVerdict {
+  /**
+   * Neither `clean` nor `reprompt` is a model-produced route.
+   *
+   * `clean` — `parse` rewrites `proceed` with zero findings, so the graph can
+   * skip the fix node instead of prompting an agent to "apply fixes" for nothing.
+   *
+   * `reprompt` — `parse` could not read JSON out of the reply at all. Returning
+   * this rather than throwing is deliberate: a throw fails the acp node and kills
+   * the whole flow with no result file, bypassing the `escalate` sink that exists
+   * to report exactly this kind of dead end.
+   */
+  route: "proceed" | "escalate" | "clean" | "reprompt";
+  findings: Finding[];
+  escalationReason?: string;
+  /** Bounded tail of an unparseable reply; set only when `route` is `reprompt`. */
+  raw?: string;
+}
+```
+
+- [ ] **Step 4: Write `verdict.ts`**
+
+Create `flows/nax-finish/verdict.ts`:
+
+```ts
+/**
+ * Turning a reviewer's reply into a deterministic route.
+ *
+ * Lives outside `nax-finish.flow.ts` for two reasons: the flow file sits within
+ * a few lines of the 600-line hard limit, and this is a cohesive unit —
+ * `routeReview` consumes exactly what the parsers produce.
+ *
+ * The central invariant: **no parser here ever throws.** acpx has no node-level
+ * retry and no error edge (`AcpNodeDefinition` offers only `prompt`/`parse`;
+ * `FlowEdge` is only `to` or `switch`), so a throw inside `parse` fails the node
+ * and fails the run — exit 1, no result file, no notification, bypassing the
+ * `escalate` node that exists to report precisely this.
+ */
+import { extractJsonObject } from "acpx/flows";
+import type { Finding, ReviewVerdict } from "./types";
+
+/** Fix rounds allowed per loop before escalating. Moved here with `routeReview`. */
+export const MAX_FIX_ATTEMPTS = 3;
+
+/**
+ * Unparseable reviews tolerated per phase before escalating.
+ *
+ * One. A reviewer that ignores the JSON contract twice in a row is not going to
+ * comply on a third ask, and each review is the most expensive node in the flow
+ * (128s and ~4.2M tokens on the run that motivated this).
+ */
+export const MAX_REPROMPT_ATTEMPTS = 1;
+
+/** How much of an unparseable reply to carry forward — it lands in a PR comment and a Telegram message. */
+export const RAW_TAIL_LIMIT = 500;
+
+function tail(text: string): string {
+  const t = text.trim();
+  return t.length <= RAW_TAIL_LIMIT ? t : `…${t.slice(-RAW_TAIL_LIMIT)}`;
+}
+
+/** Shared happy path: read the object, normalise findings, rewrite empty `proceed` to `clean`. */
+function parseVerdictJson(text: string): ReviewVerdict {
+  const raw = extractJsonObject(text) as Partial<ReviewVerdict>;
+  const findings: Finding[] = Array.isArray(raw.findings) ? raw.findings : [];
+  const route = raw.route === "escalate" ? "escalate" : findings.length === 0 ? "clean" : "proceed";
+  return { route, findings, escalationReason: raw.escalationReason };
+}
+
+/**
+ * Parser for `review_spec` / `review_quality`, whose JSON is load-bearing —
+ * `findingsOf` reads it and the fix loop is driven by it. An unreadable reply
+ * routes to `reprompt` so `routeReview` can ask once more before escalating.
+ */
+export function parseReviewVerdict(text: string): ReviewVerdict {
+  try {
+    return parseVerdictJson(text);
+  } catch {
+    return { route: "reprompt", findings: [], raw: tail(text) };
+  }
+}
+
+/**
+ * Parser for the four `fix_*` nodes, whose parsed value nothing reads —
+ * `findingsOf` only ever looks at `review_spec`/`review_quality`, and
+ * `commitFixNode` decides from git rather than from the model's word.
+ *
+ * Never routes `reprompt`: the fix nodes have unconditional edges
+ * (`fix_spec → commit_spec`), so a reprompt route would have nowhere to go.
+ */
+export function parseFixVerdict(text: string): ReviewVerdict {
+  try {
+    return parseVerdictJson(text);
+  } catch {
+    return { route: "proceed", findings: [] };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test test/unit/flows/nax-finish/verdict.test.ts --timeout=30000`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flows/nax-finish/verdict.ts flows/nax-finish/types.ts test/unit/flows/nax-finish/verdict.test.ts
+git commit -m "feat(nax-finish): split verdict parsing into review and fix parsers
+
+An unparseable reviewer reply routes to reprompt instead of throwing. A
+throw inside parse fails the acp node and kills the run with no result
+file, bypassing the escalate sink built to report exactly this."
+```
+
+---
+
+### Task 2: Add `repromptCount` and move `routeReview` into `verdict.ts`
+
+**Files:**
+- Modify: `flows/nax-finish/verdict.ts`
+- Test: `test/unit/flows/nax-finish/verdict.test.ts`
+
+**Interfaces:**
+- Consumes: `parseReviewVerdict`, `MAX_FIX_ATTEMPTS`, `MAX_REPROMPT_ATTEMPTS` from Task 1; `fixAttemptCount`, `StepsCtx`, `OutputsCtx` from `./flow-ctx`.
+- Produces: `repromptCount(ctx: StepsCtx, phase: "spec" | "quality"): number`, and `routeReview(ctx: OutputsCtx & StepsCtx, phase: "spec" | "quality"): { route: string; escalationReason?: string; findings: Finding[] }`.
+
+**Why `repromptCount` cannot just count `review_*` steps:** `commit_quality → review_quality` and `commit_gate → review_quality` are legitimate re-entries in the normal fix loop. The counter must look at each step's recorded *output*. It can, because acpx's `FlowStepRecord` carries `output` — and `StepsCtx` (`flow-ctx.ts:23-25`) already declares `steps: { nodeId: string; output?: unknown }[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/flows/nax-finish/verdict.test.ts`:
+
+```ts
+import { MAX_FIX_ATTEMPTS, MAX_REPROMPT_ATTEMPTS, repromptCount, routeReview } from "@flows/nax-finish/verdict";
+
+const stepsCtx = (steps: { nodeId: string; output?: unknown }[]) => ({ state: { steps }, outputs: {} });
+const routeCtx = (verdict: unknown, steps: { nodeId: string; output?: unknown }[] = []) => ({
+  outputs: { review_quality: verdict },
+  state: { steps },
+});
+const REPROMPT_STEP = { nodeId: "review_quality", output: { route: "reprompt", findings: [] } };
+const CLEAN_STEP = { nodeId: "review_quality", output: { route: "clean", findings: [] } };
+
+describe("repromptCount", () => {
+  test("is zero with no steps", () => {
+    expect(repromptCount(stepsCtx([]), "quality")).toBe(0);
+  });
+
+  test("ignores legitimate review re-entries that produced a real verdict", () => {
+    expect(repromptCount(stepsCtx([CLEAN_STEP, { nodeId: "commit_quality" }, CLEAN_STEP]), "quality")).toBe(0);
+  });
+
+  test("counts only steps whose output routed reprompt", () => {
+    expect(repromptCount(stepsCtx([CLEAN_STEP, REPROMPT_STEP]), "quality")).toBe(1);
+  });
+
+  test("does not count the other phase's reprompts", () => {
+    expect(repromptCount(stepsCtx([REPROMPT_STEP]), "spec")).toBe(0);
+  });
+});
+
+describe("routeReview", () => {
+  test("a reprompt verdict is NEVER routed clean", () => {
+    // Regression guard. A reprompt verdict has zero findings, so an ordering
+    // slip that checks `findings.length === 0` first would call an unread
+    // review "clean" and open a PR having verified nothing — a silent false
+    // green, strictly worse than the crash this change removes.
+    const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "prose" }), "quality");
+    expect(r.route).not.toBe("clean");
+    expect(r.route).toBe("reprompt");
+  });
+
+  test("escalates once the reprompt cap is reached, naming the raw tail", () => {
+    const steps = Array.from({ length: MAX_REPROMPT_ATTEMPTS }, () => REPROMPT_STEP);
+    const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "some prose" }, steps), "quality");
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toContain("unparseable");
+    expect(r.escalationReason).toContain("some prose");
+  });
+
+  test("still routes clean when there are no findings", () => {
+    expect(routeReview(routeCtx({ route: "clean", findings: [] }), "quality").route).toBe("clean");
+  });
+
+  test("still routes fix when there are findings under the cap", () => {
+    expect(routeReview(routeCtx({ route: "proceed", findings: [FINDING] }), "quality").route).toBe("fix");
+  });
+
+  test("still escalates an explicit escalate verdict", () => {
+    const r = routeReview(routeCtx({ route: "escalate", findings: [], escalationReason: "judgment" }), "quality");
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toBe("judgment");
+  });
+
+  test("still escalates when findings persist past the fix cap", () => {
+    const steps = Array.from({ length: MAX_FIX_ATTEMPTS }, () => ({ nodeId: "fix_quality" }));
+    const r = routeReview(routeCtx({ route: "proceed", findings: [FINDING] }, steps), "quality");
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toContain("fix attempts");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/unit/flows/nax-finish/verdict.test.ts --timeout=30000`
+Expected: FAIL — `repromptCount` and `routeReview` are not exported.
+
+- [ ] **Step 3: Append `repromptCount` and `routeReview` to `verdict.ts`**
+
+First extend the import block at the top of the file — these three names are unused until
+now, so adding them in Task 1 would have tripped Biome's unused-import rule:
+
+```ts
+import { fixAttemptCount, type OutputsCtx, type StepsCtx } from "./flow-ctx";
+```
+
+Then append:
+
+```ts
+/**
+ * How many times this phase's review already came back unparseable.
+ *
+ * Counts step *outputs*, not step ids: `commit_quality → review_quality` and
+ * `commit_gate → review_quality` are legitimate re-entries in the normal fix
+ * loop, so counting bare `review_<phase>` steps would escalate a healthy run.
+ *
+ * This is observable only because `parseReviewVerdict` returns rather than
+ * throws — a returned verdict makes acpx record the step as successful with
+ * this output. A throw would record it `failed`, with nothing to count.
+ */
+export function repromptCount(ctx: StepsCtx, phase: "spec" | "quality"): number {
+  return (ctx.state.steps ?? []).filter(
+    (s) => s.nodeId === `review_${phase}` && (s.output as ReviewVerdict | undefined)?.route === "reprompt",
+  ).length;
+}
+
+/**
+ * Turn a reviewer verdict into a deterministic route.
+ *
+ * `clean` (no findings) skips the fix node entirely — prompting an agent to
+ * "apply the recommended fixes" for an empty finding list burns a turn and
+ * invites unrequested edits.
+ *
+ * The `reprompt` branch MUST come first. A reprompt verdict carries zero
+ * findings, so checking `findings.length === 0` ahead of it would route an
+ * unreadable review to `clean`, and the flow would open a PR having reviewed
+ * nothing. That silent false green is worse than the crash this replaces.
+ */
+export function routeReview(
+  ctx: OutputsCtx & StepsCtx,
+  phase: "spec" | "quality",
+): { route: string; escalationReason?: string; findings: Finding[] } {
+  const verdict = (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`];
+  const findings = verdict?.findings ?? [];
+  if (verdict?.route === "reprompt") {
+    const attempts = repromptCount(ctx, phase);
+    if (attempts < MAX_REPROMPT_ATTEMPTS) return { route: "reprompt", findings };
+    return {
+      route: "escalate",
+      escalationReason:
+        `${phase} reviewer returned unparseable output after ${attempts + 1} attempts. ` +
+        `Last reply: ${verdict.raw ?? "(empty)"}`,
+      findings,
+    };
+  }
+  if (verdict?.route === "escalate") {
+    return {
+      route: "escalate",
+      escalationReason: verdict.escalationReason ?? `${phase} review raised a finding needing human judgment`,
+      findings,
+    };
+  }
+  if (findings.length === 0) return { route: "clean", findings };
+  const attempts = fixAttemptCount(ctx, `fix_${phase}`);
+  if (attempts >= MAX_FIX_ATTEMPTS) {
+    return {
+      route: "escalate",
+      escalationReason: `${phase} review still reporting ${findings.length} finding(s) after ${attempts} fix attempts.`,
+      findings,
+    };
+  }
+  return { route: "fix", findings };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test test/unit/flows/nax-finish/verdict.test.ts --timeout=30000`
+Expected: PASS, 21 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flows/nax-finish/verdict.ts test/unit/flows/nax-finish/verdict.test.ts
+git commit -m "feat(nax-finish): route unparseable reviews to a capped reprompt
+
+The reprompt branch is checked before the findings-empty branch: a
+reprompt verdict has zero findings, so the reverse order would call an
+unread review clean and ship a PR having verified nothing."
+```
+
+---
+
+### Task 3: Add the retry variant to `buildReviewPrompt`
+
+**Files:**
+- Modify: `flows/nax-finish/review-prompts.ts:330-333` (signature) and both return branches
+- Test: `test/unit/flows/nax-finish/review-prompts.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-2.
+- Produces: `buildReviewPrompt(phase, args)` gains an optional `retry?: boolean` on `args`. Task 4 passes it.
+
+`buildReviewPrompt` has two return branches — a full review (no `args.since`) and an incremental one (with `since`). Both end with `JSON_CONTRACT`. The retry notice goes at the **front** of both, where a lead instruction is hardest to lose, while `JSON_CONTRACT` stays last.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/flows/nax-finish/review-prompts.test.ts`:
+
+```ts
+describe("buildReviewPrompt retry variant", () => {
+  const base = { base: "origin/main", specPath: "spec.md" };
+
+  test("omits the retry notice by default", () => {
+    expect(buildReviewPrompt("quality", base)).not.toContain("previous reply could not be parsed");
+  });
+
+  test("leads a full review with the retry notice when retrying", () => {
+    const p = buildReviewPrompt("quality", { ...base, retry: true });
+    expect(p).toContain("previous reply could not be parsed");
+    expect(p.indexOf("previous reply could not be parsed")).toBeLessThan(p.indexOf("You are the QUALITY reviewer"));
+  });
+
+  test("leads an incremental review with the retry notice too", () => {
+    const p = buildReviewPrompt("spec", { ...base, since: "abc123", priorFindings: [], retry: true });
+    expect(p).toContain("previous reply could not be parsed");
+    expect(p).toContain("abc123");
+  });
+
+  test("keeps the JSON contract last on a retry", () => {
+    const p = buildReviewPrompt("quality", { ...base, retry: true });
+    expect(p.trimEnd().endsWith("}")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/unit/flows/nax-finish/review-prompts.test.ts --timeout=30000`
+Expected: FAIL — the retry notice is absent, and `retry` is not on the args type.
+
+- [ ] **Step 3: Implement**
+
+In `flows/nax-finish/review-prompts.ts`, add above `buildReviewPrompt`:
+
+```ts
+/**
+ * Prepended when a previous attempt at this review returned something that was
+ * not JSON. Lead position, not appended: the failure mode is a model that
+ * narrates its findings and forgets the contract at the end of a long turn.
+ */
+const RETRY_NOTICE = [
+  "IMPORTANT — your previous reply could not be parsed as JSON, so it was discarded entirely.",
+  "Do not narrate your findings in prose. Do not describe what you reported.",
+  "Your entire reply must be the JSON object described at the end of this prompt: first char `{`, last char `}`.",
+].join("\n");
+```
+
+Change the signature to accept `retry`:
+
+```ts
+export function buildReviewPrompt(
+  phase: "spec" | "quality",
+  args: { base: string; specPath: string; since?: string | null; priorFindings?: Finding[]; retry?: boolean },
+): string {
+  const dims = phase === "spec" ? SPEC_REVIEW_DIMENSIONS : QUALITY_REVIEW_DIMENSIONS;
+  const lead = args.retry ? [RETRY_NOTICE] : [];
+```
+
+Then spread `lead` into the front of both existing return arrays. The full-review branch becomes:
+
+```ts
+  if (!args.since) {
+    return [
+      ...lead,
+      `You are the ${phase.toUpperCase()} reviewer for a completed feature.`,
+      `The spec/requirements source is: ${args.specPath}. Read it in full.`,
+      `Fetch and review the diff: \`git diff ${args.base}...HEAD\` (also \`--name-only\` for the file list).`,
+      WORKER_PROTOCOL,
+      dims,
+      CLASSIFIER,
+      JSON_CONTRACT,
+    ].join("\n\n");
+  }
+```
+
+And the incremental branch keeps every one of its existing entries in order, with `...lead,` inserted as the first element:
+
+```ts
+  return [
+    ...lead,
+    `You are the ${phase.toUpperCase()} reviewer for a completed feature, continuing a review you already started.`,
+    // ...every existing entry unchanged, through JSON_CONTRACT
+  ].join("\n\n");
+```
+
+Change nothing else about either array.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test test/unit/flows/nax-finish/review-prompts.test.ts --timeout=30000`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flows/nax-finish/review-prompts.ts test/unit/flows/nax-finish/review-prompts.test.ts
+git commit -m "feat(nax-finish): lead a retried review with a JSON-only notice"
+```
+
+---
+
+### Task 4: Wire the flow — delete the moved code, add the reprompt edges
+
+**Files:**
+- Modify: `flows/nax-finish/nax-finish.flow.ts` — delete lines 74 (`MAX_FIX_ATTEMPTS`), 130-135 + 136-158 (`routeReview` + docstring), 255-262 (`parseVerdict` + docstring); update imports; wire parsers; add switch cases; pass `retry`
+- Test: `test/unit/flows/nax-finish/flow-graph.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3.
+- Produces: the finished graph. Nothing downstream depends on new names.
+
+Verify the exact line numbers with `grep -n "^const MAX_FIX_ATTEMPTS\|^function routeReview\|^function parseVerdict" flows/nax-finish/nax-finish.flow.ts` before deleting — a preceding task may have shifted them.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/flows/nax-finish/flow-graph.test.ts`:
+
+```ts
+describe("reprompt edges", () => {
+  test("route_spec routes reprompt back to review_spec", () => {
+    expect(switchOf("route_spec").cases.reprompt).toBe("review_spec");
+  });
+
+  test("route_quality routes reprompt back to review_quality", () => {
+    expect(switchOf("route_quality").cases.reprompt).toBe("review_quality");
+  });
+
+  test("the existing routes are untouched", () => {
+    expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
+    expect(switchOf("route_quality").cases.fix).toBe("fix_quality");
+    expect(switchOf("route_quality").cases.escalate).toBe("escalate");
+  });
+
+  test("route_quality yields reprompt for an unparseable verdict", async () => {
+    const out = await nodeRun<{ route: string }>("route_quality").run(
+      ctxOf({ outputs: { review_quality: { route: "reprompt", findings: [], raw: "prose" } } }),
+    );
+    expect(out.route).toBe("reprompt");
+  });
+
+  test("review_quality leads with the retry notice after a reprompt", () => {
+    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: [{ nodeId: "review_quality", output: { route: "reprompt", findings: [] } }] as never,
+      }),
+    );
+    expect(prompt).toContain("previous reply could not be parsed");
+  });
+
+  test("a retried review is a FULL review, not an incremental one", () => {
+    // incrementalSince scopes a re-review to firstCommit.shaBefore..HEAD by finding
+    // the first commit_* step after the last review_<phase>. On a reprompt re-entry
+    // no commit_* follows, so it returns null and the whole base...HEAD diff is
+    // re-read. That is right — the previous attempt produced no verdict, so there is
+    // no cleared window to skip. Pinned so nobody "optimises" it into an incremental.
+    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: [{ nodeId: "review_quality", output: { route: "reprompt", findings: [] } }] as never,
+      }),
+    );
+    expect(prompt).toContain("git diff origin/main...HEAD");
+    expect(prompt).not.toContain("continuing a review you already started");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/unit/flows/nax-finish/flow-graph.test.ts --timeout=30000`
+Expected: FAIL — `cases.reprompt` is `undefined`.
+
+- [ ] **Step 3: Implement**
+
+1. Delete `const MAX_FIX_ATTEMPTS = 3;`, the whole `routeReview` function with its docstring, and the whole `parseVerdict` function with its docstring.
+
+2. Update the imports at the top:
+
+```ts
+import { defineFlow } from "acpx/flows";   // extractJsonObject no longer used here
+```
+
+and add:
+
+```ts
+import { MAX_FIX_ATTEMPTS, parseFixVerdict, parseReviewVerdict, repromptCount, routeReview } from "./verdict";
+```
+
+3. Point each acp node at the right parser:
+
+| node | `parse:` |
+|:--|:--|
+| `review_spec` | `parseReviewVerdict` |
+| `review_quality` | `parseReviewVerdict` |
+| `fix_acceptance` | `parseFixVerdict` |
+| `fix_spec` | `parseFixVerdict` |
+| `fix_quality` | `parseFixVerdict` |
+| `fix_gate` | `parseFixVerdict` |
+
+4. Pass `retry` from both review nodes' `prompt(ctx)`. For `review_quality`:
+
+```ts
+      prompt(ctx) {
+        const outs = loadCtxOf(ctx);
+        return buildReviewPrompt("quality", {
+          base: outs.base ?? "origin/main",
+          specPath: outs.specPath ?? "",
+          since: incrementalSince(ctx, "quality"),
+          priorFindings: findingsOf(ctx, "quality"),
+          retry: repromptCount(ctx, "quality") > 0,
+        });
+      },
+```
+
+Make the identical change in `review_spec` with `"spec"` in all four places.
+
+5. Add the `reprompt` case to both review switch edges:
+
+```ts
+    {
+      from: "route_spec",
+      switch: {
+        on: "$.route",
+        cases: { clean: "review_quality", fix: "fix_spec", escalate: "escalate", reprompt: "review_spec" },
+      },
+    },
+```
+
+```ts
+    {
+      from: "route_quality",
+      switch: {
+        on: "$.route",
+        cases: { clean: "quality_gates", fix: "fix_quality", escalate: "escalate", reprompt: "review_quality" },
+      },
+    },
+```
+
+- [ ] **Step 4: Run the flow tests**
+
+Run: `bun test test/unit/flows/nax-finish/ --timeout=60000`
+Expected: PASS, including the pre-existing `flow-graph.test.ts` and `flow-commits.test.ts` suites.
+
+- [ ] **Step 5: Verify the line budget and the full gate**
+
+```bash
+wc -l flows/nax-finish/nax-finish.flow.ts   # expect ~533, must be < 600
+bun run lint
+bun run typecheck
+```
+
+Expected: `wc -l` under 600, and both commands clean. `bun run lint` includes `check:file-sizes` and `check:flows-no-bun`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flows/nax-finish/nax-finish.flow.ts test/unit/flows/nax-finish/flow-graph.test.ts
+git commit -m "feat(nax-finish): wire the reprompt route into the review loops
+
+Moves routeReview and MAX_FIX_ATTEMPTS to verdict.ts. The flow file sits
+within a few lines of the 600-line limit on main and is 45 lines longer
+on feat/finish-pr-body, so the extraction is what keeps it passing
+check:file-sizes after that branch merges."
+```
+
+---
+
+### Task 5: Full suite and PR
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run the whole suite**
+
+Run: `bun run test`
+Expected: PASS. If anything unrelated to `flows/nax-finish/` fails, check whether it also fails on `origin/main` before treating it as a regression from this work.
+
+- [ ] **Step 2: Confirm no `src/` import leaked into `flows/`**
+
+Run: `grep -rn "from \"@/\|from \"\.\./\.\./src" flows/nax-finish/`
+Expected: no output.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/nax-finish-verdict-recovery
+gh pr create --base main --title "fix(nax-finish): survive an unparseable reviewer reply" --body "$(cat <<'EOF'
+## Problem
+
+A reviewer returning prose instead of JSON threw inside `parseVerdict`, failing the
+acp node and killing the whole flow — exit 1, no result file, no notification.
+
+Observed on `rs-stock/pipeline-run-chat-context` (flow run
+`2026-08-05T154112386Z-nax-finish-600cf3f3`): the run itself was clean, 4/4 stories,
+but the flow died at `review_quality` after 128s and ~4.2M tokens, losing the quality
+review, the quality gates and the PR.
+
+`parseVerdict` was the `parse` for all six acp nodes, and four of them
+(`fix_acceptance`, `fix_spec`, `fix_quality`, `fix_gate`) never read the parsed value —
+so four nodes could kill a multi-hour run over output nothing consumes.
+
+## Change
+
+- `flows/nax-finish/verdict.ts` (new) owns verdict parsing and review routing
+- `parseReviewVerdict` routes an unreadable reply to `reprompt` instead of throwing;
+  `routeReview` retries the review once, then escalates
+- `parseFixVerdict` never throws, for the four nodes whose verdict is unread
+- `routeReview` and `MAX_FIX_ATTEMPTS` move out of the flow file, which was within a
+  few lines of the 600-line limit
+- Escalation now reaches the existing `escalate` sink, which writes the result file
+  before delivery — so the plugin always gets a result and Telegram always fires
+
+## Notes
+
+The `reprompt` branch is checked before the findings-empty branch. A reprompt verdict
+carries zero findings, so the reverse order would route an unread review to `clean` and
+open a PR having verified nothing — a silent false green, worse than the crash.
+
+The regression fixture is the real 927-byte reply from the run above, not a synthetic
+string: the point is that a chatty reviewer emits no brace at all, defeating every
+`extractJsonObject` tier.
+
+## Test plan
+
+- [x] `bun test test/unit/flows/nax-finish/`
+- [x] `bun run lint` (includes `check:file-sizes`, `check:flows-no-bun`)
+- [x] `bun run typecheck`
+- [x] `bun run test`
+EOF
+)"
+```
+
+---
+
+## Merge note
+
+`feat/finish-pr-body` is in flight against the same flow. It adds 45 lines to
+`nax-finish.flow.ts`, and it moved `flows/nax-finish/pr-body.ts` to
+`flows/nax-finish/steps/pr-body.ts`. Neither collides with the regions this plan edits
+(`routeReview`, `parseVerdict`, the node `parse:` fields, the review switch edges), and
+its `types.ts` change is to `FinishRound` while this one is to `ReviewVerdict`. Expect a
+small textual conflict in the flow file's import block at worst.
+
+## Out of scope
+
+- Node-level retry or `onError` edges in acpx
+- Reviewer model or profile changes
+- The two rs-stock findings the crash discarded
+- The `nax-finish` post-run `shouldRun` gate, which correctly declines on `main`

--- a/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
@@ -1,0 +1,203 @@
+# nax-finish verdict recovery
+
+**Date:** 2026-08-06
+**Status:** designed, not implemented
+
+## Problem
+
+A reviewer node in the `nax-finish` flow returned prose instead of JSON. `parseVerdict`
+threw, the node failed, and the whole flow died with exit 1 and no result file. The
+post-run plugin had nothing to read and nothing to notify from.
+
+Observed on `rs-stock/pipeline-run-chat-context`, flow run
+`2026-08-05T154112386Z-nax-finish-600cf3f3`. The run itself was clean — 4/4 stories,
+$27.27, 3h47m. The flow got through `load_ctx → acceptance → review_spec → route_spec →
+fix_spec → commit_spec → acceptance → review_spec → route_spec` and died at
+`review_quality` after 128s and ~4.2M tokens. The reviewer's final message was a
+927-byte narration ending:
+
+> "Reported two findings: a HIGH-confidence correctness regression … and a
+> lower-confidence design gap …"
+
+No `{` anywhere in it. `extractJsonObject` is already maximally lenient — `compat` mode
+tries direct parse, then a fenced block, then a balanced-brace substring scan
+(`acpx/src/flows/json.ts`) — and all three tiers miss on text with no braces at all.
+The prompt does state the contract (`review-prompts.ts:305`, `JSON_CONTRACT`: "Return
+exactly one JSON object and nothing else"), so this is model non-compliance, not a
+missing instruction.
+
+What the crash cost: the quality review's two findings, the quality gates, and the PR.
+The spec-phase fix survived because `commit_spec` had already committed it
+(`08986709` on `feat/pipeline-run-chat-context`).
+
+## Blast radius
+
+`parseVerdict` is the `parse` hook for all six acp nodes, but only two of them read the
+parsed value:
+
+| node | parsed value used? |
+|:--|:--|
+| `review_spec` | yes — `findingsOf` reads it |
+| `review_quality` | yes — `findingsOf` reads it |
+| `fix_acceptance` | no |
+| `fix_spec` | no |
+| `fix_quality` | no |
+| `fix_gate` | no |
+
+`findingsOf` (`flow-ctx.ts:59-62`) only ever reads `review_spec` / `review_quality`.
+The four `fix_*` nodes route unconditionally (`fix_spec → commit_spec`), and
+`commitFixNode` decides from git rather than from the model's word. So four nodes can
+kill a multi-hour run over output nothing reads.
+
+## Constraints
+
+**`parse` is the only seam.** acpx's `AcpNodeDefinition` exposes `prompt`, `parse`,
+`profile`, `session`, `timeoutMs` — no retry, no `onError`. `FlowEdge` is only `{to}`
+or `{switch}`, so there is no error edge to route to. A fix stays inside the parse
+functions and the switch cases the flow owns, or it becomes an acpx change.
+
+**`nax-finish.flow.ts` is 599 lines** against the repo's 600-line `SRC_LIMIT`. New
+logic goes in its own module.
+
+**The `escalate` node is already the right sink.** It writes the result file *before*
+attempting delivery, pushes partial fixes, and notifies Telegram — built exactly so
+"a human is needed" always gets reported (#1399). The `parse` throw is the one path
+that bypasses it.
+
+## Design
+
+### Architecture
+
+New module `flows/nax-finish/verdict.ts` owning both parsers, the cap constant, and the
+attempt counter. `parseVerdict` is deleted from `nax-finish.flow.ts` and replaced by two
+imports — a net line reduction, which matters at 599/600.
+
+`ReviewVerdict.route` (`types.ts:23`) widens from `"proceed" | "escalate" | "clean"` to
+include `"reprompt"`, documented the same way `clean` already is: not a model-produced
+route, synthesised by `parse` so the graph can branch on it.
+
+### Components
+
+```ts
+// flows/nax-finish/verdict.ts
+export const MAX_REPROMPT_ATTEMPTS = 1;
+
+/** review_spec / review_quality — JSON is load-bearing; garbage routes to reprompt. */
+export function parseReviewVerdict(text: string): ReviewVerdict
+
+/** fix_* — parsed value is never read; best-effort, never throws. */
+export function parseFixVerdict(text: string): ReviewVerdict
+
+/** How many times this phase's review already came back unparseable. */
+export function repromptCount(ctx: StepsCtx, phase: FinishPhase): number
+```
+
+`parseReviewVerdict` keeps the existing body — `extractJsonObject`, findings array,
+`proceed`-with-zero-findings rewritten to `clean` — wrapped so a throw becomes
+`{ route: "reprompt", findings: [], raw: <truncated tail> }`.
+
+`parseFixVerdict` does the same parse but returns `{ route: "proceed", findings: [] }`
+on garbage. It never throws and never routes to `reprompt`, because the `fix_*` nodes
+have unconditional edges with nowhere for a reprompt to go.
+
+`repromptCount` counts step records where `nodeId === review_<phase>` **and**
+`output.route === "reprompt"`. Counting bare `review_*` entries would be wrong:
+`commit_quality → review_quality` and `commit_gate → review_quality` are legitimate
+re-entries in the normal fix loop. This works because acpx's `FlowStepRecord` carries
+`output` (`acpx/src/flows/types.ts:216-234`); the flow's local
+`state: { steps: { nodeId: string }[] }` annotation is a narrowing of a richer runtime
+object, so it widens to `{ nodeId: string; output?: unknown }`.
+
+### Data flow
+
+```
+review_quality  parse fails → { route: "reprompt", findings: [], raw: <tail> }
+      │
+      ▼
+route_quality = routeReview(ctx, "quality")
+      │
+      ├─ repromptCount < 1  → { route: "reprompt" } ──→ review_quality
+      │                                                  (retry: true prompt)
+      └─ repromptCount >= 1 → { route: "escalate",
+                                 escalationReason: "quality reviewer returned
+                                 unparseable output after 2 attempts: <tail>" }
+                                                    ──→ escalate
+```
+
+Two new edge cases: `reprompt: "review_spec"` on `route_spec`, and
+`reprompt: "review_quality"` on `route_quality`.
+
+The review nodes' `prompt(ctx)` passes `retry: repromptCount(ctx, phase) > 0` to
+`buildReviewPrompt`, which on retry leads with a hard JSON-only reminder ahead of the
+existing `JSON_CONTRACT`. Both review nodes are `session: { isolated: true }`, so each
+retry runs in a fresh session and the prompt is already self-contained — there is no
+conversational continuity to preserve.
+
+### Error handling
+
+`routeReview` currently reads:
+
+```ts
+if (verdict?.route === "escalate") { … }
+if (findings.length === 0) return { route: "clean", findings };   // ← danger
+```
+
+A reprompt verdict has zero findings. If the reprompt check goes *after* that line, an
+unparseable review is read as **clean**, and the flow proceeds to `quality_gates` and
+opens a PR having reviewed nothing — a silent false green, strictly worse than today's
+loud crash. **The reprompt check must be the first branch in `routeReview`**, and that
+ordering gets its own test.
+
+Invariants after this change:
+
+- No `parse` in the flow can throw. All six acp nodes become non-fatal.
+- Every unparseable path terminates at `escalate`, which writes the result file before
+  delivery — so the plugin always gets a result and Telegram always fires.
+- `findingsOf` returns `[]` for a reprompt verdict. No phantom findings leak into a fix
+  prompt or the audit trail.
+- The raw tail embedded in `escalationReason` is truncated to 500 characters, since it
+  lands in a PR comment and a Telegram message.
+
+### Testing
+
+`test/unit/flows/nax-finish/verdict.test.ts` (new):
+
+- `parseReviewVerdict` on valid JSON, fenced JSON, and JSON embedded in prose — all
+  still parse, since `extractJsonObject`'s three tiers are unchanged
+- `parseReviewVerdict` on prose with no braces → `route: "reprompt"`
+- `parseFixVerdict` never throws on any of the same inputs
+- The regression fixture is the **real captured output** — the 927-byte artifact from
+  the rs-stock run (`sha256-926e009aa773a68da5cb0aaf126d3ea50feb81dc81fd6d6f618bcd4acea4b20d`),
+  not a synthetic `"not json"` string
+- `repromptCount` ignores legitimate `review_*` re-entries and counts only steps whose
+  output routed `reprompt`
+
+`test/unit/flows/nax-finish/flow-graph.test.ts` (extend):
+
+- `route_spec` and `route_quality` each have a `reprompt` case pointing back at their
+  review node
+- `routeReview` returns `reprompt` below the cap and `escalate` at the cap
+- **a reprompt verdict is never routed `clean`** — the ordering guard
+
+### Files
+
+| file | change |
+|:--|:--|
+| `flows/nax-finish/verdict.ts` | new — both parsers, cap, counter |
+| `flows/nax-finish/nax-finish.flow.ts` | drop `parseVerdict`, import the two parsers, wire per node, reorder `routeReview`, add 2 switch cases |
+| `flows/nax-finish/types.ts` | widen `ReviewVerdict.route` with `"reprompt"` |
+| `flows/nax-finish/review-prompts.ts` | `retry` param on `buildReviewPrompt` |
+| `test/unit/flows/nax-finish/verdict.test.ts` | new |
+| `test/unit/flows/nax-finish/flow-graph.test.ts` | extend |
+
+## Out of scope
+
+- Node-level retry or `onError` edges in acpx. That would benefit every flow, but it
+  touches a separate package and needs an acpx release.
+- Reviewer model or profile changes. The failing reviewer was
+  `nax-quality-reviewer` (claude-agent-acp, sonnet); swapping models is a different
+  lever and would not make the flow survive the next non-compliant reply.
+- The two rs-stock findings the crash discarded. They are real and tracked separately
+  against `rs-stock/pipeline-run-chat-context`.
+- The `nax-finish` post-run `shouldRun` gate. It correctly declines on `main`; that it
+  declines at `debug` level is a separate observability issue.

--- a/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
@@ -9,9 +9,9 @@ A reviewer node in the `nax-finish` flow returned prose instead of JSON. `parseV
 threw, the node failed, and the whole flow died with exit 1 and no result file. The
 post-run plugin had nothing to read and nothing to notify from.
 
-Observed on `rs-stock/pipeline-run-chat-context`, flow run
-`2026-08-05T154112386Z-nax-finish-600cf3f3`. The run itself was clean — 4/4 stories,
-$27.27, 3h47m. The flow got through `load_ctx → acceptance → review_spec → route_spec →
+Observed on `rs-stock`, flow run
+`2026-08-05T154112386Z-nax-finish-600cf3f3`. The run itself was clean — 4/4 stories.
+The flow got through `load_ctx → acceptance → review_spec → route_spec →
 fix_spec → commit_spec → acceptance → review_spec → route_spec` and died at
 `review_quality` after 128s and ~4.2M tokens. The reviewer's final message was a
 927-byte narration ending:
@@ -27,8 +27,8 @@ exactly one JSON object and nothing else"), so this is model non-compliance, not
 missing instruction.
 
 What the crash cost: the quality review's two findings, the quality gates, and the PR.
-The spec-phase fix survived because `commit_spec` had already committed it
-(`08986709` on `feat/pipeline-run-chat-context`).
+The spec-phase fix survived because `commit_spec` had already committed it to the
+feature branch before the crash.
 
 ## Blast radius
 
@@ -220,9 +220,10 @@ Invariants after this change:
   still parse, since `extractJsonObject`'s three tiers are unchanged
 - `parseReviewVerdict` on prose with no braces → `route: "reprompt"`
 - `parseFixVerdict` never throws on any of the same inputs
-- The regression fixture is the **real captured output** — the 927-byte artifact from
+- The regression fixture is the **real captured output** — the artifact from
   the rs-stock run (`sha256-926e009aa773a68da5cb0aaf126d3ea50feb81dc81fd6d6f618bcd4acea4b20d`),
-  not a synthetic `"not json"` string
+  with private identifiers replaced by generic equivalents, not a synthetic
+  `"not json"` string
 - `repromptCount` ignores legitimate `review_*` re-entries and counts only steps whose
   output routed `reprompt`
 
@@ -252,6 +253,6 @@ Invariants after this change:
   `nax-quality-reviewer` (claude-agent-acp, sonnet); swapping models is a different
   lever and would not make the flow survive the next non-compliant reply.
 - The two rs-stock findings the crash discarded. They are real and tracked separately
-  against `rs-stock/pipeline-run-chat-context`.
+  in that project.
 - The `nax-finish` post-run `shouldRun` gate. It correctly declines on `main`; that it
   declines at `debug` level is a separate observability issue.

--- a/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
@@ -56,10 +56,17 @@ kill a multi-hour run over output nothing reads.
 or `{switch}`, so there is no error edge to route to. A fix stays inside the parse
 functions and the switch cases the flow owns, or it becomes an acpx change.
 
-**`nax-finish.flow.ts` is 599 lines** against a 600-line hard limit for source files,
-enforced by `bun run check:file-sizes` as part of `bun run lint`. Adding to it fails the
-lint gate. New logic goes in its own module — and enough existing logic must *leave* the
-flow file to buy headroom, because the additions alone would push it to ~607.
+**`nax-finish.flow.ts` is near a 600-line hard limit** for source files, enforced by
+`bun run check:file-sizes` as part of `bun run lint`.
+
+The count depends on which branch you measure: **568 on `origin/main`**, but **599 on
+`feat/finish-pr-body`**, whose in-flight work adds 45 lines to this file. This change
+branches from `origin/main`, so the additions alone (~15) would land at ~583 and pass —
+until `feat/finish-pr-body` merges, at which point the same file would be ~614 and fail.
+
+So the headroom is not optional, it is only *deferred*. Moving `routeReview` out lands
+the file at ~533 on this branch and ~564 after that merge — under the limit in both
+worlds, in whichever order they land.
 
 **The `escalate` node is already the right sink.** It writes the result file *before*
 attempting delivery, pushes partial fixes, and notifies Telegram — built exactly so
@@ -73,11 +80,11 @@ that bypasses it.
 New module `flows/nax-finish/verdict.ts` owning everything that turns a reviewer's reply
 into a route: both parsers, both loop caps, the attempt counter, and `routeReview`.
 
-Moving `routeReview` out is what makes the line budget work. Removing `parseVerdict`
-alone (~7 lines) against the additions (~15) would net **+8 → ~607**, over the limit.
-Taking `routeReview` and its docstring too (~31 lines) nets roughly **-35 → ~564**, with
-real headroom. It is also the cohesive split: `routeReview` consumes exactly what the
-parsers produce.
+Moving `routeReview` out is what makes the line budget survive the
+`feat/finish-pr-body` merge (see Constraints). Removing `parseVerdict` alone (~7 lines)
+against the additions (~15) nets **+8**; taking `routeReview` and its docstring too
+(~31 lines) nets roughly **-35**. It is also the cohesive split: `routeReview` consumes
+exactly what the parsers produce.
 
 `MAX_FIX_ATTEMPTS` moves with it, since `routeReview` needs it. The flow file imports it
 back for its three other users — the acceptance node and the two `quality_gates` caps.
@@ -221,7 +228,7 @@ Invariants after this change:
 | file | change |
 |:--|:--|
 | `flows/nax-finish/verdict.ts` | new — both parsers, both caps, counter, `routeReview` |
-| `flows/nax-finish/nax-finish.flow.ts` | drop `parseVerdict`, `routeReview`, `MAX_FIX_ATTEMPTS`; import them back; wire parsers per node; add 2 switch cases; ~599 → ~564 |
+| `flows/nax-finish/nax-finish.flow.ts` | drop `parseVerdict`, `routeReview`, `MAX_FIX_ATTEMPTS`; import them back; wire parsers per node; add 2 switch cases; 568 → ~533 |
 | `flows/nax-finish/types.ts` | widen `ReviewVerdict.route` with `"reprompt"` |
 | `flows/nax-finish/review-prompts.ts` | `retry` param on `buildReviewPrompt` |
 | `test/unit/flows/nax-finish/verdict.test.ts` | new |

--- a/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
@@ -136,17 +136,27 @@ re-entries in the normal fix loop. This works because acpx's `FlowStepRecord` ca
 `state: { steps: { nodeId: string }[] }` annotation is a narrowing of a richer runtime
 object, so it widens to `{ nodeId: string; output?: unknown }`.
 
+**The count is self-inclusive, not self-exclusive.** acpx's runtime calls
+`recordFlowStepOutcome(runDir, state, step)` (`acpx/src/flows/runtime.ts:262`), which
+pushes the just-finished step onto `state.steps` (`acpx/src/flows/runtime.ts:499`),
+*before* the next node (`route_<phase>`) runs. So by the time `routeReview` reads
+`ctx.state.steps`, the current round's own `review_<phase>` step — the one that just
+routed `reprompt` — is already included. On the very first unparseable reply
+`repromptCount` already returns `1`, not `0`. `routeReview`'s gate must therefore compare
+`attempts <= MAX_REPROMPT_ATTEMPTS`, not `<` — see "Data flow" below.
+
 ### Data flow
 
 ```
 review_quality  parse fails → { route: "reprompt", findings: [], raw: <tail> }
-      │
+      │  (acpx records this step into state.steps BEFORE route_quality runs)
       ▼
 route_quality = routeReview(ctx, "quality")
       │
-      ├─ repromptCount < 1  → { route: "reprompt" } ──→ review_quality
-      │                                                  (retry: true prompt)
-      └─ repromptCount >= 1 → { route: "escalate",
+      ├─ repromptCount <= 1  → { route: "reprompt" } ──→ review_quality
+      │  (round 1: 1 reprompt step already recorded)     (retry: true prompt)
+      └─ repromptCount > 1   → { route: "escalate",
+      │  (round 2: 2 reprompt steps already recorded)
                                  escalationReason: "quality reviewer returned
                                  unparseable output after 2 attempts: <tail>" }
                                                     ──→ escalate

--- a/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-nax-finish-verdict-recovery-design.md
@@ -56,8 +56,10 @@ kill a multi-hour run over output nothing reads.
 or `{switch}`, so there is no error edge to route to. A fix stays inside the parse
 functions and the switch cases the flow owns, or it becomes an acpx change.
 
-**`nax-finish.flow.ts` is 599 lines** against the repo's 600-line `SRC_LIMIT`. New
-logic goes in its own module.
+**`nax-finish.flow.ts` is 599 lines** against a 600-line hard limit for source files,
+enforced by `bun run check:file-sizes` as part of `bun run lint`. Adding to it fails the
+lint gate. New logic goes in its own module — and enough existing logic must *leave* the
+flow file to buy headroom, because the additions alone would push it to ~607.
 
 **The `escalate` node is already the right sink.** It writes the result file *before*
 attempting delivery, pushes partial fixes, and notifies Telegram — built exactly so
@@ -68,9 +70,18 @@ that bypasses it.
 
 ### Architecture
 
-New module `flows/nax-finish/verdict.ts` owning both parsers, the cap constant, and the
-attempt counter. `parseVerdict` is deleted from `nax-finish.flow.ts` and replaced by two
-imports — a net line reduction, which matters at 599/600.
+New module `flows/nax-finish/verdict.ts` owning everything that turns a reviewer's reply
+into a route: both parsers, both loop caps, the attempt counter, and `routeReview`.
+
+Moving `routeReview` out is what makes the line budget work. Removing `parseVerdict`
+alone (~7 lines) against the additions (~15) would net **+8 → ~607**, over the limit.
+Taking `routeReview` and its docstring too (~31 lines) nets roughly **-35 → ~564**, with
+real headroom. It is also the cohesive split: `routeReview` consumes exactly what the
+parsers produce.
+
+`MAX_FIX_ATTEMPTS` moves with it, since `routeReview` needs it. The flow file imports it
+back for its three other users — the acceptance node and the two `quality_gates` caps.
+No cycle: `verdict.ts` imports nothing from the flow.
 
 `ReviewVerdict.route` (`types.ts:23`) widens from `"proceed" | "escalate" | "clean"` to
 include `"reprompt"`, documented the same way `clean` already is: not a model-produced
@@ -80,6 +91,7 @@ route, synthesised by `parse` so the graph can branch on it.
 
 ```ts
 // flows/nax-finish/verdict.ts
+export const MAX_FIX_ATTEMPTS = 3;      // moved from nax-finish.flow.ts
 export const MAX_REPROMPT_ATTEMPTS = 1;
 
 /** review_spec / review_quality — JSON is load-bearing; garbage routes to reprompt. */
@@ -89,8 +101,17 @@ export function parseReviewVerdict(text: string): ReviewVerdict
 export function parseFixVerdict(text: string): ReviewVerdict
 
 /** How many times this phase's review already came back unparseable. */
-export function repromptCount(ctx: StepsCtx, phase: FinishPhase): number
+export function repromptCount(ctx: StepsCtx, phase: "spec" | "quality"): number
+
+/** Moved verbatim from the flow file, plus the reprompt branch. */
+export function routeReview(ctx: OutputsCtx & StepsCtx, phase: "spec" | "quality"): {
+  route: string; escalationReason?: string; findings: Finding[]
+}
 ```
+
+`repromptCount` and `routeReview` take `"spec" | "quality"`, not `FinishPhase` — the
+latter also admits `"acceptance"` and `"gate"`, which have no review node. This matches
+`incrementalSince`'s existing signature (`flow-ctx.ts:88`).
 
 `parseReviewVerdict` keeps the existing body — `extractJsonObject`, findings array,
 `proceed`-with-zero-findings rewritten to `clean` — wrapped so a throw becomes
@@ -132,6 +153,22 @@ The review nodes' `prompt(ctx)` passes `retry: repromptCount(ctx, phase) > 0` to
 existing `JSON_CONTRACT`. Both review nodes are `session: { isolated: true }`, so each
 retry runs in a fresh session and the prompt is already self-contained — there is no
 conversational continuity to preserve.
+
+### Two interactions that are correct by construction
+
+**Returning beats throwing, and that is what makes the counter work.** Because `parse`
+now returns a verdict rather than throwing, acpx records the step as *successful* with
+`output.route === "reprompt"`. `repromptCount` can therefore see it. Had `parse` kept
+throwing, the step would be recorded `failed` with no output, and there would be nothing
+to count.
+
+**A retry is a full re-review, not a narrowed one.** `incrementalSince` scopes a
+re-review to `firstCommit.shaBefore..HEAD` by finding the first `commit_*` step after
+this phase's last `review_<phase>`. On a reprompt re-entry the steps are
+`[… review_quality, route_quality]` — no `commit_*` follows, so it returns `null` and the
+retry re-reads the whole `base...HEAD` diff. That is the right answer: the previous
+attempt produced no verdict, so there is no cleared window to skip. Worth stating
+explicitly so nobody later "optimises" the retry into an incremental review.
 
 ### Error handling
 
@@ -183,8 +220,8 @@ Invariants after this change:
 
 | file | change |
 |:--|:--|
-| `flows/nax-finish/verdict.ts` | new — both parsers, cap, counter |
-| `flows/nax-finish/nax-finish.flow.ts` | drop `parseVerdict`, import the two parsers, wire per node, reorder `routeReview`, add 2 switch cases |
+| `flows/nax-finish/verdict.ts` | new — both parsers, both caps, counter, `routeReview` |
+| `flows/nax-finish/nax-finish.flow.ts` | drop `parseVerdict`, `routeReview`, `MAX_FIX_ATTEMPTS`; import them back; wire parsers per node; add 2 switch cases; ~599 → ~564 |
 | `flows/nax-finish/types.ts` | widen `ReviewVerdict.route` with `"reprompt"` |
 | `flows/nax-finish/review-prompts.ts` | `retry` param on `buildReviewPrompt` |
 | `test/unit/flows/nax-finish/verdict.test.ts` | new |

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -41,7 +41,7 @@
  *   that is killed or times out — no terminal node runs on that path, and a
  *   crashed finish is exactly when the record of what it changed matters most.
  */
-import { defineFlow, extractJsonObject } from "acpx/flows";
+import { defineFlow } from "acpx/flows";
 import { buildFixCommitMessage } from "./commit-message";
 import { findingsOf, fixAttemptCount, gateOutputs, incrementalSince, inputOf, loadCtxOf } from "./flow-ctx";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
@@ -66,6 +66,7 @@ import {
 } from "./steps";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle } from "./steps/pr-body";
 import type { FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
+import { MAX_FIX_ATTEMPTS, parseFixVerdict, parseReviewVerdict, repromptCount, routeReview } from "./verdict";
 
 /**
  * Injectable seam for the `open_pr` node's title/body assembly — tests stub
@@ -77,14 +78,6 @@ export const _openPrDeps = {
   buildFinishTitle,
   buildFinishBody,
 };
-
-/**
- * Cap on fix-and-reverify iterations, per phase, before escalating instead of
- * looping forever. acpx's flow engine has no built-in cycle guard, so without
- * this cap a stubborn failure (LLM can't fix it, or fixes something else each
- * time) hangs `acpx flow run` — and the post-run plugin awaits that subprocess.
- */
-const MAX_FIX_ATTEMPTS = 3;
 
 /**
  * Re-run the acceptance gate, routing on the shared fix-cap rules.
@@ -137,38 +130,6 @@ async function acceptanceGateNode(ctx: {
     };
   }
   return { route: "fix", output: r.output };
-}
-
-/**
- * Turn a reviewer verdict into a deterministic route.
- *
- * `clean` (no findings) skips the fix node entirely — prompting an agent to
- * "apply the recommended fixes" for an empty finding list burns a turn and
- * invites unrequested edits.
- */
-function routeReview(
-  ctx: { outputs: unknown; state: { steps: { nodeId: string }[] } },
-  phase: "spec" | "quality",
-): { route: string; escalationReason?: string; findings: ReviewVerdict["findings"] } {
-  const verdict = (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`];
-  const findings = verdict?.findings ?? [];
-  if (verdict?.route === "escalate") {
-    return {
-      route: "escalate",
-      escalationReason: verdict.escalationReason ?? `${phase} review raised a finding needing human judgment`,
-      findings,
-    };
-  }
-  if (findings.length === 0) return { route: "clean", findings };
-  const attempts = fixAttemptCount(ctx, `fix_${phase}`);
-  if (attempts >= MAX_FIX_ATTEMPTS) {
-    return {
-      route: "escalate",
-      escalationReason: `${phase} review still reporting ${findings.length} finding(s) after ${attempts} fix attempts.`,
-      findings,
-    };
-  }
-  return { route: "fix", findings };
 }
 
 /**
@@ -271,14 +232,6 @@ function commitFixNode(phase: FinishPhase) {
   };
 }
 
-/** Normalise a reviewer's JSON, rewriting a findings-free `proceed` to `clean`. */
-function parseVerdict(text: string): ReviewVerdict {
-  const raw = extractJsonObject(text) as Partial<ReviewVerdict>;
-  const findings = Array.isArray(raw.findings) ? raw.findings : [];
-  const route = raw.route === "escalate" ? "escalate" : findings.length === 0 ? "clean" : "proceed";
-  return { route, findings, escalationReason: raw.escalationReason };
-}
-
 export default defineFlow({
   name: "nax-finish",
   permissions: {
@@ -313,7 +266,7 @@ export default defineFlow({
     fix_acceptance: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("acceptance", ctx),
-      parse: parseVerdict,
+      parse: parseFixVerdict,
     },
     commit_acceptance: commitFixNode("acceptance"),
     review_spec: {
@@ -327,9 +280,10 @@ export default defineFlow({
           specPath: outs.specPath ?? "",
           since: incrementalSince(ctx, "spec"),
           priorFindings: findingsOf(ctx, "spec"),
+          retry: repromptCount(ctx, "spec") > 0,
         });
       },
-      parse: parseVerdict,
+      parse: parseReviewVerdict,
     },
     route_spec: {
       nodeType: "compute",
@@ -338,7 +292,7 @@ export default defineFlow({
     fix_spec: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("spec", ctx),
-      parse: parseVerdict,
+      parse: parseFixVerdict,
     },
     commit_spec: commitFixNode("spec"),
     review_quality: {
@@ -352,9 +306,10 @@ export default defineFlow({
           specPath: outs.specPath ?? "",
           since: incrementalSince(ctx, "quality"),
           priorFindings: findingsOf(ctx, "quality"),
+          retry: repromptCount(ctx, "quality") > 0,
         });
       },
-      parse: parseVerdict,
+      parse: parseReviewVerdict,
     },
     route_quality: {
       nodeType: "compute",
@@ -363,13 +318,13 @@ export default defineFlow({
     fix_quality: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("quality", ctx),
-      parse: parseVerdict,
+      parse: parseFixVerdict,
     },
     commit_quality: commitFixNode("quality"),
     fix_gate: {
       nodeType: "acp",
       prompt: (ctx) => fixPrompt("gate", ctx),
-      parse: parseVerdict,
+      parse: parseFixVerdict,
     },
     commit_gate: commitFixNode("gate"),
     quality_gates: {
@@ -557,7 +512,10 @@ export default defineFlow({
     { from: "review_spec", to: "route_spec" },
     {
       from: "route_spec",
-      switch: { on: "$.route", cases: { clean: "review_quality", fix: "fix_spec", escalate: "escalate" } },
+      switch: {
+        on: "$.route",
+        cases: { clean: "review_quality", fix: "fix_spec", escalate: "escalate", reprompt: "review_spec" },
+      },
     },
     // Spec fixes re-run the acceptance gate first (they can break it), and the
     // acceptance node's `proceed` edge leads back into review_spec for re-review.
@@ -566,7 +524,10 @@ export default defineFlow({
     { from: "review_quality", to: "route_quality" },
     {
       from: "route_quality",
-      switch: { on: "$.route", cases: { clean: "quality_gates", fix: "fix_quality", escalate: "escalate" } },
+      switch: {
+        on: "$.route",
+        cases: { clean: "quality_gates", fix: "fix_quality", escalate: "escalate", reprompt: "review_quality" },
+      },
     },
     // Quality fixes are re-reviewed by the same lens; the repo-root gates that
     // follow catch anything the fix broke mechanically.

--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -313,6 +313,17 @@ const JSON_CONTRACT = [
 ].join("\n");
 
 /**
+ * Prepended when a previous attempt at this review returned something that was
+ * not JSON. Lead position, not appended: the failure mode is a model that
+ * narrates its findings and forgets the contract at the end of a long turn.
+ */
+const RETRY_NOTICE = [
+  "IMPORTANT — your previous reply could not be parsed as JSON, so it was discarded entirely.",
+  "Do not narrate your findings in prose. Do not describe what you reported.",
+  "Your entire reply must be the JSON object described at the end of this prompt: first char `{`, last char `}`.",
+].join("\n");
+
+/**
  * Build the reviewer prompt.
  *
  * With `since` set this is a **re-review**: the same reviewer already read the
@@ -329,11 +340,19 @@ const JSON_CONTRACT = [
  */
 export function buildReviewPrompt(
   phase: "spec" | "quality",
-  args: { base: string; specPath: string; since?: string | null; priorFindings?: Finding[] },
+  args: {
+    base: string;
+    specPath: string;
+    since?: string | null;
+    priorFindings?: Finding[];
+    retry?: boolean;
+  },
 ): string {
   const dims = phase === "spec" ? SPEC_REVIEW_DIMENSIONS : QUALITY_REVIEW_DIMENSIONS;
+  const lead = args.retry ? [RETRY_NOTICE] : [];
   if (!args.since) {
     return [
+      ...lead,
       `You are the ${phase.toUpperCase()} reviewer for a completed feature.`,
       `The spec/requirements source is: ${args.specPath}. Read it in full.`,
       `Fetch and review the diff: \`git diff ${args.base}...HEAD\` (also \`--name-only\` for the file list).`,
@@ -344,6 +363,7 @@ export function buildReviewPrompt(
     ].join("\n\n");
   }
   return [
+    ...lead,
     `You are the ${phase.toUpperCase()} reviewer for a completed feature, continuing a review you already started.`,
     `On your previous pass over \`git diff ${args.base}...HEAD\` you raised the findings below, and they have since been fixed and committed. Everything else in that diff you already judged acceptable — do not re-derive a verdict on it.`,
     `Your findings from the previous pass:\n${JSON.stringify(args.priorFindings ?? [], null, 2)}`,

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -16,13 +16,21 @@ export interface Finding {
 }
 export interface ReviewVerdict {
   /**
-   * `clean` is not a model-produced route — the review nodes' `parse` rewrites
-   * `proceed` with zero findings to `clean` so the graph can skip the fix node
-   * entirely instead of prompting an agent to "apply fixes" for nothing.
+   * Neither `clean` nor `reprompt` is a model-produced route.
+   *
+   * `clean` — `parse` rewrites `proceed` with zero findings, so the graph can
+   * skip the fix node instead of prompting an agent to "apply fixes" for nothing.
+   *
+   * `reprompt` — `parse` could not read JSON out of the reply at all. Returning
+   * this rather than throwing is deliberate: a throw fails the acp node and kills
+   * the whole flow with no result file, bypassing the `escalate` sink that exists
+   * to report exactly this kind of dead end.
    */
-  route: "proceed" | "escalate" | "clean";
+  route: "proceed" | "escalate" | "clean" | "reprompt";
   findings: Finding[];
   escalationReason?: string;
+  /** Bounded tail of an unparseable reply; set only when `route` is `reprompt`. */
+  raw?: string;
 }
 /** Wall-clock budgets, forwarded from `finish.autoFlow.timeouts` by the plugin. */
 export interface FinishTimeouts {

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -82,6 +82,16 @@ export function parseFixVerdict(text: string): ReviewVerdict {
  * This is observable only because `parseReviewVerdict` returns rather than
  * throws — a returned verdict makes acpx record the step as successful with
  * this output. A throw would record it `failed`, with nothing to count.
+ *
+ * SELF-INCLUSIVE, not self-exclusive: acpx's runtime calls
+ * `recordFlowStepOutcome(runDir, state, step)` (acpx/src/flows/runtime.ts:262),
+ * which pushes the just-finished step onto `state.steps`
+ * (acpx/src/flows/runtime.ts:499), BEFORE `resolveNextNode` runs and before the
+ * following node (`route_<phase>`) executes. So by the time `routeReview` reads
+ * `ctx.state.steps` here, the current round's own `review_<phase>` step is
+ * already included. On the very first unparseable reply this already returns
+ * 1, not 0. `routeReview`'s comparison against `MAX_REPROMPT_ATTEMPTS` MUST
+ * stay `<=` (not `<`) for that reason — see routeReview below.
  */
 export function repromptCount(ctx: StepsCtx, phase: "spec" | "quality"): number {
   return (ctx.state.steps ?? []).filter(
@@ -108,12 +118,15 @@ export function routeReview(
   const verdict = (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`];
   const findings = verdict?.findings ?? [];
   if (verdict?.route === "reprompt") {
+    // `attempts` is self-inclusive (see repromptCount) — it already counts this
+    // round's failure, so `<=` (not `<`) is what makes MAX_REPROMPT_ATTEMPTS=1
+    // tolerate exactly one retry before escalating.
     const attempts = repromptCount(ctx, phase);
-    if (attempts < MAX_REPROMPT_ATTEMPTS) return { route: "reprompt", findings };
+    if (attempts <= MAX_REPROMPT_ATTEMPTS) return { route: "reprompt", findings };
     return {
       route: "escalate",
       escalationReason:
-        `${phase} reviewer returned unparseable output after ${attempts + 1} attempts. ` +
+        `${phase} reviewer returned unparseable output after ${attempts} attempts. ` +
         `Last reply: ${verdict.raw ?? "(empty)"}`,
       findings,
     };

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -1,0 +1,72 @@
+/**
+ * Turning a reviewer's reply into a deterministic route.
+ *
+ * Lives outside `nax-finish.flow.ts` for two reasons: the flow file sits within
+ * a few lines of the 600-line hard limit, and this is a cohesive unit —
+ * `routeReview` consumes exactly what the parsers produce.
+ *
+ * The central invariant: **no parser here ever throws.** acpx has no node-level
+ * retry and no error edge (`AcpNodeDefinition` offers only `prompt`/`parse`;
+ * `FlowEdge` is only `to` or `switch`), so a throw inside `parse` fails the node
+ * and fails the run — exit 1, no result file, no notification, bypassing the
+ * `escalate` node that exists to report precisely this.
+ */
+import { extractJsonObject } from "acpx/flows";
+import type { Finding, ReviewVerdict } from "./types";
+
+/** Fix rounds allowed per loop before escalating. Moved here with `routeReview`. */
+export const MAX_FIX_ATTEMPTS = 3;
+
+/**
+ * Unparseable reviews tolerated per phase before escalating.
+ *
+ * One. A reviewer that ignores the JSON contract twice in a row is not going to
+ * comply on a third ask, and each review is the most expensive node in the flow
+ * (128s and ~4.2M tokens on the run that motivated this).
+ */
+export const MAX_REPROMPT_ATTEMPTS = 1;
+
+/** How much of an unparseable reply to carry forward — it lands in a PR comment and a Telegram message. */
+export const RAW_TAIL_LIMIT = 500;
+
+function tail(text: string): string {
+  const t = text.trim();
+  return t.length <= RAW_TAIL_LIMIT ? t : `…${t.slice(-(RAW_TAIL_LIMIT - 1))}`;
+}
+
+/** Shared happy path: read the object, normalise findings, rewrite empty `proceed` to `clean`. */
+function parseVerdictJson(text: string): ReviewVerdict {
+  const raw = extractJsonObject(text) as Partial<ReviewVerdict>;
+  const findings: Finding[] = Array.isArray(raw.findings) ? raw.findings : [];
+  const route = raw.route === "escalate" ? "escalate" : findings.length === 0 ? "clean" : "proceed";
+  return { route, findings, escalationReason: raw.escalationReason };
+}
+
+/**
+ * Parser for `review_spec` / `review_quality`, whose JSON is load-bearing —
+ * `findingsOf` reads it and the fix loop is driven by it. An unreadable reply
+ * routes to `reprompt` so `routeReview` can ask once more before escalating.
+ */
+export function parseReviewVerdict(text: string): ReviewVerdict {
+  try {
+    return parseVerdictJson(text);
+  } catch {
+    return { route: "reprompt", findings: [], raw: tail(text) };
+  }
+}
+
+/**
+ * Parser for the four `fix_*` nodes, whose parsed value nothing reads —
+ * `findingsOf` only ever looks at `review_spec`/`review_quality`, and
+ * `commitFixNode` decides from git rather than from the model's word.
+ *
+ * Never routes `reprompt`: the fix nodes have unconditional edges
+ * (`fix_spec → commit_spec`), so a reprompt route would have nowhere to go.
+ */
+export function parseFixVerdict(text: string): ReviewVerdict {
+  try {
+    return parseVerdictJson(text);
+  } catch {
+    return { route: "proceed", findings: [] };
+  }
+}

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -15,7 +15,15 @@ import { extractJsonObject } from "acpx/flows";
 import { type OutputsCtx, type StepsCtx, fixAttemptCount } from "./flow-ctx";
 import type { Finding, ReviewVerdict } from "./types";
 
-/** Fix rounds allowed per loop before escalating. Moved here with `routeReview`. */
+/**
+ * Cap on fix-and-reverify iterations, per phase, before escalating instead of
+ * looping forever. acpx's flow engine has no built-in cycle guard, so without
+ * this cap a stubborn failure (LLM can't fix it, or fixes something else each
+ * time) hangs `acpx flow run` — and the post-run plugin awaits that subprocess.
+ *
+ * Lives here rather than in the flow file because `routeReview` needs it; the
+ * flow imports it back for the acceptance node and the two `quality_gates` caps.
+ */
 export const MAX_FIX_ATTEMPTS = 3;
 
 /**

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -12,6 +12,7 @@
  * `escalate` node that exists to report precisely this.
  */
 import { extractJsonObject } from "acpx/flows";
+import { type OutputsCtx, type StepsCtx, fixAttemptCount } from "./flow-ctx";
 import type { Finding, ReviewVerdict } from "./types";
 
 /** Fix rounds allowed per loop before escalating. Moved here with `routeReview`. */
@@ -69,4 +70,69 @@ export function parseFixVerdict(text: string): ReviewVerdict {
   } catch {
     return { route: "proceed", findings: [] };
   }
+}
+
+/**
+ * How many times this phase's review already came back unparseable.
+ *
+ * Counts step *outputs*, not step ids: `commit_quality → review_quality` and
+ * `commit_gate → review_quality` are legitimate re-entries in the normal fix
+ * loop, so counting bare `review_<phase>` steps would escalate a healthy run.
+ *
+ * This is observable only because `parseReviewVerdict` returns rather than
+ * throws — a returned verdict makes acpx record the step as successful with
+ * this output. A throw would record it `failed`, with nothing to count.
+ */
+export function repromptCount(ctx: StepsCtx, phase: "spec" | "quality"): number {
+  return (ctx.state.steps ?? []).filter(
+    (s) => s.nodeId === `review_${phase}` && (s.output as ReviewVerdict | undefined)?.route === "reprompt",
+  ).length;
+}
+
+/**
+ * Turn a reviewer verdict into a deterministic route.
+ *
+ * `clean` (no findings) skips the fix node entirely — prompting an agent to
+ * "apply the recommended fixes" for an empty finding list burns a turn and
+ * invites unrequested edits.
+ *
+ * The `reprompt` branch MUST come first. A reprompt verdict carries zero
+ * findings, so checking `findings.length === 0` ahead of it would route an
+ * unreadable review to `clean`, and the flow would open a PR having reviewed
+ * nothing. That silent false green is worse than the crash this replaces.
+ */
+export function routeReview(
+  ctx: OutputsCtx & StepsCtx,
+  phase: "spec" | "quality",
+): { route: string; escalationReason?: string; findings: Finding[] } {
+  const verdict = (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`];
+  const findings = verdict?.findings ?? [];
+  if (verdict?.route === "reprompt") {
+    const attempts = repromptCount(ctx, phase);
+    if (attempts < MAX_REPROMPT_ATTEMPTS) return { route: "reprompt", findings };
+    return {
+      route: "escalate",
+      escalationReason:
+        `${phase} reviewer returned unparseable output after ${attempts + 1} attempts. ` +
+        `Last reply: ${verdict.raw ?? "(empty)"}`,
+      findings,
+    };
+  }
+  if (verdict?.route === "escalate") {
+    return {
+      route: "escalate",
+      escalationReason: verdict.escalationReason ?? `${phase} review raised a finding needing human judgment`,
+      findings,
+    };
+  }
+  if (findings.length === 0) return { route: "clean", findings };
+  const attempts = fixAttemptCount(ctx, `fix_${phase}`);
+  if (attempts >= MAX_FIX_ATTEMPTS) {
+    return {
+      route: "escalate",
+      escalationReason: `${phase} review still reporting ${findings.length} finding(s) after ${attempts} fix attempts.`,
+      findings,
+    };
+  }
+  return { route: "fix", findings };
 }

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -700,3 +700,54 @@ describe("escalate node", () => {
     expect(JSON.parse(wrote)).toMatchObject({ status: "escalated", escalationReason: "r" });
   });
 });
+
+describe("reprompt edges", () => {
+  test("route_spec routes reprompt back to review_spec", () => {
+    expect(switchOf("route_spec").cases.reprompt).toBe("review_spec");
+  });
+
+  test("route_quality routes reprompt back to review_quality", () => {
+    expect(switchOf("route_quality").cases.reprompt).toBe("review_quality");
+  });
+
+  test("the existing routes are untouched", () => {
+    expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
+    expect(switchOf("route_quality").cases.fix).toBe("fix_quality");
+    expect(switchOf("route_quality").cases.escalate).toBe("escalate");
+  });
+
+  test("route_quality yields reprompt for an unparseable verdict", async () => {
+    const out = await nodeRun<{ route: string }>("route_quality").run(
+      ctxOf({ outputs: { review_quality: { route: "reprompt", findings: [], raw: "prose" } } }),
+    );
+    expect(out.route).toBe("reprompt");
+  });
+
+  test("review_quality leads with the retry notice after a reprompt", () => {
+    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: [{ nodeId: "review_quality", output: { route: "reprompt", findings: [] } }] as never,
+      }),
+    );
+    expect(prompt).toContain("previous reply could not be parsed");
+  });
+
+  test("a retried review is a FULL review, not an incremental one", () => {
+    // incrementalSince scopes a re-review to firstCommit.shaBefore..HEAD by finding
+    // the first commit_* step after the last review_<phase>. On a reprompt re-entry
+    // no commit_* follows, so it returns null and the whole base...HEAD diff is
+    // re-read. That is right — the previous attempt produced no verdict, so there is
+    // no cleared window to skip. Pinned so nobody "optimises" it into an incremental.
+    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: [{ nodeId: "review_quality", output: { route: "reprompt", findings: [] } }] as never,
+      }),
+    );
+    expect(prompt).toContain("git diff origin/main...HEAD");
+    expect(prompt).not.toContain("continuing a review you already started");
+  });
+});

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -716,11 +716,37 @@ describe("reprompt edges", () => {
     expect(switchOf("route_quality").cases.escalate).toBe("escalate");
   });
 
-  test("route_quality yields reprompt for an unparseable verdict", async () => {
+  // acpx's runtime pushes the just-finished step onto `state.steps`
+  // (recordFlowStepOutcome, runtime.ts:262/499) BEFORE the next node runs, so
+  // by the time `route_quality` executes, its own triggering `review_quality`
+  // step is already recorded. These two tests model that real ordering —
+  // round 1's `steps` has exactly the 1 step just recorded, round 2's has 2 —
+  // and the round-1 case would FAIL under the old (buggy) `<` comparison,
+  // which escalated on the very first unparseable reply instead of retrying.
+  test("route_quality yields reprompt on the first unparseable verdict (round 1)", async () => {
+    const verdict = { route: "reprompt", findings: [], raw: "prose" };
     const out = await nodeRun<{ route: string }>("route_quality").run(
-      ctxOf({ outputs: { review_quality: { route: "reprompt", findings: [], raw: "prose" } } }),
+      ctxOf({
+        outputs: { review_quality: verdict },
+        steps: [{ nodeId: "review_quality", output: verdict }] as never,
+      }),
     );
     expect(out.route).toBe("reprompt");
+  });
+
+  test("route_quality escalates on the second consecutive unparseable verdict (round 2)", async () => {
+    const verdict = { route: "reprompt", findings: [], raw: "prose" };
+    const out = await nodeRun<{ route: string; escalationReason?: string }>("route_quality").run(
+      ctxOf({
+        outputs: { review_quality: verdict },
+        steps: [
+          { nodeId: "review_quality", output: verdict },
+          { nodeId: "review_quality", output: verdict },
+        ] as never,
+      }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.escalationReason).toContain("after 2 attempts");
   });
 
   test("review_quality leads with the retry notice after a reprompt", () => {

--- a/test/unit/flows/nax-finish/review-prompts.test.ts
+++ b/test/unit/flows/nax-finish/review-prompts.test.ts
@@ -107,3 +107,28 @@ describe("buildReviewPrompt — incremental re-review", () => {
     }
   });
 });
+
+describe("buildReviewPrompt retry variant", () => {
+  const base = { base: "origin/main", specPath: "spec.md" };
+
+  test("omits the retry notice by default", () => {
+    expect(buildReviewPrompt("quality", base)).not.toContain("previous reply could not be parsed");
+  });
+
+  test("leads a full review with the retry notice when retrying", () => {
+    const p = buildReviewPrompt("quality", { ...base, retry: true });
+    expect(p).toContain("previous reply could not be parsed");
+    expect(p.indexOf("previous reply could not be parsed")).toBeLessThan(p.indexOf("You are the QUALITY reviewer"));
+  });
+
+  test("leads an incremental review with the retry notice too", () => {
+    const p = buildReviewPrompt("spec", { ...base, since: "abc123", priorFindings: [], retry: true });
+    expect(p).toContain("previous reply could not be parsed");
+    expect(p).toContain("abc123");
+  });
+
+  test("keeps the JSON contract last on a retry", () => {
+    const p = buildReviewPrompt("quality", { ...base, retry: true });
+    expect(p.trimEnd().endsWith("}")).toBe(true);
+  });
+});

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { parseFixVerdict, parseReviewVerdict } from "@flows/nax-finish/verdict";
+import {
+  MAX_FIX_ATTEMPTS,
+  MAX_REPROMPT_ATTEMPTS,
+  parseFixVerdict,
+  parseReviewVerdict,
+  repromptCount,
+  routeReview,
+} from "@flows/nax-finish/verdict";
 
 // The real 927-byte reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3
 // on rs-stock/pipeline-run-chat-context. Not a synthetic "not json" string: the point is
@@ -73,5 +80,72 @@ describe("parseFixVerdict", () => {
 
   test("never throws on empty output", () => {
     expect(parseFixVerdict("").route).toBe("proceed");
+  });
+});
+
+const stepsCtx = (steps: { nodeId: string; output?: unknown }[]) => ({ state: { steps }, outputs: {} });
+const routeCtx = (verdict: unknown, steps: { nodeId: string; output?: unknown }[] = []) => ({
+  outputs: { review_quality: verdict },
+  state: { steps },
+});
+const REPROMPT_STEP = { nodeId: "review_quality", output: { route: "reprompt", findings: [] } };
+const CLEAN_STEP = { nodeId: "review_quality", output: { route: "clean", findings: [] } };
+
+describe("repromptCount", () => {
+  test("is zero with no steps", () => {
+    expect(repromptCount(stepsCtx([]), "quality")).toBe(0);
+  });
+
+  test("ignores legitimate review re-entries that produced a real verdict", () => {
+    expect(repromptCount(stepsCtx([CLEAN_STEP, { nodeId: "commit_quality" }, CLEAN_STEP]), "quality")).toBe(0);
+  });
+
+  test("counts only steps whose output routed reprompt", () => {
+    expect(repromptCount(stepsCtx([CLEAN_STEP, REPROMPT_STEP]), "quality")).toBe(1);
+  });
+
+  test("does not count the other phase's reprompts", () => {
+    expect(repromptCount(stepsCtx([REPROMPT_STEP]), "spec")).toBe(0);
+  });
+});
+
+describe("routeReview", () => {
+  test("a reprompt verdict is NEVER routed clean", () => {
+    // Regression guard. A reprompt verdict has zero findings, so an ordering
+    // slip that checks `findings.length === 0` first would call an unread
+    // review "clean" and open a PR having verified nothing — a silent false
+    // green, strictly worse than the crash this change removes.
+    const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "prose" }), "quality");
+    expect(r.route).not.toBe("clean");
+    expect(r.route).toBe("reprompt");
+  });
+
+  test("escalates once the reprompt cap is reached, naming the raw tail", () => {
+    const steps = Array.from({ length: MAX_REPROMPT_ATTEMPTS }, () => REPROMPT_STEP);
+    const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "some prose" }, steps), "quality");
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toContain("unparseable");
+    expect(r.escalationReason).toContain("some prose");
+  });
+
+  test("still routes clean when there are no findings", () => {
+    expect(routeReview(routeCtx({ route: "clean", findings: [] }), "quality").route).toBe("clean");
+  });
+
+  test("still routes fix when there are findings under the cap", () => {
+    expect(routeReview(routeCtx({ route: "proceed", findings: [FINDING] }), "quality").route).toBe("fix");
+  });
+
+  test("still escalates an explicit escalate verdict", () => {
+    const r = routeReview(routeCtx({ route: "escalate", findings: [], escalationReason: "judgment" }), "quality");
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toBe("judgment");
+  });
+
+  test("still escalates when findings persist past the fix cap", () => {
+    const steps = Array.from({ length: MAX_FIX_ATTEMPTS }, () => ({ nodeId: "fix_quality" }));
+    const r = routeReview(routeCtx({ route: "proceed", findings: [FINDING] }, steps), "quality");
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toContain("fix attempts");
   });
 });

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -8,18 +8,20 @@ import {
   routeReview,
 } from "@flows/nax-finish/verdict";
 
-// The real 927-byte reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3
-// on rs-stock/pipeline-run-chat-context. Not a synthetic "not json" string: the point is
-// that a chatty reviewer emits no brace at all, which defeats every extractJsonObject tier.
+// The real reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3 on
+// rs-stock, with private identifiers replaced by generic equivalents — the shape
+// (long, chatty, no brace anywhere) is authentic, only the names are not. Not a
+// synthetic "not json" string: the point is that a chatty reviewer emits no brace at
+// all, which defeats every extractJsonObject tier.
 const REAL_UNPARSEABLE =
   "Good, not a concern — self-contained change with a matching doc comment. " +
-  "Let's check the Python test files briefly for pipeline.py resolver, and the " +
-  "`apps/api/_pipeline_adapter.py` registration for unused import warnings etc." +
+  "Let's check the test files briefly for the request-routing resolver, and the " +
+  "`src/server/request_handler.py` registration for unused import warnings etc." +
   "Good, that exists as expected. Now let's check the gate-blocked probing logic once " +
-  "more and the `measureForNode`/`findGateBlocker` for edge cases against the AC that " +
+  "more and the `computeNodeMetrics`/`locateBlockingGate` for edge cases against the AC that " +
   '"does not render the gate\'s own output payload" — seems fine. I have enough for ' +
-  "findings.Reported two findings: a HIGH-confidence correctness regression (screen/" +
-  "backtest chat context now emits `Strategy: undefined | Universe: undefined`).";
+  "findings.Reported two findings: a HIGH-confidence correctness regression (the " +
+  "dashboard summary panel now emits `Label: undefined | Category: undefined`).";
 
 const FINDING = { severity: "HIGH", title: "t", problem: "p", fix: "f" };
 

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -120,11 +120,25 @@ describe("routeReview", () => {
     expect(r.route).toBe("reprompt");
   });
 
-  test("escalates once the reprompt cap is reached, naming the raw tail", () => {
-    const steps = Array.from({ length: MAX_REPROMPT_ATTEMPTS }, () => REPROMPT_STEP);
+  // acpx records a step's outcome (`recordFlowStepOutcome`, runtime.ts:262/499)
+  // BEFORE the next node runs, so by the time `routeReview` executes for the
+  // current round, that round's own `review_quality` step is already in
+  // `ctx.state.steps`. These two tests model that real ordering: round N's
+  // `steps` array has exactly N reprompt entries (not N-1), and would FAIL
+  // under the old `attempts < MAX_REPROMPT_ATTEMPTS` comparison — round 1
+  // would incorrectly escalate immediately instead of retrying.
+  test("reprompts on the first unparseable reply (round 1: 1 reprompt step already recorded)", () => {
+    const steps = [REPROMPT_STEP];
+    const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "some prose" }, steps), "quality");
+    expect(r.route).toBe("reprompt");
+  });
+
+  test("escalates on the second consecutive unparseable reply, naming the raw tail", () => {
+    const steps = Array.from({ length: MAX_REPROMPT_ATTEMPTS + 1 }, () => REPROMPT_STEP);
     const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "some prose" }, steps), "quality");
     expect(r.route).toBe("escalate");
     expect(r.escalationReason).toContain("unparseable");
+    expect(r.escalationReason).toContain("after 2 attempts");
     expect(r.escalationReason).toContain("some prose");
   });
 

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { parseFixVerdict, parseReviewVerdict } from "@flows/nax-finish/verdict";
+
+// The real 927-byte reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3
+// on rs-stock/pipeline-run-chat-context. Not a synthetic "not json" string: the point is
+// that a chatty reviewer emits no brace at all, which defeats every extractJsonObject tier.
+const REAL_UNPARSEABLE =
+  "Good, not a concern — self-contained change with a matching doc comment. " +
+  "Let's check the Python test files briefly for pipeline.py resolver, and the " +
+  "`apps/api/_pipeline_adapter.py` registration for unused import warnings etc." +
+  "Good, that exists as expected. Now let's check the gate-blocked probing logic once " +
+  "more and the `measureForNode`/`findGateBlocker` for edge cases against the AC that " +
+  '"does not render the gate\'s own output payload" — seems fine. I have enough for ' +
+  "findings.Reported two findings: a HIGH-confidence correctness regression (screen/" +
+  "backtest chat context now emits `Strategy: undefined | Universe: undefined`).";
+
+const FINDING = { severity: "HIGH", title: "t", problem: "p", fix: "f" };
+
+describe("parseReviewVerdict", () => {
+  test("parses a bare JSON object", () => {
+    const v = parseReviewVerdict(JSON.stringify({ route: "proceed", findings: [FINDING] }));
+    expect(v.route).toBe("proceed");
+    expect(v.findings).toHaveLength(1);
+  });
+
+  test("rewrites proceed-with-no-findings to clean", () => {
+    expect(parseReviewVerdict(JSON.stringify({ route: "proceed", findings: [] })).route).toBe("clean");
+  });
+
+  test("honours an explicit escalate route", () => {
+    const v = parseReviewVerdict(JSON.stringify({ route: "escalate", findings: [], escalationReason: "r" }));
+    expect(v.route).toBe("escalate");
+    expect(v.escalationReason).toBe("r");
+  });
+
+  test("still parses fenced JSON", () => {
+    const v = parseReviewVerdict('```json\n{"route":"proceed","findings":[]}\n```');
+    expect(v.route).toBe("clean");
+  });
+
+  test("still parses JSON embedded in prose", () => {
+    const v = parseReviewVerdict(`Here you go:\n{"route":"proceed","findings":[]}\nDone.`);
+    expect(v.route).toBe("clean");
+  });
+
+  test("routes reprompt on the real unparseable reply, with no findings", () => {
+    const v = parseReviewVerdict(REAL_UNPARSEABLE);
+    expect(v.route).toBe("reprompt");
+    expect(v.findings).toEqual([]);
+  });
+
+  test("carries a bounded tail of the raw reply", () => {
+    const v = parseReviewVerdict("x".repeat(2000));
+    expect(v.raw).toBeDefined();
+    expect((v.raw as string).length).toBeLessThanOrEqual(500);
+  });
+
+  test("routes reprompt on empty output", () => {
+    expect(parseReviewVerdict("").route).toBe("reprompt");
+  });
+});
+
+describe("parseFixVerdict", () => {
+  test("parses JSON like the review parser", () => {
+    expect(parseFixVerdict(JSON.stringify({ route: "proceed", findings: [FINDING] })).findings).toHaveLength(1);
+  });
+
+  test("never throws and never routes reprompt on garbage", () => {
+    const v = parseFixVerdict(REAL_UNPARSEABLE);
+    expect(v.route).toBe("proceed");
+    expect(v.findings).toEqual([]);
+  });
+
+  test("never throws on empty output", () => {
+    expect(parseFixVerdict("").route).toBe("proceed");
+  });
+});


### PR DESCRIPTION
## Problem

A reviewer node returning prose instead of JSON threw inside `parseVerdict`, failing the
acp node and killing the whole flow — exit 1, no result file, no notification.

acpx has no node-level retry and no error edge: `AcpNodeDefinition` offers only
`prompt`/`parse`/`profile`/`session`/`timeoutMs`, and `FlowEdge` is only `{to}` or
`{switch}`. So a throw in `parse` fails the run outright, bypassing the `escalate` node
built precisely to report "a human is needed" (#1399).

Observed in production: the run itself was clean, but the flow died at `review_quality`
after 128s, losing the quality review, the quality gates and the PR. The reply contained
no `{` anywhere, which defeats all three of `extractJsonObject`'s tiers (direct → fenced
→ balanced-brace scan). The prompt does state the contract, so this is model
non-compliance, not a missing instruction.

`parseVerdict` was the `parse` for all six acp nodes, and four of them
(`fix_acceptance`, `fix_spec`, `fix_quality`, `fix_gate`) never read the parsed value —
`findingsOf` only ever reads `review_spec`/`review_quality`. So four nodes could kill a
multi-hour run over output nothing consumes.

## Change

- `flows/nax-finish/verdict.ts` (new) owns verdict parsing and review routing
- `parseReviewVerdict` routes an unreadable reply to `reprompt` instead of throwing;
  `routeReview` retries the review once with a JSON-only notice, then escalates
- `parseFixVerdict` never throws and never routes `reprompt`, for the four nodes whose
  verdict is unread — their edges are unconditional, so a reprompt there has nowhere to go
- `routeReview` and `MAX_FIX_ATTEMPTS` move out of the flow file (568 → 529 lines), which
  keeps it under the 600-line limit once the in-flight `feat/finish-pr-body` work lands
- Escalation now reaches the existing `escalate` sink, which writes the result file
  before delivery — so the plugin always gets a result and Telegram always fires

## The subtle part, for reviewers

**`repromptCount` is self-inclusive**, and `routeReview`'s gate depends on it.

acpx calls `recordFlowStepOutcome` (`runtime.ts:262`), which pushes the finished step
onto the live `state.steps` (`runtime.ts:499`), *before* `resolveNextNode` (`:263`) and
before the next node runs — and `makeFlowNodeContext` hands that same state on. Since
`route_<phase>` runs immediately after `review_<phase>`, the just-failed review step is
already present when `routeReview` reads it.

So on the first unparseable reply `repromptCount` returns `1`, not `0`, and the gate must
be `attempts <= MAX_REPROMPT_ATTEMPTS`. An earlier revision of this branch used `<`,
which escalated on the *first* bad reply and made the entire retry mechanism dead code —
with every test still green, because the tests hand-built a `state.steps` shape the
runtime never produces. The tests now mirror the real ordering and fail under `<`.

The `reprompt` branch is also checked *before* the findings-empty branch. A reprompt
verdict carries zero findings, so the reverse order would route an unread review to
`clean` and open a PR having verified nothing — a silent false green, worse than the
crash.

## Test plan

- [x] `bun test test/unit/flows/nax-finish/` — 213 passing
- [x] `bun run test` — 1130 integration + 24 UI, all phases pass
- [x] `bun run lint` (includes `check:file-sizes`, `check:flows-no-bun`)
- [x] `bun run typecheck`

## Follow-ups (not in this PR)

- No test verifies that our `state.steps` test fixtures actually match what acpx
  produces. The ordering is mirrored by hand; if acpx ever reorders, the tests stay green
  and the flow breaks. A test asserting fixture shape against real acpx behavior would
  close the class rather than this instance.
- The `spec` phase's reprompt round-trip has static edge assertions but no live
  round-1/round-2 walk like `quality` does. Same code path, parameterized by phase.