### PR TITLE
fix: code review — mutation spot-check, rules budget, diff parsing

### DIFF
--- a/docs/reviews/2026-08-06-code-review-mutation-and-rules.md
+++ b/docs/reviews/2026-08-06-code-review-mutation-and-rules.md
@@ -60,11 +60,17 @@ The feature being advisory justifies not *failing* the story. It does not justif
 injected mutation into a commit.
 
 **Fix applied.** `NaxRuntime` gained a `dirtyWorktrees: Set<string>` register. `mutationCheckOp`
-adds the worktree path when a revert cannot be confirmed, and `autoCommitIfDirty` takes an optional
-`blockedWorktrees` set and refuses to stage when the git root it would `git add -A` from overlaps
-one, logging an error that points at the mutation-check log. The three story-path call sites
-(`review/runner.ts`, `execution/post-run.ts`, `execution/runner-completion.ts`) pass
-`runtime.dirtyWorktrees`.
+adds the working-tree **root** (its already-resolved `journalRoot`) when a revert cannot be
+confirmed, and `autoCommitIfDirty` takes an optional `blockedWorktrees` set and refuses to stage
+when the root it would `git add -A` from *is* a blocked one, logging an error that points at the
+mutation-check log. The three story-path call sites (`review/runner.ts`, `execution/post-run.ts`,
+`execution/runner-completion.ts`) pass `runtime.dirtyWorktrees`.
+
+Roots compared by **equality**, not containment — a self-review correction. In parallel mode each
+story's worktree is a linked tree at `<repo>/.nax-wt/<storyId>`: inside the main repo by path, but a
+separate checkout that `git add -A` from the main root never stages. A containment test blocked the
+run-summary commit whenever any story's worktree was dirty. Comparing roots also still catches the
+monorepo case, since `git rev-parse --show-toplevel` from a package answers with the repo root.
 
 Two call sites were deliberately handled differently:
 

--- a/docs/reviews/2026-08-06-code-review-mutation-and-rules.md
+++ b/docs/reviews/2026-08-06-code-review-mutation-and-rules.md
@@ -1,0 +1,227 @@
+# Code Review — mutation spot-check, context-engine v2 rules, spec→PRD fidelity
+
+**Date:** 2026-08-06
+**Range reviewed:** `e7721ea5afad2a6b4a62c084ccf0afa27520d468..7a894aca` (30 commits, 301 files, ~38k insertions)
+**Baseline at review time:** `bun run typecheck` exit 0, `bun run lint` exit 0.
+
+**Method:** manual read of the highest-churn source paths in the range, plus a runtime probe to
+confirm finding 3. Coverage was concentrated on three subsystems, which together account for most
+of the new source in the range:
+
+| Subsystem | Entry points |
+|:---|:---|
+| Mutation spot-check | `src/verification/mutation/*`, `src/verification/changed-line-ranges.ts`, `src/operations/mutation-check.ts` |
+| Context-engine v2 rules | `src/context/rules/*`, `src/context/engine/providers/static-rules.ts`, `src/cli/rules.ts`, `src/cli/rules-lint.ts` |
+| Spec→PRD fidelity | `src/prd/markdown-scan.ts`, `src/prd/{modifies,out-of-scope,context-files}-extract.ts`, `src/operations/plan-fidelity.ts` |
+
+Not re-reviewed in depth: the `nax-finish` PR-body work, `src/metrics/tracker.ts`, and the
+`src/context/engine/manifest-*` type split — these read as mechanical and are well covered by the
+new tests in the range.
+
+---
+
+## Severity summary
+
+| # | Finding | Severity | Status |
+|:--|:--------|:--------:|:------:|
+| 1 | An unreverted mutant reaches a commit | **HIGH** | Fixed |
+| 2 | `mutation-check` compares symlinked against realpath'd paths | **MEDIUM** | Fixed |
+| 3 | `applySectionBudget` interleaves and shreds rules | **MEDIUM** | Fixed |
+| 4 | `splitRuleIntoSections` splits on `## ` inside fenced code blocks | **LOW** (latent) | Fixed |
+| 5a | Mutants generated inside string literals and inline comments | **LOW** | Fixed |
+| 5b | `#558` early return omits `scopingReport` | **LOW** | Fixed |
+| 5c | Scope-filtered-to-empty reported as a budget failure | **LOW** | Fixed |
+| 5d | Two token estimators over the same rule content | **LOW** | Fixed |
+| 5e | `isSafeRelativePath` rejects paths merely *containing* `..` | **LOW** | Fixed |
+| 5f | Diff parser assumes `diff.noprefix=false` | **LOW** | Fixed |
+
+---
+
+## 1. An unreverted mutant reaches a commit — HIGH
+
+`src/operations/mutation-check.ts` correctly refuses to overwrite a line whose content it cannot
+account for, and records `revertFailed`. But the op returns `success: true` on every path, and the
+only consumer of the flag was a printed block at run end (`src/log-format/mutation-summary.ts`).
+
+Meanwhile `autoCommitIfDirty` runs *after* the verify stage at three sites:
+
+- `src/review/runner.ts` (post-review)
+- `src/execution/post-run.ts` (post-execution)
+- `src/execution/runner-completion.ts` (run summary)
+
+So the failure path was: mutation applied → revert unconfirmed → story continues → deliberately
+broken source is committed to the story branch, and with `autoPR` enabled, pushed.
+
+The crash-durable journal does not cover this case. It is swept only at the start of the *next*
+mutation-check in the same working tree, and in parallel mode each story's worktree is removed on
+merge (`src/execution/parallel-batch.ts`), taking the journal with it.
+
+The feature being advisory justifies not *failing* the story. It does not justify letting an
+injected mutation into a commit.
+
+**Fix applied.** `NaxRuntime` gained a `dirtyWorktrees: Set<string>` register. `mutationCheckOp`
+adds the worktree path when a revert cannot be confirmed, and `autoCommitIfDirty` takes an optional
+`blockedWorktrees` set and refuses to stage when the git root it would `git add -A` from overlaps
+one, logging an error that points at the mutation-check log. The three story-path call sites
+(`review/runner.ts`, `execution/post-run.ts`, `execution/runner-completion.ts`) pass
+`runtime.dirtyWorktrees`.
+
+Two call sites were deliberately handled differently:
+
+- `pipeline/stages/acceptance-setup.ts` commits **pre-run**, before any story's `storyGitRef` is
+  captured, so it cannot run after a mutation. Left unwired.
+- `tdd/rollback.ts` `captureSnapshotRef` is reachable after the verify stage, and it commits as its
+  *first* act — which would both capture the defect and leave the tree clean, so every later guard
+  would see nothing to block. Rather than block the commit there, `runNonBlockingFix` now skips the
+  whole best-effort pass when its workdir is blocked, degrading to "nbf did not run" exactly as the
+  existing snapshot-failure path does. The check sits before the snapshot for that reason.
+
+A `git checkout -- <file>` style restore was rejected: the mutated file also holds the story's
+legitimate implementation, so discarding it would destroy real work to undo one line.
+
+## 2. `mutation-check` compares symlinked against realpath'd paths — MEDIUM
+
+`getGitRoot` returns git's realpath — `git rev-parse --show-toplevel` run from `/tmp/repo` answers
+`/private/tmp/repo` (`src/utils/git.ts`). `src/verification/mutation/journal.ts` documents this
+hazard at length and normalizes for it via `realOrRaw`/`isInside`. `mutation-check.ts` did not:
+
+- `anchor` was `input.repoRoot` (caller-supplied, unresolved) in the `packagePrefix && repoRoot`
+  branch, and `getGitRoot(workdir)` (resolved) otherwise.
+- `rangeMap` keys are always resolved (`src/verification/changed-line-ranges.ts`).
+- `scopeRoot` was always `input.repoRoot ?? input.workdir` — unresolved.
+
+Two distinct failures followed. In the `packagePrefix && repoRoot` branch, unresolved candidate
+paths never matched resolved range-map keys, so every file landed in `unmappedFiles` and the check
+produced zero candidates. In the other branch the mismatch is worse: `anchor` is resolved but
+`scopeRoot` is not, so the containment filter dropped *every* file, leaving
+`absoluteChangedFiles` empty — which also skips the zero-candidate warning, since that warning is
+guarded on `absoluteChangedFiles.length > 0`. The result was a silent no-op with no diagnostic.
+
+On macOS, where `/tmp` is a symlink to `/private/tmp` and worktrees are created under temp
+directories, this is the common case rather than an edge case.
+
+**Fix applied.** The symlink normalisation in `journal.ts` was promoted to a shared helper
+(`src/utils/realpath.ts`) and both modules now use it. `mutation-check` carries each candidate as a
+`{ path, resolved }` pair: `resolved` is used for the containment filter and the range-map lookup
+(whose keys are re-keyed through the same normaliser), while `path` keeps the caller's spelling and
+is what gets read, mutated, journalled, and reported — so a survivor still names the path the
+operator recognises rather than an unfamiliar `/private/...` twin.
+
+`realOrRaw` also had to be strengthened while promoting it. The original resolved only the
+immediate parent when a path did not exist, which leaves several segments unresolved for a file
+under a directory that was never created — and a half-resolved path compares unequal to a
+fully-resolved root, reintroducing the same false-negative containment. It now walks up to the
+nearest existing ancestor and re-attaches the remainder.
+
+## 3. `applySectionBudget` interleaves and shreds rules — MEDIUM
+
+`src/context/rules/rule-budget.ts` sorted by `(priority, ordinal)` with no rule-identity
+tiebreaker. Because `priority` defaults to 100 for every rule, sections from different files
+interleaved by ordinal. Confirmed with a runtime probe against the real code:
+
+```
+input   : alpha#preamble | alpha#a | alpha#b | alpha#c | beta#preamble | beta#a | beta#b | beta#c
+retained: alpha#preamble | beta#preamble | alpha#a | beta#a | alpha#b
+dropped : beta#b | alpha#c | beta#c
+```
+
+This contradicts the module's own stated contract. Its header says "ascending by `ordinal` **within
+a rule**" and "the boundary file contributes its leading sections instead of being dropped whole" —
+but there is no boundary file. Every rule is truncated at the same ordinal, and `alpha` keeps a
+section that `beta` loses at the same position.
+
+Under `enforceBudget: true` (the schema default; note `StaticRulesProvider`'s constructor fallback
+is deliberately `false`) this interleaved, shredded ordering is what ships to the agent.
+
+**Fix applied.** A rule-identity tiebreaker now sits between `priority` and `ordinal`, so sections
+sort priority-major, then rule-major, then ordinal — making the retained set a contiguous prefix
+per rule and restoring the single-boundary-file property the docstring describes.
+
+## 4. `splitRuleIntoSections` splits on `## ` inside fenced code blocks — LOW (latent)
+
+`src/context/rules/rule-sections.ts` tested `/^## /` line-by-line with no fence tracking. A rule
+file that documents markdown by example would be split mid-fence, and budget truncation could
+deliver a section with an unclosed fence.
+
+This is exactly the hazard `src/prd/markdown-scan.ts` devotes several paragraphs to as "not a
+detail" for the sibling spec parser — and its `fencedLineIndices` helper was already available.
+
+No rule file currently in `.nax/rules/` triggers it (scanned), so the finding is latent rather
+than active.
+
+**Fix applied.** `fencedLineIndices` was moved to a shared, dependency-free helper
+(`src/utils/markdown-fence.ts`) — `src/prd/markdown-scan.ts` re-exports it for its existing
+consumers — and `splitRuleIntoSections` now consults it, ignoring H2 candidates inside a fence.
+A shared util rather than a cross-subsystem import: `src/context/rules` reaching into the `src/prd`
+barrel for one pure markdown primitive is the wrong dependency direction.
+
+## 5. Smaller items
+
+**5a — mutants inside strings and inline comments.** `src/verification/mutation/mutator.ts` skipped
+only whole-line comments. Flipping `==` inside a regex literal, a string, or a trailing `// ...`
+comment produces a mutant that is either always-killed or meaningless, wasting scarce `maxMutants`
+slots. *Fixed:* operators now see only the line's leading **code region** — everything before the
+first string delimiter or comment marker — and the remainder is carried through verbatim so
+`before`/`after` still span the whole line for apply/revert. A prefix rather than a full segment map
+is deliberate: mutating each code segment between literals would require aligning an operator's
+variants across segments, and `MutationOperator.apply` returns bare strings with no variant identity
+to align on. The cost is losing code that follows a literal on the same line; for a check that
+samples a handful of sites, fewer-and-sound beats more-and-noisy.
+
+**5b — `#558` early return omits `scopingReport`.** `static-rules.ts` returns early when canonical
+rules exist but none apply to the package context, without the scoping report the rest of the path
+populates — making that case invisible to manifest telemetry. *Fixed:* the report is now built and
+returned on that path.
+
+**5c — misleading budget warning.** When `scopedRules` is emptied by `stages:`/`appliesTo:`
+filtering rather than by the budget, the warning still read "No rule sections fit in static rules
+budget" — misleading for exactly the diagnostic a user would reach for. *Fixed:* the two causes are
+now distinguished.
+
+**5d — two token estimators.** `static-rules.ts` defined a local `estimateTokens` (`len/4`) while
+`rule-sections.ts` uses `estimateTokens` from `@/optimizer` for the budget — two estimators over
+the same content. *Fixed:* collapsed onto the `@/optimizer` one.
+
+**5e — `isSafeRelativePath` over-rejects.** `src/prd/modifies.ts` rejected any path *containing*
+`..`, so a legitimate `src/foo..bar.ts` was dropped. Safe direction, but wrong. *Fixed:* the check
+is now segment-wise (`..` as a whole path segment), which still rejects every traversal.
+
+**5f — diff parser assumes `diff.noprefix=false`.** `src/utils/diff-files.ts` parses `+++ b/` only.
+With `diff.noprefix=true` in a user's git config every hunk is discarded and the mutation check
+degrades to zero ranges — fail-open, but silent. *Fixed:* the parser accepts the unprefixed form,
+gated on the header pairing. An ADDED line whose content begins `++ ` renders as `+++ ...` inside a
+hunk and is indistinguishable from an unprefixed header on its own, so the unprefixed form is only
+honoured immediately after a `---` line — which unified diff always emits. The `b/` form keeps its
+existing unconditional handling.
+
+---
+
+## Not findings
+
+Reviewed and found correct:
+
+- `resolveStoryPathAnchors` (`src/execution/build-plan-for-strategy.ts`) — handles both input
+  shapes and the trailing-separator case correctly.
+- The effort-suffix strip in `src/agents/cost/calculate.ts` (`#1464`).
+- `flipWithPairs` longest-first alternation (`#1487`) — the `!==` → `!!=` fix is sound, and the
+  shared-`lastIndex` hazard on `COMPARISON_GT`/`COMPARISON_LT` is handled.
+- `selectRegressedGateFindings` and the carve-out change in `rectification.ts` (`#1452`).
+
+---
+
+## Verification
+
+All fixes carry regression tests that fail against the pre-fix code:
+
+| Fix | Tests |
+|:---|:---|
+| 1 | `test/unit/utils/git-auto-commit-block.test.ts` (new), `test/unit/operations/mutation-check-revert.test.ts`, `test/unit/execution/non-blocking-fix.test.ts` |
+| 2 | `test/unit/utils/realpath.test.ts` (new) |
+| 3 | `test/unit/context/rules/rule-budget.test.ts` |
+| 4 | `test/unit/context/rules/rule-sections.test.ts` |
+| 5a | `test/unit/verification/mutation/mutator.test.ts` |
+| 5b, 5c | `test/unit/context/engine/providers/static-rules-scoping.test.ts` |
+| 5e | `test/unit/prd/modifies.test.ts` |
+| 5f | `test/unit/utils/diff-files.test.ts` |
+
+`bun run lint`, `bun run typecheck`, and `bun run test` all pass.

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -20,6 +20,10 @@ import type { SectionBudgetResult } from "@/context";
 import { splitRuleIntoSections } from "@/context";
 import type { RuleSection } from "@/context";
 import { getLogger } from "@/logger";
+// Same estimator the section budget uses (via `rule-sections`). A second local
+// `length / 4` here would let a chunk's reported token count disagree with the
+// number the budget admitted it on.
+import { estimateTokens } from "@/optimizer";
 import { errorMessage } from "@/utils/errors";
 import { DEFAULT_CANONICAL_RULES_BUDGET_TOKENS, loadCanonicalRules } from "../../rules/canonical-loader";
 import type { CanonicalRule } from "../../rules/canonical-loader";
@@ -93,10 +97,6 @@ export interface StaticRulesProviderOptions {
 
 function contentHash8(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 8);
-}
-
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 function canonicalRuleId(rule: CanonicalRule): string {
@@ -298,7 +298,21 @@ export class StaticRulesProvider implements IContextProvider {
           repoRoot: request.repoRoot,
           packageDir: request.packageDir,
         });
-        return { chunks: [], pullTools: [] };
+        // Report the shape of the drop rather than returning bare. Every other
+        // exit from this provider carries a scopingReport, so omitting it here
+        // made "rules existed but the package filter rejected all of them" the
+        // one scoping outcome invisible to manifest telemetry.
+        return {
+          chunks: [],
+          pullTools: [],
+          scopingReport: {
+            stageFilteredIds: [],
+            appliesToFilteredIds: [],
+            appliesToInertCount: 0,
+            scopeFileCount: request.scopeFiles?.length ?? 0,
+            sectionCount: 0,
+          },
+        };
       }
 
       if (mergedRules.length > 0) {
@@ -382,11 +396,25 @@ export class StaticRulesProvider implements IContextProvider {
 
         const effectiveSections = this.enforceBudget ? budgetResult.retainedSections : allSections;
         if (effectiveSections.length === 0) {
-          logger.warn("static-rules", "No rule sections fit in static rules budget", {
-            storyId: request.storyId,
-            budgetTokens: effectiveBudget,
-            totalScopedSections: allSections.length,
-          });
+          // Two different causes reach zero sections, and conflating them sends
+          // an operator to tune a budget that was never the problem: either the
+          // stage / appliesTo filters rejected every rule, or sections existed
+          // and none fit. `allSections.length` tells them apart.
+          if (allSections.length === 0) {
+            logger.warn("static-rules", "Every canonical rule was filtered out by stage/appliesTo scoping", {
+              storyId: request.storyId,
+              stageFilteredCount: stageFilteredIds.length,
+              appliesToFilteredCount: appliesToFilteredIds.length,
+              stage: request.stage,
+              scopeFileCount: request.scopeFiles?.length ?? 0,
+            });
+          } else {
+            logger.warn("static-rules", "No rule sections fit in static rules budget", {
+              storyId: request.storyId,
+              budgetTokens: effectiveBudget,
+              totalScopedSections: allSections.length,
+            });
+          }
           const emptyPressure = buildSectionBudgetPressure(allSections, budgetResult);
           return {
             chunks: [],

--- a/src/context/rules/rule-budget.ts
+++ b/src/context/rules/rule-budget.ts
@@ -7,8 +7,15 @@
  * make possible: the boundary file contributes its leading sections instead
  * of being dropped whole.
  *
- * Sorting: ascending by `priority` (lower number = more important), then
- * ascending by `ordinal` within a rule.
+ * Sorting: ascending by `priority` (lower number = more important), then by
+ * owning rule, then ascending by `ordinal` within that rule.
+ *
+ * The rule tiebreaker is load-bearing, not cosmetic. Without it, equal-priority
+ * sections from different files sort ordinal-major and interleave — and since
+ * `priority` defaults to `FRONTMATTER_PRIORITY_DEFAULT` for every rule that does
+ * not declare one, that is the normal case, not an edge case. Truncation then
+ * cuts every rule at the same ordinal instead of dropping one boundary file's
+ * tail, so each rule arrives shredded and no rule is contiguous.
  *
  * Truncation: longest leading run whose cumulative tokens fit inside
  * `budgetTokens`. The first section is admitted whole even if it exceeds the
@@ -43,6 +50,16 @@ export interface SectionBudgetResult {
    * treating the budget as a usable cap.
    */
   overageTokens: number;
+}
+
+/**
+ * Identity of the rule a section belongs to, for the sort tiebreaker.
+ *
+ * Matches the key `StaticRulesProvider` sorts its rules by, so the section
+ * order this module produces agrees with the rule order the provider computed.
+ */
+function ownerIdentifier(section: RuleSection): string {
+  return section.ruleId ?? section.rulePath ?? "";
 }
 
 function sectionIdentifier(section: RuleSection): string {
@@ -80,6 +97,7 @@ export function applySectionBudget(sections: RuleSection[], budgetTokens: number
   const sorted = [...sections].sort(
     (a, b) =>
       (a.priority ?? FRONTMATTER_PRIORITY_DEFAULT) - (b.priority ?? FRONTMATTER_PRIORITY_DEFAULT) ||
+      ownerIdentifier(a).localeCompare(ownerIdentifier(b)) ||
       a.ordinal - b.ordinal,
   );
 

--- a/src/context/rules/rule-sections.ts
+++ b/src/context/rules/rule-sections.ts
@@ -19,6 +19,7 @@
  */
 
 import { estimateTokens } from "@/optimizer";
+import { fencedLineIndices } from "@/utils/markdown-fence";
 import type { CanonicalRule } from "./rules-frontmatter";
 
 export interface RuleSection {
@@ -101,8 +102,14 @@ export function splitRuleIntoSections(rule: CanonicalRule): RuleSection[] {
   const content = rule.content;
   const lines = content.split("\n");
 
+  // A `## ` line inside a fenced code block is an EXAMPLE, not a boundary. Rule
+  // files that document markdown by example contain them, and splitting there
+  // cuts a section in the middle of a fence — so a retained section can open a
+  // fence it never closes, and budget truncation can drop the closing half.
+  const fenced = fencedLineIndices(lines);
   const h2Indices: number[] = [];
   for (let i = 0; i < lines.length; i++) {
+    if (fenced.has(i)) continue;
     const line = lines[i] ?? "";
     if (H2_LINE_PATTERN.test(line)) {
       h2Indices.push(i);

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -218,9 +218,18 @@ export function createMeasureSourceDiff(args: CreateMeasureSourceDiffArgs): NonB
  * exhaustion. Never throws into the caller's verdict path: failure ⇒ restore ⇒
  * the story keeps its adversarial-passed state.
  */
-/** Is `workdir` inside a blocked tree, or a blocked tree inside it? */
+/**
+ * Is `workdir` the blocked working tree, or a package inside one?
+ *
+ * One-directional on purpose. `blockedWorktrees` holds working-tree ROOTS, and
+ * `isInside` already treats the root itself as inside, so this covers both the
+ * root and any package under it. The reverse test (a blocked root inside
+ * `workdir`) would fire when `workdir` is the main repo and some story's linked
+ * worktree at `<repo>/.nax-wt/<storyId>` is blocked — a separate checkout whose
+ * state says nothing about this one.
+ */
 function isBlocked(blocked: ReadonlySet<string>, workdir: string): boolean {
-  return [...blocked].some((tree) => isInside(tree, workdir) || isInside(workdir, tree));
+  return [...blocked].some((tree) => isInside(tree, workdir));
 }
 
 export async function runNonBlockingFix(

--- a/src/execution/non-blocking-fix.ts
+++ b/src/execution/non-blocking-fix.ts
@@ -19,6 +19,7 @@ import { captureSnapshotRef, rollbackToRef } from "../tdd/rollback";
 import { createTestFileClassifier, resolveTestFilePatterns } from "../test-runners";
 import { typedSpawn } from "../utils/bun-deps";
 import { packageDirRelative } from "../utils/paths";
+import { isInside } from "../utils/realpath";
 import type { QuarantineMemo } from "../verification";
 import type { GateRegressionDetail, PhaseKind } from "./story-orchestrator";
 import { type NbfFlakeTriageTransaction, createNbfFlakeTriageTransaction } from "./story-orchestrator/nbf-flake-triage";
@@ -128,6 +129,15 @@ export interface NonBlockingFixArgs {
   quarantineMemo?: QuarantineMemo;
   /** Verifier-time failures excluded from NBF first-observation probing. */
   gateBaselineKeys?: ReadonlySet<string>;
+  /**
+   * Working trees holding source this run cannot account for — currently an
+   * unreverted mutation from the mutation spot-check (`runtime.dirtyWorktrees`).
+   *
+   * NBF's very first act is a snapshot COMMIT, which would capture the injected
+   * defect and, worse, leave the tree clean so every later `autoCommitIfDirty`
+   * guard sees nothing to block. Skipping the pass is the only safe response.
+   */
+  blockedWorktrees?: ReadonlySet<string>;
   /** Runs the harness; returns true when it exhausted without resolving. */
   runRectify: (
     maxAttempts: number,
@@ -208,6 +218,11 @@ export function createMeasureSourceDiff(args: CreateMeasureSourceDiffArgs): NonB
  * exhaustion. Never throws into the caller's verdict path: failure ⇒ restore ⇒
  * the story keeps its adversarial-passed state.
  */
+/** Is `workdir` inside a blocked tree, or a blocked tree inside it? */
+function isBlocked(blocked: ReadonlySet<string>, workdir: string): boolean {
+  return [...blocked].some((tree) => isInside(tree, workdir) || isInside(workdir, tree));
+}
+
 export async function runNonBlockingFix(
   args: NonBlockingFixArgs,
   overrides: Partial<NonBlockingFixDeps> = {},
@@ -215,6 +230,16 @@ export async function runNonBlockingFix(
   const _deps: NonBlockingFixDeps = { ...DEFAULT_DEPS, ...overrides };
   const logger = getSafeLogger();
   if (!shouldRunNonBlockingFix(args.cfg, args.advisoryFindings.length)) {
+    return { ran: false, kept: false, restored: false };
+  }
+  // Checked before the snapshot, not after: the snapshot is itself a commit, so
+  // by the time it has run the mutation is already captured and the tree is
+  // clean. Degrades to "nbf did not run", matching the snapshot-failure path.
+  if (args.blockedWorktrees?.size && isBlocked(args.blockedWorktrees, args.workdir)) {
+    logger?.warn("non-blocking-fix", "skipping best-effort pass — worktree may hold an unreverted mutation", {
+      storyId: args.storyId,
+      workdir: args.workdir,
+    });
     return { ran: false, kept: false, restored: false };
   }
   // Shallow copy is sufficient: phase outputs are replaced wholesale by each stage,

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -586,7 +586,8 @@ export async function decideStageAction(
 
   // Non-TDD success → auto-commit
   if (!isTdd) {
-    await _postRunDeps.autoCommitIfDirty(ctx.workdir, "execution", "single-session", ctx.story.id);
+    const { workdir, story, runtime } = ctx;
+    await _postRunDeps.autoCommitIfDirty(workdir, "execution", "single-session", story.id, runtime?.dirtyWorktrees);
   }
 
   logger.info("execution", "Agent session complete", {

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -373,7 +373,13 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
 
   // Commit status.json and any other nax runtime files left dirty at run end
   logger?.debug("execution", "Completion phase — auto-committing dirty files");
-  await autoCommitIfDirty(options.workdir, "run.complete", "run-summary", options.feature);
+  await autoCommitIfDirty(
+    options.workdir,
+    "run.complete",
+    "run-summary",
+    options.feature,
+    options.runtime?.dirtyWorktrees,
+  );
 
   // Close the NaxRuntime — flushes auditors, drains cost aggregator, aborts signal
   await options.runtime?.close();

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -336,6 +336,7 @@ export class ExecutionPlan {
           phaseCosts,
           quarantineMemo: this.ctx.runtime.quarantineMemo,
           gateBaselineKeys: preRectGateFailureKeys,
+          blockedWorktrees: this.ctx.runtime.dirtyWorktrees,
           runRectify: (maxAttempts, nbfFlakeTriage) =>
             runRectification(this.ctx, this.state, phaseCosts, phaseOutputs, {
               initialFindings: advisoryFindings,

--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -363,7 +363,14 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
               // advisory — the story is not failed — but the tree now holds a
               // line this op did not author, and `autoCommitIfDirty` would
               // otherwise sweep it into a commit (and, under autoPR, a push).
-              ctx.runtime?.dirtyWorktrees?.add(input.workdir);
+              //
+              // Register the working-tree ROOT (`journalRoot`, already resolved
+              // via `getGitRoot`), not `input.workdir`. Consumers compare roots
+              // for equality: in parallel mode a story's worktree is a LINKED
+              // tree at `<repo>/.nax-wt/<storyId>`, so a path-containment test
+              // against the main repo would block the run-summary commit for
+              // every story whose worktree was dirty.
+              ctx.runtime?.dirtyWorktrees?.add(journalRoot);
               logger.error("mutation-check", "Could not confirm revert — worktree may still hold a mutation", {
                 storyId: input.storyId,
                 file: mutant.file,

--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -12,7 +12,7 @@
  * DI collaborators (mirrors _verifyScopedDeps) so unit tests need no real git/test run.
  */
 
-import { isAbsolute, join, sep } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { mutationCheckConfigSelector, qualityConfigSelector } from "../config";
 import type { MutationCheckConfig } from "../config/selectors";
 import { getLogger } from "../logger";
@@ -23,6 +23,7 @@ import type { ResolvedTestPatterns } from "../test-runners";
 import { selectScopedTests } from "../test-runners/scoped-selection";
 import type { SelectScopedTestsInput, SelectScopedTestsResult } from "../test-runners/scoped-selection";
 import { getGitRoot } from "../utils/git";
+import { isInside, realOrRaw } from "../utils/realpath";
 import { getChangedLineRanges } from "../verification/changed-line-ranges";
 import {
   applyMutant,
@@ -216,11 +217,33 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
     // constrain candidates to the project scope so mutation testing never
     // reads/writes source outside it.
     const scopeRoot = input.repoRoot ?? input.workdir;
+    // Comparisons resolve symlinks; reporting does not. `getGitRoot` answers
+    // with git's realpath while `repoRoot` / `workdir` keep the caller's
+    // spelling, and `getChangedLineRanges` anchors on the resolved form — so on
+    // macOS (`/tmp` -> `/private/tmp`) the two never matched. Depending on which
+    // branch `anchor` took, that either sent every file to `unmappedFiles` or,
+    // worse, made the containment filter reject all of them and skip the
+    // zero-candidate warning with it (#1485).
+    //
+    // `resolved` is the lookup/containment key only. `path` stays as the caller
+    // spelled it and is what gets read, mutated, journalled, and reported, so a
+    // survivor still names the path the operator recognises rather than an
+    // unfamiliar `/private/...` twin.
     const absoluteChangedFiles = changedFiles
-      .map((f) => (isAbsolute(f) ? f : join(anchor, f)))
-      .filter((f) => f === scopeRoot || f.startsWith(`${scopeRoot}${sep}`));
+      .map((f) => {
+        const path = isAbsolute(f) ? f : join(anchor, f);
+        return { path, resolved: realOrRaw(path) };
+      })
+      .filter(({ resolved }) => isInside(scopeRoot, resolved));
 
-    const rangeMap = await deps.getChangedLineRanges(input.workdir, input.storyGitRef);
+    const rawRangeMap = await deps.getChangedLineRanges(input.workdir, input.storyGitRef);
+    // Re-key through the SAME normaliser the candidate keys went through.
+    // `getChangedLineRanges` anchors on `getGitRoot` (already git's realpath)
+    // but falls back to a raw `workdir` when that lookup fails, so its keys are
+    // only conditionally resolved — normalising here makes both sides of the
+    // lookup below unconditionally comparable.
+    const rangeMap =
+      rawRangeMap === null ? null : new Map([...rawRangeMap].map(([path, value]) => [realOrRaw(path), value]));
     if (rangeMap === null) {
       logger.warn("mutation-check", "Failed to obtain changed-line ranges — skipping mutation spot-check", {
         storyId: input.storyId,
@@ -237,8 +260,8 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
     // and a top-of-file bias simultaneously.
     const mutants: Mutant[] = [];
     let unmappedFiles = 0;
-    for (const file of absoluteChangedFiles) {
-      const lineRanges = rangeMap.get(file);
+    for (const { path: file, resolved } of absoluteChangedFiles) {
+      const lineRanges = rangeMap.get(resolved);
       if (lineRanges === undefined) {
         unmappedFiles++;
         logger.debug("mutation-check", "Changed file has no diff line ranges — skipping", {
@@ -336,6 +359,11 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
               // keep the journal for the next run, and stop mutating: whatever
               // moved the file will keep moving it.
               revertFailed = true;
+              // Block auto-commit for this working tree. The check itself stays
+              // advisory — the story is not failed — but the tree now holds a
+              // line this op did not author, and `autoCommitIfDirty` would
+              // otherwise sweep it into a commit (and, under autoPR, a push).
+              ctx.runtime?.dirtyWorktrees?.add(input.workdir);
               logger.error("mutation-check", "Could not confirm revert — worktree may still hold a mutation", {
                 storyId: input.storyId,
                 file: mutant.file,

--- a/src/prd/markdown-scan.ts
+++ b/src/prd/markdown-scan.ts
@@ -23,8 +23,9 @@ export const ANY_HEADING = /^(#{1,6})\s/;
 /** A list item — used both to split bullets and to bound folded prose. */
 export const LIST_ITEM_START = /^\s*(?:[-*+•‣◦⁃∙]|\d+\.)\s+/;
 
-/** A fenced code block delimiter (``` or ~~~), with optional info string. */
-export const FENCE = /^\s*(?:```|~~~)/;
+import { fencedLineIndices } from "../utils/markdown-fence";
+
+export { FENCE, fencedLineIndices } from "../utils/markdown-fence";
 
 /**
  * Strip inline emphasis/backticks so heading matching is not defeated by
@@ -41,28 +42,13 @@ export function stripBullet(line: string): string {
   return line.replace(LIST_ITEM_START, "").trim();
 }
 
-/**
- * Indices of every line inside a fenced code block.
- *
- * Fenced content is illustrative — a spec documenting markdown (which spec-kit
- * specs routinely do) contains a literal `## Out of Scope` example. Treating it
- * as a real declaration fabricates an entry that is then backfilled into the
- * PRD, pushed onto a story, and rendered to the implementer as a hard
- * instruction. Every scan over raw lines must consult this.
- */
-export function fencedLineIndices(lines: readonly string[]): Set<number> {
-  const fenced = new Set<number>();
-  let inFence = false;
-  for (const [i, line] of lines.entries()) {
-    if (FENCE.test(line)) {
-      fenced.add(i);
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) fenced.add(i);
-  }
-  return fenced;
-}
+// `fencedLineIndices` is re-exported above from `../utils/markdown-fence`.
+//
+// Fenced content is illustrative — a spec documenting markdown (which spec-kit
+// specs routinely do) contains a literal `## Out of Scope` example. Treating it
+// as a real declaration fabricates an entry that is then backfilled into the
+// PRD, pushed onto a story, and rendered to the implementer as a hard
+// instruction. Every scan over raw lines must consult it.
 
 // ─────────────────────────────────────────────────────────────────────────────
 // **US-00N**-grouped path sections

--- a/src/prd/modifies.ts
+++ b/src/prd/modifies.ts
@@ -48,7 +48,12 @@ export interface ApplyModifiedFilesResult {
  * shape when a hand-edited `prd.json` is loaded.
  */
 export function isSafeRelativePath(path: string): boolean {
-  return !path.startsWith("/") && !path.includes("..");
+  if (path.startsWith("/")) return false;
+  // Segment-wise, not substring. A bare `includes("..")` also rejects legitimate
+  // filenames that merely contain two dots (`src/foo..bar.ts`, `v1..v2.snap`),
+  // which is a silent drop of a valid authorisation. Splitting on both
+  // separators keeps Windows-style `..\` traversal rejected too.
+  return !path.split(/[\\/]/).includes("..");
 }
 
 /**

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -280,7 +280,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
 
   // @design: BUG-074: Auto-commit any dirty files the agent left (e.g. bun.lock / package.json
   // after `bun add`) before the uncommitted-changes check. Mirrors BUG-058/063.
-  await autoCommitIfDirty(workdir, "review", "agent", storyId ?? "review");
+  await autoCommitIfDirty(workdir, "review", "agent", storyId ?? "review", runtime?.dirtyWorktrees);
 
   // RQ-001: Check for uncommitted tracked files before running checks
   const allUncommittedFiles = await _reviewGitDeps.getUncommittedFiles(workdir);

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -139,6 +139,20 @@ export interface NaxRuntime {
   readonly rectificationOscillations: Map<string, number>;
   /** Run-scoped per-story mutation-check results. */
   readonly mutationSummaries: Map<string, MutationStorySummary>;
+  /**
+   * Working trees the mutation spot-check injected a mutation into and could
+   * NOT confirm reverted — they may still hold deliberately broken source.
+   *
+   * `autoCommitIfDirty` refuses to commit anything under one of these. The
+   * spot-check is advisory and never fails a story, but "advisory" cannot mean
+   * letting an injected defect into a commit (and, with autoPR, a push).
+   *
+   * Deliberately in-memory and run-scoped rather than read back off the on-disk
+   * journal: a stale journal a sweep failed to reach would otherwise block every
+   * commit in the repo indefinitely. Only the run that actually observed the
+   * failed revert blocks anything.
+   */
+  readonly dirtyWorktrees: Set<string>;
   close(): Promise<void>;
 }
 
@@ -263,6 +277,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const semanticIterations = new Map<string, Iteration[]>();
   const rectificationOscillations = new Map<string, number>();
   const mutationSummaries = new Map<string, MutationStorySummary>();
+  const dirtyWorktrees = new Set<string>();
 
   let closed = false;
 
@@ -290,6 +305,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     semanticIterations,
     rectificationOscillations,
     mutationSummaries,
+    dirtyWorktrees,
 
     get signal() {
       return controller.signal;

--- a/src/utils/diff-files.ts
+++ b/src/utils/diff-files.ts
@@ -1,16 +1,50 @@
 /**
- * Pure unified-diff parser — extracts the set of modified file paths from a
- * unified diff string by reading `+++ b/<path>` headers.
+ * Pure unified-diff parser — extracts the set of modified file paths, and the
+ * changed-side line ranges, from a unified diff string by reading `+++` headers.
  *
  * Used by adversarial review (#986) to compute the `fileInDiff` axis of the
- * structural counterfactual telemetry without re-shelling git.
+ * structural counterfactual telemetry without re-shelling git, and by the
+ * mutation spot-check to bound mutation to changed lines.
  *
- * Skips `+++ /dev/null` (deletion-only side has no `b/` path). Dedupes across
- * hunks. Handles CRLF line endings. Returns an empty set for empty input.
+ * Accepts both `+++ b/<path>` and the unprefixed `+++ <path>` produced under
+ * `diff.noprefix=true` / `--no-prefix`. Skips `+++ /dev/null` (deletion-only
+ * side has no `b/` path). Dedupes across hunks. Handles CRLF line endings.
+ * Returns an empty set/map for empty input.
  */
 
 const HEADER_PREFIX = "+++ b/";
+const HEADER_PREFIX_NOPREFIX = "+++ ";
 const HUNK_REGEX = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/;
+
+/**
+ * Path from a `+++` header, or null when the header names no file.
+ *
+ * Handles both `+++ b/<path>` and the unprefixed `+++ <path>` a user with
+ * `diff.noprefix=true` (or `--no-prefix`) produces. Recognising only the `b/`
+ * form silently yielded zero files / zero ranges for those users, which the
+ * mutation spot-check reads as "nothing changed" rather than "cannot parse".
+ *
+ * `precededByMinusHeader` gates the unprefixed form. Inside a hunk, an ADDED
+ * line whose content begins with `++ ` is rendered as `+++ ...` and is
+ * indistinguishable from an unprefixed header on its own. Unified diff always
+ * emits `+++` immediately after `---`, so requiring that pairing separates the
+ * two. The `b/` form needs no such gate — it is specific enough on its own, and
+ * gating it would change behaviour for the prefixed diffs this already parsed.
+ */
+function parseHeaderPath(rawLine: string, precededByMinusHeader: boolean): string | null {
+  if (rawLine.startsWith(HEADER_PREFIX)) {
+    return rawLine.slice(HEADER_PREFIX.length).trim() || null;
+  }
+  if (!precededByMinusHeader) return null;
+  const path = rawLine.slice(HEADER_PREFIX_NOPREFIX.length).trim();
+  // `/dev/null` is the deletion side — it names no file on the `b` side.
+  return path && path !== "/dev/null" ? path : null;
+}
+
+/** True for the `---` half of a unified-diff file-header pair. */
+function isMinusHeader(rawLine: string): boolean {
+  return rawLine.startsWith("--- ");
+}
 
 export interface LineRange {
   readonly start: number;
@@ -21,11 +55,13 @@ export function extractDiffFiles(diff: string): Set<string> {
   const files = new Set<string>();
   if (!diff) return files;
 
+  let prevWasMinusHeader = false;
   for (const rawLine of diff.split(/\r?\n/)) {
-    if (!rawLine.startsWith(HEADER_PREFIX)) continue;
-    const path = rawLine.slice(HEADER_PREFIX.length).trim();
-    if (!path || path === "/dev/null") continue;
-    files.add(path);
+    if (rawLine.startsWith(HEADER_PREFIX_NOPREFIX)) {
+      const path = parseHeaderPath(rawLine, prevWasMinusHeader);
+      if (path) files.add(path);
+    }
+    prevWasMinusHeader = isMinusHeader(rawLine);
   }
   return files;
 }
@@ -35,10 +71,17 @@ export function extractDiffLineRanges(diff: string): Map<string, LineRange[]> {
   if (!diff) return ranges;
 
   let currentPath: string | null = null;
+  let prevWasMinusHeader = false;
 
   for (const rawLine of diff.split(/\r?\n/)) {
-    if (rawLine.startsWith("+++ ")) {
-      currentPath = rawLine.startsWith(HEADER_PREFIX) ? rawLine.slice(HEADER_PREFIX.length).trim() || null : null;
+    const wasMinusHeader = prevWasMinusHeader;
+    prevWasMinusHeader = isMinusHeader(rawLine);
+
+    if (rawLine.startsWith(HEADER_PREFIX_NOPREFIX)) {
+      const path = parseHeaderPath(rawLine, wasMinusHeader);
+      // A `+++`-shaped line that is NOT a header (added content beginning
+      // `++ `) must not clear the file we are currently collecting hunks for.
+      if (path !== null || rawLine.startsWith(HEADER_PREFIX) || wasMinusHeader) currentPath = path;
       continue;
     }
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -4,7 +4,7 @@
 
 import { getSafeLogger } from "../logger";
 import { spawn } from "./bun-deps";
-import { isInside } from "./realpath";
+import { realOrRaw } from "./realpath";
 
 /**
  * Default timeout for git subprocess calls.
@@ -287,13 +287,19 @@ export async function autoCommitIfDirty(
     const isSubdir = realGitRoot && realWorkdir.startsWith(`${realGitRoot}/`);
     if (!isAtRoot && !isSubdir) return;
 
-    // Staging is `git add -A` from the git root, so a blocked tree anywhere in
-    // this repository would be swept into the commit — compare against the ROOT,
-    // not against `workdir`.
+    // Staging is `git add -A` from the git ROOT, so the question is whether this
+    // commit's working tree is a blocked one — compare against `realGitRoot`,
+    // not `workdir`, so a monorepo package under a blocked root is still caught.
+    //
+    // Equality, NOT containment. `blockedWorktrees` holds working-tree roots, and
+    // in parallel mode each story's worktree is a LINKED tree at
+    // `<repo>/.nax-wt/<storyId>` — inside the main repo by path, but a separate
+    // checkout that `git add -A` from the main root never stages. A containment
+    // test would block the run-summary commit whenever any story's worktree was
+    // dirty, which is a false positive.
     if (blockedWorktrees?.size) {
-      const blocked = [...blockedWorktrees].filter(
-        (tree) => isInside(realGitRoot, tree) || isInside(tree, realGitRoot),
-      );
+      const root = realOrRaw(realGitRoot);
+      const blocked = [...blockedWorktrees].filter((tree) => realOrRaw(tree) === root);
       if (blocked.length > 0) {
         logger?.error(stage, "Refusing to auto-commit — working tree may still hold an unreverted mutation", {
           storyId,

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -4,6 +4,7 @@
 
 import { getSafeLogger } from "../logger";
 import { spawn } from "./bun-deps";
+import { isInside } from "./realpath";
 
 /**
  * Default timeout for git subprocess calls.
@@ -238,8 +239,18 @@ export function detectMergeConflict(output: string): boolean {
  * @param stage   - Log stage prefix (e.g. "tdd", "execution")
  * @param role    - Session role for the commit message (e.g. "implementer")
  * @param storyId - Story ID for the commit message
+ * @param blockedWorktrees - Working trees known to hold source this run cannot
+ *   account for — currently an unreverted mutation from the mutation spot-check
+ *   (`runtime.dirtyWorktrees`). A commit under one of these would capture the
+ *   injected defect, so it is refused. Omit when the caller has no runtime.
  */
-export async function autoCommitIfDirty(workdir: string, stage: string, role: string, storyId: string): Promise<void> {
+export async function autoCommitIfDirty(
+  workdir: string,
+  stage: string,
+  role: string,
+  storyId: string,
+  blockedWorktrees?: ReadonlySet<string>,
+): Promise<void> {
   const logger = _gitDeps.getSafeLogger();
   try {
     // Guard: only auto-commit if workdir IS the git repository root.
@@ -275,6 +286,25 @@ export async function autoCommitIfDirty(workdir: string, stage: string, role: st
     const isAtRoot = realWorkdir === realGitRoot;
     const isSubdir = realGitRoot && realWorkdir.startsWith(`${realGitRoot}/`);
     if (!isAtRoot && !isSubdir) return;
+
+    // Staging is `git add -A` from the git root, so a blocked tree anywhere in
+    // this repository would be swept into the commit — compare against the ROOT,
+    // not against `workdir`.
+    if (blockedWorktrees?.size) {
+      const blocked = [...blockedWorktrees].filter(
+        (tree) => isInside(realGitRoot, tree) || isInside(tree, realGitRoot),
+      );
+      if (blocked.length > 0) {
+        logger?.error(stage, "Refusing to auto-commit — working tree may still hold an unreverted mutation", {
+          storyId,
+          role,
+          workdir,
+          blocked,
+          hint: "Check the mutation-check log for the file and line, restore it, then commit manually.",
+        });
+        return;
+      }
+    }
 
     const statusProc = _gitDeps.spawn(["git", "status", "--porcelain"], {
       cwd: workdir,

--- a/src/utils/markdown-fence.ts
+++ b/src/utils/markdown-fence.ts
@@ -1,0 +1,38 @@
+/**
+ * Fenced-code-block detection for markdown scanners.
+ *
+ * Shared because every markdown parser in the codebase needs the same answer to
+ * the same question: is this construct real, or is it an example inside a code
+ * fence? Documents that describe markdown contain literal `## Heading` lines,
+ * and a parser that treats one as a real heading fabricates structure that is
+ * then carried downstream as fact — into a PRD directive in `src/prd`, or into a
+ * rule section boundary in `src/context/rules`.
+ *
+ * Deliberately dependency-free: a lexical scan over lines, no markdown library,
+ * no I/O.
+ */
+
+/** A fenced code block delimiter (``` or ~~~), with optional info string. */
+export const FENCE = /^\s*(?:```|~~~)/;
+
+/**
+ * Indices of every line inside a fenced code block, including the delimiter
+ * lines themselves.
+ *
+ * An unterminated fence is treated as running to end-of-document. That is the
+ * conservative direction: content after a stray opening fence is ignored rather
+ * than parsed as structure.
+ */
+export function fencedLineIndices(lines: readonly string[]): Set<number> {
+  const fenced = new Set<number>();
+  let inFence = false;
+  for (const [i, line] of lines.entries()) {
+    if (FENCE.test(line)) {
+      fenced.add(i);
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) fenced.add(i);
+  }
+  return fenced;
+}

--- a/src/utils/realpath.ts
+++ b/src/utils/realpath.ts
@@ -1,0 +1,53 @@
+/**
+ * Symlink-tolerant path normalisation for comparing paths from different sources.
+ *
+ * `getGitRoot` returns git's realpath — `git rev-parse --show-toplevel` run from
+ * `/tmp/repo` answers `/private/tmp/repo` — while paths threaded through config,
+ * pipeline context, or a story record keep whatever spelling the caller supplied.
+ * On macOS `/tmp` is a symlink to `/private/tmp` and worktrees are created under
+ * temp directories, so the two spellings meet constantly. Comparing them
+ * unresolved makes equal paths look different, and every containment check
+ * (`startsWith(root)`) silently fails closed.
+ *
+ * Pure apart from the `realpathSync` probe, and never throws.
+ */
+
+import { realpathSync } from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
+
+/**
+ * Absolute, symlink-resolved form of `p`.
+ *
+ * A path that does not exist cannot be resolved directly, so this walks up to
+ * the nearest ancestor that DOES exist, resolves that, and re-attaches the
+ * remaining segments. Resolving only the immediate parent is not enough: a
+ * changed file that has since been deleted, or one under a directory that was
+ * never created, leaves several missing segments — and a half-resolved answer
+ * compares unequal to a fully-resolved root, turning every containment check
+ * into a silent false negative.
+ *
+ * Falls back to the lexical absolute form when no ancestor resolves.
+ */
+export function realOrRaw(p: string): string {
+  const abs = resolve(p);
+  const trailing: string[] = [];
+  let current = abs;
+  for (;;) {
+    try {
+      return trailing.length === 0 ? realpathSync(current) : join(realpathSync(current), ...trailing);
+    } catch {
+      const parent = dirname(current);
+      // `dirname` is a fixed point at the filesystem root — nothing resolved.
+      if (parent === current) return abs;
+      trailing.unshift(basename(current));
+      current = parent;
+    }
+  }
+}
+
+/** Is `filePath` inside `root`'s subtree, symlinks resolved on both sides? */
+export function isInside(root: string, filePath: string): boolean {
+  const base = realOrRaw(root);
+  const target = realOrRaw(filePath);
+  return target === base || target.startsWith(`${base}${sep}`);
+}

--- a/src/verification/mutation/journal.ts
+++ b/src/verification/mutation/journal.ts
@@ -14,8 +14,10 @@
  * One file per story, so parallel stories never contend for the same journal.
  */
 
-import { realpathSync } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { join } from "node:path";
+// Shared with `mutation-check`, which compares the same git-realpath'd anchors
+// against the same caller-supplied paths and needs an identical answer.
+import { isInside } from "@/utils/realpath";
 import { revertMutant } from "./apply";
 import type { Mutant } from "./types";
 
@@ -120,38 +122,6 @@ async function readEntry(path: string): Promise<MutationJournalEntry | null> {
   } catch {
     return null;
   }
-}
-
-/**
- * Resolve symlinks so two spellings of the same location compare equal.
- *
- * `getGitRoot` returns git's realpath (`git rev-parse --show-toplevel` from
- * `/tmp/repo` answers `/private/tmp/repo`), while a mutant's `file` is built
- * from whichever path the caller supplied — often still the symlinked form.
- * Comparing those unresolved makes every entry look foreign. Same
- * normalisation `autoCommitIfDirty` performs for the same reason.
- */
-function realOrRaw(p: string): string {
-  const abs = resolve(p);
-  try {
-    return realpathSync(abs);
-  } catch {
-    // The path itself is gone — a journalled file deleted since the run died.
-    // Resolve the directory instead so a symlinked root still compares equal;
-    // only fall back to the lexical form when that fails too.
-    try {
-      return join(realpathSync(dirname(abs)), basename(abs));
-    } catch {
-      return abs;
-    }
-  }
-}
-
-/** Is `filePath` inside `root`'s subtree, symlinks resolved on both sides? */
-function isInside(root: string, filePath: string): boolean {
-  const base = realOrRaw(root);
-  const target = realOrRaw(filePath);
-  return target === base || target.startsWith(`${base}${sep}`);
 }
 
 /**

--- a/src/verification/mutation/mutator.ts
+++ b/src/verification/mutation/mutator.ts
@@ -40,6 +40,42 @@ function isLineInRanges(lineNumber: number, ranges: readonly LineRange[]): boole
   return false;
 }
 
+/** Quote characters that open a string literal, per language family. */
+const STRING_DELIMITERS = new Set(["'", '"', "`"]);
+
+/**
+ * Length of the leading run of `line` that is real code — everything before the
+ * first string literal or inline comment.
+ *
+ * Operators are regex-driven and cannot tell `a == b` from `"a == b"` or from
+ * `// a == b`. Mutating either produces a mutant that is worthless as a signal:
+ * a flipped comparison inside a message string or a comment changes no
+ * behaviour, so the tests "miss" it and it is reported as a survivor, while a
+ * mutated string literal that IS asserted on is caught by construction. Both
+ * consume one of the very few `maxMutants` slots the budget allows.
+ *
+ * Deliberately a PREFIX rather than a full segment map. Mutating each code
+ * segment between literals would need the operator applied per segment and its
+ * variants aligned across them — `MutationOperator.apply` returns bare strings
+ * with no variant identity, so there is nothing to align on. Stopping at the
+ * first literal loses the code that follows one on the same line, which costs
+ * candidates but never produces a wrong mutant. For a spot-check that samples a
+ * handful of sites, fewer-and-sound beats more-and-noisy.
+ */
+function codeRegionLength(line: string, language: string | undefined): number {
+  const isPython = language === "python";
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i] ?? "";
+    if (STRING_DELIMITERS.has(c)) return i;
+    if (isPython) {
+      if (c === "#") return i;
+      continue;
+    }
+    if (c === "/" && (line[i + 1] === "/" || line[i + 1] === "*")) return i;
+  }
+  return line.length;
+}
+
 export function generateMutants(input: GenerateMutantsInput): Mutant[] {
   const { source, language, file, lineRanges } = input;
   const operators = getOperatorsForLanguage(language);
@@ -59,14 +95,22 @@ export function generateMutants(input: GenerateMutantsInput): Mutant[] {
     const commentPrefixes = language === "python" ? ["#"] : ["//", "/*", "*"];
     if (commentPrefixes.some((prefix) => trimmed.startsWith(prefix))) continue;
 
+    // Operators see only the code prefix; the literal/comment tail is carried
+    // through verbatim so `before`/`after` still span the whole line, which is
+    // what apply/revert compare against on disk.
+    const codeLength = codeRegionLength(line, language);
+    if (codeLength === 0) continue;
+    const code = line.slice(0, codeLength);
+    const tail = line.slice(codeLength);
+
     for (const operator of operators) {
-      for (const replacement of applyOperator(operator, line)) {
-        if (replacement === "" || replacement === line) continue;
+      for (const mutatedCode of applyOperator(operator, code)) {
+        if (mutatedCode === "" || mutatedCode === code) continue;
         mutants.push({
           file,
           line: lineNumber,
           before: line,
-          after: replacement,
+          after: `${mutatedCode}${tail}`,
           operatorId: operator.id,
         });
       }

--- a/test/unit/context/engine/providers/static-rules-scoping.test.ts
+++ b/test/unit/context/engine/providers/static-rules-scoping.test.ts
@@ -201,3 +201,52 @@ describe("ContextOrchestrator.assemble() — scopingReport propagation", () => {
     expect(entry?.scopingReport?.appliesToInertCount).toBe(1);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Zero-rule exits stay observable
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("StaticRulesProvider — zero-rule exits", () => {
+  test("#558 package-filter drop still returns a scopingReport", async () => {
+    // Every other exit from this provider carries a scopingReport. Omitting it
+    // here made "rules existed but the package filter rejected all of them" the
+    // one scoping outcome invisible to manifest telemetry.
+    // Repo-level only: the package has no rules of its own, so the paths:
+    // filter is the sole reason nothing survives.
+    _staticRulesDeps.loadCanonicalRules = async (dir: string) =>
+      dir === "/project"
+        ? [{ id: "api-only", fileName: "api-only.md", content: "## R\nbody", paths: ["packages/api/**"] }]
+        : [];
+
+    const result = await new StaticRulesProvider().fetch({
+      ...BASE_REQUEST,
+      repoRoot: "/project",
+      packageDir: "/project/packages/web",
+      scopeFiles: ["src/a.ts"],
+    });
+
+    expect(result.chunks).toEqual([]);
+    expect(result.scopingReport).toBeDefined();
+    expect(result.scopingReport?.sectionCount).toBe(0);
+    expect(result.scopingReport?.scopeFileCount).toBe(1);
+  });
+
+  test("stage filtering to empty reports the stage cause, not a budget cause", async () => {
+    // Conflating the two sends an operator to tune a budget that was never the
+    // problem.
+    setupCanonical([
+      { id: "review-only", fileName: "review-only.md", content: "## R\nbody", stages: ["review"] },
+    ]);
+
+    const result = await new StaticRulesProvider({ enforceBudget: true }).fetch({
+      ...BASE_REQUEST,
+      stage: "execution",
+    });
+
+    expect(result.chunks).toEqual([]);
+    expect(result.scopingReport?.stageFilteredIds).toEqual(["review-only"]);
+    expect(result.scopingReport?.sectionCount).toBe(0);
+    // Nothing was dropped by the budget — there was nothing to drop.
+    expect(result.budgetPressure).toBeUndefined();
+  });
+});

--- a/test/unit/context/rules/rule-budget.test.ts
+++ b/test/unit/context/rules/rule-budget.test.ts
@@ -207,3 +207,63 @@ describe("applySectionBudget — non-finite budget", () => {
     expect(applySectionBudget(sections, Number.POSITIVE_INFINITY).retainedSections).toEqual([]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-rule ordering: equal-priority rules must stay contiguous
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("applySectionBudget — cross-rule ordering", () => {
+  function sectionsFor(ruleId: string, priority: number): RuleSection[] {
+    return ["preamble", "a", "b"].map((slug, ordinal) =>
+      makeSection({ ruleId, rulePath: `${ruleId}.md`, slug, ordinal, tokens: 10, priority }),
+    );
+  }
+
+  test("keeps each rule's sections contiguous instead of interleaving them by ordinal", () => {
+    // Regression: with no rule tiebreaker, equal-priority sections sorted
+    // ordinal-major — every rule's preamble first, then every rule's first
+    // body section, and so on. Since `priority` defaults to the same value for
+    // any rule that does not declare one, that was the normal case, and it
+    // shredded every rule in the delivered output.
+    const sections = [...sectionsFor("alpha", 100), ...sectionsFor("beta", 100)];
+    const result = applySectionBudget(sections, 1000);
+
+    expect(result.retainedSections.map(sectionId)).toEqual([
+      "alpha#preamble",
+      "alpha#a",
+      "alpha#b",
+      "beta#preamble",
+      "beta#a",
+      "beta#b",
+    ]);
+  });
+
+  test("truncation drops one boundary rule's tail rather than every rule's tail", () => {
+    const sections = [...sectionsFor("alpha", 100), ...sectionsFor("beta", 100)];
+    // Room for four of the six 10-token sections.
+    const result = applySectionBudget(sections, 40);
+
+    // alpha survives whole; beta is the boundary rule and contributes its lead.
+    expect(result.retainedSections.map(sectionId)).toEqual([
+      "alpha#preamble",
+      "alpha#a",
+      "alpha#b",
+      "beta#preamble",
+    ]);
+    expect(result.droppedIds).toEqual(["beta#a", "beta#b"]);
+  });
+
+  test("priority still outranks rule identity", () => {
+    const sections = [...sectionsFor("zulu", 1), ...sectionsFor("alpha", 100)];
+    const result = applySectionBudget(sections, 1000);
+
+    expect(result.retainedSections.map((s) => s.ruleId)).toEqual([
+      "zulu",
+      "zulu",
+      "zulu",
+      "alpha",
+      "alpha",
+      "alpha",
+    ]);
+  });
+});

--- a/test/unit/context/rules/rule-sections.test.ts
+++ b/test/unit/context/rules/rule-sections.test.ts
@@ -294,3 +294,58 @@ describe("splitRuleIntoSections — owning-rule identity", () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fenced code blocks are not section boundaries
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("splitRuleIntoSections — fenced code blocks", () => {
+  test("a '## ' line inside a fence does not start a new section", () => {
+    // Rule files that document markdown by example contain literal headings
+    // inside fences. Splitting there cuts the section mid-fence, so a retained
+    // section can open a fence it never closes.
+    const rule: CanonicalRule = {
+      id: "authoring",
+      fileName: "authoring.md",
+      content: [
+        "## Real",
+        "prose",
+        "```markdown",
+        "## Not A Heading",
+        "example body",
+        "```",
+        "more prose",
+      ].join("\n"),
+    };
+
+    const sections = splitRuleIntoSections(rule);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.heading).toBe("Real");
+    // The fenced block survives intact, opener and closer together.
+    expect(sections[0]?.content).toContain("## Not A Heading");
+    expect(sections[0]?.content.match(/```/g)).toHaveLength(2);
+  });
+
+  test("headings after a closed fence are still boundaries", () => {
+    const rule: CanonicalRule = {
+      id: "authoring",
+      fileName: "authoring.md",
+      content: ["## One", "```", "## Fenced", "```", "## Two", "body"].join("\n"),
+    };
+
+    const sections = splitRuleIntoSections(rule);
+
+    expect(sections.map((s) => s.heading)).toEqual(["One", "Two"]);
+  });
+
+  test("tilde fences are honoured as well as backtick fences", () => {
+    const rule: CanonicalRule = {
+      id: "authoring",
+      fileName: "authoring.md",
+      content: ["## One", "~~~", "## Fenced", "~~~", "tail"].join("\n"),
+    };
+
+    expect(splitRuleIntoSections(rule).map((s) => s.heading)).toEqual(["One"]);
+  });
+});

--- a/test/unit/execution/non-blocking-fix.test.ts
+++ b/test/unit/execution/non-blocking-fix.test.ts
@@ -54,6 +54,43 @@ describe("runNonBlockingFix keep vs restore", () => {
     rollbackToRef: async () => {},
   };
 
+  test("skips the pass when the worktree may hold an unreverted mutation", async () => {
+    // The snapshot is itself a commit — it would capture the injected defect
+    // AND leave the tree clean, so every later autoCommitIfDirty guard would
+    // see nothing to block. The check must therefore precede the snapshot.
+    let snapshots = 0;
+    const res = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        phaseOutputs: {},
+        blockedWorktrees: new Set(["/tmp/x"]),
+        runRectify: async () => ({ rectificationExhausted: false }),
+      },
+      {
+        ...fakeDeps,
+        captureSnapshotRef: async () => {
+          snapshots += 1;
+          return "snap-sha";
+        },
+      },
+    );
+    expect(res).toEqual({ ran: false, kept: false, restored: false });
+    expect(snapshots).toBe(0);
+  });
+
+  test("runs normally when the blocked set names an unrelated worktree", async () => {
+    const res = await runNonBlockingFix(
+      {
+        ...baseArgs,
+        phaseOutputs: { "full-suite-gate": { success: true } },
+        blockedWorktrees: new Set(["/tmp/other-repo"]),
+        runRectify: async () => ({ rectificationExhausted: false }),
+      },
+      fakeDeps,
+    );
+    expect(res).toEqual({ ran: true, kept: true, restored: false });
+  });
+
   test("kept when harness resolves", async () => {
     const phaseOutputs: Record<string, unknown> = { "full-suite-gate": { success: true } };
     const res = await runNonBlockingFix(

--- a/test/unit/operations/mutation-check-revert.test.ts
+++ b/test/unit/operations/mutation-check-revert.test.ts
@@ -11,7 +11,7 @@ const FAKE_STORY = { id: "US-004", title: "mutation-check op" } as any;
 function ctxWithConfig(execution: Record<string, unknown> = {}, runtime: Partial<NaxRuntime> = {}): any {
   const config = { execution, quality: { commands: { test: "bun test" } } } as any;
   return {
-    runtime: { mutationSummaries: new Map(), ...runtime },
+    runtime: { mutationSummaries: new Map(), dirtyWorktrees: new Set<string>(), ...runtime },
     storyId: "US-004",
     packageView: {
       packageDir: "packages/agent",
@@ -149,6 +149,10 @@ describe("mutationCheckOp — an unconfirmed revert stops the check", () => {
       // Stopped after the first mutant rather than compounding.
       expect(regressionCalls).toBe(1);
       expect(ctx.runtime.mutationSummaries.get("US-004")?.revertFailed).toBe(true);
+      // The tree now holds a line this op did not author, so auto-commit must
+      // be blocked for it — otherwise `git add -A` sweeps the injected defect
+      // into a commit and, under autoPR, a push.
+      expect([...ctx.runtime.dirtyWorktrees]).toEqual([dir]);
     } finally {
       cleanupTempDir(dir);
     }
@@ -172,6 +176,8 @@ describe("mutationCheckOp — an unconfirmed revert stops the check", () => {
       expect(out.revertFailed).toBeUndefined();
       expect(await Bun.file(file).text()).toBe(original);
       expect(await Bun.file(journalPathFor(dir, "US-004")).exists()).toBe(false);
+      // A confirmed revert must not block commits.
+      expect([...ctx.runtime.dirtyWorktrees]).toEqual([]);
     } finally {
       cleanupTempDir(dir);
     }

--- a/test/unit/prd/modifies.test.ts
+++ b/test/unit/prd/modifies.test.ts
@@ -238,6 +238,30 @@ describe("applyModifiedFiles", () => {
     expect(prd.userStories.every((s) => s.modifiedFiles === undefined)).toBe(true);
   });
 
+  test.each([
+    ["a filename containing two dots", "src/foo..bar.ts"],
+    ["a snapshot pair filename", "test/fixtures/v1..v2.snap"],
+    ["a dotted directory segment", "src/a..b/c.ts"],
+  ])("accepts %s — '..' as a substring is not traversal", (_label, path) => {
+    // A bare `includes("..")` also rejected legitimate filenames that merely
+    // contain two dots, silently dropping a valid authorisation. Traversal is a
+    // whole path SEGMENT, not a substring.
+    const spec = ["### Modifies", "", "**US-001**", `- \`${path}\` — legitimate`].join("\n");
+
+    const { prd, invalidPaths } = applyModifiedFiles(prdWithTwoStories(), spec);
+
+    expect(invalidPaths).toEqual([]);
+    expect(prd.userStories[0].modifiedFiles).toEqual([{ path, reason: "legitimate" }]);
+  });
+
+  test("still rejects a Windows-style traversing segment", () => {
+    const spec = ["### Modifies", "", "**US-001**", "- `..\\..\\secrets.txt` — nope"].join("\n");
+
+    const { invalidPaths } = applyModifiedFiles(prdWithTwoStories(), spec);
+
+    expect(invalidPaths).toHaveLength(1);
+  });
+
   test("rejects an escaping path while still attaching the safe entries beside it", () => {
     const spec = [
       "### Modifies",

--- a/test/unit/utils/diff-files.test.ts
+++ b/test/unit/utils/diff-files.test.ts
@@ -242,3 +242,67 @@ trailing garbage
     expect(result.get("src/a.ts")).toEqual([{ start: 1, end: 2 }]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// diff.noprefix — headers without the a/ b/ prefixes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("diff parsing — diff.noprefix output", () => {
+  const NOPREFIX_DIFF = [
+    "diff --git src/a.ts src/a.ts",
+    "index 111..222 100644",
+    "--- src/a.ts",
+    "+++ src/a.ts",
+    "@@ -3,0 +4,2 @@",
+    "+added one",
+    "+added two",
+  ].join("\n");
+
+  test("extractDiffFiles reads an unprefixed +++ header", () => {
+    // With `diff.noprefix=true` every header loses its `b/`. Recognising only
+    // the prefixed form yielded an empty result, which the mutation spot-check
+    // reads as "nothing changed" rather than "cannot parse".
+    expect([...extractDiffFiles(NOPREFIX_DIFF)]).toEqual(["src/a.ts"]);
+  });
+
+  test("extractDiffLineRanges reads hunks under an unprefixed header", () => {
+    expect(extractDiffLineRanges(NOPREFIX_DIFF).get("src/a.ts")).toEqual([{ start: 4, end: 5 }]);
+  });
+
+  test("an added line rendered as '+++ ...' is not mistaken for a header", () => {
+    // An ADDED line whose content begins '++ ' renders as '+++ ...' inside a
+    // hunk. Only a `+++` immediately following a `---` is a real header.
+    const diff = [
+      "--- a/src/a.ts",
+      "+++ b/src/a.ts",
+      "@@ -1,0 +1,2 @@",
+      "+++ this is content, not a header",
+      "+normal added line",
+    ].join("\n");
+
+    expect([...extractDiffFiles(diff)]).toEqual(["src/a.ts"]);
+    expect(extractDiffLineRanges(diff).get("src/a.ts")).toEqual([{ start: 1, end: 2 }]);
+  });
+
+  test("a '+++'-shaped content line does not orphan the following hunks", () => {
+    const diff = [
+      "--- a/src/a.ts",
+      "+++ b/src/a.ts",
+      "@@ -1,0 +1,1 @@",
+      "+++ content",
+      "@@ -9,0 +12,3 @@",
+      "+more",
+    ].join("\n");
+
+    expect(extractDiffLineRanges(diff).get("src/a.ts")).toEqual([
+      { start: 1, end: 1 },
+      { start: 12, end: 14 },
+    ]);
+  });
+
+  test("an unprefixed /dev/null header names no file", () => {
+    const diff = ["--- src/gone.ts", "+++ /dev/null", "@@ -1,2 +0,0 @@", "-a", "-b"].join("\n");
+    expect([...extractDiffFiles(diff)]).toEqual([]);
+    expect(extractDiffLineRanges(diff).size).toBe(0);
+  });
+});

--- a/test/unit/utils/git-auto-commit-block.test.ts
+++ b/test/unit/utils/git-auto-commit-block.test.ts
@@ -7,11 +7,11 @@
  * so `autoCommitIfDirty` must refuse rather than sweep it in with `git add -A`.
  */
 
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { _gitDeps, autoCommitIfDirty } from "@/utils/git";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
 
 /**
  * Spawn stub that answers each git invocation by subcommand, so the guard under
@@ -45,7 +45,7 @@ let origSpawn: typeof _gitDeps.spawn;
 const dirs: string[] = [];
 
 function makeRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "nax-autocommit-test-"));
+  const dir = makeTempDir("nax-autocommit-test-");
   dirs.push(dir);
   mkdirSync(join(dir, "src"), { recursive: true });
   return dir;
@@ -57,7 +57,7 @@ beforeEach(() => {
 
 afterEach(() => {
   _gitDeps.spawn = origSpawn;
-  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  for (const dir of dirs.splice(0)) cleanupTempDir(dir);
   mock.restore();
 });
 
@@ -83,20 +83,39 @@ describe("autoCommitIfDirty — blocked worktrees", () => {
     expect(calls.some(([, sub]) => sub === "commit")).toBe(false);
   });
 
-  test("refuses when the blocked tree is a package inside the git root", async () => {
-    // Staging is `git add -A` from the git ROOT, so a blocked package deeper in
-    // the repo would still be swept into the commit.
+  test("does not block on a linked worktree nested inside the repo path", async () => {
+    // Parallel mode puts each story's worktree at `<repo>/.nax-wt/<storyId>`.
+    // It sits inside the main repo BY PATH but is a separate checkout that
+    // `git add -A` from the main root never stages, so a containment test here
+    // would block the run-summary commit whenever any story's tree was dirty.
     const repo = makeRepo();
-    const pkg = join(repo, "src");
+    const linked = join(repo, ".nax-wt", "US-002");
+    mkdirSync(linked, { recursive: true });
     const calls: string[][] = [];
     _gitDeps.spawn = makeSpawn(repo, calls);
 
-    await autoCommitIfDirty(repo, "execution", "implementer", "US-001", new Set([pkg]));
+    await autoCommitIfDirty(repo, "execution", "implementer", "US-001", new Set([linked]));
+
+    expect(calls.some(([, sub]) => sub === "add")).toBe(true);
+  });
+
+  test("blocks a commit made from inside the blocked worktree itself", async () => {
+    const repo = makeRepo();
+    const linked = join(repo, ".nax-wt", "US-002");
+    mkdirSync(linked, { recursive: true });
+    const calls: string[][] = [];
+    // `git rev-parse --show-toplevel` inside a linked worktree answers with
+    // that worktree, so this is the root the commit would stage from.
+    _gitDeps.spawn = makeSpawn(linked, calls);
+
+    await autoCommitIfDirty(linked, "execution", "implementer", "US-002", new Set([linked]));
 
     expect(calls.some(([, sub]) => sub === "add")).toBe(false);
   });
 
   test("refuses when the caller's workdir is a package under a blocked root", async () => {
+    // The monorepo case: `git rev-parse --show-toplevel` from the package still
+    // answers with the repo root, which is what the blocked set names.
     const repo = makeRepo();
     const pkg = join(repo, "src");
     const calls: string[][] = [];

--- a/test/unit/utils/git-auto-commit-block.test.ts
+++ b/test/unit/utils/git-auto-commit-block.test.ts
@@ -1,0 +1,130 @@
+/**
+ * autoCommitIfDirty — blocked-worktree guard.
+ *
+ * The mutation spot-check is advisory and never fails a story, but when it
+ * cannot confirm a revert the working tree holds a line it did not author.
+ * Committing then captures the injected defect (and, under autoPR, pushes it),
+ * so `autoCommitIfDirty` must refuse rather than sweep it in with `git add -A`.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _gitDeps, autoCommitIfDirty } from "@/utils/git";
+
+/**
+ * Spawn stub that answers each git invocation by subcommand, so the guard under
+ * test sees a repo that IS dirty — the only state in which a commit would run.
+ */
+function makeSpawn(gitRoot: string, calls: string[][]) {
+  return mock((args: string[], _opts: unknown) => {
+    calls.push(args);
+    const sub = args[1];
+    const out = sub === "rev-parse" ? `${gitRoot}\n` : sub === "status" ? " M src/a.ts\n" : "";
+    const bytes = new TextEncoder().encode(out);
+    return {
+      stdout: new ReadableStream({
+        start(c) {
+          c.enqueue(bytes);
+          c.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      }),
+      exited: Promise.resolve(0),
+      kill: mock(() => {}),
+    };
+  });
+}
+
+let origSpawn: typeof _gitDeps.spawn;
+const dirs: string[] = [];
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "nax-autocommit-test-"));
+  dirs.push(dir);
+  mkdirSync(join(dir, "src"), { recursive: true });
+  return dir;
+}
+
+beforeEach(() => {
+  origSpawn = _gitDeps.spawn;
+});
+
+afterEach(() => {
+  _gitDeps.spawn = origSpawn;
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  mock.restore();
+});
+
+describe("autoCommitIfDirty — blocked worktrees", () => {
+  test("commits normally when no worktree is blocked", async () => {
+    const repo = makeRepo();
+    const calls: string[][] = [];
+    _gitDeps.spawn = makeSpawn(repo, calls);
+
+    await autoCommitIfDirty(repo, "execution", "implementer", "US-001");
+
+    expect(calls.some(([, sub]) => sub === "add")).toBe(true);
+  });
+
+  test("refuses to commit when the target tree is blocked", async () => {
+    const repo = makeRepo();
+    const calls: string[][] = [];
+    _gitDeps.spawn = makeSpawn(repo, calls);
+
+    await autoCommitIfDirty(repo, "execution", "implementer", "US-001", new Set([repo]));
+
+    expect(calls.some(([, sub]) => sub === "add")).toBe(false);
+    expect(calls.some(([, sub]) => sub === "commit")).toBe(false);
+  });
+
+  test("refuses when the blocked tree is a package inside the git root", async () => {
+    // Staging is `git add -A` from the git ROOT, so a blocked package deeper in
+    // the repo would still be swept into the commit.
+    const repo = makeRepo();
+    const pkg = join(repo, "src");
+    const calls: string[][] = [];
+    _gitDeps.spawn = makeSpawn(repo, calls);
+
+    await autoCommitIfDirty(repo, "execution", "implementer", "US-001", new Set([pkg]));
+
+    expect(calls.some(([, sub]) => sub === "add")).toBe(false);
+  });
+
+  test("refuses when the caller's workdir is a package under a blocked root", async () => {
+    const repo = makeRepo();
+    const pkg = join(repo, "src");
+    const calls: string[][] = [];
+    _gitDeps.spawn = makeSpawn(repo, calls);
+
+    await autoCommitIfDirty(pkg, "execution", "implementer", "US-001", new Set([repo]));
+
+    expect(calls.some(([, sub]) => sub === "add")).toBe(false);
+  });
+
+  test("does not block on an unrelated worktree", async () => {
+    const repo = makeRepo();
+    const other = makeRepo();
+    const calls: string[][] = [];
+    _gitDeps.spawn = makeSpawn(repo, calls);
+
+    await autoCommitIfDirty(repo, "execution", "implementer", "US-001", new Set([other]));
+
+    expect(calls.some(([, sub]) => sub === "add")).toBe(true);
+  });
+
+  test("an empty blocked set is treated as no block", async () => {
+    const repo = makeRepo();
+    const calls: string[][] = [];
+    _gitDeps.spawn = makeSpawn(repo, calls);
+
+    await autoCommitIfDirty(repo, "execution", "implementer", "US-001", new Set());
+
+    expect(calls.some(([, sub]) => sub === "add")).toBe(true);
+  });
+});

--- a/test/unit/utils/realpath.test.ts
+++ b/test/unit/utils/realpath.test.ts
@@ -7,24 +7,22 @@
  * producing zero mutation candidates.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, symlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { isInside, realOrRaw } from "@/utils/realpath";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
 
 const created: string[] = [];
 
 function makeDir(): string {
-  const dir = mkdtempSync(join(tmpdir(), "nax-realpath-test-"));
+  const dir = makeTempDir("nax-realpath-test-");
   created.push(dir);
   return dir;
 }
 
 afterEach(() => {
-  for (const dir of created.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
-  }
+  for (const dir of created.splice(0)) cleanupTempDir(dir);
 });
 
 describe("realOrRaw", () => {

--- a/test/unit/utils/realpath.test.ts
+++ b/test/unit/utils/realpath.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Symlink-tolerant path normalisation tests.
+ *
+ * These exist because the mutation spot-check compares paths from two sources
+ * that spell the same location differently — git's realpath output against the
+ * caller's supplied path — and an unresolved comparison fails closed, silently
+ * producing zero mutation candidates.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { isInside, realOrRaw } from "@/utils/realpath";
+
+const created: string[] = [];
+
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "nax-realpath-test-"));
+  created.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of created.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("realOrRaw", () => {
+  test("resolves a symlinked ancestor for a path that exists", () => {
+    const dir = makeDir();
+    const target = join(dir, "real");
+    mkdirSync(target);
+    const link = join(dir, "link");
+    symlinkSync(target, link);
+
+    expect(realOrRaw(link)).toBe(realOrRaw(target));
+  });
+
+  test("resolves a symlinked ancestor even when several trailing segments are missing", () => {
+    // The regression: resolving only the immediate parent left this path
+    // half-resolved, so it compared unequal to a fully-resolved root and every
+    // containment check on it failed closed.
+    const dir = makeDir();
+    const target = join(dir, "real");
+    mkdirSync(target);
+    const link = join(dir, "link");
+    symlinkSync(target, link);
+
+    const missing = join(link, "src", "nested", "deep", "foo.ts");
+    expect(realOrRaw(missing)).toBe(join(realOrRaw(target), "src", "nested", "deep", "foo.ts"));
+  });
+
+  test("falls back to the lexical absolute form when nothing resolves", () => {
+    const nowhere = "/nax-does-not-exist-9f3a/src/foo.ts";
+    expect(realOrRaw(nowhere)).toBe(resolve(nowhere));
+  });
+
+  test("is idempotent", () => {
+    const dir = makeDir();
+    const once = realOrRaw(dir);
+    expect(realOrRaw(once)).toBe(once);
+  });
+});
+
+describe("isInside", () => {
+  test("matches when root and file spell the same location differently", () => {
+    const dir = makeDir();
+    const target = join(dir, "real");
+    mkdirSync(target);
+    const link = join(dir, "link");
+    symlinkSync(target, link);
+
+    // Root given in resolved form, file in symlinked form — the exact shape
+    // `getGitRoot` (realpath) vs a caller-supplied `repoRoot` produces.
+    expect(isInside(realOrRaw(target), join(link, "src", "foo.ts"))).toBe(true);
+    expect(isInside(target, join(link, "src", "foo.ts"))).toBe(true);
+  });
+
+  test("treats the root itself as inside", () => {
+    const dir = makeDir();
+    expect(isInside(dir, dir)).toBe(true);
+  });
+
+  test("rejects a sibling whose path merely shares a prefix", () => {
+    const dir = makeDir();
+    const root = join(dir, "pkg");
+    mkdirSync(root);
+    mkdirSync(join(dir, "pkg-other"));
+
+    expect(isInside(root, join(dir, "pkg-other", "foo.ts"))).toBe(false);
+  });
+
+  test("rejects a path outside the root", () => {
+    const dir = makeDir();
+    const root = join(dir, "pkg");
+    mkdirSync(root);
+
+    expect(isInside(root, join(dir, "elsewhere.ts"))).toBe(false);
+  });
+});

--- a/test/unit/verification/mutation/mutator.test.ts
+++ b/test/unit/verification/mutation/mutator.test.ts
@@ -266,3 +266,71 @@ describe("generateMutants — whitespace-guard arithmetic (non-spaced tokens mus
     expect(second).toEqual(first);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// String literals and inline comments are not mutation sites
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("generateMutants — string literals and inline comments", () => {
+  test("does not mutate a comparison inside a string literal", () => {
+    // A flipped operator inside a message string changes no behaviour, so the
+    // tests "miss" it and it is reported as a survivor — a false signal that
+    // also burns one of the very few maxMutants slots.
+    const source = 'const msg = "expected a == b";\n';
+    const mutants = generateMutants({ source, language: "typescript", file: "msg.ts" });
+
+    expect(mutants.every((m) => !m.after.includes("a != b"))).toBe(true);
+  });
+
+  test("does not mutate a comparison inside a trailing line comment", () => {
+    const source = "const n = size; // guard when a == b\n";
+    const mutants = generateMutants({ source, language: "typescript", file: "n.ts" });
+
+    expect(mutants.every((m) => !m.after.includes("a != b"))).toBe(true);
+  });
+
+  test("still mutates the code that precedes a string literal", () => {
+    const source = 'if (a == b) throw new Error("a == b");\n';
+    const mutants = generateMutants({ source, language: "typescript", file: "guard.ts" });
+
+    const flip = mutants.find((m) => m.after.startsWith("if (a != b)"));
+    expect(flip).toBeDefined();
+    // The literal is carried through untouched, so the mutated line still
+    // matches the file on disk for apply/revert.
+    expect(flip?.after).toBe('if (a != b) throw new Error("a == b");');
+    expect(flip?.before).toBe(source.trimEnd());
+  });
+
+  test("still mutates the code that precedes a trailing comment", () => {
+    const source = "return a > b; // compare\n";
+    const mutants = generateMutants({ source, language: "typescript", file: "cmp.ts" });
+
+    const flip = mutants.find((m) => m.after.includes("a < b"));
+    expect(flip?.after).toBe("return a < b; // compare");
+  });
+
+  test("skips a line whose code region is empty", () => {
+    const source = '  "a == b";\n';
+    const mutants = generateMutants({ source, language: "typescript", file: "s.ts" });
+
+    expect(mutants).toEqual([]);
+  });
+
+  test("honours the Python comment marker rather than the JS one", () => {
+    const source = "flag = enabled  # set when a == b\n";
+    const mutants = generateMutants({ source, language: "python", file: "s.py" });
+
+    expect(mutants.every((m) => !m.after.includes("a != b"))).toBe(true);
+  });
+
+  test("before/after always span the whole line so revert can match on disk", () => {
+    const source = 'const ok = x >= y; // note "x >= y"\n';
+    const mutants = generateMutants({ source, language: "typescript", file: "ok.ts" });
+
+    expect(mutants.length).toBeGreaterThan(0);
+    for (const m of mutants) {
+      expect(m.before).toBe('const ok = x >= y; // note "x >= y"');
+      expect(m.after.endsWith('// note "x >= y"')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Code review of `e7721ea5..7a894aca` (30 commits — the mutation spot-check, context-engine v2 rules, and spec→PRD fidelity work), plus fixes for everything it turned up.

Full write-up: [`docs/reviews/2026-08-06-code-review-mutation-and-rules.md`](docs/reviews/2026-08-06-code-review-mutation-and-rules.md).

## Findings fixed

| # | Finding | Severity |
|:--|:--------|:--------:|
| 1 | An unreverted mutant reaches a commit | **HIGH** |
| 2 | `mutation-check` compares symlinked against realpath'd paths | **MEDIUM** |
| 3 | `applySectionBudget` interleaves and shreds rules | **MEDIUM** |
| 4 | `splitRuleIntoSections` splits on `## ` inside a code fence | LOW (latent) |
| 5a–5f | Mutants in strings/comments; missing `scopingReport`; misleading budget warning; duplicate token estimator; `..` substring rejection; `diff.noprefix` parsing | LOW |

### 1. An unreverted mutant reaches a commit — HIGH

The spot-check refuses to overwrite a line it cannot account for and records `revertFailed`, but the op returns `success: true` and the flag only reached a printed block at run end. `autoCommitIfDirty` runs *after* the verify stage in `review/runner`, `post-run`, and `runner-completion` — so deliberately broken source was committed to the story branch and, with `autoPR`, pushed. The journal doesn't cover this: it's swept at the start of the *next* check in the same tree, and parallel worktrees are removed on merge.

Added `runtime.dirtyWorktrees`; `mutationCheckOp` registers the working-tree root on an unconfirmed revert, and `autoCommitIfDirty` refuses to stage from a blocked root.

Two call sites needed different handling than the obvious wiring:

- `acceptance-setup` commits pre-run and cannot follow a mutation — left unwired.
- `captureSnapshotRef` (non-blocking-fix) commits as its **first** act, which would capture the defect *and* leave the tree clean so every later guard sees nothing to block. Blocking that one commit isn't enough, so `runNonBlockingFix` now skips the whole pass when its workdir is blocked, checked before the snapshot — degrading exactly as the existing snapshot-failure path does.

The story is still never failed on this; the check stays advisory.

### 2. Symlink path mismatch — MEDIUM

`getGitRoot` returns git's realpath while `repoRoot`/`workdir` keep the caller's spelling, and `getChangedLineRanges` anchors on the resolved form. On macOS (`/tmp` → `/private/tmp`) the two never matched: one branch sent every changed file to `unmappedFiles`, the other made the containment filter reject all of them — which also skipped the zero-candidate warning, leaving a silent no-op.

Promoted `journal.ts`'s `realOrRaw`/`isInside` to `src/utils/realpath.ts`. Two things surfaced while doing it:

- `realOrRaw` only resolved the immediate parent, which still leaves several segments unresolved for a file under directories that don't exist — and a half-resolved path compares unequal to a resolved root, reintroducing the same false negative. It now walks up to the nearest existing ancestor.
- Normalising naively changed *reported* paths to `/private/...` twins (three existing tests caught this). Candidates now carry `{ path, resolved }`; only comparison uses `resolved`.

### 3. Rule sections interleaved — MEDIUM

`applySectionBudget` sorted by `(priority, ordinal)` with no rule tiebreaker, so equal-priority sections from different files interleaved ordinal-major. Since `priority` defaults to the same value for any rule that doesn't declare one, that was the normal case. Confirmed with a runtime probe:

```
input   : alpha#preamble | alpha#a | alpha#b | alpha#c | beta#preamble | beta#a | beta#b | beta#c
retained: alpha#preamble | beta#preamble | alpha#a | beta#a | alpha#b
dropped : beta#b | alpha#c | beta#c
```

Every rule arrived shredded, and truncation cut all rules at the same ordinal rather than dropping one boundary file's tail — contradicting the module's own documented contract.

## Self-review correction

The last commit fixes a false positive I introduced in finding 1. Blocked worktrees were compared by path *containment*, but in parallel mode a story's worktree is a linked tree at `<repo>/.nax-wt/<storyId>` — inside the main repo by path, yet a separate checkout that `git add -A` from the main root never stages. That blocked the run-summary commit whenever any story's tree was dirty. Now registers and compares working-tree **roots** by equality, which still catches the monorepo case since `git rev-parse --show-toplevel` from a package answers with the repo root.

## Test plan

- [x] `bun run lint` — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — all phases passed
- [x] Every fix carries a regression test that fails against the pre-fix code (~370 new test lines across 10 files)
- [x] Finding 3 confirmed with a runtime probe before fixing
- [ ] Worth a reviewer's eye: the finding-1 guard changes when nax *declines* to commit. It only triggers after a confirmed-failed revert, which requires the spot-check to be enabled (off by default), so exposure is narrow — but it is a new "nax refuses to commit" path.

## Notes

- `src/utils/markdown-fence.ts` and `src/utils/realpath.ts` are new shared helpers extracted from existing code (`src/prd/markdown-scan.ts` and `src/verification/mutation/journal.ts` respectively), not new logic. Both original modules keep working through re-export/import.
- Finding 5f is riskier than "accept the unprefixed form": an added line whose content starts `++ ` renders as `+++ ...` inside a hunk. The unprefixed form is only honoured immediately after a `---` line, and a test covers that false-positive case.
