### PR TITLE
fix(mutation): verify every revert and survive an interrupted run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ TEST_SUMMARY_*.md
 .nax-pids
 .nax/metrics.json
 .nax/finish-audit/
+.nax/mutation-journal/
 
 .nax/**/runs/
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -467,7 +467,9 @@ SURVIVING MUTANTS
 
 Treat each line as "this line's behaviour is not pinned by a test" and decide whether it deserves one.
 
-**Restoring the worktree.** A `finally` covers a thrown error but not process death, so each mutation is also journalled to `.nax/mutation-journal/<storyId>.json` *before* it is written to disk and the journal entry is removed only once the revert is confirmed. If a run is interrupted — Ctrl+C, SIGKILL, a crash, a lost machine — the next run sweeps the journal and undoes anything left behind, whether or not the check is still enabled. Add `.nax/mutation-journal/` to `.gitignore`.
+**Restoring the worktree.** A `finally` covers a thrown error but not process death, so each mutation is also journalled to `.nax/mutation-journal/<storyId>.json` *before* it is written to disk, and the entry is removed only once the revert is confirmed. If a run is interrupted — Ctrl+C, SIGKILL, a crash, a lost machine — the next run sweeps the journal and undoes anything left behind, whether or not the check is still enabled.
+
+The journal is anchored to the **working tree** (the git root of `workdir`), not the project root, so in parallel mode each git worktree keeps its own and concurrent stories cannot restore each other's in-flight mutations. A sweep also skips any entry naming a file outside its own tree. `nax init` adds `.nax/mutation-journal/` to `.gitignore` and it is written to `.git/info/exclude` for every worktree — nax auto-commits with `git add -A`, so an un-ignored journal would land in the feature branch.
 
 Reverting is verified, never positional: the line must still hold the exact mutant that was written. If something else rewrote it in the meantime (a formatter, codegen, the agent), nax writes nothing — restoring a stale line over content it cannot account for is the one outcome nothing downstream can undo. It logs the file, line, and what it actually found, stops mutating that story, and prints a final block:
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -426,7 +426,7 @@ Example with defaults: a story can cycle through review→autofix up to 5 times 
 
 Green tests prove the code passes the suite; they do not prove the suite would notice if the code were wrong. The mutation spot-check injects a small number of deliberate defects into the story's changed source files, re-runs the scoped tests against each one, and reports any mutant the suite failed to catch.
 
-It is **opt-in and advisory** — it runs after `full-suite-gate` and can never fail a story. Every mutation is reverted in a `finally`, so the worktree is restored even if a test run crashes.
+It is **opt-in and advisory** — it runs after `full-suite-gate` and can never fail a story. Every mutation is reverted in a `finally`, so the worktree is restored even if a test run throws.
 
 ```json
 {
@@ -466,6 +466,17 @@ SURVIVING MUTANTS
 ```
 
 Treat each line as "this line's behaviour is not pinned by a test" and decide whether it deserves one.
+
+**Restoring the worktree.** A `finally` covers a thrown error but not process death, so each mutation is also journalled to `.nax/mutation-journal/<storyId>.json` *before* it is written to disk and the journal entry is removed only once the revert is confirmed. If a run is interrupted — Ctrl+C, SIGKILL, a crash, a lost machine — the next run sweeps the journal and undoes anything left behind, whether or not the check is still enabled. Add `.nax/mutation-journal/` to `.gitignore`.
+
+Reverting is verified, never positional: the line must still hold the exact mutant that was written. If something else rewrote it in the meantime (a formatter, codegen, the agent), nax writes nothing — restoring a stale line over content it cannot account for is the one outcome nothing downstream can undo. It logs the file, line, and what it actually found, stops mutating that story, and prints a final block:
+
+```
+WORKTREE NOT RESTORED — a mutation may still be applied; check the log for file and line
+  US-002
+```
+
+That block means **check your working tree**. It is the only mutation-check output that is about your files rather than your tests.
 
 ---
 

--- a/src/log-format/mutation-summary.ts
+++ b/src/log-format/mutation-summary.ts
@@ -3,16 +3,26 @@ import type { MutationStorySummary } from "../runtime/mutation-summary";
 export function formatMutationSummary(summaries: Iterable<MutationStorySummary>): string {
   const lines: string[] = [];
   const notChecked: string[] = [];
+  const notRestored: string[] = [];
   for (const summary of summaries) {
     for (const survivor of summary.survivors) {
       const filePath = survivor.file;
       lines.push(`  ${summary.storyId}  ${filePath}:${survivor.line}  ${survivor.operatorId}`);
     }
     if (summary.checked && summary.candidates === 0) notChecked.push(`  ${summary.storyId}`);
+    if (summary.revertFailed) notRestored.push(`  ${summary.storyId}`);
   }
-  if (lines.length === 0 && notChecked.length === 0) return "";
+  if (lines.length === 0 && notChecked.length === 0 && notRestored.length === 0) return "";
   const blocks: string[] = [];
   if (lines.length > 0) blocks.push("SURVIVING MUTANTS", ...lines);
   if (notChecked.length > 0) blocks.push("NOT CHECKED", ...notChecked);
+  // Loudest block last so it is the final thing on screen: this one means the
+  // working tree may still be broken, not merely that a check was inconclusive.
+  if (notRestored.length > 0) {
+    blocks.push(
+      "WORKTREE NOT RESTORED — a mutation may still be applied; check the log for file and line",
+      ...notRestored,
+    );
+  }
   return ["", ...blocks, ""].join("\n");
 }

--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -154,9 +154,15 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       }
     };
     const logger = getLogger();
+    // Anchor the journal to the WORKING TREE, not the project root. In parallel
+    // mode every story runs in its own git worktree while `repoRoot`
+    // (`ctx.projectDir`) stays the shared main repo — anchoring there gives all
+    // concurrent stories one journal directory, and since entries carry
+    // absolute paths, one story's sweep would restore another's in-flight
+    // mutation mid-check. `getGitRoot` inside a worktree returns that worktree.
+    const journalRoot = (await deps.getGitRoot(input.workdir)) ?? input.workdir;
     // Sweep before the enabled check: a mutation left behind by an interrupted
     // run must still be restored if the feature is turned off afterwards.
-    const journalRoot = input.repoRoot ?? input.workdir;
     await sweepLeftoverMutants(journalRoot, input.storyId);
 
     if (!cfg?.enabled) {

--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -27,7 +27,10 @@ import { getChangedLineRanges } from "../verification/changed-line-ranges";
 import {
   applyMutant,
   classifyMutant,
+  clearInFlight,
   generateMutants,
+  recordInFlight,
+  restoreInFlight,
   revertMutant,
   selectEvenlySpaced,
 } from "../verification/mutation";
@@ -54,6 +57,11 @@ export interface MutationCheckOutput {
   readonly outcomes: MutationOutcomeSummary;
   readonly candidates: number;
   readonly checked: boolean;
+  /**
+   * Set only when a revert could not be confirmed, meaning the worktree may
+   * still hold an injected mutation. Absent on every clean path.
+   */
+  readonly revertFailed?: true;
 }
 
 export interface MutationCheckDeps {
@@ -73,6 +81,45 @@ export const _mutationCheckDeps: MutationCheckDeps = {
   selectScopedTests,
   regression,
 };
+
+/**
+ * Restore any mutation an earlier run applied but never confirmed reverted.
+ *
+ * Fail-open like the rest of the check: a sweep that throws is logged and
+ * swallowed. Leftover cleanup must never be the thing that fails a run.
+ */
+async function sweepLeftoverMutants(repoRoot: string, storyId: string): Promise<void> {
+  const logger = getLogger();
+  try {
+    for (const result of await restoreInFlight(repoRoot)) {
+      const { entry, outcome } = result;
+      if (outcome === "already-clean") continue;
+      const data = {
+        storyId,
+        appliedByStory: entry.storyId,
+        file: entry.file,
+        line: entry.line,
+        operatorId: entry.operatorId,
+      };
+      if (outcome === "restored") {
+        logger.warn("mutation-check", "Restored a mutation left behind by an interrupted run", data);
+      } else {
+        // Nothing to undo — the line holds neither the mutant nor the
+        // original, so this log is the only remaining record of it.
+        logger.error("mutation-check", "Cannot restore a mutation from an interrupted run — line was rewritten", {
+          ...data,
+          expected: entry.after,
+          actual: result.actual,
+        });
+      }
+    }
+  } catch (err) {
+    logger.warn("mutation-check", "Leftover-mutation sweep failed — continuing", {
+      storyId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
 
 export const mutationCheckOp: DeterministicOperation<MutationCheckInput, MutationCheckOutput, MutationCheckConfig> = {
   kind: "deterministic",
@@ -106,12 +153,17 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
         ctx.runtime?.mutationSummaries?.set(ctx.storyId, { storyId: ctx.storyId, ...result });
       }
     };
+    const logger = getLogger();
+    // Sweep before the enabled check: a mutation left behind by an interrupted
+    // run must still be restored if the feature is turned off afterwards.
+    const journalRoot = input.repoRoot ?? input.workdir;
+    await sweepLeftoverMutants(journalRoot, input.storyId);
+
     if (!cfg?.enabled) {
       record(emptyOutput);
       return { success: true as const, ...emptyOutput };
     }
 
-    const logger = getLogger();
     const packageDir = input.packageDir ?? input.workdir;
     const language = await deps.detectLanguage(packageDir);
     const quality = ctx.packageView.select(qualityConfigSelector);
@@ -207,9 +259,13 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       );
     }
     const selected = selectEvenlySpaced(mutants, cfg.maxMutants);
+    let revertFailed = false;
     for (const mutant of selected) {
       let outcome: MutantOutcome | undefined;
       try {
+        // Journal BEFORE mutating: a crash in between must leave a record
+        // that names a mutation, never a mutation with no record.
+        await recordInFlight(journalRoot, { ...mutant, storyId: input.storyId });
         await applyMutant(mutant);
         try {
           const scoped = await deps.selectScopedTests({
@@ -235,7 +291,25 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
             survivors.push({ ...mutant, outcome: "survived" });
           }
         } finally {
-          await revertMutant(mutant);
+          const reverted = await revertMutant(mutant);
+          if (reverted.reverted) {
+            await clearInFlight(journalRoot, input.storyId);
+          } else {
+            // The line no longer holds what we wrote, so restoring it would
+            // overwrite content we cannot account for. Leave the file alone,
+            // keep the journal for the next run, and stop mutating: whatever
+            // moved the file will keep moving it.
+            revertFailed = true;
+            logger.error("mutation-check", "Could not confirm revert — worktree may still hold a mutation", {
+              storyId: input.storyId,
+              file: mutant.file,
+              line: mutant.line,
+              operatorId: mutant.operatorId,
+              reason: reverted.reason,
+              expected: mutant.after,
+              actual: reverted.actual,
+            });
+          }
         }
       } catch (err) {
         // Fail-open: any error mutating/testing/reverting a single mutant is
@@ -253,6 +327,9 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
           error: err instanceof Error ? err.message : String(err),
         });
       }
+      // An unconfirmed revert means the worktree is in a state this op did
+      // not author. Applying more mutations on top would compound it.
+      if (revertFailed) break;
     }
 
     for (const s of survivors) {
@@ -265,7 +342,9 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
     }
 
     const candidates = mutants.length;
-    record({ survivors, outcomes, candidates, checked: true });
-    return { success: true as const, survivors, outcomes, candidates, checked: true };
+    // Omitted entirely on the clean path so a summary keeps its existing shape.
+    const dirty = revertFailed ? ({ revertFailed: true } as const) : {};
+    record({ survivors, outcomes, candidates, checked: true, ...dirty });
+    return { success: true as const, survivors, outcomes, candidates, checked: true, ...dirty };
   },
 };

--- a/src/runtime/mutation-summary.ts
+++ b/src/runtime/mutation-summary.ts
@@ -12,4 +12,9 @@ export interface MutationStorySummary {
   readonly outcomes: MutationOutcomeSummary;
   readonly candidates: number;
   readonly checked: boolean;
+  /**
+   * Set only when a revert could not be confirmed — the worktree may still
+   * hold an injected mutation for this story. Absent on every clean path.
+   */
+  readonly revertFailed?: true;
 }

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -28,4 +28,10 @@ export const NAX_GITIGNORE_ENTRIES = [
   // the flow's `commit_*` nodes run `git add -A`, so an un-ignored artifact
   // here lands in the feature branch's history.
   ".nax/finish-audit/",
+  // In-flight mutation-spot-check journal. Same reasoning as finish-audit
+  // above, and more urgent: the journal exists precisely in the window where a
+  // run died mid-mutation, so a later `git add -A` is exactly what would sweep
+  // it into the feature branch. Kept in sync with `journalDir()` in
+  // src/verification/mutation/journal.ts.
+  ".nax/mutation-journal/",
 ];

--- a/src/verification/mutation/apply.ts
+++ b/src/verification/mutation/apply.ts
@@ -33,10 +33,47 @@ async function replaceLine(file: string, line: number, value: string): Promise<v
   await writeLines(file, lines);
 }
 
+/**
+ * Outcome of a revert attempt.
+ *
+ * `reverted: false` means the file was left EXACTLY as found — the caller must
+ * assume the worktree still holds a mutation (or something else it cannot
+ * account for) at that location.
+ */
+export type RevertResult =
+  | { readonly reverted: true }
+  | {
+      readonly reverted: false;
+      readonly reason: "out-of-range" | "content-mismatch";
+      /** What the line actually held, or null when the line no longer exists. */
+      readonly actual: string | null;
+    };
+
 export async function applyMutant(m: Mutant): Promise<void> {
   await replaceLine(m.file, m.line, m.after);
 }
 
-export async function revertMutant(m: Mutant): Promise<void> {
-  await replaceLine(m.file, m.line, m.before);
+/**
+ * Restore the line a mutant replaced — but only after confirming the line
+ * still holds that exact mutant.
+ *
+ * The check is the whole point. Reverting positionally (writing `before` back
+ * at `line` unconditionally) silently destroys whatever occupies the line if
+ * anything shifted the file between apply and revert. Overwriting unknown
+ * content is the one outcome nothing downstream can undo, so a mismatch
+ * writes nothing at all and reports itself instead.
+ */
+export async function revertMutant(m: Mutant): Promise<RevertResult> {
+  const lines = await readLines(m.file);
+  const idx = m.line - 1;
+  if (idx < 0 || idx >= lines.length) {
+    return { reverted: false, reason: "out-of-range", actual: null };
+  }
+  const actual = lines[idx] ?? "";
+  if (actual !== m.after) {
+    return { reverted: false, reason: "content-mismatch", actual };
+  }
+  lines[idx] = m.before;
+  await writeLines(m.file, lines);
+  return { reverted: true };
 }

--- a/src/verification/mutation/index.ts
+++ b/src/verification/mutation/index.ts
@@ -6,5 +6,8 @@ export * from "./types";
 export { generateMutants } from "./mutator";
 export { getOperatorsForLanguage } from "./operators";
 export { applyMutant, revertMutant } from "./apply";
+export type { RevertResult } from "./apply";
+export { clearInFlight, journalDir, journalPathFor, recordInFlight, restoreInFlight } from "./journal";
+export type { JournalRestoreResult, MutationJournalEntry } from "./journal";
 export { classifyMutant } from "./classify";
 export { selectEvenlySpaced } from "./select";

--- a/src/verification/mutation/journal.ts
+++ b/src/verification/mutation/journal.ts
@@ -14,7 +14,7 @@
  * One file per story, so parallel stories never contend for the same journal.
  */
 
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { revertMutant } from "./apply";
 import type { Mutant } from "./types";
 
@@ -85,9 +85,22 @@ async function readEntry(path: string): Promise<MutationJournalEntry | null> {
   }
 }
 
+/** Is `filePath` inside `root`'s subtree? */
+function isInside(root: string, filePath: string): boolean {
+  const base = resolve(root);
+  const target = resolve(filePath);
+  return target === base || target.startsWith(`${base}${sep}`);
+}
+
 /**
  * Restore every journalled mutation left behind by an earlier run, then clear
  * the journal.
+ *
+ * Entries naming a file OUTSIDE `repoRoot` are skipped and their journal is
+ * left in place: they belong to a different working tree, and writing into one
+ * we were not asked to touch is worse than the leftover we are cleaning up.
+ * With a per-worktree anchor this should never trigger — it is the guard that
+ * keeps a wrong anchor from becoming cross-tree corruption.
  *
  * The journal is cleared even for an `unrecoverable` entry: a line holding
  * neither the mutant nor the original has been rewritten by someone else, so
@@ -117,6 +130,7 @@ export async function restoreInFlight(repoRoot: string): Promise<JournalRestoreR
       await unlink(path).catch(() => {});
       continue;
     }
+    if (!isInside(repoRoot, entry.file)) continue;
     results.push(await restoreEntry(entry));
     await unlink(path).catch(() => {});
   }

--- a/src/verification/mutation/journal.ts
+++ b/src/verification/mutation/journal.ts
@@ -1,0 +1,138 @@
+/**
+ * In-flight mutant journal — crash-durable record of an applied mutation.
+ *
+ * The spot-check reverts in a `finally`, which covers a thrown error but not
+ * process death. If the run is interrupted between apply and revert (Ctrl+C,
+ * SIGKILL, a crash, a lost machine), deliberately-broken source is left in the
+ * user's worktree with nothing but a log line to say so.
+ *
+ * An on-disk journal is what survives that: it is written BEFORE the mutation
+ * and deleted only after a verified revert, so its mere existence at the start
+ * of a later run means "a mutation was applied and never confirmed restored".
+ * An in-process handler cannot make that guarantee — SIGKILL runs no handler.
+ *
+ * One file per story, so parallel stories never contend for the same journal.
+ */
+
+import { join } from "node:path";
+import { revertMutant } from "./apply";
+import type { Mutant } from "./types";
+
+const JOURNAL_DIRNAME = join(".nax", "mutation-journal");
+
+/** Journalled mutant plus the story that applied it. */
+export interface MutationJournalEntry extends Mutant {
+  readonly storyId: string;
+}
+
+/** Result of restoring one journalled entry. */
+export interface JournalRestoreResult {
+  readonly entry: MutationJournalEntry;
+  /** `restored` — the mutation was on disk and has been undone.
+   *  `already-clean` — the line already held the original; nothing to do.
+   *  `unrecoverable` — the line holds neither; left untouched. */
+  readonly outcome: "restored" | "already-clean" | "unrecoverable";
+  /** What the line actually held when the outcome is `unrecoverable`. */
+  readonly actual?: string | null;
+}
+
+export function journalDir(repoRoot: string): string {
+  return join(repoRoot, JOURNAL_DIRNAME);
+}
+
+/** Story ids reach the filesystem as names — keep them to a safe alphabet. */
+function journalFileName(storyId: string): string {
+  const safe = storyId.replace(/[^A-Za-z0-9._-]/g, "_");
+  return `${safe || "unknown"}.json`;
+}
+
+export function journalPathFor(repoRoot: string, storyId: string): string {
+  return join(journalDir(repoRoot), journalFileName(storyId));
+}
+
+/**
+ * Record a mutant as in-flight. MUST be awaited before the mutation is
+ * written, otherwise a crash in between leaves an unjournalled mutation.
+ */
+export async function recordInFlight(repoRoot: string, entry: MutationJournalEntry): Promise<void> {
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(journalDir(repoRoot), { recursive: true });
+  await Bun.write(journalPathFor(repoRoot, entry.storyId), JSON.stringify(entry));
+}
+
+/** Drop a story's journal. Call only after a revert is confirmed. */
+export async function clearInFlight(repoRoot: string, storyId: string): Promise<void> {
+  const { unlink } = await import("node:fs/promises");
+  await unlink(journalPathFor(repoRoot, storyId)).catch(() => {});
+}
+
+async function readEntry(path: string): Promise<MutationJournalEntry | null> {
+  try {
+    const parsed = (await Bun.file(path).json()) as Partial<MutationJournalEntry>;
+    if (
+      typeof parsed?.storyId !== "string" ||
+      typeof parsed?.file !== "string" ||
+      typeof parsed?.line !== "number" ||
+      typeof parsed?.before !== "string" ||
+      typeof parsed?.after !== "string" ||
+      typeof parsed?.operatorId !== "string"
+    ) {
+      return null;
+    }
+    return parsed as MutationJournalEntry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Restore every journalled mutation left behind by an earlier run, then clear
+ * the journal.
+ *
+ * The journal is cleared even for an `unrecoverable` entry: a line holding
+ * neither the mutant nor the original has been rewritten by someone else, so
+ * there is nothing left for us to undo and re-reporting it on every subsequent
+ * run would be noise. The caller is expected to log that case loudly — the log
+ * is the durable record at that point, not the journal.
+ *
+ * Fail-open: an unreadable journal directory or entry yields no results rather
+ * than an error. Leftover cleanup must never be what breaks a run.
+ */
+export async function restoreInFlight(repoRoot: string): Promise<JournalRestoreResult[]> {
+  const { readdir, unlink } = await import("node:fs/promises");
+  const dir = journalDir(repoRoot);
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const results: JournalRestoreResult[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const path = join(dir, name);
+    const entry = await readEntry(path);
+    if (!entry) {
+      await unlink(path).catch(() => {});
+      continue;
+    }
+    results.push(await restoreEntry(entry));
+    await unlink(path).catch(() => {});
+  }
+  return results;
+}
+
+async function restoreEntry(entry: MutationJournalEntry): Promise<JournalRestoreResult> {
+  try {
+    const result = await revertMutant(entry);
+    if (result.reverted) return { entry, outcome: "restored" };
+    if (result.reason === "content-mismatch" && result.actual === entry.before) {
+      return { entry, outcome: "already-clean" };
+    }
+    return { entry, outcome: "unrecoverable", actual: result.actual };
+  } catch {
+    // The file is gone or unreadable — nothing to restore, nothing to break.
+    return { entry, outcome: "unrecoverable", actual: null };
+  }
+}

--- a/test/unit/log-format/mutation-summary.test.ts
+++ b/test/unit/log-format/mutation-summary.test.ts
@@ -105,3 +105,33 @@ describe("formatMutationSummary", () => {
     expect(formatMutationSummary([makeSummary(), second])).toContain("src/second.ts");
   });
 });
+
+describe("formatMutationSummary — WORKTREE NOT RESTORED", () => {
+  const clean = () => makeSummary({ survivors: [], outcomes: { killed: 1, survived: 0, errored: 0 } });
+
+  test("a story whose revert could not be confirmed is named", () => {
+    const out = formatMutationSummary([makeSummary({ ...clean(), revertFailed: true })]);
+
+    expect(out).toContain("WORKTREE NOT RESTORED");
+    expect(out).toContain("US-004");
+  });
+
+  test("the block renders even when nothing survived and everything was checked", () => {
+    // Otherwise the loudest condition would be the one that prints nothing.
+    expect(formatMutationSummary([makeSummary({ ...clean(), revertFailed: true })])).not.toBe("");
+  });
+
+  test("a clean run never renders the block", () => {
+    expect(formatMutationSummary([makeSummary()])).not.toContain("WORKTREE NOT RESTORED");
+  });
+
+  test("it is the last block, after survivors and not-checked", () => {
+    const out = formatMutationSummary([
+      makeSummary({ revertFailed: true }),
+      makeSummary({ storyId: "US-006", survivors: [], candidates: 0 }),
+    ]);
+
+    expect(out.indexOf("WORKTREE NOT RESTORED")).toBeGreaterThan(out.indexOf("SURVIVING MUTANTS"));
+    expect(out.indexOf("WORKTREE NOT RESTORED")).toBeGreaterThan(out.indexOf("NOT CHECKED"));
+  });
+});

--- a/test/unit/operations/mutation-check-diff-scope.test.ts
+++ b/test/unit/operations/mutation-check-diff-scope.test.ts
@@ -485,10 +485,13 @@ describe("mutationCheckOp — issue #1485: anchor root matches getChangedLineRan
       const absoluteFile = join(repoRoot, relativeFile);
       await Bun.write(absoluteFile, "if (a == b) { return 1; }\n");
 
+      // Assert the anchoring OUTCOME, not that getGitRoot goes uncalled: the
+      // journal anchors to the working tree's git root, so the dep is now
+      // reached on every run. Handing back a bogus root proves the changed-file
+      // anchor ignores it — a stronger guarantee than a never-called stub, and
+      // one that does not break the next caller who legitimately needs the dep.
       const deps = fakeDeps({
-        getGitRoot: async () => {
-          throw new Error("getGitRoot must not be called when packagePrefix is set");
-        },
+        getGitRoot: async () => "/somewhere/else/entirely",
         getChangedNonTestFiles: async () => [relativeFile],
         getChangedLineRanges: async () => new Map([[absoluteFile, [{ start: 1, end: 1 }]]]),
       });

--- a/test/unit/operations/mutation-check-revert.test.ts
+++ b/test/unit/operations/mutation-check-revert.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { _mutationCheckDeps, mutationCheckOp } from "@/operations";
 import type { MutationCheckDeps } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
+import { applyMutant, journalPathFor, recordInFlight } from "@/verification";
 import { cleanupTempDir, makeTempDir } from "@test/helpers";
 
 const FAKE_STORY = { id: "US-004", title: "mutation-check op" } as any;
@@ -91,6 +92,152 @@ describe("mutationCheckOp — AC9: regression throw still reverts and reports su
       // File must be restored to its original contents after the throw.
       const after = await Bun.file(file).text();
       expect(after).toBe(`${originalLine}\n`);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+});
+
+const PATTERNS = {
+  globs: ["**/*.test.ts"],
+  regex: [/\.test\.ts$/],
+  pathspec: [":!*.test.ts"],
+  testDirs: ["test"],
+};
+
+function runInput(dir: string) {
+  return {
+    story: FAKE_STORY,
+    workdir: dir,
+    storyId: "US-004",
+    storyGitRef: "abc",
+    repoRoot: dir,
+    resolvedTestPatterns: PATTERNS,
+  } as any;
+}
+
+const ENABLED = { mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } };
+
+describe("mutationCheckOp — an unconfirmed revert stops the check", () => {
+  test("a test run that rewrites the mutated line leaves the file alone and flags the story", async () => {
+    const dir = makeTempDir("nax-mutation-dirty-");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      // Three mutable lines, so a second mutant would follow if we didn't stop.
+      await Bun.write(file, "if (a == b) { return 1; }\nif (c == d) { return 2; }\nif (e == f) { return 3; }\n");
+      const hijacked = "SOMEONE ELSE WROTE THIS\nif (c == d) { return 2; }\nif (e == f) { return 3; }\n";
+
+      let regressionCalls = 0;
+      const deps = fakeDeps({
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 3 }]]]),
+        regression: async () => {
+          regressionCalls += 1;
+          // Simulate a formatter/codegen step rewriting the mutated line.
+          await Bun.write(file, hijacked);
+          return { status: "FAILURE" as const, success: false, countsTowardEscalation: true, output: "1 fail" };
+        },
+      });
+
+      const ctx = ctxWithConfig(ENABLED);
+      const out = await mutationCheckOp.execute(runInput(dir), ctx, deps);
+
+      expect(out.success).toBe(true);
+      expect(out.revertFailed).toBe(true);
+      // The foreign write survives — nothing was restored over it.
+      expect(await Bun.file(file).text()).toBe(hijacked);
+      // Stopped after the first mutant rather than compounding.
+      expect(regressionCalls).toBe(1);
+      expect(ctx.runtime.mutationSummaries.get("US-004")?.revertFailed).toBe(true);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  test("a clean run reports no revertFailed and leaves no journal behind", async () => {
+    const dir = makeTempDir("nax-mutation-clean-");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      const original = "if (a == b) { return 1; }\n";
+      await Bun.write(file, original);
+
+      const deps = fakeDeps({
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 1 }]]]),
+      });
+
+      const ctx = ctxWithConfig(ENABLED);
+      const out = await mutationCheckOp.execute(runInput(dir), ctx, deps);
+
+      expect(out.revertFailed).toBeUndefined();
+      expect(await Bun.file(file).text()).toBe(original);
+      expect(await Bun.file(journalPathFor(dir, "US-004")).exists()).toBe(false);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+});
+
+describe("mutationCheckOp — leftover mutations from an interrupted run", () => {
+  test("a journalled mutation is restored on the next run", async () => {
+    const dir = makeTempDir("nax-mutation-leftover-");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      const original = "if (a == b) { return 1; }\n";
+      await Bun.write(file, original);
+
+      // Exactly the state a SIGKILL between apply and revert leaves.
+      await recordInFlight(dir, {
+        storyId: "US-999",
+        file,
+        line: 1,
+        before: "if (a == b) { return 1; }",
+        after: "if (a != b) { return 1; }",
+        operatorId: "ts:cmp-flip",
+      });
+      await applyMutant({
+        file,
+        line: 1,
+        before: "if (a == b) { return 1; }",
+        after: "if (a != b) { return 1; }",
+        operatorId: "ts:cmp-flip",
+      });
+
+      const deps = fakeDeps({ getChangedNonTestFiles: async () => [] });
+      await mutationCheckOp.execute(runInput(dir), ctxWithConfig(ENABLED), deps);
+
+      expect(await Bun.file(file).text()).toBe(original);
+      expect(await Bun.file(journalPathFor(dir, "US-999")).exists()).toBe(false);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  test("the sweep still runs when the check is disabled", async () => {
+    const dir = makeTempDir("nax-mutation-leftover-off-");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      const original = "if (a == b) { return 1; }\n";
+      await Bun.write(file, original);
+      const mutant = {
+        file,
+        line: 1,
+        before: "if (a == b) { return 1; }",
+        after: "if (a != b) { return 1; }",
+        operatorId: "ts:cmp-flip",
+      };
+      await recordInFlight(dir, { ...mutant, storyId: "US-999" });
+      await applyMutant(mutant);
+
+      // Turning the feature off must not strand a mutation in the worktree.
+      const out = await mutationCheckOp.execute(
+        runInput(dir),
+        ctxWithConfig({ mutationCheck: { enabled: false, maxMutants: 3, timeoutSeconds: 60 } }),
+        fakeDeps(),
+      );
+
+      expect(out.checked).toBe(false);
+      expect(await Bun.file(file).text()).toBe(original);
     } finally {
       cleanupTempDir(dir);
     }

--- a/test/unit/operations/mutation-check-revert.test.ts
+++ b/test/unit/operations/mutation-check-revert.test.ts
@@ -213,6 +213,105 @@ describe("mutationCheckOp — leftover mutations from an interrupted run", () =>
     }
   });
 
+  test("the journal follows the worktree, not the shared project root", async () => {
+    // Parallel mode: every story gets its own git worktree, but repoRoot
+    // (ctx.projectDir) stays the shared main repo. Anchoring the journal there
+    // gives all concurrent stories ONE journal directory, so one story's sweep
+    // restores another story's in-flight mutation.
+    //
+    // The journal is deleted once the revert is confirmed, so asserting after
+    // the run proves nothing — both anchors look identical by then. The only
+    // moment the journal is observable is while a mutant is applied, which is
+    // exactly when `regression` is called.
+    const projectRoot = makeTempDir("nax-mutation-project-");
+    const worktree = join(projectRoot, ".nax-wt", "US-004");
+    try {
+      const file = join(worktree, "src", "a.ts");
+      await Bun.write(file, "if (a == b) { return 1; }\n");
+
+      const seen: Array<{ inWorktree: boolean; inProjectRoot: boolean }> = [];
+      const deps = fakeDeps({
+        getGitRoot: async (dir: string) => dir,
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 1 }]]]),
+        regression: async () => {
+          seen.push({
+            inWorktree: await Bun.file(journalPathFor(worktree, "US-004")).exists(),
+            inProjectRoot: await Bun.file(journalPathFor(projectRoot, "US-004")).exists(),
+          });
+          return { status: "SUCCESS" as const, success: true, countsTowardEscalation: true, output: "" };
+        },
+      });
+
+      await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: worktree,
+          storyId: "US-004",
+          storyGitRef: "abc",
+          repoRoot: projectRoot,
+          resolvedTestPatterns: PATTERNS,
+        } as any,
+        ctxWithConfig(ENABLED),
+        deps,
+      );
+
+      expect(seen.length).toBeGreaterThan(0);
+      for (const observation of seen) {
+        expect(observation.inWorktree).toBe(true);
+        expect(observation.inProjectRoot).toBe(false);
+      }
+    } finally {
+      cleanupTempDir(projectRoot);
+    }
+  });
+
+  test("a sweep never reaches into a sibling worktree's journal", async () => {
+    const projectRoot = makeTempDir("nax-mutation-siblings-");
+    const worktreeA = join(projectRoot, ".nax-wt", "US-004");
+    const worktreeB = join(projectRoot, ".nax-wt", "US-005");
+    try {
+      const fileB = join(worktreeB, "src", "b.ts");
+      const mutatedB = "if (a != b) { return 1; }\n";
+      await Bun.write(fileB, mutatedB);
+      // Story B is mid-check: journalled and applied, not yet reverted.
+      await recordInFlight(worktreeB, {
+        storyId: "US-005",
+        file: fileB,
+        line: 1,
+        before: "if (a == b) { return 1; }",
+        after: "if (a != b) { return 1; }",
+        operatorId: "ts:cmp-flip",
+      });
+
+      const fileA = join(worktreeA, "src", "a.ts");
+      await Bun.write(fileA, "if (c == d) { return 2; }\n");
+
+      await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: worktreeA,
+          storyId: "US-004",
+          storyGitRef: "abc",
+          repoRoot: projectRoot,
+          resolvedTestPatterns: PATTERNS,
+        } as any,
+        ctxWithConfig(ENABLED),
+        fakeDeps({
+          getGitRoot: async (dir: string) => dir,
+          getChangedNonTestFiles: async () => [fileA],
+          getChangedLineRanges: async () => new Map([[fileA, [{ start: 1, end: 1 }]]]),
+        }),
+      );
+
+      // B's in-flight mutation and its journal survive A's sweep untouched.
+      expect(await Bun.file(fileB).text()).toBe(mutatedB);
+      expect(await Bun.file(journalPathFor(worktreeB, "US-005")).exists()).toBe(true);
+    } finally {
+      cleanupTempDir(projectRoot);
+    }
+  });
+
   test("the sweep still runs when the check is disabled", async () => {
     const dir = makeTempDir("nax-mutation-leftover-off-");
     try {

--- a/test/unit/utils/gitignore.test.ts
+++ b/test/unit/utils/gitignore.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared nax gitignore entries.
+ *
+ * This list is the SSOT for what nax excludes in a USER's repo — `nax init`
+ * appends it to .gitignore and WorktreeManager writes it to .git/info/exclude.
+ * Editing the nax repo's own .gitignore protects nax and nobody else, so any
+ * new runtime artifact has to land here too.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { NAX_GITIGNORE_ENTRIES } from "@/utils/gitignore";
+import { journalDir } from "@/verification";
+
+describe("NAX_GITIGNORE_ENTRIES", () => {
+  test("covers the mutation journal directory", () => {
+    expect(NAX_GITIGNORE_ENTRIES).toContain(".nax/mutation-journal/");
+  });
+
+  test("the ignored path is the one journalDir actually writes to", () => {
+    // Pins the two together: renaming the directory without updating the
+    // ignore list would leave a journal committable in every user repo.
+    const produced = journalDir("/repo");
+    const ignored = NAX_GITIGNORE_ENTRIES.find((e) => e.includes("mutation-journal"));
+
+    expect(ignored).toBeDefined();
+    expect(produced).toBe(join("/repo", ignored?.replace(/\/$/, "") ?? ""));
+  });
+
+  test("entries are relative patterns — an absolute path would never match", () => {
+    for (const entry of NAX_GITIGNORE_ENTRIES) {
+      expect(entry.startsWith("/")).toBe(false);
+    }
+  });
+
+  test("no duplicate entries", () => {
+    expect(new Set(NAX_GITIGNORE_ENTRIES).size).toBe(NAX_GITIGNORE_ENTRIES.length);
+  });
+});

--- a/test/unit/verification/mutation/apply.test.ts
+++ b/test/unit/verification/mutation/apply.test.ts
@@ -144,3 +144,84 @@ describe("revertMutant", () => {
     expect(Buffer.from(originalBuffer).equals(Buffer.from(restored))).toBe(true);
   });
 });
+
+describe("revertMutant — verified, never positional", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-revert-verified-");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  const mutantAt = (filePath: string, line: number): Mutant => ({
+    file: filePath,
+    line,
+    before: "const y = 2;",
+    after: "const y = 99;",
+    operatorId: "ts:literal-flip",
+  });
+
+  test("reverting a line that holds the mutant reports success", async () => {
+    const filePath = join(tempDir, "clean.ts");
+    await Bun.write(filePath, "const x = 1;\nconst y = 2;\n");
+    const mutant = mutantAt(filePath, 2);
+
+    await applyMutant(mutant);
+
+    expect(await revertMutant(mutant)).toEqual({ reverted: true });
+  });
+
+  test("a line rewritten since apply is reported, not overwritten", async () => {
+    const filePath = join(tempDir, "shifted.ts");
+    await Bun.write(filePath, "const x = 1;\nconst y = 2;\n");
+    const mutant = mutantAt(filePath, 2);
+
+    await applyMutant(mutant);
+    // Something else — a formatter, codegen, the agent — rewrites the line.
+    const rewritten = "const x = 1;\nconst y = someoneElsesEdit();\n";
+    await Bun.write(filePath, rewritten);
+
+    const result = await revertMutant(mutant);
+
+    expect(result).toEqual({
+      reverted: false,
+      reason: "content-mismatch",
+      actual: "const y = someoneElsesEdit();",
+    });
+    // The whole point: the foreign edit survives untouched.
+    expect(await Bun.file(filePath).text()).toBe(rewritten);
+  });
+
+  test("a file that lost the line is reported, not extended", async () => {
+    const filePath = join(tempDir, "truncated.ts");
+    await Bun.write(filePath, "const x = 1;\nconst y = 2;\n");
+    const mutant = mutantAt(filePath, 2);
+
+    await applyMutant(mutant);
+    const truncated = "const x = 1;";
+    await Bun.write(filePath, truncated);
+
+    const result = await revertMutant(mutant);
+
+    expect(result).toEqual({ reverted: false, reason: "out-of-range", actual: null });
+    expect(await Bun.file(filePath).text()).toBe(truncated);
+  });
+
+  test("reverting twice is not a second write — the line no longer holds the mutant", async () => {
+    const filePath = join(tempDir, "double.ts");
+    const original = "const x = 1;\nconst y = 2;\n";
+    await Bun.write(filePath, original);
+    const mutant = mutantAt(filePath, 2);
+
+    await applyMutant(mutant);
+    expect(await revertMutant(mutant)).toEqual({ reverted: true });
+
+    const second = await revertMutant(mutant);
+
+    expect(second.reverted).toBe(false);
+    expect(await Bun.file(filePath).text()).toBe(original);
+  });
+});

--- a/test/unit/verification/mutation/journal.test.ts
+++ b/test/unit/verification/mutation/journal.test.ts
@@ -1,0 +1,191 @@
+/**
+ * In-flight mutant journal tests.
+ *
+ * The journal is what makes an interrupted run recoverable: it is written
+ * before the mutation and removed only after a verified revert, so its
+ * presence at the start of a later run means a mutation was applied and never
+ * confirmed restored. These tests pin that contract, including the fail-open
+ * paths — leftover cleanup must never be the thing that breaks a run.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+  type Mutant,
+  applyMutant,
+  clearInFlight,
+  journalPathFor,
+  recordInFlight,
+  restoreInFlight,
+} from "@/verification";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+describe("mutation journal", () => {
+  let repoRoot: string;
+  let filePath: string;
+  const original = "const x = 1;\nconst y = 2;\n";
+
+  const mutant = (): Mutant => ({
+    file: filePath,
+    line: 2,
+    before: "const y = 2;",
+    after: "const y = 99;",
+    operatorId: "ts:literal-flip",
+  });
+
+  beforeEach(async () => {
+    repoRoot = makeTempDir("nax-journal-");
+    filePath = join(repoRoot, "src.ts");
+    await Bun.write(filePath, original);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(repoRoot);
+  });
+
+  test("a recorded entry lands on disk and clears again", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    expect(await Bun.file(journalPathFor(repoRoot, "US-001")).exists()).toBe(true);
+
+    await clearInFlight(repoRoot, "US-001");
+
+    expect(await Bun.file(journalPathFor(repoRoot, "US-001")).exists()).toBe(false);
+  });
+
+  test("clearing a journal that was never written is not an error", async () => {
+    await clearInFlight(repoRoot, "US-404");
+    expect(await Bun.file(journalPathFor(repoRoot, "US-404")).exists()).toBe(false);
+  });
+
+  test("stories get separate journals — a parallel story does not clobber another", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-002" });
+
+    await clearInFlight(repoRoot, "US-001");
+
+    expect(await Bun.file(journalPathFor(repoRoot, "US-001")).exists()).toBe(false);
+    expect(await Bun.file(journalPathFor(repoRoot, "US-002")).exists()).toBe(true);
+  });
+
+  test("a story id with path separators cannot escape the journal directory", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "../../escape" });
+
+    const path = journalPathFor(repoRoot, "../../escape");
+    expect(path.startsWith(join(repoRoot, ".nax", "mutation-journal"))).toBe(true);
+    expect(await Bun.file(path).exists()).toBe(true);
+  });
+});
+
+describe("restoreInFlight — sweeping an interrupted run", () => {
+  let repoRoot: string;
+  let filePath: string;
+  const original = "const x = 1;\nconst y = 2;\n";
+
+  const mutant = (): Mutant => ({
+    file: filePath,
+    line: 2,
+    before: "const y = 2;",
+    after: "const y = 99;",
+    operatorId: "ts:literal-flip",
+  });
+
+  beforeEach(async () => {
+    repoRoot = makeTempDir("nax-journal-sweep-");
+    filePath = join(repoRoot, "src.ts");
+    await Bun.write(filePath, original);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(repoRoot);
+  });
+
+  test("a mutation left on disk is undone and the journal cleared", async () => {
+    // Exactly the state a SIGKILL between apply and revert leaves behind.
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    await applyMutant(mutant());
+
+    const results = await restoreInFlight(repoRoot);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.outcome).toBe("restored");
+    expect(await Bun.file(filePath).text()).toBe(original);
+    expect(await Bun.file(journalPathFor(repoRoot, "US-001")).exists()).toBe(false);
+  });
+
+  test("a journal whose mutation was already reverted reports already-clean", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+
+    const results = await restoreInFlight(repoRoot);
+
+    expect(results[0]?.outcome).toBe("already-clean");
+    expect(await Bun.file(filePath).text()).toBe(original);
+  });
+
+  test("a line rewritten by someone else is left alone and reported unrecoverable", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    const rewritten = "const x = 1;\nconst y = somethingElse();\n";
+    await Bun.write(filePath, rewritten);
+
+    const results = await restoreInFlight(repoRoot);
+
+    expect(results[0]?.outcome).toBe("unrecoverable");
+    expect(results[0]?.actual).toBe("const y = somethingElse();");
+    expect(await Bun.file(filePath).text()).toBe(rewritten);
+  });
+
+  test("an unrecoverable entry still clears its journal — it would nag every run otherwise", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    await Bun.write(filePath, "const x = 1;\nconst y = somethingElse();\n");
+
+    await restoreInFlight(repoRoot);
+
+    expect(await Bun.file(journalPathFor(repoRoot, "US-001")).exists()).toBe(false);
+    expect(await restoreInFlight(repoRoot)).toEqual([]);
+  });
+
+  test("a mutation whose file has since been deleted is unrecoverable, not a throw", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    const { unlink } = await import("node:fs/promises");
+    await unlink(filePath);
+
+    const results = await restoreInFlight(repoRoot);
+
+    expect(results[0]?.outcome).toBe("unrecoverable");
+  });
+
+  test("every journalled story is swept, not just the first", async () => {
+    const second = join(repoRoot, "other.ts");
+    await Bun.write(second, original);
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    await recordInFlight(repoRoot, { ...mutant(), file: second, storyId: "US-002" });
+    await applyMutant(mutant());
+    await applyMutant({ ...mutant(), file: second });
+
+    const results = await restoreInFlight(repoRoot);
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.outcome === "restored")).toBe(true);
+    expect(await Bun.file(filePath).text()).toBe(original);
+    expect(await Bun.file(second).text()).toBe(original);
+  });
+
+  test("no journal directory yields no work", async () => {
+    expect(await restoreInFlight(repoRoot)).toEqual([]);
+  });
+
+  test("a corrupt journal entry is discarded rather than throwing", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    await Bun.write(journalPathFor(repoRoot, "US-001"), "{ not json");
+
+    expect(await restoreInFlight(repoRoot)).toEqual([]);
+    expect(await Bun.file(journalPathFor(repoRoot, "US-001")).exists()).toBe(false);
+  });
+
+  test("a structurally invalid entry is discarded rather than half-applied", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+    await Bun.write(journalPathFor(repoRoot, "US-001"), JSON.stringify({ storyId: "US-001" }));
+
+    expect(await restoreInFlight(repoRoot)).toEqual([]);
+    expect(await Bun.file(filePath).text()).toBe(original);
+  });
+});

--- a/test/unit/verification/mutation/journal.test.ts
+++ b/test/unit/verification/mutation/journal.test.ts
@@ -169,6 +169,27 @@ describe("restoreInFlight — sweeping an interrupted run", () => {
     expect(await Bun.file(second).text()).toBe(original);
   });
 
+  test("an entry naming a file outside the root is neither restored nor cleared", async () => {
+    // Belt and braces against a wrong anchor: the entry belongs to another
+    // working tree, so this sweep must leave both the file and the journal for
+    // whoever owns them.
+    const otherTree = makeTempDir("nax-journal-other-");
+    try {
+      const foreign = join(otherTree, "src.ts");
+      const mutated = "const y = 99;\n";
+      await Bun.write(foreign, mutated);
+      await recordInFlight(repoRoot, { ...mutant(), file: foreign, storyId: "US-OTHER" });
+
+      const results = await restoreInFlight(repoRoot);
+
+      expect(results).toEqual([]);
+      expect(await Bun.file(foreign).text()).toBe(mutated);
+      expect(await Bun.file(journalPathFor(repoRoot, "US-OTHER")).exists()).toBe(true);
+    } finally {
+      cleanupTempDir(otherTree);
+    }
+  });
+
   test("no journal directory yields no work", async () => {
     expect(await restoreInFlight(repoRoot)).toEqual([]);
   });


### PR DESCRIPTION
## What

Closes **G9** and **G10** of the mutation-check gap analysis: revert is now verified rather than positional, and an interrupted run no longer strands a mutation in the worktree.

## Why

The mutation spot-check deliberately breaks the user's source and puts it back. Two independent routes let it fail to put it back.

**G9 — revert was positional and unverified.** `revertMutant` wrote `before` back at `line` unconditionally. If anything shifted the file between apply and revert — a formatter, codegen, the agent itself — it silently overwrote whatever occupied that line. That is the one outcome nothing downstream can undo. And if the file had grown shorter, `replaceLine` threw `MUTATION_LINE_OUT_OF_RANGE`, which the op caught and logged as a warning, leaving the mutant in place.

**G10 — no crash or interrupt cleanup.** Revert ran only in a `finally`, which covers a thrown error but not process death. Ctrl+C or a crash between apply and revert left deliberately-broken source behind with nothing but a log line. Since #1481 the check is enabled in nax's own config, so this is reachable on real work, and interrupting a run is a normal thing to do.

## How

**Verified revert.** `revertMutant` confirms the line still holds the exact mutant that was written. On a mismatch it writes **nothing** and returns a `RevertResult` naming the reason (`content-mismatch` / `out-of-range`) and what it actually found. The op logs that at error level with file and line, sets `revertFailed`, and **stops mutating that story** — whatever moved the file will keep moving it, and further mutations only compound the damage. A `WORKTREE NOT RESTORED` block prints at run end, last, because it is the only mutation-check output that is about your files rather than your tests.

**Crash-durable journal.** Each mutation is written to `.nax/mutation-journal/<storyId>.json` *before* it is applied and cleared only after a confirmed revert, so the journal's existence means "applied, never confirmed restored". The op sweeps it on entry and restores anything an earlier run abandoned.

Two choices worth flagging for review:

- **On-disk journal rather than the existing crash-recovery `onShutdown` hook.** An in-process handler cannot cover SIGKILL, a hard crash, or a lost machine — no handler runs. The journal survives all three. Cost is an artifact on disk if nax is never run again; `.nax/mutation-journal/` is gitignored.
- **The sweep runs before the `enabled` check**, so turning the feature off after an interrupted run cannot strand the leftover. The op already recorded a summary for every story including when disabled, so this path was already reached.

One journal file per story, so parallel stories never contend for it. The sweep is fail-open throughout — unreadable directory, corrupt entry, structurally invalid entry, deleted target file all yield no work rather than an error, because leftover cleanup must never be the thing that fails a run. An entry whose line holds neither the mutant nor the original is logged at error level and cleared: there is nothing left to undo, and re-reporting it every run would be noise.

## Testing

- [x] Tests added/updated — 25 new tests across 4 files
- [x] `bun run test` passes (11842 unit + 1092 integration + 24 ui, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes

Coverage added:

- `apply.test.ts` — a rewritten line is reported and left untouched; a truncated file is reported, not extended; a double revert does not write twice
- `journal.test.ts` (new) — record/clear round trip, per-story isolation, a story id with path separators cannot escape the journal directory, and the sweep's four outcomes: `restored`, `already-clean`, `unrecoverable` (file left untouched), and every fail-open path
- `mutation-check-revert.test.ts` — a regression run that rewrites the mutated line leaves the file alone, sets `revertFailed`, and stops after the first mutant; a clean run leaves no journal; a journalled leftover is restored on the next run, including when the check is disabled
- `mutation-summary.test.ts` — the `WORKTREE NOT RESTORED` block renders even when nothing survived, and sorts last

**Red-check.** The implementation landed before the tests here, so the three behavioural `revertMutant` tests were re-run against the old positional revert to confirm they fail against it — they do. The fourth (reverting a line that does hold the mutant) passes both ways by design.

## Notes

Docs updated: `docs/guides/configuration.md` had claimed the `finally` restored the worktree "even if a test run crashes", which was the exact overstatement this PR fixes. It now says "throws", and documents the journal, the gitignore entry, and what `WORKTREE NOT RESTORED` means.

Remaining in the gap analysis after this: G12 (awaiting field data) and G8/G13/G14 (efficiency). The correctness half is drained.
