### PR TITLE
fix: mutation-check anchors changed files to the wrong root (#1485)

### DIFF
--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -22,6 +22,7 @@ import type { MutationOutcomeSummary } from "../runtime/mutation-summary";
 import type { ResolvedTestPatterns } from "../test-runners";
 import { selectScopedTests } from "../test-runners/scoped-selection";
 import type { SelectScopedTestsInput, SelectScopedTestsResult } from "../test-runners/scoped-selection";
+import { getGitRoot } from "../utils/git";
 import { getChangedLineRanges } from "../verification/changed-line-ranges";
 import {
   applyMutant,
@@ -59,6 +60,7 @@ export interface MutationCheckDeps {
   detectLanguage: typeof detectLanguage;
   getChangedNonTestFiles: typeof getChangedNonTestFiles;
   getChangedLineRanges: typeof getChangedLineRanges;
+  getGitRoot: typeof getGitRoot;
   selectScopedTests: (input: SelectScopedTestsInput) => Promise<SelectScopedTestsResult>;
   regression: (opts: VerificationGateOptions) => Promise<VerificationResult>;
 }
@@ -67,6 +69,7 @@ export const _mutationCheckDeps: MutationCheckDeps = {
   detectLanguage,
   getChangedNonTestFiles,
   getChangedLineRanges,
+  getGitRoot,
   selectScopedTests,
   regression,
 };
@@ -132,10 +135,15 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       undefined,
       input.repoRoot,
     );
-    // getChangedNonTestFiles returns paths relative to repoRoot — anchor them
-    // before any file I/O so resolution doesn't silently depend on the
-    // process's current working directory.
-    const anchor = input.repoRoot ?? input.workdir;
+    // getChangedNonTestFiles only strips the git-root/repoRoot prefix mismatch
+    // (issue #565) when packagePrefix is set — its returned paths are then
+    // repoRoot-relative. With no packagePrefix, that surgery never runs and the
+    // paths stay git-root-relative (raw `git diff --name-only` output). Anchor
+    // to whichever root the paths are actually relative to, matching the same
+    // git-root resolution getChangedLineRanges performs internally (#1485).
+    const anchor = input.packagePrefix
+      ? (input.repoRoot ?? input.workdir)
+      : ((await deps.getGitRoot(input.workdir)) ?? input.workdir);
     const absoluteChangedFiles = changedFiles.map((f) => (isAbsolute(f) ? f : join(anchor, f)));
 
     const rangeMap = await deps.getChangedLineRanges(input.workdir, input.storyGitRef);
@@ -154,9 +162,11 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
     // Per-file early-breaks would re-introduce the first-file-only bias
     // and a top-of-file bias simultaneously.
     const mutants: Mutant[] = [];
+    let unmappedFiles = 0;
     for (const file of absoluteChangedFiles) {
       const lineRanges = rangeMap.get(file);
       if (lineRanges === undefined) {
+        unmappedFiles++;
         logger.debug("mutation-check", "Changed file has no diff line ranges — skipping", {
           storyId: input.storyId,
           file,
@@ -176,6 +186,16 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
           error: err instanceof Error ? err.message : String(err),
         });
       }
+    }
+    // Every changed file missing from the range map is indistinguishable from
+    // "nothing mutable" at debug level — surface it so a total path-anchoring
+    // mismatch (#1485) doesn't silently produce a zero-candidate no-op.
+    if (absoluteChangedFiles.length > 0 && unmappedFiles === absoluteChangedFiles.length) {
+      logger.warn(
+        "mutation-check",
+        "No changed file matched the diff line-range map — mutation spot-check produced zero candidates, possibly due to a path-anchoring mismatch",
+        { storyId: input.storyId, changedFiles: absoluteChangedFiles.length },
+      );
     }
     const selected = selectEvenlySpaced(mutants, cfg.maxMutants);
     for (const mutant of selected) {

--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -12,7 +12,7 @@
  * DI collaborators (mirrors _verifyScopedDeps) so unit tests need no real git/test run.
  */
 
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, sep } from "node:path";
 import { mutationCheckConfigSelector, qualityConfigSelector } from "../config";
 import type { MutationCheckConfig } from "../config/selectors";
 import { getLogger } from "../logger";
@@ -136,15 +136,24 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       input.repoRoot,
     );
     // getChangedNonTestFiles only strips the git-root/repoRoot prefix mismatch
-    // (issue #565) when packagePrefix is set — its returned paths are then
-    // repoRoot-relative. With no packagePrefix, that surgery never runs and the
-    // paths stay git-root-relative (raw `git diff --name-only` output). Anchor
-    // to whichever root the paths are actually relative to, matching the same
-    // git-root resolution getChangedLineRanges performs internally (#1485).
-    const anchor = input.packagePrefix
-      ? (input.repoRoot ?? input.workdir)
-      : ((await deps.getGitRoot(input.workdir)) ?? input.workdir);
-    const absoluteChangedFiles = changedFiles.map((f) => (isAbsolute(f) ? f : join(anchor, f)));
+    // (issue #565) when both packagePrefix and repoRoot are set — its returned
+    // paths are then repoRoot-relative. Otherwise that surgery never runs and
+    // the paths stay git-root-relative (raw `git diff --name-only` output).
+    // Anchor to whichever root the paths are actually relative to, matching
+    // the same git-root resolution getChangedLineRanges performs internally
+    // (#1485). Mirror the exact gate `getChangedNonTestFiles` uses.
+    const anchor =
+      input.packagePrefix && input.repoRoot
+        ? input.repoRoot
+        : ((await deps.getGitRoot(input.workdir)) ?? input.workdir);
+    // Unfiltered git diffs from the git-root anchor can surface files outside
+    // the project (e.g. when the git root is an ancestor of repoRoot) —
+    // constrain candidates to the project scope so mutation testing never
+    // reads/writes source outside it.
+    const scopeRoot = input.repoRoot ?? input.workdir;
+    const absoluteChangedFiles = changedFiles
+      .map((f) => (isAbsolute(f) ? f : join(anchor, f)))
+      .filter((f) => f === scopeRoot || f.startsWith(`${scopeRoot}${sep}`));
 
     const rangeMap = await deps.getChangedLineRanges(input.workdir, input.storyGitRef);
     if (rangeMap === null) {

--- a/test/unit/operations/mutation-check-diff-scope.test.ts
+++ b/test/unit/operations/mutation-check-diff-scope.test.ts
@@ -36,6 +36,7 @@ function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps
     detectLanguage: async () => "typescript" as any,
     getChangedNonTestFiles: async () => [],
     getChangedLineRanges: async () => new Map(),
+    getGitRoot: async () => null,
     selectScopedTests: async () => ({
       effectiveCommand: "bun test",
       isFullSuite: true,
@@ -430,6 +431,119 @@ describe("mutationCheckOp — US-003 AC15: file with no mutable content emits no
       );
       expect(matching).toHaveLength(0);
     } finally {
+      cleanupTempDir(dir);
+    }
+  });
+});
+
+describe("mutationCheckOp — issue #1485: anchor root matches getChangedLineRanges when repoRoot diverges from git root and packagePrefix is unset", () => {
+  test("without packagePrefix, changed files anchor to the resolved git root — not repoRoot — so range-map lookups hit", async () => {
+    const dir = makeTempDir("nax-mutation-test-");
+    try {
+      // Simulate repoRoot sitting deeper than the true git root (e.g. a
+      // subdirectory checkout) with no packagePrefix configured — the
+      // exact divergence case from #1485. getChangedNonTestFiles returns a
+      // git-root-relative path; getChangedLineRanges keys its map against
+      // the same resolved git root.
+      const gitRoot = dir;
+      const repoRoot = join(dir, "nested-repo-root");
+      const relativeFile = "src/foo.ts";
+      const absoluteFile = join(gitRoot, relativeFile);
+      await Bun.write(absoluteFile, "if (a == b) { return 1; }\n");
+
+      const deps = fakeDeps({
+        getGitRoot: async () => gitRoot,
+        getChangedNonTestFiles: async () => [relativeFile],
+        getChangedLineRanges: async () => new Map([[absoluteFile, [{ start: 1, end: 1 }]]]),
+      });
+
+      const out = await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-003",
+          storyGitRef: "abc123",
+          repoRoot,
+          resolvedTestPatterns: { globs: [], regex: [], pathspec: [], testDirs: [] },
+        },
+        ctxWithConfig({ mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } }),
+        deps,
+      );
+
+      expect(out.candidates).toBeGreaterThan(0);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  test("with packagePrefix set, changed files still anchor to repoRoot (existing #565 behavior preserved)", async () => {
+    const dir = makeTempDir("nax-mutation-test-");
+    try {
+      const repoRoot = dir;
+      const relativeFile = "packages/api/src/foo.ts";
+      const absoluteFile = join(repoRoot, relativeFile);
+      await Bun.write(absoluteFile, "if (a == b) { return 1; }\n");
+
+      const deps = fakeDeps({
+        getGitRoot: async () => {
+          throw new Error("getGitRoot must not be called when packagePrefix is set");
+        },
+        getChangedNonTestFiles: async () => [relativeFile],
+        getChangedLineRanges: async () => new Map([[absoluteFile, [{ start: 1, end: 1 }]]]),
+      });
+
+      const out = await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-003",
+          storyGitRef: "abc123",
+          repoRoot,
+          packagePrefix: "packages/api",
+          resolvedTestPatterns: { globs: [], regex: [], pathspec: [], testDirs: [] },
+        },
+        ctxWithConfig({ mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } }),
+        deps,
+      );
+
+      expect(out.candidates).toBeGreaterThan(0);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  test("warns once when every changed file misses the range map (total anchoring failure signal)", async () => {
+    const dir = makeTempDir("nax-mutation-test-");
+    const warnSpy = spyOn(loggerModule.getLogger(), "warn");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      await Bun.write(file, "if (a == b) { return 1; }\n");
+      const deps = fakeDeps({
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[join(dir, "src", "other.ts"), [{ start: 1, end: 1 }]]]),
+      });
+
+      const out = await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-003",
+          storyGitRef: "abc123",
+          repoRoot: dir,
+          resolvedTestPatterns: { globs: [], regex: [], pathspec: [], testDirs: [] },
+        },
+        ctxWithConfig({ mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } }),
+        deps,
+      );
+
+      expect(out.candidates).toBe(0);
+      const calls = warnSpy.mock.calls as Array<[string, string, Record<string, unknown>]>;
+      const totalMissWarn = calls.filter(
+        ([, message]) => typeof message === "string" && message.includes("zero candidates"),
+      );
+      expect(totalMissWarn).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
       cleanupTempDir(dir);
     }
   });

--- a/test/unit/operations/mutation-check-diff-scope.test.ts
+++ b/test/unit/operations/mutation-check-diff-scope.test.ts
@@ -443,11 +443,12 @@ describe("mutationCheckOp — issue #1485: anchor root matches getChangedLineRan
       // Simulate repoRoot sitting deeper than the true git root (e.g. a
       // subdirectory checkout) with no packagePrefix configured — the
       // exact divergence case from #1485. getChangedNonTestFiles returns a
-      // git-root-relative path; getChangedLineRanges keys its map against
-      // the same resolved git root.
+      // git-root-relative path (still inside repoRoot's own subtree — this
+      // is an in-scope file, just anchored wrong); getChangedLineRanges
+      // keys its map against the same resolved git root.
       const gitRoot = dir;
       const repoRoot = join(dir, "nested-repo-root");
-      const relativeFile = "src/foo.ts";
+      const relativeFile = "nested-repo-root/src/foo.ts";
       const absoluteFile = join(gitRoot, relativeFile);
       await Bun.write(absoluteFile, "if (a == b) { return 1; }\n");
 
@@ -544,6 +545,78 @@ describe("mutationCheckOp — issue #1485: anchor root matches getChangedLineRan
       expect(totalMissWarn).toHaveLength(1);
     } finally {
       warnSpy.mockRestore();
+      cleanupTempDir(dir);
+    }
+  });
+
+  test("without packagePrefix, a changed file outside repoRoot (but inside the git root) is filtered out of scope", async () => {
+    const dir = makeTempDir("nax-mutation-test-");
+    try {
+      // git root is an ancestor of repoRoot; the changed file sits in a
+      // sibling directory that is inside the git root but outside the
+      // project's own repoRoot — it must never become a mutation candidate.
+      const gitRoot = dir;
+      const repoRoot = join(dir, "nested-repo-root");
+      const siblingFile = join(gitRoot, "other-project", "src", "foo.ts");
+      await Bun.write(siblingFile, "if (a == b) { return 1; }\n");
+
+      const deps = fakeDeps({
+        getGitRoot: async () => gitRoot,
+        getChangedNonTestFiles: async () => ["other-project/src/foo.ts"],
+        getChangedLineRanges: async () => new Map([[siblingFile, [{ start: 1, end: 1 }]]]),
+      });
+
+      const out = await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-003",
+          storyGitRef: "abc123",
+          repoRoot,
+          resolvedTestPatterns: { globs: [], regex: [], pathspec: [], testDirs: [] },
+        },
+        ctxWithConfig({ mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } }),
+        deps,
+      );
+
+      expect(out.candidates).toBe(0);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  test("packagePrefix set without repoRoot still anchors to the resolved git root, not workdir", async () => {
+    const dir = makeTempDir("nax-mutation-test-");
+    try {
+      // packagePrefix alone does not trigger getChangedNonTestFiles's prefix
+      // surgery (it also requires repoRoot) — so paths stay git-root-relative
+      // here too, and the op must fall back to the git-root anchor.
+      const gitRoot = dir;
+      const relativeFile = "packages/api/src/foo.ts";
+      const absoluteFile = join(gitRoot, relativeFile);
+      await Bun.write(absoluteFile, "if (a == b) { return 1; }\n");
+
+      const deps = fakeDeps({
+        getGitRoot: async () => gitRoot,
+        getChangedNonTestFiles: async () => [relativeFile],
+        getChangedLineRanges: async () => new Map([[absoluteFile, [{ start: 1, end: 1 }]]]),
+      });
+
+      const out = await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-003",
+          storyGitRef: "abc123",
+          packagePrefix: "packages/api",
+          resolvedTestPatterns: { globs: [], regex: [], pathspec: [], testDirs: [] },
+        },
+        ctxWithConfig({ mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } }),
+        deps,
+      );
+
+      expect(out.candidates).toBeGreaterThan(0);
+    } finally {
       cleanupTempDir(dir);
     }
   });

--- a/test/unit/operations/mutation-check-revert.test.ts
+++ b/test/unit/operations/mutation-check-revert.test.ts
@@ -30,6 +30,7 @@ function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps
     detectLanguage: async () => "typescript" as any,
     getChangedNonTestFiles: async () => [],
     getChangedLineRanges: async () => new Map(),
+    getGitRoot: async () => null,
     selectScopedTests: async () => ({
       effectiveCommand: "bun test",
       isFullSuite: true,

--- a/test/unit/operations/mutation-check-selection.test.ts
+++ b/test/unit/operations/mutation-check-selection.test.ts
@@ -44,6 +44,7 @@ function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps
     detectLanguage: async () => "typescript" as any,
     getChangedNonTestFiles: async () => [],
     getChangedLineRanges: async () => new Map(),
+    getGitRoot: async () => null,
     selectScopedTests: async () => ({
       effectiveCommand: "bun test",
       isFullSuite: true,

--- a/test/unit/operations/mutation-check.test.ts
+++ b/test/unit/operations/mutation-check.test.ts
@@ -30,6 +30,7 @@ function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps
     detectLanguage: async () => "typescript" as any,
     getChangedNonTestFiles: async () => [],
     getChangedLineRanges: async () => new Map(),
+    getGitRoot: async () => null,
     selectScopedTests: async () => ({
       effectiveCommand: "bun test",
       isFullSuite: true,


### PR DESCRIPTION
## Summary

Fixes #1485. `mutationCheckOp` (`src/operations/mutation-check.ts`) anchored `absoluteChangedFiles` to `input.repoRoot ?? input.workdir`, while `getChangedLineRanges` (`src/verification/changed-line-ranges.ts`) always anchors its returned range-map keys to the resolved git root. `getChangedNonTestFiles` only strips the git-root/repoRoot prefix mismatch (#565) when **both** `packagePrefix` and `repoRoot` are set — otherwise its returned paths stay git-root-relative. When `repoRoot` diverges from the git root and that prefix-surgery doesn't run, every `rangeMap.get(file)` lookup missed and the mutation spot-check silently produced zero candidates (`success: true`, no visible error).

- Resolve the git root via an injected `getGitRoot` and use it as the anchor whenever `getChangedNonTestFiles`'s own gate (`packagePrefix && repoRoot`) doesn't hold — mirroring its actual stripping condition exactly, not just the `packagePrefix` half of it.
- Constrain `absoluteChangedFiles` to `repoRoot`'s subtree. Anchoring to the git root is necessary for the fix, but an unfiltered git diff can surface files outside the project when the git root is an ancestor of `repoRoot` (no `packagePrefix` means `getChangedNonTestFiles` applies no path filter at all) — those must never become mutation candidates or consume the `maxMutants` budget.
- Promote the per-file "no diff line ranges" debug log to a single `logger.warn` when *every* changed file misses the range map, so a total anchoring failure is visible in run output instead of indistinguishable from a normal "nothing mutable" outcome (issue's suggested direction #3).

Implements suggested direction #2 from the issue (resolve git root once inside `mutationCheckOp`, no changes to `getChangedLineRanges`'s pinned 2-arg signature / AC-32 acceptance contract).

## Changes

- `src/operations/mutation-check.ts` — anchor + scope-filter logic, `getGitRoot` added to `MutationCheckDeps`/`_mutationCheckDeps`, total-miss warn
- `test/unit/operations/mutation-check-diff-scope.test.ts` — 5 new regression tests: divergent-root anchoring, `packagePrefix`-preserved behavior, `packagePrefix` set without `repoRoot`, out-of-scope file filtering, total-miss warn
- `test/unit/operations/mutation-check{,-revert,-selection}.test.ts` — `getGitRoot` added to the shared `fakeDeps()` fixture (interface grew a required field)

## Review

Self-reviewed via the `pr-review-toolkit:code-reviewer` agent, which flagged two Important issues (anchor gate not matching `getChangedNonTestFiles`'s exact condition; git-root anchoring widening candidate scope outside the project) — both fixed with dedicated regression tests before this PR was opened.

## Test plan

- [x] `bun test test/unit/operations/mutation-check*` — 42 pass / 0 fail
- [x] Confirmed the primary regression test fails without the fix (reverted the anchor expression locally, re-ran — `candidates` was 0)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (incl. `check-logger-storyid`, `check-file-sizes`, alias/deep-relative ratchets)
- [x] `bun run test` — full suite: 11750+ unit / 1092 integration / 24 UI, 0 failures