### PR TITLE
test(nax-finish): build state.steps fixtures from real FlowStepRecord and walk the spec phase live

### DIFF
--- a/test/contracts/flow-step-fixture-shape.contract.ts
+++ b/test/contracts/flow-step-fixture-shape.contract.ts
@@ -1,0 +1,29 @@
+/**
+ * Type-level contract: the flow-step fixtures must stay assignable to acpx's
+ * real `FlowStepRecord` and to `FlowRunState["steps"]`.
+ *
+ * Why this file exists rather than relying on the annotations in the factory
+ * itself: `tsconfig.json` excludes `test`, so nothing under `test/unit/` or
+ * `test/helpers/` is compiled by `bun run typecheck` — the annotations there are
+ * editor-time only. `test/contracts/` IS compiled (`tsconfig.contracts.json`),
+ * and tsc follows these imports, so pulling the factory in here is what turns
+ * "the fixtures match acpx's shape" from a comment into a CI gate.
+ *
+ * If acpx renames, retypes or adds a required field on `FlowStepRecord`, this
+ * file fails to compile — which is the whole point of building the fixtures out
+ * of the real type instead of `{ nodeId, output }` literals cast `as never`.
+ */
+import type { FlowRunState, FlowStepRecord } from "acpx/flows";
+import { makeFlowCtx, makeFlowStep, makeFlowSteps, reviewRounds } from "../helpers/flow-steps";
+
+const _step: FlowStepRecord = makeFlowStep("review_spec");
+const _overridden: FlowStepRecord = makeFlowStep("commit_spec", { output: { shaBefore: "abc" } });
+const _steps: FlowStepRecord[] = makeFlowSteps(["review_spec", ["commit_spec", { shaBefore: "abc" }]]);
+const _rounds: FlowStepRecord[] = reviewRounds("quality", 1, { route: "reprompt", findings: [] });
+const _ctxSteps: FlowRunState["steps"] = makeFlowCtx({ steps: _steps }).state.steps;
+
+void _step;
+void _overridden;
+void _steps;
+void _rounds;
+void _ctxSteps;

--- a/test/helpers/flow-steps.ts
+++ b/test/helpers/flow-steps.ts
@@ -1,0 +1,124 @@
+/**
+ * Fixtures for acpx's `FlowRunState.steps` — the ordered history a flow node
+ * reads through `ctx.state.steps`.
+ *
+ * ## Why this exists
+ *
+ * The nax-finish flow tests used to hand-build steps as `{ nodeId, output }`
+ * literals cast `as never`. Two things were wrong with that, and the second one
+ * shipped a bug:
+ *
+ * 1. The cast meant no test would break if acpx renamed or moved a field. The
+ *    fixtures were a two-property subset of a twelve-property record, and
+ *    nothing said so.
+ * 2. The *ordering* convention lived only in prose comments. PR #1476 shipped
+ *    `attempts < MAX_REPROMPT_ATTEMPTS` where the self-inclusive count needs
+ *    `<=`, which made its own retry edge dead code. It survived four clean
+ *    reviews and 1130 green tests because the tests hand-built a `state.steps`
+ *    shape the runtime never produces — round 1 with zero steps recorded.
+ *
+ * Building fixtures as real `FlowStepRecord` values fixes (1): `tsc` now breaks
+ * when acpx's shape changes. `reviewRounds` fixes (2) by making the wrong shape
+ * unwriteable — see its own doc comment.
+ *
+ * ## The rule
+ *
+ * One sentence explains every reader in `flows/nax-finish/flow-ctx.ts` and
+ * `flows/nax-finish/verdict.ts`:
+ *
+ * > `ctx.state.steps` holds every step that has **finished**, in completion
+ * > order. The node currently executing is not in it. The node that just
+ * > finished **is**.
+ *
+ * acpx pushes the finished step onto the live state (`recordFlowStepOutcome`)
+ * before it resolves the next node, so a node reading this array always sees
+ * its own trigger already recorded. That is why `repromptCount`, read from
+ * `route_<phase>`, already counts the current round — and why
+ * `incrementalSince`, read from the `review_<phase>` node itself rather than
+ * from the node after it, still finds the *previous* round rather than itself.
+ *
+ * Both behaviours follow from the one rule. Describing the array relative to
+ * each caller ("never includes itself" / "already includes this round") is what
+ * made them look like contradictory special cases.
+ */
+import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
+
+/** Fixed so fixtures are deterministic; no reader asserts on step timestamps. */
+const FIXED_TIME = "2026-01-01T00:00:00.000Z";
+
+/**
+ * A `FlowNodeContext` for driving a flow node's `run` / `prompt` directly.
+ *
+ * Several nax-finish test files grew their own copy of this; new files should
+ * use this one rather than adding a fourth.
+ */
+export function makeFlowCtx(over: {
+  input?: unknown;
+  outputs?: Record<string, unknown>;
+  steps?: FlowStepRecord[];
+}): FlowNodeContext {
+  return {
+    input: over.input ?? {},
+    outputs: over.outputs ?? {},
+    results: {},
+    state: { steps: over.steps ?? [] },
+    services: {},
+  } as FlowNodeContext;
+}
+
+/**
+ * One finished step, as acpx records it.
+ *
+ * Defaults describe the common case in these tests: an `acp` node that
+ * completed and produced `output`. Override anything a specific test asserts
+ * on — but prefer overriding to constructing a literal, so the day acpx adds a
+ * required field there is exactly one place to fix.
+ */
+export function makeFlowStep(nodeId: string, overrides: Partial<FlowStepRecord> = {}): FlowStepRecord {
+  return {
+    attemptId: `${nodeId}-attempt`,
+    nodeId,
+    nodeType: "acp",
+    outcome: "ok",
+    startedAt: FIXED_TIME,
+    finishedAt: FIXED_TIME,
+    promptText: null,
+    rawText: null,
+    output: undefined,
+    session: null,
+    agent: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Finished history, oldest first.
+ *
+ * Each entry is either a bare node id, or `[nodeId, output]` when a reader
+ * looks at what that step produced — `incrementalSince`, for instance, reads
+ * `shaBefore` off the first `commit_*` step after a review.
+ */
+export function makeFlowSteps(entries: readonly (string | readonly [string, unknown])[]): FlowStepRecord[] {
+  return entries.map((entry) =>
+    typeof entry === "string" ? makeFlowStep(entry) : makeFlowStep(entry[0], { output: entry[1] }),
+  );
+}
+
+/**
+ * `state.steps` as `route_<phase>` sees it on review round `round`.
+ *
+ * `round` is **1-based and self-inclusive**: round 1 yields exactly one
+ * `review_<phase>` step, because by the time `route_<phase>` runs, the review
+ * that triggered it has already been recorded. There is deliberately no way to
+ * express "round 1 with nothing recorded yet" — that state does not occur in a
+ * real run, and encoding it in a fixture is precisely the mistake that let
+ * #1476's off-by-one through.
+ *
+ * @param phase  Which review phase's history to build.
+ * @param round  1-based round number; also the number of steps returned.
+ * @param output The verdict each of those rounds produced.
+ */
+export function reviewRounds(phase: "spec" | "quality", round: number, output: unknown): FlowStepRecord[] {
+  if (round < 1) throw new Error(`reviewRounds: round is 1-based and self-inclusive, got ${round}`);
+  return Array.from({ length: round }, () => makeFlowStep(`review_${phase}`, { output }));
+}

--- a/test/helpers/flow-steps.ts
+++ b/test/helpers/flow-steps.ts
@@ -15,11 +15,26 @@
  *    `attempts < MAX_REPROMPT_ATTEMPTS` where the self-inclusive count needs
  *    `<=`, which made its own retry edge dead code. It survived four clean
  *    reviews and 1130 green tests because the tests hand-built a `state.steps`
- *    shape the runtime never produces — round 1 with zero steps recorded.
+ *    shape the runtime never produces.
  *
- * Building fixtures as real `FlowStepRecord` values fixes (1): `tsc` now breaks
- * when acpx's shape changes. `reviewRounds` fixes (2) by making the wrong shape
- * unwriteable — see its own doc comment.
+ * Returning annotated `FlowStepRecord` values fixes (1) *for a step's own
+ * fields*, and `makeFlowCtx` extends that to `state.steps` by annotating rather
+ * than asserting the inner state.
+ *
+ * That only becomes a CI gate because of
+ * `test/contracts/flow-step-fixture-shape.contract.ts`: `tsconfig.json`
+ * **excludes `test`**, so nothing under `test/unit/` or `test/helpers/` is
+ * compiled by `bun run typecheck` and these annotations would otherwise be
+ * editor-time only. The contract file lives in the one test directory that IS
+ * compiled, and imports this module so tsc follows it. Keep that import alive.
+ *
+ * Two limits worth knowing: the outer `as FlowNodeContext` in `makeFlowCtx`
+ * still suppresses checking of `FlowNodeContext`'s *other* members, so this buys
+ * step-shape fidelity rather than whole-context fidelity; and no amount of
+ * typing detects a change in acpx's *runtime ordering* — only its shape.
+ *
+ * `recordedSteps` fixes (2) by making the wrong count unwriteable at the call
+ * site that mattered — see its own doc comment.
  *
  * ## The rule
  *
@@ -41,27 +56,55 @@
  * each caller ("never includes itself" / "already includes this round") is what
  * made them look like contradictory special cases.
  */
-import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
+import type { FlowNodeContext, FlowRunState, FlowStepRecord } from "acpx/flows";
 
 /** Fixed so fixtures are deterministic; no reader asserts on step timestamps. */
 const FIXED_TIME = "2026-01-01T00:00:00.000Z";
 
 /**
+ * acpx mints a fresh attempt id per attempt, so two steps of the same node in
+ * one history must not share one. Nothing asserts on the value — only on its
+ * uniqueness — so a counter is enough and keeps the field honest for any future
+ * reader that de-duplicates by attempt.
+ */
+let attemptSeq = 0;
+
+/**
+ * The node types nax-finish actually declares, so a fixture step is labelled the
+ * way the flow labels it.
+ *
+ * `review_*` and `fix_*` are `acp`, `route_*` are `compute`, `commit_*` and the
+ * three shell-running nodes are `action`. An unrecognised id falls back to
+ * `acp`; pass `nodeType` explicitly if that is wrong for your node, because a
+ * wrong label here is exactly the kind of quiet fixture drift this module
+ * exists to prevent.
+ */
+const ACTION_NODE_IDS = new Set(["load_ctx", "acceptance", "quality_gates"]);
+
+function nodeTypeFor(nodeId: string): FlowStepRecord["nodeType"] {
+  if (nodeId.startsWith("route_")) return "compute";
+  if (nodeId.startsWith("commit_") || ACTION_NODE_IDS.has(nodeId)) return "action";
+  return "acp";
+}
+
+/**
  * A `FlowNodeContext` for driving a flow node's `run` / `prompt` directly.
  *
- * Several nax-finish test files grew their own copy of this; new files should
- * use this one rather than adding a fourth.
+ * `state` is annotated rather than asserted, so a rename of `FlowRunState.steps`
+ * upstream fails the build here instead of silently feeding every reader
+ * `undefined` (which they all `?? []` into a clean, wrong zero).
  */
 export function makeFlowCtx(over: {
   input?: unknown;
   outputs?: Record<string, unknown>;
   steps?: FlowStepRecord[];
 }): FlowNodeContext {
+  const state: Pick<FlowRunState, "steps"> = { steps: over.steps ?? [] };
   return {
     input: over.input ?? {},
     outputs: over.outputs ?? {},
     results: {},
-    state: { steps: over.steps ?? [] },
+    state,
     services: {},
   } as FlowNodeContext;
 }
@@ -69,20 +112,21 @@ export function makeFlowCtx(over: {
 /**
  * One finished step, as acpx records it.
  *
- * Defaults describe the common case in these tests: an `acp` node that
- * completed and produced `output`. Override anything a specific test asserts
- * on — but prefer overriding to constructing a literal, so the day acpx adds a
- * required field there is exactly one place to fix.
+ * `nodeType` is derived from the node id and `attemptId` is unique per step;
+ * override either when a test asserts on it. Prefer overriding to constructing
+ * a literal, so the day acpx adds a required field there is exactly one place
+ * to fix.
  */
 export function makeFlowStep(nodeId: string, overrides: Partial<FlowStepRecord> = {}): FlowStepRecord {
   return {
-    attemptId: `${nodeId}-attempt`,
+    attemptId: `${nodeId}-${++attemptSeq}`,
     nodeId,
-    nodeType: "acp",
+    nodeType: nodeTypeFor(nodeId),
+    promptText: null,
     outcome: "ok",
     startedAt: FIXED_TIME,
     finishedAt: FIXED_TIME,
-    promptText: null,
+
     rawText: null,
     output: undefined,
     session: null,
@@ -105,20 +149,22 @@ export function makeFlowSteps(entries: readonly (string | readonly [string, unkn
 }
 
 /**
- * `state.steps` as `route_<phase>` sees it on review round `round`.
+ * `count` already-finished `review_<phase>` steps, each carrying `output`.
  *
- * `round` is **1-based and self-inclusive**: round 1 yields exactly one
- * `review_<phase>` step, because by the time `route_<phase>` runs, the review
- * that triggered it has already been recorded. There is deliberately no way to
- * express "round 1 with nothing recorded yet" — that state does not occur in a
- * real run, and encoding it in a fixture is precisely the mistake that let
- * #1476's off-by-one through.
+ * The parameter counts **recorded steps, not rounds**, because the two differ
+ * depending on which node's context you are building — and conflating them is
+ * how #1476's off-by-one survived:
  *
- * @param phase  Which review phase's history to build.
- * @param round  1-based round number; also the number of steps returned.
- * @param output The verdict each of those rounds produced.
+ * - At `route_<phase>`, the review that triggered it is already recorded, so
+ *   `count` equals the round number. Round 1 is `count: 1`, and `count: 0` is
+ *   not a state that node ever observes.
+ * - At `review_<phase>` itself, the executing attempt is *not* yet recorded, so
+ *   `count` equals `round - 1`. A first attempt is `count: 0` — which does
+ *   occur, and which `repromptCount(ctx, phase) > 0` reads as "no retry
+ *   notice". Build it with `makeFlowSteps` when the rest of the history
+ *   matters, or pass `0` here.
  */
-export function reviewRounds(phase: "spec" | "quality", round: number, output: unknown): FlowStepRecord[] {
-  if (round < 1) throw new Error(`reviewRounds: round is 1-based and self-inclusive, got ${round}`);
-  return Array.from({ length: round }, () => makeFlowStep(`review_${phase}`, { output }));
+export function reviewRounds(phase: "spec" | "quality", count: number, output: unknown): FlowStepRecord[] {
+  if (count < 0) throw new Error(`reviewRounds: count is a number of recorded steps, got ${count}`);
+  return Array.from({ length: count }, () => makeFlowStep(`review_${phase}`, { output }));
 }

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -41,3 +41,4 @@ export type { FakeClock } from "./fake-clock";
 export { makeScriptedAgent, runOrchestratorE2E } from "./e2e";
 export type { ScriptedAgentSpec, ScriptedTurn, E2EOptions, E2EResult, E2EGates } from "./e2e";
 export { DEFAULT_TEST_ROUTING, makeTestContext, makeTestPRD, makeTestStory } from "./pipeline-context";
+export { makeFlowCtx, makeFlowStep, makeFlowSteps, reviewRounds } from "./flow-steps";

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -9,19 +9,20 @@ import { afterEach, describe, expect, test } from "bun:test";
 import flow from "@flows/nax-finish/nax-finish.flow";
 import { _gitDeps } from "@flows/nax-finish/steps/git";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
-import type { FlowNodeContext } from "acpx/flows";
+import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
+import { makeFlowSteps } from "@test/helpers";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
 const ctxOf = (over: {
   outputs?: Record<string, unknown>;
-  steps?: { nodeId: string; output?: unknown }[];
+  steps?: FlowStepRecord[];
 }): FlowNodeContext =>
   ({
     input: INPUT,
     outputs: over.outputs ?? {},
     results: {},
-    state: { steps: over.steps ?? [] } as never,
+    state: { steps: over.steps ?? [] },
     services: {},
   }) as FlowNodeContext;
 
@@ -267,7 +268,7 @@ describe("review nodes — incremental scoping window", () => {
   const LOAD = { load_ctx: { base: "origin/main", specPath: "s.md" } };
 
   test("the first review of a phase reads the whole branch diff", () => {
-    expect(promptOf("review_spec", { outputs: LOAD, steps: [{ nodeId: "load_ctx" }] })).toContain(
+    expect(promptOf("review_spec", { outputs: LOAD, steps: makeFlowSteps(["load_ctx"]) })).toContain(
       "git diff origin/main...HEAD",
     );
   });
@@ -275,11 +276,7 @@ describe("review nodes — incremental scoping window", () => {
   test("one commit since the last review scopes to that commit's parent tree", () => {
     const p = promptOf("review_spec", {
       outputs: { ...LOAD, review_spec: { findings: [] } },
-      steps: [
-        { nodeId: "review_spec" },
-        { nodeId: "fix_spec" },
-        { nodeId: "commit_spec", output: { shaBefore: "sha-at-review-1" } },
-      ],
+      steps: makeFlowSteps(["review_spec", "fix_spec", ["commit_spec", { shaBefore: "sha-at-review-1" }]]),
     });
     expect(p).toContain("git diff sha-at-review-1..HEAD");
   });
@@ -290,12 +287,12 @@ describe("review nodes — incremental scoping window", () => {
   test("two commits since the last review scope from the FIRST, spanning both", () => {
     const p = promptOf("review_spec", {
       outputs: { ...LOAD, review_spec: { findings: [] } },
-      steps: [
-        { nodeId: "review_spec" },
-        { nodeId: "commit_spec", output: { shaBefore: "sha-at-review-1" } },
-        { nodeId: "acceptance" },
-        { nodeId: "commit_acceptance", output: { shaBefore: "sha-after-spec-fix" } },
-      ],
+      steps: makeFlowSteps([
+        "review_spec",
+        ["commit_spec", { shaBefore: "sha-at-review-1" }],
+        "acceptance",
+        ["commit_acceptance", { shaBefore: "sha-after-spec-fix" }],
+      ]),
     });
     expect(p).toContain("git diff sha-at-review-1..HEAD");
     expect(p).not.toContain("sha-after-spec-fix..HEAD");
@@ -304,7 +301,7 @@ describe("review nodes — incremental scoping window", () => {
   test("a commit that recorded no shaBefore falls back to a full review", () => {
     const p = promptOf("review_quality", {
       outputs: { ...LOAD, review_quality: { findings: [] } },
-      steps: [{ nodeId: "review_quality" }, { nodeId: "commit_quality", output: { shaBefore: null } }],
+      steps: makeFlowSteps(["review_quality", ["commit_quality", { shaBefore: null }]]),
     });
     expect(p).toContain("git diff origin/main...HEAD");
   });
@@ -312,7 +309,7 @@ describe("review nodes — incremental scoping window", () => {
   test("only commits AFTER the last review count — an earlier one does not scope it", () => {
     const p = promptOf("review_quality", {
       outputs: { ...LOAD, review_quality: { findings: [] } },
-      steps: [{ nodeId: "commit_quality", output: { shaBefore: "old" } }, { nodeId: "review_quality" }],
+      steps: makeFlowSteps([["commit_quality", { shaBefore: "old" }], "review_quality"]),
     });
     expect(p).toContain("git diff origin/main...HEAD");
   });
@@ -321,12 +318,12 @@ describe("review nodes — incremental scoping window", () => {
   test("the gate re-entry scopes the quality re-review to the gate commit", () => {
     const p = promptOf("review_quality", {
       outputs: { ...LOAD, review_quality: { findings: [] } },
-      steps: [
-        { nodeId: "review_quality" },
-        { nodeId: "quality_gates" },
-        { nodeId: "fix_gate" },
-        { nodeId: "commit_gate", output: { shaBefore: "sha-at-clean-review" } },
-      ],
+      steps: makeFlowSteps([
+        "review_quality",
+        "quality_gates",
+        "fix_gate",
+        ["commit_gate", { shaBefore: "sha-at-clean-review" }],
+      ]),
     });
     expect(p).toContain("git diff sha-at-clean-review..HEAD");
   });

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -10,21 +10,12 @@ import flow from "@flows/nax-finish/nax-finish.flow";
 import { _gitDeps } from "@flows/nax-finish/steps/git";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
 import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
-import { makeFlowSteps } from "@test/helpers";
+import { makeFlowCtx, makeFlowSteps } from "@test/helpers";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
-const ctxOf = (over: {
-  outputs?: Record<string, unknown>;
-  steps?: FlowStepRecord[];
-}): FlowNodeContext =>
-  ({
-    input: INPUT,
-    outputs: over.outputs ?? {},
-    results: {},
-    state: { steps: over.steps ?? [] },
-    services: {},
-  }) as FlowNodeContext;
+const ctxOf = (over: { outputs?: Record<string, unknown>; steps?: FlowStepRecord[] }): FlowNodeContext =>
+  makeFlowCtx({ input: INPUT, ...over });
 
 type NodeRun<T> = { run: (ctx: FlowNodeContext) => Promise<T> | T };
 const nodeRun = <T>(id: string) => flow.nodes[id] as unknown as NodeRun<T>;

--- a/test/unit/flows/nax-finish/flow-graph-open-pr-metadata.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph-open-pr-metadata.test.ts
@@ -32,7 +32,7 @@ const ctxOf = (over: { outputs?: Record<string, unknown> }): FlowNodeContext =>
     input: INPUT,
     outputs: over.outputs ?? {},
     results: {},
-    state: { steps: [] } as never,
+    state: { steps: [] },
     services: {},
   }) as FlowNodeContext;
 

--- a/test/unit/flows/nax-finish/flow-graph-open-pr-metadata.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph-open-pr-metadata.test.ts
@@ -12,6 +12,7 @@ import { _prDeps } from "@flows/nax-finish/steps/pr";
 import type { FinishPrContext } from "@flows/nax-finish/steps/pr-body";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
 import type { FlowNodeContext } from "acpx/flows";
+import { makeFlowCtx } from "@test/helpers";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
@@ -28,13 +29,7 @@ const minimalCtx = (): FinishPrContext => ({
 });
 
 const ctxOf = (over: { outputs?: Record<string, unknown> }): FlowNodeContext =>
-  ({
-    input: INPUT,
-    outputs: over.outputs ?? {},
-    results: {},
-    state: { steps: [] },
-    services: {},
-  }) as FlowNodeContext;
+  makeFlowCtx({ input: INPUT, ...over });
 
 type NodeRun<T> = { run: (ctx: FlowNodeContext) => Promise<T> | T };
 const nodeRun = <T>(id: string) => flow.nodes[id] as unknown as NodeRun<T>;

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -8,7 +8,7 @@ import { _prDeps } from "@flows/nax-finish/steps/pr";
 import { _qualityDeps } from "@flows/nax-finish/steps/quality";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
 import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
-import { makeFlowSteps, reviewRounds } from "@test/helpers";
+import { makeFlowCtx, makeFlowSteps } from "@test/helpers";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
@@ -16,14 +16,7 @@ const ctxOf = (over: {
   input?: Record<string, unknown>;
   outputs?: Record<string, unknown>;
   steps?: FlowStepRecord[];
-}): FlowNodeContext =>
-  ({
-    input: over.input ?? INPUT,
-    outputs: over.outputs ?? {},
-    results: {},
-    state: { steps: over.steps ?? [] },
-    services: {},
-  }) as FlowNodeContext;
+}): FlowNodeContext => makeFlowCtx({ input: INPUT, ...over });
 
 type NodeRun<T> = { run: (ctx: FlowNodeContext) => Promise<T> | T };
 const nodeRun = <T>(id: string) => flow.nodes[id] as unknown as NodeRun<T>;

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -7,20 +7,21 @@ import { _gitDeps } from "@flows/nax-finish/steps/git";
 import { _prDeps } from "@flows/nax-finish/steps/pr";
 import { _qualityDeps } from "@flows/nax-finish/steps/quality";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
-import type { FlowNodeContext } from "acpx/flows";
+import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
+import { makeFlowSteps, reviewRounds } from "@test/helpers";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
 const ctxOf = (over: {
   input?: Record<string, unknown>;
   outputs?: Record<string, unknown>;
-  steps?: { nodeId: string }[];
+  steps?: FlowStepRecord[];
 }): FlowNodeContext =>
   ({
     input: over.input ?? INPUT,
     outputs: over.outputs ?? {},
     results: {},
-    state: { steps: over.steps ?? [] } as never,
+    state: { steps: over.steps ?? [] },
     services: {},
   }) as FlowNodeContext;
 
@@ -177,7 +178,7 @@ describe("acceptance node", () => {
     const out = await nodeRun<{ route: string }>("acceptance").run(
       ctxOf({
         outputs: { load_ctx: { groups: GROUPS } },
-        steps: [{ nodeId: "fix_acceptance" }, { nodeId: "fix_acceptance" }],
+        steps: makeFlowSteps(["fix_acceptance", "fix_acceptance"]),
       }),
     );
     expect(out.route).toBe("fix");
@@ -255,7 +256,7 @@ describe("acceptance node", () => {
     const out = await nodeRun<{ route: string; reason?: string }>("acceptance").run(
       ctxOf({
         outputs: { load_ctx: { groups: GROUPS } },
-        steps: [{ nodeId: "fix_acceptance" }, { nodeId: "fix_acceptance" }, { nodeId: "fix_acceptance" }],
+        steps: makeFlowSteps(["fix_acceptance", "fix_acceptance", "fix_acceptance"]),
       }),
     );
     expect(out.route).toBe("escalate");
@@ -293,7 +294,7 @@ describe("review parse + route_* nodes", () => {
     const out = nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
       ctxOf({
         outputs: { review_spec: { route: "proceed", findings: [finding] } },
-        steps: [{ nodeId: "fix_spec" }, { nodeId: "fix_spec" }, { nodeId: "fix_spec" }],
+        steps: makeFlowSteps(["fix_spec", "fix_spec", "fix_spec"]),
       }),
     ) as { route: string; escalationReason?: string };
     expect(out.route).toBe("escalate");
@@ -400,7 +401,7 @@ describe("quality_gates node", () => {
       const out = await nodeRun<{ route: string; reason?: string }>("quality_gates").run(
         ctxOf({
           outputs: { load_ctx: { groups: GROUPS } },
-          steps: [{ nodeId: "fix_gate" }, { nodeId: "fix_gate" }, { nodeId: "fix_gate" }],
+          steps: makeFlowSteps(["fix_gate", "fix_gate", "fix_gate"]),
         }),
       );
 
@@ -438,7 +439,7 @@ describe("quality_gates node", () => {
     _qualityDeps.readText = async () => JSON.stringify({ quality: { commands: { lint: "bun run lint" } } });
     _qualityDeps.runShell = async () => ({ exitCode: 1, stdout: "", stderr: "lint bad" });
     const out = await nodeRun<{ route: string; reason?: string }>("quality_gates").run(
-      ctxOf({ steps: [{ nodeId: "fix_gate" }, { nodeId: "fix_gate" }, { nodeId: "fix_gate" }] }),
+      ctxOf({ steps: makeFlowSteps(["fix_gate", "fix_gate", "fix_gate"]) }),
     );
     expect(out.route).toBe("escalate");
     expect(out.reason).toContain("lint");
@@ -698,82 +699,5 @@ describe("escalate node", () => {
 
     expect(out.deliveryError).toBeTruthy();
     expect(JSON.parse(wrote)).toMatchObject({ status: "escalated", escalationReason: "r" });
-  });
-});
-
-describe("reprompt edges", () => {
-  test("route_spec routes reprompt back to review_spec", () => {
-    expect(switchOf("route_spec").cases.reprompt).toBe("review_spec");
-  });
-
-  test("route_quality routes reprompt back to review_quality", () => {
-    expect(switchOf("route_quality").cases.reprompt).toBe("review_quality");
-  });
-
-  test("the existing routes are untouched", () => {
-    expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
-    expect(switchOf("route_quality").cases.fix).toBe("fix_quality");
-    expect(switchOf("route_quality").cases.escalate).toBe("escalate");
-  });
-
-  // acpx's runtime pushes the just-finished step onto `state.steps`
-  // (recordFlowStepOutcome, runtime.ts:262/499) BEFORE the next node runs, so
-  // by the time `route_quality` executes, its own triggering `review_quality`
-  // step is already recorded. These two tests model that real ordering —
-  // round 1's `steps` has exactly the 1 step just recorded, round 2's has 2 —
-  // and the round-1 case would FAIL under the old (buggy) `<` comparison,
-  // which escalated on the very first unparseable reply instead of retrying.
-  test("route_quality yields reprompt on the first unparseable verdict (round 1)", async () => {
-    const verdict = { route: "reprompt", findings: [], raw: "prose" };
-    const out = await nodeRun<{ route: string }>("route_quality").run(
-      ctxOf({
-        outputs: { review_quality: verdict },
-        steps: [{ nodeId: "review_quality", output: verdict }] as never,
-      }),
-    );
-    expect(out.route).toBe("reprompt");
-  });
-
-  test("route_quality escalates on the second consecutive unparseable verdict (round 2)", async () => {
-    const verdict = { route: "reprompt", findings: [], raw: "prose" };
-    const out = await nodeRun<{ route: string; escalationReason?: string }>("route_quality").run(
-      ctxOf({
-        outputs: { review_quality: verdict },
-        steps: [
-          { nodeId: "review_quality", output: verdict },
-          { nodeId: "review_quality", output: verdict },
-        ] as never,
-      }),
-    );
-    expect(out.route).toBe("escalate");
-    expect(out.escalationReason).toContain("after 2 attempts");
-  });
-
-  test("review_quality leads with the retry notice after a reprompt", () => {
-    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
-    const prompt = node.prompt(
-      ctxOf({
-        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
-        steps: [{ nodeId: "review_quality", output: { route: "reprompt", findings: [] } }] as never,
-      }),
-    );
-    expect(prompt).toContain("previous reply could not be parsed");
-  });
-
-  test("a retried review is a FULL review, not an incremental one", () => {
-    // incrementalSince scopes a re-review to firstCommit.shaBefore..HEAD by finding
-    // the first commit_* step after the last review_<phase>. On a reprompt re-entry
-    // no commit_* follows, so it returns null and the whole base...HEAD diff is
-    // re-read. That is right — the previous attempt produced no verdict, so there is
-    // no cleared window to skip. Pinned so nobody "optimises" it into an incremental.
-    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
-    const prompt = node.prompt(
-      ctxOf({
-        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
-        steps: [{ nodeId: "review_quality", output: { route: "reprompt", findings: [] } }] as never,
-      }),
-    );
-    expect(prompt).toContain("git diff origin/main...HEAD");
-    expect(prompt).not.toContain("continuing a review you already started");
   });
 });

--- a/test/unit/flows/nax-finish/flow-reprompt.test.ts
+++ b/test/unit/flows/nax-finish/flow-reprompt.test.ts
@@ -41,13 +41,14 @@ describe("reprompt edges", () => {
     expect(switchOf("route_quality").cases.escalate).toBe("escalate");
   });
 
-  // `reviewRounds(phase, N, …)` builds the finished-step history acpx really
-  // produces: by the time `route_<phase>` runs, the `review_<phase>` step that
-  // triggered it is already recorded, so round N carries N steps rather than
-  // N-1. Both round-1 cases below FAIL under the old (buggy) `<` comparison,
+  // `reviewRounds(phase, N, …)` builds N *already-finished* review steps. At a
+  // `route_<phase>` node that equals the round number, because the review that
+  // triggered the route is recorded before the route runs; at a `review_<phase>`
+  // node it is one less, since the executing attempt is not yet recorded. See
+  // test/helpers/flow-steps.ts.
+  //
+  // Both round-1 route cases below FAIL under the old (buggy) `<` comparison,
   // which escalated on the very first unparseable reply instead of retrying.
-  // See test/helpers/flow-steps.ts for why the fixture cannot express the
-  // shape that hid that bug.
   test("route_quality yields reprompt on the first unparseable verdict (round 1)", async () => {
     const verdict = { route: "reprompt", findings: [], raw: "prose" };
     const out = await nodeRun<{ route: string }>("route_quality").run(
@@ -70,6 +71,24 @@ describe("reprompt edges", () => {
     expect(out.route).toBe("escalate");
     expect(out.escalationReason).toContain("after 2 attempts");
   });
+
+  // The complement of the retry-notice tests, and the case the old `round`
+  // naming made look unrepresentable: a review node on its FIRST attempt has
+  // zero recorded steps of its own, so `repromptCount(ctx, phase) > 0` is
+  // false and the prompt must not open with a retry apology.
+  test.each(["spec", "quality"] as const)(
+    "review_%s on its first attempt carries no retry notice",
+    (phase) => {
+      const node = flow.nodes[`review_${phase}`] as unknown as { prompt: (c: FlowNodeContext) => string };
+      const prompt = node.prompt(
+        ctxOf({
+          outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+          steps: reviewRounds(phase, 0, REPROMPT_VERDICT),
+        }),
+      );
+      expect(prompt).not.toContain("previous reply could not be parsed");
+    },
+  );
 
   test("review_quality leads with the retry notice after a reprompt", () => {
     const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };

--- a/test/unit/flows/nax-finish/flow-reprompt.test.ts
+++ b/test/unit/flows/nax-finish/flow-reprompt.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import flow from "@flows/nax-finish/nax-finish.flow";
+import type { FlowNodeContext } from "acpx/flows";
+import { makeFlowCtx, reviewRounds } from "@test/helpers";
+
+/**
+ * The reprompt path: what happens when a reviewer replies with prose instead of
+ * the JSON verdict contract.
+ *
+ * Split out of `flow-graph.test.ts` (800-line test cap). Kept whole rather than
+ * scattered because the round-1/round-2 pairs only make sense read together —
+ * see `test/helpers/flow-steps.ts` for the step-ordering rule they encode.
+ */
+
+const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
+const ctxOf = (over: { outputs?: Record<string, unknown>; steps?: FlowNodeContext["state"]["steps"] }) =>
+  makeFlowCtx({ input: INPUT, ...over });
+
+type NodeRun<T> = { run: (ctx: FlowNodeContext) => Promise<T> | T };
+const nodeRun = <T>(id: string) => flow.nodes[id] as unknown as NodeRun<T>;
+const switchOf = (from: string) => {
+  const edge = flow.edges.find((e) => e.from === from && "switch" in e);
+  if (!edge || !("switch" in edge)) throw new Error(`no switch edge from ${from}`);
+  return edge.switch;
+};
+
+const REPROMPT_VERDICT = { route: "reprompt", findings: [] };
+
+describe("reprompt edges", () => {
+  test("route_spec routes reprompt back to review_spec", () => {
+    expect(switchOf("route_spec").cases.reprompt).toBe("review_spec");
+  });
+
+  test("route_quality routes reprompt back to review_quality", () => {
+    expect(switchOf("route_quality").cases.reprompt).toBe("review_quality");
+  });
+
+  test("the existing routes are untouched", () => {
+    expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
+    expect(switchOf("route_quality").cases.fix).toBe("fix_quality");
+    expect(switchOf("route_quality").cases.escalate).toBe("escalate");
+  });
+
+  // `reviewRounds(phase, N, …)` builds the finished-step history acpx really
+  // produces: by the time `route_<phase>` runs, the `review_<phase>` step that
+  // triggered it is already recorded, so round N carries N steps rather than
+  // N-1. Both round-1 cases below FAIL under the old (buggy) `<` comparison,
+  // which escalated on the very first unparseable reply instead of retrying.
+  // See test/helpers/flow-steps.ts for why the fixture cannot express the
+  // shape that hid that bug.
+  test("route_quality yields reprompt on the first unparseable verdict (round 1)", async () => {
+    const verdict = { route: "reprompt", findings: [], raw: "prose" };
+    const out = await nodeRun<{ route: string }>("route_quality").run(
+      ctxOf({
+        outputs: { review_quality: verdict },
+        steps: reviewRounds("quality", 1, verdict),
+      }),
+    );
+    expect(out.route).toBe("reprompt");
+  });
+
+  test("route_quality escalates on the second consecutive unparseable verdict (round 2)", async () => {
+    const verdict = { route: "reprompt", findings: [], raw: "prose" };
+    const out = await nodeRun<{ route: string; escalationReason?: string }>("route_quality").run(
+      ctxOf({
+        outputs: { review_quality: verdict },
+        steps: reviewRounds("quality", 2, verdict),
+      }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.escalationReason).toContain("after 2 attempts");
+  });
+
+  test("review_quality leads with the retry notice after a reprompt", () => {
+    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: reviewRounds("quality", 1, REPROMPT_VERDICT),
+      }),
+    );
+    expect(prompt).toContain("previous reply could not be parsed");
+  });
+
+  test("a retried review is a FULL review, not an incremental one", () => {
+    // incrementalSince scopes a re-review to firstCommit.shaBefore..HEAD by finding
+    // the first commit_* step after the last review_<phase>. On a reprompt re-entry
+    // no commit_* follows, so it returns null and the whole base...HEAD diff is
+    // re-read. That is right — the previous attempt produced no verdict, so there is
+    // no cleared window to skip. Pinned so nobody "optimises" it into an incremental.
+    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: reviewRounds("quality", 1, REPROMPT_VERDICT),
+      }),
+    );
+    expect(prompt).toContain("git diff origin/main...HEAD");
+    expect(prompt).not.toContain("continuing a review you already started");
+  });
+
+  // The `spec` phase had only the two static edge assertions above, while
+  // `quality` was walked live. That asymmetry is a real coverage hole, not a
+  // stylistic one: `repromptCount` and `routeReview` are phase-parameterised,
+  // so a hardcoded "quality" anywhere in that path — or a `review_spec` prompt
+  // that forgets to pass `retry` — is invisible to the quality-only walk. These
+  // mirror the four quality cases against the spec phase.
+  test("route_spec yields reprompt on the first unparseable verdict (round 1)", async () => {
+    const out = await nodeRun<{ route: string }>("route_spec").run(
+      ctxOf({
+        outputs: { review_spec: REPROMPT_VERDICT },
+        steps: reviewRounds("spec", 1, REPROMPT_VERDICT),
+      }),
+    );
+    expect(out.route).toBe("reprompt");
+  });
+
+  test("route_spec escalates on the second consecutive unparseable verdict (round 2)", async () => {
+    const out = await nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
+      ctxOf({
+        outputs: { review_spec: REPROMPT_VERDICT },
+        steps: reviewRounds("spec", 2, REPROMPT_VERDICT),
+      }),
+    );
+    expect(out.route).toBe("escalate");
+    expect(out.escalationReason).toContain("after 2 attempts");
+  });
+
+  test("review_spec leads with the retry notice after a reprompt", () => {
+    const node = flow.nodes.review_spec as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: reviewRounds("spec", 1, REPROMPT_VERDICT),
+      }),
+    );
+    expect(prompt).toContain("previous reply could not be parsed");
+  });
+
+  test("a retried spec review is a FULL review, not an incremental one", () => {
+    const node = flow.nodes.review_spec as unknown as { prompt: (c: FlowNodeContext) => string };
+    const prompt = node.prompt(
+      ctxOf({
+        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
+        steps: reviewRounds("spec", 1, REPROMPT_VERDICT),
+      }),
+    );
+    expect(prompt).toContain("git diff origin/main...HEAD");
+    expect(prompt).not.toContain("continuing a review you already started");
+  });
+
+  // The counters are per phase. A spec reprompt must not push the quality
+  // phase toward its cap, or a run that stumbled once in each phase would
+  // escalate the second one on its first unparseable reply.
+  test("a spec reprompt does not count toward the quality phase's cap", async () => {
+    const out = await nodeRun<{ route: string }>("route_quality").run(
+      ctxOf({
+        outputs: { review_quality: REPROMPT_VERDICT },
+        steps: [...reviewRounds("spec", 2, REPROMPT_VERDICT), ...reviewRounds("quality", 1, REPROMPT_VERDICT)],
+      }),
+    );
+    expect(out.route).toBe("reprompt");
+  });
+});

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -7,6 +7,8 @@ import {
   repromptCount,
   routeReview,
 } from "@flows/nax-finish/verdict";
+import type { FlowStepRecord } from "acpx/flows";
+import { makeFlowStep, makeFlowSteps, reviewRounds } from "@test/helpers";
 
 // The real reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3 on
 // rs-stock, with private identifiers replaced by generic equivalents — the shape
@@ -85,13 +87,14 @@ describe("parseFixVerdict", () => {
   });
 });
 
-const stepsCtx = (steps: { nodeId: string; output?: unknown }[]) => ({ state: { steps }, outputs: {} });
-const routeCtx = (verdict: unknown, steps: { nodeId: string; output?: unknown }[] = []) => ({
+const stepsCtx = (steps: FlowStepRecord[]) => ({ state: { steps }, outputs: {} });
+const routeCtx = (verdict: unknown, steps: FlowStepRecord[] = []) => ({
   outputs: { review_quality: verdict },
   state: { steps },
 });
-const REPROMPT_STEP = { nodeId: "review_quality", output: { route: "reprompt", findings: [] } };
-const CLEAN_STEP = { nodeId: "review_quality", output: { route: "clean", findings: [] } };
+const REPROMPT = { route: "reprompt", findings: [] };
+const REPROMPT_STEP = makeFlowStep("review_quality", { output: REPROMPT });
+const CLEAN_STEP = makeFlowStep("review_quality", { output: { route: "clean", findings: [] } });
 
 describe("repromptCount", () => {
   test("is zero with no steps", () => {
@@ -99,7 +102,7 @@ describe("repromptCount", () => {
   });
 
   test("ignores legitimate review re-entries that produced a real verdict", () => {
-    expect(repromptCount(stepsCtx([CLEAN_STEP, { nodeId: "commit_quality" }, CLEAN_STEP]), "quality")).toBe(0);
+    expect(repromptCount(stepsCtx([CLEAN_STEP, makeFlowStep("commit_quality"), CLEAN_STEP]), "quality")).toBe(0);
   });
 
   test("counts only steps whose output routed reprompt", () => {
@@ -122,21 +125,19 @@ describe("routeReview", () => {
     expect(r.route).toBe("reprompt");
   });
 
-  // acpx records a step's outcome (`recordFlowStepOutcome`, runtime.ts:262/499)
-  // BEFORE the next node runs, so by the time `routeReview` executes for the
-  // current round, that round's own `review_quality` step is already in
-  // `ctx.state.steps`. These two tests model that real ordering: round N's
-  // `steps` array has exactly N reprompt entries (not N-1), and would FAIL
-  // under the old `attempts < MAX_REPROMPT_ATTEMPTS` comparison — round 1
-  // would incorrectly escalate immediately instead of retrying.
+  // `reviewRounds(phase, N, …)` builds the history acpx really produces: round
+  // N carries N recorded review steps, not N-1, because the step that triggered
+  // `route_<phase>` is recorded before `route_<phase>` runs. The round-1 case
+  // FAILS under the old `attempts < MAX_REPROMPT_ATTEMPTS` comparison, which
+  // escalated on the very first unparseable reply instead of retrying.
   test("reprompts on the first unparseable reply (round 1: 1 reprompt step already recorded)", () => {
-    const steps = [REPROMPT_STEP];
+    const steps = reviewRounds("quality", 1, REPROMPT);
     const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "some prose" }, steps), "quality");
     expect(r.route).toBe("reprompt");
   });
 
   test("escalates on the second consecutive unparseable reply, naming the raw tail", () => {
-    const steps = Array.from({ length: MAX_REPROMPT_ATTEMPTS + 1 }, () => REPROMPT_STEP);
+    const steps = reviewRounds("quality", MAX_REPROMPT_ATTEMPTS + 1, REPROMPT);
     const r = routeReview(routeCtx({ route: "reprompt", findings: [], raw: "some prose" }, steps), "quality");
     expect(r.route).toBe("escalate");
     expect(r.escalationReason).toContain("unparseable");
@@ -159,7 +160,7 @@ describe("routeReview", () => {
   });
 
   test("still escalates when findings persist past the fix cap", () => {
-    const steps = Array.from({ length: MAX_FIX_ATTEMPTS }, () => ({ nodeId: "fix_quality" }));
+    const steps = makeFlowSteps(Array.from({ length: MAX_FIX_ATTEMPTS }, () => "fix_quality"));
     const r = routeReview(routeCtx({ route: "proceed", findings: [FINDING] }, steps), "quality");
     expect(r.route).toBe("escalate");
     expect(r.escalationReason).toContain("fix attempts");


### PR DESCRIPTION
Closes the two test-coverage follow-ups left unbuilt by #1476.

## Why

#1476 shipped `attempts < MAX_REPROMPT_ATTEMPTS` where the self-inclusive count needs `<=`. That off-by-one made its own retry edge dead code, and it survived four clean reviews and 1130 green tests — because the tests hand-built `ctx.state.steps` as `{ nodeId, output }` literals cast `as never`, modelling a shape the runtime never produces. Two problems behind that:

1. The cast meant no test would break if acpx renamed or moved a field. The fixtures were a two-property subset of a twelve-property record, and nothing said so.
2. The step-ordering convention lived only in prose comments.

## What changed

**`test/helpers/flow-steps.ts`** — fixtures are now real `FlowStepRecord` values (`makeFlowStep` / `makeFlowSteps` / `reviewRounds`), plus `makeFlowCtx` for the context itself. Every `as never` on `state.steps` is gone from the four nax-finish test files, and the three hand-rolled `ctxOf` builders now share one factory.

`reviewRounds(phase, count, output)` counts **recorded steps, not rounds** — the distinction the old naming got wrong. At `route_<phase>` that equals the round number (the triggering review is already recorded); at `review_<phase>` it is one less (the executing attempt is not). Conflating them is how the off-by-one survived.

**The module header states the one rule that explains both readers**, which were previously documented per-caller and read as contradictory:

> `ctx.state.steps` holds every step that has finished, in completion order. The node currently executing is not in it. The node that just finished is.

That is why `repromptCount` (read from `route_*`) is self-inclusive *and* `incrementalSince` (read from `review_*` itself) still finds the previous round.

**`test/contracts/flow-step-fixture-shape.contract.ts`** — makes the shape claim a real gate. `tsconfig.json` excludes `test`, so nothing under `test/unit/` or `test/helpers/` is compiled by `bun run typecheck`; without this file the annotations would be editor-time only. `test/contracts/` is the one test directory `tsconfig.contracts.json` compiles, and tsc follows its imports. Wiring all of `test/` in instead is not viable here — it currently reports 2025 pre-existing errors.

**Spec-phase coverage** — the `spec` phase had two static edge assertions while `quality` was walked live. It now has the same four live tests, plus a phase-isolation test and a first-attempt test. `repromptCount`/`routeReview` are phase-parameterised, so a hardcoded `"quality"` was invisible to a quality-only walk. `flow-graph.test.ts` crossed the 800-line cap, so the reprompt block moved to `flow-reprompt.test.ts`.

## Verification

Verified by mutation, not by green — each mutation applied, observed failing, then reverted:

| Mutation | Result |
|---|---|
| `attempts <= MAX_REPROMPT_ATTEMPTS` → `<` (the original #1476 bug) | 4 tests fail, incl. both new spec cases |
| `repromptCount`'s phase filter → `startsWith("review_")` | 2 fail, incl. the new phase-isolation test |
| `retry: repromptCount(...) > 0` → `retry: true` | 1 fails (the new first-attempt test) |
| Drop a required field from `makeFlowStep` | `bun run typecheck` fails |
| Rename the annotated `state.steps` | `bun run typecheck` fails |

Full suite green: 11590 + 1092 + 24 pass, 0 fail. Typecheck and lint clean.

**Test-only change — no source files touched.**

## Known limits

- The outer `as FlowNodeContext` in `makeFlowCtx` still suppresses checking of `FlowNodeContext`'s other members. This buys step-shape fidelity, not whole-context fidelity.
- No amount of typing detects a change in acpx's runtime *ordering* — only its shape. Verifying ordering would mean executing acpx's `FlowRunner` in tests, which was considered and deliberately ruled out.
- `test/unit/` and `test/helpers/` remain outside `bun run typecheck` (2025 pre-existing errors). Worth its own issue.
