### PR TITLE
fix(mutation): stop ts:cmp-flip rewriting `!==` into the invalid `!!=`, add operator-table tests

### DIFF
--- a/src/verification/mutation/index.ts
+++ b/src/verification/mutation/index.ts
@@ -4,6 +4,7 @@
 
 export * from "./types";
 export { generateMutants } from "./mutator";
+export { getOperatorsForLanguage } from "./operators";
 export { applyMutant, revertMutant } from "./apply";
 export { classifyMutant } from "./classify";
 export { selectEvenlySpaced } from "./select";

--- a/src/verification/mutation/operators.ts
+++ b/src/verification/mutation/operators.ts
@@ -13,12 +13,16 @@ type PatternReplacement = readonly [RegExp, string];
 /**
  * TypeScript/JavaScript comparison flips — includes the JS-only strict-equality
  * operators (`===` / `!==`).
+ *
+ * Ordered longest-first: `flipWithPairs` resolves overlapping sites by
+ * alternation order, so `===` / `!==` must precede `==` / `!=` or the strict
+ * operators are consumed as the loose one they contain (issue #1487).
  */
 const TS_COMPARISON_PAIRS: ReadonlyArray<PatternReplacement> = [
-  [/==/g, "!="],
-  [/!=/g, "=="],
   [/===/g, "!=="],
   [/!==/g, "==="],
+  [/==/g, "!="],
+  [/!=/g, "=="],
   [/>=/g, "<="],
   [/<=/g, ">="],
 ];
@@ -64,17 +68,48 @@ function applyComparisonBracketFlip(snippet: string): string[] {
   return results;
 }
 
+/** One matched operator site: where it starts and how many chars it spans. */
+type Site = readonly [start: number, length: number];
+
+/**
+ * Produce one mutant per operator in `pairs` that occurs in `snippet`, with
+ * every occurrence of that operator flipped together.
+ *
+ * The snippet is tokenized ONCE with a combined alternation regex, so each
+ * character position is claimed by exactly one pair. Regex alternation is
+ * leftmost-first, which is why the pair tables are ordered longest-first: it
+ * makes an overlapping shorter operator structurally unable to match inside a
+ * longer one, rather than relying on a per-pattern guard. Before this, the
+ * `==` pair matched the `==` inside `!==` and rewrote it to the uncompilable
+ * `!!=` (issue #1487).
+ *
+ * Pair patterns must not contain capturing groups — one group per pair is
+ * added here to attribute each match back to the pair that produced it.
+ */
 function flipWithPairs(pairs: ReadonlyArray<PatternReplacement>, snippet: string): string[] {
+  const combined = new RegExp(pairs.map(([pattern]) => `(${pattern.source})`).join("|"), "g");
+  const sitesByPair = new Map<number, Site[]>();
+  for (const match of snippet.matchAll(combined)) {
+    const pairIndex = match.slice(1).findIndex((group) => group !== undefined);
+    if (pairIndex < 0 || match[0].length === 0) continue;
+    const sites = sitesByPair.get(pairIndex) ?? [];
+    sites.push([match.index, match[0].length]);
+    sitesByPair.set(pairIndex, sites);
+  }
+
   const seen = new Set<string>();
   const results: string[] = [];
-  for (const [pattern, replacement] of pairs) {
-    if (pattern.test(snippet)) {
-      pattern.lastIndex = 0;
-      const produced = snippet.replace(pattern, replacement);
-      if (!seen.has(produced)) {
-        seen.add(produced);
-        results.push(produced);
-      }
+  for (const pairIndex of [...sitesByPair.keys()].sort((a, b) => a - b)) {
+    const replacement = pairs[pairIndex]?.[1];
+    if (replacement === undefined) continue;
+    // Splice from the end so earlier sites keep their original offsets.
+    let produced = snippet;
+    for (const [start, length] of [...(sitesByPair.get(pairIndex) ?? [])].reverse()) {
+      produced = produced.slice(0, start) + replacement + produced.slice(start + length);
+    }
+    if (produced !== snippet && !seen.has(produced)) {
+      seen.add(produced);
+      results.push(produced);
     }
   }
   return results;

--- a/test/unit/verification/mutation/operators.test.ts
+++ b/test/unit/verification/mutation/operators.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Per-language mutation operator table tests.
+ *
+ * These exercise `getOperatorsForLanguage` and each operator's `apply`
+ * directly, rather than through `generateMutants`. The indirect route cannot
+ * distinguish "this language has no table" from "this operator produced
+ * nothing", and it hides which of the 16 operator ids actually ran — the blind
+ * spot that let `ts:cmp-flip` ship rewriting `!==` into the uncompilable
+ * `!!=` (issue #1487).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { getOperatorsForLanguage } from "@/verification";
+import type { MutationOperator } from "@/verification";
+
+/** Normalise the `string | string[]` operator return into an array. */
+function applied(op: MutationOperator, snippet: string): string[] {
+  const out = op.apply(snippet);
+  return Array.isArray(out) ? out : [out];
+}
+
+/** Look up one operator by id, failing loudly when the table lacks it. */
+function operator(language: string, id: string): MutationOperator {
+  const op = getOperatorsForLanguage(language).find((o) => o.id === id);
+  if (!op) throw new Error(`no operator "${id}" in the ${language} table`);
+  return op;
+}
+
+const LANGUAGE_IDS: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
+  ["typescript", ["ts:cmp-flip", "ts:cmp-bracket-flip", "ts:bool-flip", "ts:arith-flip"]],
+  ["javascript", ["ts:cmp-flip", "ts:cmp-bracket-flip", "ts:bool-flip", "ts:arith-flip"]],
+  ["python", ["py:cmp-flip", "py:cmp-bracket-flip", "py:bool-flip", "py:arith-flip"]],
+  ["go", ["go:cmp-flip", "go:cmp-bracket-flip", "go:bool-flip", "go:arith-flip"]],
+  ["rust", ["rust:cmp-flip", "rust:cmp-bracket-flip", "rust:bool-flip", "rust:arith-flip"]],
+];
+
+describe("getOperatorsForLanguage — language dispatch", () => {
+  test.each(LANGUAGE_IDS)("%s exposes exactly its four operator ids, in order", (language, ids) => {
+    expect(getOperatorsForLanguage(language).map((o) => o.id)).toEqual([...ids]);
+  });
+
+  test("javascript resolves to the same table instance as typescript", () => {
+    expect(getOperatorsForLanguage("javascript")).toBe(getOperatorsForLanguage("typescript"));
+  });
+
+  test("an undefined language yields no operators", () => {
+    expect(getOperatorsForLanguage(undefined)).toEqual([]);
+  });
+
+  test("an unsupported language yields no operators", () => {
+    expect(getOperatorsForLanguage("ruby")).toEqual([]);
+  });
+
+  test("language matching is exact — no casing or extension fallback", () => {
+    expect(getOperatorsForLanguage("TypeScript")).toEqual([]);
+    expect(getOperatorsForLanguage("ts")).toEqual([]);
+  });
+
+  test("every operator id is unique across all supported languages", () => {
+    const ids = LANGUAGE_IDS.filter(([lang]) => lang !== "javascript").flatMap(([, langIds]) => langIds);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("cmp-flip — strict equality must not be shredded (#1487)", () => {
+  test("!== flips only to === , never to the uncompilable !!=", () => {
+    const results = applied(operator("typescript", "ts:cmp-flip"), "const x = a !== b;");
+
+    expect(results).toEqual(["const x = a === b;"]);
+    expect(results.some((r) => r.includes("!!="))).toBe(false);
+  });
+
+  test("=== flips only to !==", () => {
+    expect(applied(operator("typescript", "ts:cmp-flip"), "const x = a === b;")).toEqual([
+      "const x = a !== b;",
+    ]);
+  });
+
+  test("a line mixing strict and loose equality mutates each independently", () => {
+    const results = applied(operator("typescript", "ts:cmp-flip"), "if (a === b && c != d) {");
+
+    expect(results).toContain("if (a !== b && c != d) {");
+    expect(results).toContain("if (a === b && c == d) {");
+    expect(results.some((r) => r.includes("!!="))).toBe(false);
+  });
+});
+
+describe("cmp-flip — loose and relational operators", () => {
+  test.each([
+    ["x = a == b;", "x = a != b;"],
+    ["x = a != b;", "x = a == b;"],
+    ["x = a >= b;", "x = a <= b;"],
+    ["x = a <= b;", "x = a >= b;"],
+  ])("%s produces %s", (snippet, expected) => {
+    expect(applied(operator("typescript", "ts:cmp-flip"), snippet)).toContain(expected);
+  });
+
+  test("every occurrence of an operator on the line is flipped together", () => {
+    expect(applied(operator("go", "go:cmp-flip"), "if a == b && c == d {")).toEqual([
+      "if a != b && c != d {",
+    ]);
+  });
+
+  test("a snippet with no comparison operator produces nothing", () => {
+    expect(applied(operator("go", "go:cmp-flip"), "count := total")).toEqual([]);
+  });
+
+  test("the universal table has no strict-equality entry — === is left alone", () => {
+    // Python/Go/Rust have no `===`; the table must not invent a flip for it.
+    expect(applied(operator("python", "py:cmp-flip"), "x = a >= b")).toEqual(["x = a <= b"]);
+  });
+});
+
+describe("cmp-bracket-flip — bare > and < require whitespace on both sides", () => {
+  test.each(["python", "go", "rust"])("%s flips a bare > to <", (language) => {
+    expect(applied(operator(language, `${language === "python" ? "py" : language}:cmp-bracket-flip`), "if a > b")).toEqual(
+      ["if a < b"],
+    );
+  });
+
+  test("a bare < flips to >", () => {
+    expect(applied(operator("rust", "rust:cmp-bracket-flip"), "if a < b {")).toEqual(["if a > b {"]);
+  });
+
+  test("an arrow function is not a comparison", () => {
+    expect(applied(operator("typescript", "ts:cmp-bracket-flip"), "const f = (x) => x;")).toEqual([]);
+  });
+
+  test("a generic parameter list is not a comparison", () => {
+    expect(applied(operator("typescript", "ts:cmp-bracket-flip"), "let xs: Array<string> = [];")).toEqual(
+      [],
+    );
+  });
+
+  test(">= and <= are left to cmp-flip", () => {
+    expect(applied(operator("typescript", "ts:cmp-bracket-flip"), "if (a >= b) {")).toEqual([]);
+  });
+});
+
+describe("bool-flip — per-language literal spelling", () => {
+  test.each([
+    ["typescript", "ts", "const ok = true;", "const ok = false;"],
+    ["go", "go", "ok := true", "ok := false"],
+    ["rust", "rust", "let ok = true;", "let ok = false;"],
+    ["python", "py", "ok = True", "ok = False"],
+  ])("%s flips its true literal", (language, prefix, snippet, expected) => {
+    expect(applied(operator(language, `${prefix}:bool-flip`), snippet)).toEqual([expected]);
+  });
+
+  test("python does not flip the lowercase JS spelling", () => {
+    expect(applied(operator("python", "py:bool-flip"), "ok = true")).toEqual([]);
+  });
+
+  test("typescript does not flip the capitalised Python spelling", () => {
+    expect(applied(operator("typescript", "ts:bool-flip"), "const ok = True;")).toEqual([]);
+  });
+
+  test("the literal must stand alone — substrings are not flipped", () => {
+    expect(applied(operator("typescript", "ts:bool-flip"), "const truely = trueish;")).toEqual([]);
+  });
+
+  test("a line carrying both literals yields one mutant per direction", () => {
+    const results = applied(operator("typescript", "ts:bool-flip"), "const a = true, b = false;");
+
+    expect(results).toContain("const a = false, b = false;");
+    expect(results).toContain("const a = true, b = true;");
+  });
+});
+
+describe("arith-flip — whitespace-guarded binary operators", () => {
+  test.each([
+    ["const s = a + b;", "const s = a - b;"],
+    ["const s = a - b;", "const s = a + b;"],
+    ["const s = a * b;", "const s = a / b;"],
+    ["const s = a / b;", "const s = a * b;"],
+  ])("%s produces %s", (snippet, expected) => {
+    expect(applied(operator("typescript", "ts:arith-flip"), snippet)).toContain(expected);
+  });
+
+  test("a module specifier is not arithmetic", () => {
+    expect(applied(operator("typescript", "ts:arith-flip"), 'import { x } from "../config";')).toEqual(
+      [],
+    );
+  });
+
+  test("a URL is not arithmetic", () => {
+    expect(applied(operator("typescript", "ts:arith-flip"), 'const u = "https://a/b/c";')).toEqual([]);
+  });
+
+  test("a dangling trailing operator is not mutated", () => {
+    expect(applied(operator("typescript", "ts:arith-flip"), "const s = a +")).toEqual([]);
+  });
+
+  test("all four languages share the same arithmetic behaviour", () => {
+    for (const [language, prefix] of [
+      ["python", "py"],
+      ["go", "go"],
+      ["rust", "rust"],
+    ] as const) {
+      expect(applied(operator(language, `${prefix}:arith-flip`), "s = a + b")).toContain("s = a - b");
+    }
+  });
+});
+
+describe("operators are pure and repeatable", () => {
+  // The tables hold module-level /g regexes; a leaked `lastIndex` would make
+  // the second call on identical input disagree with the first.
+  test.each(LANGUAGE_IDS.flatMap(([language, ids]) => ids.map((id) => [language, id] as const)))(
+    "%s %s returns identical output on repeated calls",
+    (language, id) => {
+      const op = operator(language, id);
+      const snippet = "if a == b && x > y and s = c + d or ok = true or flag = True";
+
+      expect(applied(op, snippet)).toEqual(applied(op, snippet));
+    },
+  );
+
+  test("an operator never returns duplicate replacements", () => {
+    const results = applied(operator("typescript", "ts:cmp-flip"), "if (a === b) {");
+    expect(new Set(results).size).toBe(results.length);
+  });
+
+  test("an operator never returns the snippet unchanged", () => {
+    for (const [language, ids] of LANGUAGE_IDS) {
+      for (const id of ids) {
+        const snippet = "if a == b && x > y and s = c + d or ok = true";
+        expect(applied(operator(language, id), snippet)).not.toContain(snippet);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes `ts:cmp-flip` rewriting `!==` into the uncompilable `!!=`, and adds the operator-table test file (`test/unit/verification/mutation/operators.test.ts`) that was named in the polyglot operator design but never created.

## Why

Closes #1487

`generateMutants({ source: "const x = a !== b;", language: "typescript", ... })` produced **two** mutants:

```
ts:cmp-flip: "const x = a !!= b;"   <-- invalid syntax
ts:cmp-flip: "const x = a === b;"   <-- correct
```

`flipWithPairs` applied every entry of `TS_COMPARISON_PAIRS` independently to the *original* snippet, so `[/==/g, "!="]` matched the `==` inside `!==`. `===` escaped the same bug only by coincidence — `/==/g` on `a === b` happens to yield the valid `a !== b`, which then deduped against the correct result.

Since #1480 an unbuildable mutant classifies `errored` rather than a false `killed`, so this is no longer a correctness hole in the verdict — but `maxMutants` defaults to 3, and `selectEvenlySpaced` can spend a slot on a candidate incapable of ever being killed or surviving on merit. `!==` is common in TS source. TS/JS only; `UNIVERSAL_COMPARISON_PAIRS` has no strict-equality entries.

## How

- `flipWithPairs` now tokenizes the snippet **once** with a combined alternation regex (one capture group per pair for attribution), collects the sites each pair claimed, and splices replacements from the end so earlier offsets stay valid. Each character position is therefore claimed by exactly one pair.
- `TS_COMPARISON_PAIRS` is reordered longest-first (`===`, `!==` ahead of `==`, `!=`). Regex alternation is leftmost-first, so this is what makes the overlap *structurally* impossible instead of guarded case-by-case — the same shape as the existing whitespace guards on the arithmetic and bare `>`/`<` operators, which already sidestep this class.
- One mutant per operator kind present, with every occurrence of that operator flipped together — unchanged from before.
- `getOperatorsForLanguage` is exported from the mutation barrel so the language dispatch can be asserted directly.

## Testing

- [x] Tests added/updated — 65 new tests in `test/unit/verification/mutation/operators.test.ts`
- [x] `bun run test` passes (11817 unit + 1092 integration + 24 ui, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes

The new file exercises `getOperatorsForLanguage` and each operator's `apply` **directly** rather than through `generateMutants`. The indirect route cannot distinguish "no table for this language" from "this operator produced nothing", and it hides which of the 16 operator ids actually ran — precisely the blind spot that let this defect ship. Coverage added:

- language dispatch: all five keys, exact id lists and order, `javascript` resolving to the same table instance as `typescript`, `undefined` -> `[]`, unknown language -> `[]`, and no casing/extension fallback
- the three ids with no prior coverage anywhere: `py:cmp-bracket-flip`, `go:cmp-flip`, `rust:cmp-bracket-flip`
- per-operator negative cases that pin the existing guards: arrow functions and generics are not `cmp-bracket-flip` sites; module specifiers, URLs and dangling operators are not `arith-flip` sites; `bool-flip` respects per-language literal spelling and does not match substrings
- purity: every operator returns identical output on repeated calls, guarding the module-level `/g` `lastIndex` hazard the source comments call out

63 of the 65 assertions passed against the pre-fix code — they document behaviour that was already correct. Two failed on `!==`, and those are the ones this fix turns green.

## Notes

Closes item **G6** of the mutation-check gap analysis. That report's "6 of 16 operator ids untested" figure was stale — #1480's multi-line fixtures had already covered most of them incidentally; three were genuinely uncovered.

Pair patterns must not contain capturing groups, since `flipWithPairs` now adds one per pair to attribute matches. None currently do (the existing guards are lookarounds, which do not capture); this is stated in the function docstring.
