### PR TITLE
fix(mutation): resolve symlinks before the journal containment check, and hoist scoped test selection

### DIFF
--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -29,6 +29,7 @@ import {
   classifyMutant,
   clearInFlight,
   generateMutants,
+  mayHaveJournal,
   recordInFlight,
   restoreInFlight,
   revertMutant,
@@ -154,6 +155,19 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       }
     };
     const logger = getLogger();
+    // A mutation left behind by an interrupted run must still be restored if
+    // the feature is turned off afterwards, so the sweep precedes the enabled
+    // gate. Resolving the anchor costs a `git rev-parse` subprocess though, and
+    // the feature is off by default — so when it is disabled, probe the paths
+    // already in hand first and spawn nothing unless a journal might exist.
+    if (!cfg?.enabled) {
+      if (await mayHaveJournal([input.workdir, input.repoRoot])) {
+        await sweepLeftoverMutants((await deps.getGitRoot(input.workdir)) ?? input.workdir, input.storyId);
+      }
+      record(emptyOutput);
+      return { success: true as const, ...emptyOutput };
+    }
+
     // Anchor the journal to the WORKING TREE, not the project root. In parallel
     // mode every story runs in its own git worktree while `repoRoot`
     // (`ctx.projectDir`) stays the shared main repo — anchoring there gives all
@@ -161,14 +175,7 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
     // absolute paths, one story's sweep would restore another's in-flight
     // mutation mid-check. `getGitRoot` inside a worktree returns that worktree.
     const journalRoot = (await deps.getGitRoot(input.workdir)) ?? input.workdir;
-    // Sweep before the enabled check: a mutation left behind by an interrupted
-    // run must still be restored if the feature is turned off afterwards.
     await sweepLeftoverMutants(journalRoot, input.storyId);
-
-    if (!cfg?.enabled) {
-      record(emptyOutput);
-      return { success: true as const, ...emptyOutput };
-    }
 
     const packageDir = input.packageDir ?? input.workdir;
     const language = await deps.detectLanguage(packageDir);

--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -265,77 +265,101 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       );
     }
     const selected = selectEvenlySpaced(mutants, cfg.maxMutants);
-    let revertFailed = false;
-    for (const mutant of selected) {
-      let outcome: MutantOutcome | undefined;
+    // Loop-invariant: every argument comes from `input`/`quality`, none from
+    // the mutant, so the scoped selection is identical on every iteration.
+    // Resolving it once turns maxMutants git-diff-plus-import-grep passes into
+    // one. Kept behind the emptiness guard because "no mutants selected" must
+    // still mean "no test selection performed".
+    let scoped: SelectScopedTestsResult | undefined;
+    if (selected.length > 0) {
       try {
-        // Journal BEFORE mutating: a crash in between must leave a record
-        // that names a mutation, never a mutation with no record.
-        await recordInFlight(journalRoot, { ...mutant, storyId: input.storyId });
-        await applyMutant(mutant);
-        try {
-          const scoped = await deps.selectScopedTests({
-            workdir: input.workdir,
-            storyId: input.storyId,
-            storyGitRef: input.storyGitRef,
-            testCommand: baseTestCommand,
-            testScopedTemplate: quality.quality?.commands?.testScoped,
-            smartRunnerConfig: quality.execution?.smartTestRunner,
-            fallbackFullSuiteCommand: baseTestCommand,
-            repoRoot: input.repoRoot,
-            packagePrefix: input.packagePrefix,
-            resolvedTestPatterns: input.resolvedTestPatterns,
-          });
-          const result = await deps.regression({
-            workdir: input.workdir,
-            command: scoped.effectiveCommand,
-            timeoutSeconds: cfg.timeoutSeconds,
-          });
-          outcome = classifyMutant(result);
-          outcomes[outcome] += 1;
-          if (outcome === "survived") {
-            survivors.push({ ...mutant, outcome: "survived" });
-          }
-        } finally {
-          const reverted = await revertMutant(mutant);
-          if (reverted.reverted) {
-            await clearInFlight(journalRoot, input.storyId);
-          } else {
-            // The line no longer holds what we wrote, so restoring it would
-            // overwrite content we cannot account for. Leave the file alone,
-            // keep the journal for the next run, and stop mutating: whatever
-            // moved the file will keep moving it.
-            revertFailed = true;
-            logger.error("mutation-check", "Could not confirm revert — worktree may still hold a mutation", {
-              storyId: input.storyId,
-              file: mutant.file,
-              line: mutant.line,
-              operatorId: mutant.operatorId,
-              reason: reverted.reason,
-              expected: mutant.after,
-              actual: reverted.actual,
-            });
-          }
-        }
-      } catch (err) {
-        // Fail-open: any error mutating/testing/reverting a single mutant is
-        // never a gate failure — log and move on to the next mutant. A mutant
-        // whose outcome was already recorded (e.g. revert failed after a
-        // successful verification) is not re-counted as errored.
-        if (outcome === undefined) {
-          outcomes.errored += 1;
-        }
-        logger.warn("mutation-check", "Error processing mutant — skipping", {
+        scoped = await deps.selectScopedTests({
+          workdir: input.workdir,
           storyId: input.storyId,
-          file: mutant.file,
-          line: mutant.line,
-          operatorId: mutant.operatorId,
+          storyGitRef: input.storyGitRef,
+          testCommand: baseTestCommand,
+          testScopedTemplate: quality.quality?.commands?.testScoped,
+          smartRunnerConfig: quality.execution?.smartTestRunner,
+          fallbackFullSuiteCommand: baseTestCommand,
+          repoRoot: input.repoRoot,
+          packagePrefix: input.packagePrefix,
+          resolvedTestPatterns: input.resolvedTestPatterns,
+        });
+      } catch (err) {
+        // Same observable outcome as when this threw per-mutant inside the
+        // loop — every selected mutant counts as errored — except now nothing
+        // was written to the worktree to get there.
+        outcomes.errored += selected.length;
+        logger.warn("mutation-check", "Scoped test selection failed — skipping mutation spot-check", {
+          storyId: input.storyId,
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      // An unconfirmed revert means the worktree is in a state this op did
-      // not author. Applying more mutations on top would compound it.
-      if (revertFailed) break;
+    }
+
+    let revertFailed = false;
+    // `scoped === undefined` means selection failed above; the outcome is
+    // already recorded and nothing may be written to the worktree.
+    if (scoped !== undefined) {
+      for (const mutant of selected) {
+        let outcome: MutantOutcome | undefined;
+        try {
+          // Journal BEFORE mutating: a crash in between must leave a record
+          // that names a mutation, never a mutation with no record.
+          await recordInFlight(journalRoot, { ...mutant, storyId: input.storyId });
+          await applyMutant(mutant);
+          try {
+            const result = await deps.regression({
+              workdir: input.workdir,
+              command: scoped.effectiveCommand,
+              timeoutSeconds: cfg.timeoutSeconds,
+            });
+            outcome = classifyMutant(result);
+            outcomes[outcome] += 1;
+            if (outcome === "survived") {
+              survivors.push({ ...mutant, outcome: "survived" });
+            }
+          } finally {
+            const reverted = await revertMutant(mutant);
+            if (reverted.reverted) {
+              await clearInFlight(journalRoot, input.storyId);
+            } else {
+              // The line no longer holds what we wrote, so restoring it would
+              // overwrite content we cannot account for. Leave the file alone,
+              // keep the journal for the next run, and stop mutating: whatever
+              // moved the file will keep moving it.
+              revertFailed = true;
+              logger.error("mutation-check", "Could not confirm revert — worktree may still hold a mutation", {
+                storyId: input.storyId,
+                file: mutant.file,
+                line: mutant.line,
+                operatorId: mutant.operatorId,
+                reason: reverted.reason,
+                expected: mutant.after,
+                actual: reverted.actual,
+              });
+            }
+          }
+        } catch (err) {
+          // Fail-open: any error mutating/testing/reverting a single mutant is
+          // never a gate failure — log and move on to the next mutant. A mutant
+          // whose outcome was already recorded (e.g. revert failed after a
+          // successful verification) is not re-counted as errored.
+          if (outcome === undefined) {
+            outcomes.errored += 1;
+          }
+          logger.warn("mutation-check", "Error processing mutant — skipping", {
+            storyId: input.storyId,
+            file: mutant.file,
+            line: mutant.line,
+            operatorId: mutant.operatorId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        // An unconfirmed revert means the worktree is in a state this op did
+        // not author. Applying more mutations on top would compound it.
+        if (revertFailed) break;
+      }
     }
 
     for (const s of survivors) {

--- a/src/verification/mutation/index.ts
+++ b/src/verification/mutation/index.ts
@@ -7,7 +7,14 @@ export { generateMutants } from "./mutator";
 export { getOperatorsForLanguage } from "./operators";
 export { applyMutant, revertMutant } from "./apply";
 export type { RevertResult } from "./apply";
-export { clearInFlight, journalDir, journalPathFor, recordInFlight, restoreInFlight } from "./journal";
+export {
+  clearInFlight,
+  journalDir,
+  journalPathFor,
+  mayHaveJournal,
+  recordInFlight,
+  restoreInFlight,
+} from "./journal";
 export type { JournalRestoreResult, MutationJournalEntry } from "./journal";
 export { classifyMutant } from "./classify";
 export { selectEvenlySpaced } from "./select";

--- a/src/verification/mutation/journal.ts
+++ b/src/verification/mutation/journal.ts
@@ -14,7 +14,8 @@
  * One file per story, so parallel stories never contend for the same journal.
  */
 
-import { join, resolve, sep } from "node:path";
+import { realpathSync } from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { revertMutant } from "./apply";
 import type { Mutant } from "./types";
 
@@ -48,6 +49,42 @@ function journalFileName(storyId: string): string {
 
 export function journalPathFor(repoRoot: string, storyId: string): string {
   return join(journalDir(repoRoot), journalFileName(storyId));
+}
+
+/**
+ * Cheap "is there anything to sweep?" probe for a set of candidate roots.
+ *
+ * The sweep must run before the mutation check's `enabled` gate, so that
+ * disabling the feature after an interrupted run cannot strand a mutation.
+ * Resolving the real anchor costs a `git rev-parse` subprocess, and the
+ * feature is off by default — so every nax user would pay a spawn per story
+ * for a feature they never turned on. A journal exists only in the window
+ * after a run died mid-mutation, so a directory check on the paths we already
+ * hold rules that out almost always, without spawning anything.
+ *
+ * Deliberately conservative: `true` means "maybe, go resolve the real anchor",
+ * never "definitely".
+ *
+ * KNOWN LIMIT: it probes only the paths given, not their ancestors, so it
+ * cannot see a journal at a git root that sits above both — the monorepo +
+ * worktree shape, where the root is the worktree and `workdir` is a package
+ * inside it. Callers must therefore use this ONLY to skip work when the
+ * feature is disabled, never to decide where to write. Missing a leftover
+ * there needs the feature to have been enabled, crashed, and then disabled,
+ * and the worktree holding it is removed on merge; paying a subprocess per
+ * story for every user who never enabled the feature is the certain cost.
+ */
+export async function mayHaveJournal(candidateRoots: ReadonlyArray<string | undefined>): Promise<boolean> {
+  const { stat } = await import("node:fs/promises");
+  for (const root of candidateRoots) {
+    if (!root) continue;
+    try {
+      if ((await stat(journalDir(root))).isDirectory()) return true;
+    } catch {
+      // Not present under this candidate — try the next.
+    }
+  }
+  return false;
 }
 
 /**
@@ -85,10 +122,35 @@ async function readEntry(path: string): Promise<MutationJournalEntry | null> {
   }
 }
 
-/** Is `filePath` inside `root`'s subtree? */
+/**
+ * Resolve symlinks so two spellings of the same location compare equal.
+ *
+ * `getGitRoot` returns git's realpath (`git rev-parse --show-toplevel` from
+ * `/tmp/repo` answers `/private/tmp/repo`), while a mutant's `file` is built
+ * from whichever path the caller supplied — often still the symlinked form.
+ * Comparing those unresolved makes every entry look foreign. Same
+ * normalisation `autoCommitIfDirty` performs for the same reason.
+ */
+function realOrRaw(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    // The path itself is gone — a journalled file deleted since the run died.
+    // Resolve the directory instead so a symlinked root still compares equal;
+    // only fall back to the lexical form when that fails too.
+    try {
+      return join(realpathSync(dirname(abs)), basename(abs));
+    } catch {
+      return abs;
+    }
+  }
+}
+
+/** Is `filePath` inside `root`'s subtree, symlinks resolved on both sides? */
 function isInside(root: string, filePath: string): boolean {
-  const base = resolve(root);
-  const target = resolve(filePath);
+  const base = realOrRaw(root);
+  const target = realOrRaw(filePath);
   return target === base || target.startsWith(`${base}${sep}`);
 }
 

--- a/test/unit/operations/mutation-check-revert.test.ts
+++ b/test/unit/operations/mutation-check-revert.test.ts
@@ -266,6 +266,59 @@ describe("mutationCheckOp — leftover mutations from an interrupted run", () =>
     }
   });
 
+  test("a monorepo workdir still journals into the worktree root, not the package dir", async () => {
+    // `workdir` is `join(worktreePath, story.workdir)` — the PACKAGE dir, not
+    // the worktree root. Anchoring through getGitRoot is what absorbs that:
+    // `git rev-parse --show-toplevel` from inside a linked worktree returns
+    // the worktree, whatever subdirectory it is run from. This stub mimics
+    // that containment rather than echoing its argument.
+    const projectRoot = makeTempDir("nax-mutation-mono-");
+    const worktree = join(projectRoot, ".nax-wt", "US-004");
+    const packageDir = join(worktree, "packages", "api");
+    try {
+      const file = join(packageDir, "src", "a.ts");
+      await Bun.write(file, "if (a == b) { return 1; }\n");
+
+      const seen: Array<{ atWorktree: boolean; atPackage: boolean; atProjectRoot: boolean }> = [];
+      const deps = fakeDeps({
+        getGitRoot: async (dir: string) => (dir.startsWith(worktree) ? worktree : projectRoot),
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 1 }]]]),
+        regression: async () => {
+          seen.push({
+            atWorktree: await Bun.file(journalPathFor(worktree, "US-004")).exists(),
+            atPackage: await Bun.file(journalPathFor(packageDir, "US-004")).exists(),
+            atProjectRoot: await Bun.file(journalPathFor(projectRoot, "US-004")).exists(),
+          });
+          return { status: "SUCCESS" as const, success: true, countsTowardEscalation: true, output: "" };
+        },
+      });
+
+      await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: packageDir,
+          storyId: "US-004",
+          storyGitRef: "abc",
+          repoRoot: projectRoot,
+          packagePrefix: "packages/api",
+          resolvedTestPatterns: PATTERNS,
+        } as any,
+        ctxWithConfig(ENABLED),
+        deps,
+      );
+
+      expect(seen.length).toBeGreaterThan(0);
+      for (const observation of seen) {
+        expect(observation.atWorktree).toBe(true);
+        expect(observation.atPackage).toBe(false);
+        expect(observation.atProjectRoot).toBe(false);
+      }
+    } finally {
+      cleanupTempDir(projectRoot);
+    }
+  });
+
   test("a sweep never reaches into a sibling worktree's journal", async () => {
     const projectRoot = makeTempDir("nax-mutation-siblings-");
     const worktreeA = join(projectRoot, ".nax-wt", "US-004");

--- a/test/unit/operations/mutation-check-revert.test.ts
+++ b/test/unit/operations/mutation-check-revert.test.ts
@@ -365,6 +365,30 @@ describe("mutationCheckOp — leftover mutations from an interrupted run", () =>
     }
   });
 
+  test("a disabled check with a clean tree spawns no git", async () => {
+    // The feature is off by default, so every nax user would otherwise pay a
+    // `git rev-parse` subprocess per story for a feature they never enabled.
+    const dir = makeTempDir("nax-mutation-nospawn-");
+    try {
+      let gitRootCalls = 0;
+      const out = await mutationCheckOp.execute(
+        runInput(dir),
+        ctxWithConfig({ mutationCheck: { enabled: false, maxMutants: 3, timeoutSeconds: 60 } }),
+        fakeDeps({
+          getGitRoot: async () => {
+            gitRootCalls += 1;
+            return dir;
+          },
+        }),
+      );
+
+      expect(out.checked).toBe(false);
+      expect(gitRootCalls).toBe(0);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
   test("the sweep still runs when the check is disabled", async () => {
     const dir = makeTempDir("nax-mutation-leftover-off-");
     try {

--- a/test/unit/operations/mutation-check-selection.test.ts
+++ b/test/unit/operations/mutation-check-selection.test.ts
@@ -290,4 +290,108 @@ describe("mutationCheckOp — US-002 AC14: empty selection returns all-zero outc
       cleanupTempDir(dir);
     }
   });
+
+  test("scoped test selection is resolved once per story, not once per mutant", async () => {
+    // Every argument comes from the op's input, none from the mutant, so this
+    // is loop-invariant — N mutants used to mean N git-diff + import-grep
+    // passes for an identical answer.
+    const dir = makeTempDir("nax-mutation-test-");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      await Bun.write(file, "if (a == b) { return 1; }\nif (c == d) { return 2; }\nif (e == f) { return 3; }\n");
+
+      let selectCalls = 0;
+      let regressionCalls = 0;
+      const deps = fakeDeps({
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 3 }]]]),
+        selectScopedTests: async () => {
+          selectCalls += 1;
+          return {
+            effectiveCommand: "bun test src/foo.test.ts",
+            isFullSuite: false,
+            thresholdFallback: false,
+            isMonorepoOrchestrator: false,
+          };
+        },
+        regression: async () => {
+          regressionCalls += 1;
+          return { status: "SUCCESS" as const, success: true, countsTowardEscalation: true, output: "" };
+        },
+      });
+
+      await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-004",
+          storyGitRef: "abc",
+          repoRoot: dir,
+          resolvedTestPatterns: {
+            globs: ["**/*.test.ts"],
+            regex: [/\.test\.ts$/],
+            pathspec: [":!*.test.ts"],
+            testDirs: ["test"],
+          },
+        },
+        ctxWithConfig({ mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } }),
+        deps,
+      );
+
+      expect(regressionCalls).toBeGreaterThan(1);
+      expect(selectCalls).toBe(1);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  test("a failed scoped selection errors every mutant without touching the worktree", async () => {
+    const dir = makeTempDir("nax-mutation-test-");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      const original = "if (a == b) { return 1; }\nif (c == d) { return 2; }\n";
+      await Bun.write(file, original);
+
+      let regressionCalls = 0;
+      const deps = fakeDeps({
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 2 }]]]),
+        selectScopedTests: async () => {
+          throw new Error("smart runner exploded");
+        },
+        regression: async () => {
+          regressionCalls += 1;
+          return { status: "SUCCESS" as const, success: true, countsTowardEscalation: true, output: "" };
+        },
+      });
+
+      const out = await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-004",
+          storyGitRef: "abc",
+          repoRoot: dir,
+          resolvedTestPatterns: {
+            globs: ["**/*.test.ts"],
+            regex: [/\.test\.ts$/],
+            pathspec: [":!*.test.ts"],
+            testDirs: ["test"],
+          },
+        },
+        ctxWithConfig({ mutationCheck: { enabled: true, maxMutants: 3, timeoutSeconds: 60 } }),
+        deps,
+      );
+
+      // Fail-open, and the same outcome shape as when this threw per-mutant
+      // inside the loop — except no mutation was ever written to disk.
+      expect(out.success).toBe(true);
+      expect(out.outcomes.errored).toBeGreaterThan(0);
+      expect(out.outcomes.killed + out.outcomes.survived).toBe(0);
+      expect(regressionCalls).toBe(0);
+      expect(await Bun.file(file).text()).toBe(original);
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
 });

--- a/test/unit/verification/mutation/journal.test.ts
+++ b/test/unit/verification/mutation/journal.test.ts
@@ -15,6 +15,7 @@ import {
   applyMutant,
   clearInFlight,
   journalPathFor,
+  mayHaveJournal,
   recordInFlight,
   restoreInFlight,
 } from "@/verification";
@@ -65,6 +66,18 @@ describe("mutation journal", () => {
 
     expect(await Bun.file(journalPathFor(repoRoot, "US-001")).exists()).toBe(false);
     expect(await Bun.file(journalPathFor(repoRoot, "US-002")).exists()).toBe(true);
+  });
+
+  test("mayHaveJournal reports nothing to sweep on a clean tree", async () => {
+    expect(await mayHaveJournal([repoRoot, undefined])).toBe(false);
+  });
+
+  test("mayHaveJournal finds a journal under any supplied candidate", async () => {
+    await recordInFlight(repoRoot, { ...mutant(), storyId: "US-001" });
+
+    expect(await mayHaveJournal([repoRoot])).toBe(true);
+    expect(await mayHaveJournal(["/definitely/not/here", repoRoot])).toBe(true);
+    expect(await mayHaveJournal([undefined, undefined])).toBe(false);
   });
 
   test("a story id with path separators cannot escape the journal directory", async () => {
@@ -188,6 +201,36 @@ describe("restoreInFlight — sweeping an interrupted run", () => {
     } finally {
       cleanupTempDir(otherTree);
     }
+  });
+
+  test("a symlinked root still matches its realpath — the sweep is not silently skipped", async () => {
+    // `getGitRoot` returns git's realpath (`rev-parse --show-toplevel` from
+    // /tmp/x answers /private/tmp/x), while a mutant's `file` is built from
+    // whatever path the caller supplied. Comparing them unresolved made every
+    // entry look foreign, so the sweep restored nothing and journals piled up.
+    const { symlinkSync } = await import("node:fs");
+    const linkRoot = join(repoRoot, "link-to-tree");
+    const realTree = join(repoRoot, "real-tree");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(realTree, { recursive: true });
+    symlinkSync(realTree, linkRoot);
+
+    const file = join(realTree, "src.ts");
+    await Bun.write(file, original);
+    // Journal anchored at the REAL path, entry naming the SYMLINK path.
+    await recordInFlight(realTree, {
+      ...mutant(),
+      file: join(linkRoot, "src.ts"),
+      storyId: "US-001",
+    });
+    await applyMutant({ ...mutant(), file: join(linkRoot, "src.ts") });
+    expect(await Bun.file(file).text()).not.toBe(original);
+
+    const results = await restoreInFlight(realTree);
+
+    expect(results.map((r) => r.outcome)).toEqual(["restored"]);
+    expect(await Bun.file(file).text()).toBe(original);
+    expect(await Bun.file(journalPathFor(realTree, "US-001")).exists()).toBe(false);
   });
 
   test("no journal directory yields no work", async () => {


### PR DESCRIPTION
## What

Three things, in descending order of importance:

1. **A HIGH correctness fix to the merged #1489** — a symlinked project path silently disabled mutation crash-recovery entirely. Details and the reproduction are in [this comment](https://github.com/nathapp-io/nax/pull/1490#issuecomment-5204869336); the fix is commit `77f9e016`.
2. **Closes G8** of the mutation-check gap analysis — `selectScopedTests` was resolved once per mutant instead of once per story.
3. **Adds the monorepo worktree test owed from #1489**, plus a MEDIUM fix removing a `git rev-parse` subprocess per story for a feature that is off by default.

The PR started as (2) and (3); (1) came out of a self-review afterwards, which is why the branch name still reads `hoist-scoped-selection`.

## Why

**G8.** `selectScopedTests` was called inside the mutant loop, but every argument comes from the op's input — `workdir`, `storyId`, `storyGitRef`, the test commands, `repoRoot`, `packagePrefix`, `resolvedTestPatterns` — and none from the mutant. All N calls computed the same answer. Each one does two git diffs plus source-to-test mapping plus an import grep, so at the default `maxMutants: 3` that is three passes where one suffices.

**The owed test.** #1489 anchored the mutation journal to `getGitRoot(workdir)`. That is correct, but for a reason the shipped test did not exercise: `workdir` is `join(worktreePath, story.workdir)` — the *package* directory, not the worktree root (`parallel-worker.ts:72`). It lands right only because `git rev-parse --show-toplevel` returns the worktree for any path inside it, absorbing the package nesting. The test I shipped stubbed `getGitRoot` as an echo of its argument *and* passed a workdir that was already the worktree root, so it proved nothing about the monorepo shape.

## How

**G8** — the selection is resolved once, before the loop, and behaviour is preserved in both directions that matter:

- It stays behind the emptiness guard. An existing test asserts `selectCalls === 0` when no mutants are selected, and "no mutants selected" must keep meaning "no test selection performed".
- A selection that throws now counts every selected mutant as `errored` — the same observable outcome as when the call threw per-mutant inside the loop — except no mutation is written to the worktree on the way there. Strictly better: the old path applied a mutant, threw, and relied on the `finally` to undo it, once per mutant.

**The test** uses a package-joined `workdir` (`<worktree>/packages/api`) and a `getGitRoot` stub that mimics real containment (any path under the worktree maps to the worktree) rather than echoing its input. It asserts the journal appears at the worktree root and at neither the package dir nor the shared project root, observed from inside the `regression` dep — the only moment a mutant is applied and the journal is on disk.

## Testing

- [x] Tests added/updated — 3 new tests
- [x] `bun run test` passes (11852 unit + 1092 integration + 24 ui, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes

Both new assertions were **checked red against the code they describe**: the G8 test fails with the selection put back inside the loop, and the monorepo test fails with the anchor at raw `workdir`. The third test (failed selection errors every mutant without touching the worktree) pins the new error path.

## Notes

Not done here, deliberately: **G13** (mutant dedupe/equivalence) is near-pointless at `maxMutants: 3` with even spacing across distinct lines, and equivalent-mutant detection is a research problem rather than a gap item. **G14** is half not-a-defect — mutants share one working tree, so serial execution is required, not a shortcoming; parallelising would need a worktree per mutant and cost more than the three minutes it saves. The real part of G14 is the missing run-level time budget, which is worth building only once G12 has field data showing the check actually consumes meaningful wall clock. Optimising before that is guesswork.

