### PR TITLE
docs(mutation-check): document the mutation spot-check and enable it in nax's own config

### DIFF
--- a/.nax/config.json
+++ b/.nax/config.json
@@ -79,6 +79,11 @@
     "permissionProfile": "unrestricted",
     "sessionTimeoutSeconds": 7200,
     "maxStoriesPerFeature": 15,
+    "mutationCheck": {
+      "enabled": true,
+      "maxMutants": 3,
+      "timeoutSeconds": 60
+    },
     "smartTestRunner": {
       "testFilePatterns": [
         "**/*.test.ts",

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -422,6 +422,53 @@ Example with defaults: a story can cycle through review→autofix up to 5 times 
 
 ---
 
+### Mutation Spot-Check
+
+Green tests prove the code passes the suite; they do not prove the suite would notice if the code were wrong. The mutation spot-check injects a small number of deliberate defects into the story's changed source files, re-runs the scoped tests against each one, and reports any mutant the suite failed to catch.
+
+It is **opt-in and advisory** — it runs after `full-suite-gate` and can never fail a story. Every mutation is reverted in a `finally`, so the worktree is restored even if a test run crashes.
+
+```json
+{
+  "execution": {
+    "mutationCheck": {
+      "enabled": true,
+      "maxMutants": 3,
+      "timeoutSeconds": 60
+    }
+  }
+}
+```
+
+| Field | Default | Description |
+|:------|:--------|:------------|
+| `enabled` | `false` | Master switch. When `false` the phase is not even scheduled. |
+| `maxMutants` | `3` | Mutants tested per story (1–50). Candidates are gathered across **all** changed files, then sampled evenly across that list — so raising this widens coverage rather than digging deeper into the first file. |
+| `timeoutSeconds` | `60` | Per-mutant scoped test-run timeout (5–600). |
+
+**Cost:** one scoped test run per mutant, serially. Worst case adds `maxMutants × timeoutSeconds` to a story — 3 minutes at the defaults.
+
+**Operators** are regex-based and language-scoped, four per language: comparison flips (`==`↔`!=`, `>=`↔`<=`, and whitespace-delimited `>`/`<`), boolean-literal flips, and whitespace-delimited arithmetic flips (`+`↔`-`, `*`↔`/`). Supported languages: `typescript`, `javascript`, `python`, `go`, `rust`. Any other language yields no operators and the check is a no-op. The whitespace gating is deliberate — it keeps the mutator away from module specifiers (`"../config"`), URLs, generics (`Array<string>`), and arrow functions, all of which would otherwise produce mutants that merely fail to compile.
+
+**Outcomes** are counted per story as `killed` / `survived` / `errored`:
+
+| Outcome | Meaning |
+|:--------|:--------|
+| `killed` | Tests ran and failed — the suite caught the defect. Requires evidence the tests actually executed (a non-zero pass/fail tally), so a mutant that fails to build is never miscounted as a kill. |
+| `survived` | Tests ran and passed with the defect in place — **a gap in the suite.** |
+| `errored` | The mutant never produced a real test result (build failure, unresolvable module, unparseable runner output, timeout). Discarded, not a signal about test quality. |
+
+Survivors are logged per story, and in headless mode (non-`json`) a `SURVIVING MUTANTS` block is printed at run end listing `storyId  file:line  operatorId`:
+
+```
+SURVIVING MUTANTS
+  US-002  src/config/merge.ts:88  ts:cmp-flip
+```
+
+Treat each line as "this line's behaviour is not pinned by a test" and decide whether it deserves one.
+
+---
+
 ### Monorepo Acceptance Test Exclusion
 
 nax generates per-package acceptance test files at `<package-root>/.nax-acceptance.test.ts`. These files are meant to be run by nax only — **not** by your regular test suite.

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -90,6 +90,13 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "execution.regressionGate": "Regression gate settings (full suite after scoped tests)",
   "execution.regressionGate.enabled": "Enable full-suite regression gate",
   "execution.regressionGate.timeoutSeconds": "Timeout for regression run in seconds",
+  "execution.mutationCheck":
+    "Mutation spot-check — an advisory probe that injects a few small defects into the story's changed source files and re-runs the scoped tests to see whether the suite catches them. Never fails a story; surviving mutants are reported at run end.",
+  "execution.mutationCheck.enabled": "Enable the mutation spot-check (default: false — opt-in)",
+  "execution.mutationCheck.maxMutants":
+    "Mutants tested per story (default: 3). Candidates are gathered across all changed files and sampled evenly, so raising this widens coverage at a cost of one scoped test run per mutant.",
+  "execution.mutationCheck.timeoutSeconds":
+    "Per-mutant scoped test-run timeout in seconds (default: 60). Worst-case added wall clock per story is maxMutants x timeoutSeconds.",
   "execution.storyIsolation":
     'Story isolation mode. "shared" (default): all stories run on the main branch. "worktree": each story runs in an isolated git worktree (.nax-wt/<storyId>/); passed stories merge into main, failed commits never reach main.',
 

--- a/test/unit/cli/config-descriptions.test.ts
+++ b/test/unit/cli/config-descriptions.test.ts
@@ -45,6 +45,28 @@ describe("FIELD_DESCRIPTIONS.precheck.storySizeGate action and maxReplanAttempts
   });
 });
 
+describe("FIELD_DESCRIPTIONS.execution.mutationCheck", () => {
+  const KEYS = [
+    "execution.mutationCheck",
+    "execution.mutationCheck.enabled",
+    "execution.mutationCheck.maxMutants",
+    "execution.mutationCheck.timeoutSeconds",
+  ];
+
+  test.each(KEYS)("%s has a non-empty description", (key) => {
+    expect(typeof FIELD_DESCRIPTIONS[key]).toBe("string");
+    expect(FIELD_DESCRIPTIONS[key].length).toBeGreaterThan(0);
+  });
+
+  test("the parent description states the check is advisory", () => {
+    expect(FIELD_DESCRIPTIONS["execution.mutationCheck"].toLowerCase()).toContain("advisory");
+  });
+
+  test("enabled description records the opt-in default", () => {
+    expect(FIELD_DESCRIPTIONS["execution.mutationCheck.enabled"]).toContain("false");
+  });
+});
+
 describe("FIELD_DESCRIPTIONS structure for per-agent models", () => {
   test("models.claude description exists for agent tier definitions", () => {
     expect(FIELD_DESCRIPTIONS["models.claude"]).toBeDefined();


### PR DESCRIPTION
## What

Documents `execution.mutationCheck` and enables it in nax's own `.nax/config.json`.

## Why

The mutation spot-check has never run in the field. It is opt-in (`enabled` defaults to `false`), and the key is absent from `docs/guides/configuration.md`, from `src/cli/config-descriptions.ts`, and from nax's own config — an opt-in feature nobody can discover is a feature nobody opts into. Gap-analysis items G11 (undocumented) and G12 (zero field evidence).

#1480 is what makes this worth doing now: before it, the default budget was spent on unbuildable import-path mutants that were miscounted as `killed`, so turning the gate on would have produced a confident false all-clear. The signal is honest and visible now, so running it here is how the false-alarm-rate and kill-rate evidence accumulates — the evidence the design named as the gate for promoting this from advisory to a soft gate that feeds rectification.

## How

- **`docs/guides/configuration.md`** — new "Mutation Spot-Check" section: placement after `full-suite-gate`, advisory/fail-open guarantee and the revert-in-`finally`, the three fields with their ranges, cost (`maxMutants x timeoutSeconds`, ~3 min at defaults), the four operators and five supported languages, why the operators are whitespace-gated, `killed`/`survived`/`errored` semantics, and the `SURVIVING MUTANTS` run-end block.
- **`src/cli/config-descriptions.ts`** — `execution.mutationCheck` + `.enabled` / `.maxMutants` / `.timeoutSeconds`, so `nax config` describes them.
- **`.nax/config.json`** — enabled at the schema defaults (`maxMutants: 3`, `timeoutSeconds: 60`).
- **`test/unit/cli/config-descriptions.test.ts`** — 6 tests pinning the new descriptions.

No behaviour change beyond the config flip: this PR touches no `src/verification/mutation/` or operation code.

## Testing

- [x] `loadConfig(repoRoot)` resolves `execution.mutationCheck` to `{"enabled":true,"maxMutants":3,"timeoutSeconds":60}` against the real config file
- [x] `bun run test` — all phases pass (includes `dead-quality-flags.test.ts`, which reads the real `.nax/config.json`)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes

## Notes

- Cost of the flip: up to 3 extra scoped test runs per story on nax's own runs, 60s cap each. The check cannot fail a story, so the exposure is wall clock only. Lower `maxMutants` if it proves too slow in practice.
- `docs/ROADMAP.md` was also named under G11 and is deliberately left alone — it is a per-release historical log with no open entry this belongs under.
- Still open from the same gap analysis, not addressed here: G3 (mutants drawn from whole changed files rather than changed diff lines), G6 (no direct test file for `operators.ts`), G9/G10 (positional revert, no interrupt cleanup), G8/G13/G14 (efficiency).
