### PR TITLE
fix(nax-finish): repair the PR title, body narrative, and diffstat scope

### DIFF
--- a/flows/nax-finish/flow-ctx.ts
+++ b/flows/nax-finish/flow-ctx.ts
@@ -54,10 +54,28 @@ export function loadCtxOf(ctx: OutputsCtx): LoadCtxOutput {
  * Absent when the node was skipped by config, died, or produced only
  * whitespace — `amend_body` treats all three identically, so there is one
  * branch downstream rather than three.
+ *
+ * Accepts the bare string the node used to return as well as the
+ * `{ narrative, title }` it returns now: a flow resumed from a run recorded
+ * before the title landed replays the old shape from its journal.
  */
 export function narrativeOf(ctx: OutputsCtx): string | undefined {
   const out = (ctx.outputs as Record<string, unknown>).narrative;
-  return typeof out === "string" && out.trim().length > 0 ? out : undefined;
+  const prose = typeof out === "string" ? out : (out as { narrative?: unknown } | undefined)?.narrative;
+  return typeof prose === "string" && prose.trim().length > 0 ? prose : undefined;
+}
+
+/**
+ * The narrative node's parsed PR title, already sanitised by `parseTitle`.
+ *
+ * Absent whenever the node is — `resolveTitle` then falls back to
+ * `feat: <feature>`, which is what shipped before and what auto-PR opens with.
+ */
+export function prTitleOf(ctx: OutputsCtx): string | undefined {
+  const out = (ctx.outputs as Record<string, unknown>).narrative;
+  if (typeof out !== "object" || out === null) return undefined;
+  const title = (out as { title?: unknown }).title;
+  return typeof title === "string" && title.trim().length > 0 ? title : undefined;
 }
 
 export function gateOutputs(ctx: OutputsCtx): { failing?: string[]; ran?: string[] } {

--- a/flows/nax-finish/narrative.ts
+++ b/flows/nax-finish/narrative.ts
@@ -17,6 +17,31 @@ export const NARRATIVE_MAX_CHARS = 4000;
 
 const TRUNCATION_SUFFIX = "…";
 
+/**
+ * Sentinel wrapping the prose, so `parseNarrative` has an explicit anchor
+ * rather than an inferred one.
+ *
+ * acpx hands `parse` the concatenation of *every* agent message chunk in the
+ * turn — `chunks.join("")` in its `createQuietCaptureOutput`. This node reads
+ * the diff with tools, so the agent's between-tool-call narration ("Now I have
+ * a clear picture. Let me check…") is structurally part of that string. A
+ * prompt asking for "no preamble" cannot prevent it; only a delimiter can.
+ *
+ * A sentinel rather than the JSON contract the sibling nodes use: this payload
+ * is multi-paragraph prose about code, full of backticks, quotes and newlines.
+ * Literal newlines inside a JSON string are invalid JSON, so a JSON contract
+ * would fail on exactly the inputs this node exists to carry.
+ */
+const OPEN_TAG = "<narrative>";
+const CLOSE_TAG = "</narrative>";
+
+/**
+ * Headings the agent emits despite being told not to. Anchors the fallback
+ * strip when the sentinel is absent: everything up to and including the
+ * heading is preamble.
+ */
+const HEADING_RE = /^[\s\S]*?(?:\*\*What changed\*\*|##+\s*What changed)\s*/i;
+
 /** Headings a spec uses for its lead paragraph, in priority order. */
 const SUMMARY_HEADINGS = ["summary", "overview"] as const;
 
@@ -57,7 +82,10 @@ export function buildNarrativePrompt(args: { base: string }): string {
     "anything a reviewer would otherwise have to reconstruct from the diff by hand.",
     `Hard limit: ${NARRATIVE_MAX_CHARS} characters.`,
     "Do not write a heading — the heading is added for you.",
-    "Return the prose only. No JSON, no code fences, no preamble.",
+    "",
+    `Wrap the prose in ${OPEN_TAG} and ${CLOSE_TAG}, and write nothing after the`,
+    "closing tag. Everything outside those tags is discarded, so anything you say",
+    "while working through the diff is safe to leave where it falls.",
   ].join("\n");
 }
 
@@ -66,10 +94,33 @@ export function buildNarrativePrompt(args: { base: string }): string {
  *
  * Never throws. A throw inside `parse` fails the node, and acpx has no error
  * edge — see `verdict.ts`. Here that would mean the flow dying *after* the PR
- * was already opened.
+ * was already opened, so every branch below degrades instead of rejecting.
+ *
+ * Three tiers, strongest anchor first:
+ *   1. Sentinel — the contract the prompt asks for.
+ *   2. Heading — the agent ignored the sentinel but still wrote
+ *      `**What changed**`, which marks where its preamble stopped.
+ *   3. Bare trim — no anchor available; better a narrative with preamble than
+ *      no narrative at all.
  */
 export function parseNarrative(text: string): string {
-  return typeof text === "string" ? text.trim() : "";
+  if (typeof text !== "string") return "";
+
+  // Last opening tag, not the first: if the agent narrates the tag before
+  // emitting it for real ("I'll wrap this in <narrative>"), the real one wins.
+  const open = text.lastIndexOf(OPEN_TAG);
+  if (open !== -1) {
+    const from = open + OPEN_TAG.length;
+    const close = text.indexOf(CLOSE_TAG, from);
+    const inner = (close === -1 ? text.slice(from) : text.slice(from, close)).trim();
+    if (inner) return inner;
+  }
+
+  // Strip tag markers before the heading pass: an empty or malformed sentinel
+  // falls through to here, and leftover `<narrative>` markup in a PR body is
+  // worse than the preamble this function exists to remove.
+  const untagged = text.split(OPEN_TAG).join("").split(CLOSE_TAG).join("");
+  return untagged.replace(HEADING_RE, "").trim();
 }
 
 function truncate(text: string): string {

--- a/flows/nax-finish/narrative.ts
+++ b/flows/nax-finish/narrative.ts
@@ -12,6 +12,8 @@
  * test can reach it.
  */
 
+import { TITLE_CLOSE_TAG, TITLE_MAX_CHARS, TITLE_OPEN_TAG, parseTitle } from "./pr-title";
+
 /** Longest narrative rendered into a PR body, in characters, including the ellipsis. */
 export const NARRATIVE_MAX_CHARS = 4000;
 
@@ -41,6 +43,9 @@ const CLOSE_TAG = "</narrative>";
  * heading is preamble.
  */
 const HEADING_RE = /^[\s\S]*?(?:\*\*What changed\*\*|##+\s*What changed)\s*/i;
+
+/** A `<title>…</title>` block, closed or not — removed wholesale from the prose. */
+const TITLE_BLOCK_RE = new RegExp(`${TITLE_OPEN_TAG}[\\s\\S]*?(?:${TITLE_CLOSE_TAG}|$)`, "gi");
 
 /** Headings a spec uses for its lead paragraph, in priority order. */
 const SUMMARY_HEADINGS = ["summary", "overview"] as const;
@@ -83,9 +88,17 @@ export function buildNarrativePrompt(args: { base: string }): string {
     `Hard limit: ${NARRATIVE_MAX_CHARS} characters.`,
     "Do not write a heading — the heading is added for you.",
     "",
-    `Wrap the prose in ${OPEN_TAG} and ${CLOSE_TAG}, and write nothing after the`,
-    "closing tag. Everything outside those tags is discarded, so anything you say",
-    "while working through the diff is safe to leave where it falls.",
+    "Then write the pull request title: a conventional-commit subject describing",
+    `the change (\`fix: …\`, \`feat: …\`, \`refactor: …\`), at most ${TITLE_MAX_CHARS} characters.`,
+    "Describe what the change does — not the feature's name, which the reader",
+    "can already see on the branch.",
+    "",
+    "Reply with exactly these two blocks, and write nothing after the last one:",
+    `${TITLE_OPEN_TAG}conventional-commit subject${TITLE_CLOSE_TAG}`,
+    `${OPEN_TAG}the prose${CLOSE_TAG}`,
+    "",
+    "Everything outside those tags is discarded, so anything you say while working",
+    "through the diff is safe to leave where it falls.",
   ].join("\n");
 }
 
@@ -118,9 +131,27 @@ export function parseNarrative(text: string): string {
 
   // Strip tag markers before the heading pass: an empty or malformed sentinel
   // falls through to here, and leftover `<narrative>` markup in a PR body is
-  // worse than the preamble this function exists to remove.
-  const untagged = text.split(OPEN_TAG).join("").split(CLOSE_TAG).join("");
+  // worse than the preamble this function exists to remove. The title block
+  // goes entirely — tags and content — since it is not part of the prose.
+  const untagged = text.replace(TITLE_BLOCK_RE, "").split(OPEN_TAG).join("").split(CLOSE_TAG).join("");
   return untagged.replace(HEADING_RE, "").trim();
+}
+
+/** What the `narrative` acp node returns: the prose, and the title to rename the PR to. */
+export interface NarrativeNodeResult {
+  narrative: string;
+  title?: string;
+}
+
+/**
+ * `parse` for the narrative acp node.
+ *
+ * Both halves are optional to the flow: a missing title leaves the PR on
+ * `feat: <feature>`, and missing prose leaves the body's mechanical sections
+ * alone. Never throws, for the reason `parseNarrative` documents.
+ */
+export function parseNarrativeNode(text: string): NarrativeNodeResult {
+  return { narrative: parseNarrative(text), title: parseTitle(text) };
 }
 
 function truncate(text: string): string {

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -44,7 +44,7 @@
 import { defineFlow } from "acpx/flows";
 import { buildFixCommitMessage } from "./commit-message";
 import { findingsOf, fixAttemptCount, gateOutputs, incrementalSince, inputOf, loadCtxOf } from "./flow-ctx";
-import { narrativePrompt, parseNarrative } from "./narrative";
+import { narrativePrompt, parseNarrativeNode } from "./narrative";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
 import {
   _contextDeps,
@@ -449,7 +449,7 @@ export default defineFlow({
       session: { isolated: true },
       profile: process.env.NAX_FINISH_NARRATIVE_PROFILE || undefined,
       prompt: narrativePrompt,
-      parse: parseNarrative,
+      parse: parseNarrativeNode,
     },
     amend_body: {
       nodeType: "action",

--- a/flows/nax-finish/pr-title.ts
+++ b/flows/nax-finish/pr-title.ts
@@ -1,0 +1,140 @@
+/**
+ * The PR title — sentinel, sanitiser, and the fallback chain.
+ *
+ * `buildFinishTitle` used to return `feat: <feature>` unconditionally, so every
+ * finish-opened PR was titled with its feature slug: `feat: schema-drift-gate`
+ * describes the run, not the change. The narrative node has already read the
+ * whole diff by the time the body is amended, so a real conventional-commit
+ * subject costs one extra sentinel in a prompt that was being sent anyway.
+ *
+ * No deterministic source can replace it. The spec's H1 is the slug in prose
+ * (`# SPEC: Schema drift gate`), the PRD carries no feature-level title, and
+ * concatenating story titles reads worse than the slug it replaces — which is
+ * why this is the one part of the PR metadata that is model-derived, and why
+ * everything below assumes the model may return junk.
+ *
+ * Lives beside `narrative.ts` rather than in `src/prompts/builders/` for the
+ * same reason that file gives: `flows/` runs in acpx's Node process and imports
+ * nothing from `src/`.
+ */
+
+/** Sentinel wrapping the title. See `narrative.ts` for why a delimiter is required at all. */
+export const TITLE_OPEN_TAG = "<title>";
+export const TITLE_CLOSE_TAG = "</title>";
+
+/**
+ * Longest title rendered onto a PR.
+ *
+ * 72 is the conventional-commit subject norm, and GitHub truncates around this
+ * width in list views.
+ */
+export const TITLE_MAX_CHARS = 72;
+
+/**
+ * Conventional-commit prefix, split into the type-with-scope and the subject.
+ *
+ * Types mirror the list in `.claude/rules/project-conventions.md`, plus
+ * `revert`. Captured rather than merely tested so the two halves can be
+ * rejoined with exactly one space — `feat:no space` and `feat:` both reach
+ * here, and testing alone let the latter become `feat: feat:`.
+ *
+ * A title arriving without any prefix is prefixed rather than rejected: the
+ * prose is usually right even when the model forgets the ceremony.
+ */
+const CONVENTIONAL_PREFIX_RE =
+  /^((?:feat|fix|refactor|perf|docs|test|chore|ci|build|style|revert)(?:\([^)]*\))?!?):\s*([\s\S]*)$/i;
+
+const DEFAULT_TYPE = "feat";
+
+/** Wrapping quotes/backticks the model adds when it treats the title as a quoted string. */
+const WRAPPING_CHARS = new Set(['"', "'", "`", "*", "_"]);
+
+function stripWrapping(text: string): string {
+  let out = text;
+  // Loop: models nest these ("`fix: thing`" arrives quoted *and* fenced).
+  while (out.length >= 2) {
+    const first = out[0];
+    const last = out[out.length - 1];
+    if (first !== undefined && first === last && WRAPPING_CHARS.has(first)) {
+      out = out.slice(1, -1).trim();
+      continue;
+    }
+    break;
+  }
+  return out;
+}
+
+/**
+ * Cut to `TITLE_MAX_CHARS` on a word boundary where one is available.
+ *
+ * A mid-word cut reads as corruption rather than brevity; falling back to a
+ * hard slice only matters for a title with no spaces at all.
+ */
+function clamp(text: string): string {
+  if (text.length <= TITLE_MAX_CHARS) return text;
+  const cut = text.slice(0, TITLE_MAX_CHARS);
+  const lastSpace = cut.lastIndexOf(" ");
+  // Guard against a long type prefix eating the whole budget: only honour a
+  // word boundary that leaves a meaningful subject behind.
+  const MIN_KEEP = 20;
+  return (lastSpace >= MIN_KEEP ? cut.slice(0, lastSpace) : cut).trimEnd();
+}
+
+/**
+ * Normalise a model-supplied title, or `undefined` if nothing usable survives.
+ *
+ * Never throws — this feeds `parse` on an acp node, and the flow's PR is
+ * already open by the time it runs.
+ */
+export function sanitizeTitle(raw: string | undefined): string | undefined {
+  if (typeof raw !== "string") return undefined;
+
+  // First non-empty line: a title is single-line by definition, and a model
+  // that adds a rationale below it must not push that onto the PR.
+  const firstLine = raw.split(/\r?\n/).find((line) => line.trim().length > 0);
+  if (firstLine === undefined) return undefined;
+
+  // Collapse internal runs of whitespace before measuring, so the length cap
+  // reflects what a reader sees.
+  let title = stripWrapping(firstLine.trim()).replace(/\s+/g, " ");
+  // Markdown heading marks, for a model that answers the "write a title" ask
+  // with a heading.
+  title = title.replace(/^#+\s*/, "").trim();
+  title = stripWrapping(title);
+  // Trailing sentence punctuation — conventional-commit subjects carry none.
+  title = title.replace(/[.\s]+$/, "");
+  if (!title) return undefined;
+
+  const match = CONVENTIONAL_PREFIX_RE.exec(title);
+  const type = match?.[1] ?? DEFAULT_TYPE;
+  const subject = (match?.[2] ?? title).trim();
+  // A bare `feat:` carries no subject, and a type alone is not a title.
+  if (!subject) return undefined;
+
+  return clamp(`${type}: ${subject}`);
+}
+
+/**
+ * Extract the title from the narrative node's reply.
+ *
+ * Last opening tag wins, mirroring `parseNarrative` — a model that narrates the
+ * tag before emitting it must not beat the real one.
+ */
+export function parseTitle(text: string): string | undefined {
+  if (typeof text !== "string") return undefined;
+  const open = text.lastIndexOf(TITLE_OPEN_TAG);
+  if (open === -1) return undefined;
+  const from = open + TITLE_OPEN_TAG.length;
+  const close = text.indexOf(TITLE_CLOSE_TAG, from);
+  return sanitizeTitle(close === -1 ? text.slice(from) : text.slice(from, close));
+}
+
+/**
+ * The title to render, best source first.
+ *
+ * `feat: <feature>` remains the floor: it is what shipped before, it is what
+ * the auto-PR plugin opens with, and it is always available.
+ */
+export function resolveTitle(agentTitle: string | undefined, feature: string): string {
+  return sanitizeTitle(agentTitle) ?? `${DEFAULT_TYPE}: ${feature}`;
+}

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -5,11 +5,14 @@
  * The finish flow opens a PR via `openOrPromotePr` and used to ship a
  * hardcoded `nax-finish: <feature>` title and a one-sentence body, throwing
  * away every artifact the run produced on the way. This module restores that
- * context as a deterministic markdown body — the title matches
- * `src/plugins/builtin/auto-pr/pr-body.ts:buildTitle`, and the body is
- * assembled by string joins over the fields in `FinishPrContext`. No model
- * call: every section is reproducible from artifacts that exist before
- * `open_pr` runs, and so the body stays greppable in PR history.
+ * context as a deterministic markdown body, assembled by string joins over the
+ * fields in `FinishPrContext`. Every *section* is reproducible from artifacts
+ * that exist before `open_pr` runs, so the body stays greppable in PR history.
+ *
+ * Two fields are the exception, and both arrive later, from the narrative node
+ * that runs after the PR is already open: `narrative` and `title`. Each has a
+ * deterministic fallback (`resolveNarrative`, `resolveTitle`) so `open_pr` never
+ * waits on a model — see `steps/pr-narrative.ts`.
  *
  * Reimplemented here (rather than imported from `src/`) because `flows/`
  * ships to a different runtime — `acpx flow run` runs it in acpx's own Node
@@ -20,6 +23,7 @@ import { dirname, isAbsolute, join } from "node:path";
 import { runArgv } from "../exec";
 import { readSpecSummary, resolveNarrative } from "../narrative";
 import { findPrTemplate } from "../pr-template";
+import { resolveTitle } from "../pr-title";
 import type { Finding, FinishInput, FinishRound, RunFn } from "../types";
 import type { Forge } from "./forge";
 import { readRounds } from "./result";
@@ -55,6 +59,11 @@ export interface FinishPrContext {
   template?: string;
   /** Resolved "What changed" prose. Absent when neither source produced text. */
   narrative?: string;
+  /**
+   * Resolved conventional-commit PR title. Always set — `resolveTitle` falls
+   * back to `feat: <feature>` when the narrative node produced nothing usable.
+   */
+  title: string;
   rounds: FinishRound[];
   run: {
     durationMs?: number;
@@ -202,7 +211,7 @@ async function loadTemplate(workdir: string, forge: Forge | undefined): Promise<
 
 export async function loadFinishPrContext(
   input: FinishInput,
-  args: { base: string; gatesRan: string[]; forge?: Forge; specPath?: string; narrative?: string },
+  args: { base: string; gatesRan: string[]; forge?: Forge; specPath?: string; narrative?: string; title?: string },
 ): Promise<FinishPrContext> {
   const inputPrdPath = input.prdPath || "prd.json";
   const prdPath = isAbsolute(inputPrdPath) ? inputPrdPath : join(input.workdir, inputPrdPath);
@@ -236,6 +245,7 @@ export async function loadFinishPrContext(
     artifactSummary: stat.artifactSummary,
     template,
     narrative: resolveNarrative(args.narrative, specSummary),
+    title: resolveTitle(args.title, input.feature),
     run: {
       durationMs: status?.durationMs,
       storiesPassed: status?.progress?.passed,
@@ -245,12 +255,18 @@ export async function loadFinishPrContext(
 }
 
 /**
- * Conventional-commit title matching `buildTitle` in
- * `src/plugins/builtin/auto-pr/pr-body.ts`, so finish-opened and
- * auto-PR-opened PRs read the same in a list view.
+ * The PR title: the narrative node's conventional-commit subject when it
+ * produced one, else `feat: <feature>`.
+ *
+ * That fallback is what this returned unconditionally, and is still what
+ * `buildTitle` in `src/plugins/builtin/auto-pr/pr-body.ts` opens with — so a
+ * finish run that reaches `open_pr` before the narrative node has spoken still
+ * reads identically to an auto-PR-opened one in a list view. The two diverge
+ * only once there is something better to say: `feat: schema-drift-gate` names
+ * the run, not the change.
  */
 export function buildFinishTitle(ctx: FinishPrContext): string {
-  return `feat: ${ctx.feature}`;
+  return ctx.title;
 }
 
 /**

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -137,6 +137,12 @@ function storiesFrom(prd: PrdArtifact | undefined): FinishPrStory[] {
  */
 const NAX_ARTIFACT_PATHSPEC = "**/.nax/**";
 
+/** The two halves of the branch's diff: what is under review, and what was held out. */
+interface DiffstatResult {
+  diffstat?: string;
+  artifactSummary?: string;
+}
+
 /** Run `git diff <...args>` under `workdir`, or `undefined` on any non-happy path. */
 async function runGitDiff(workdir: string, args: string[]): Promise<string | undefined> {
   try {
@@ -164,7 +170,7 @@ async function runGitDiff(workdir: string, args: string[]): Promise<string | und
  * optional, and a routine empty-branch finish must not lose `open_pr` to a
  * throw that the body can simply skip.
  */
-async function runDiffstat(workdir: string, base: string): Promise<{ diffstat?: string; artifactSummary?: string }> {
+async function runDiffstat(workdir: string, base: string): Promise<DiffstatResult> {
   // An empty `base` would interpolate to `...HEAD`, which git resolves as
   // `HEAD...HEAD` — exit 0, empty stdout — masking the missing-base case as
   // "no changes" instead of skipping explicitly.
@@ -214,7 +220,7 @@ export async function loadFinishPrContext(
     PrdArtifact | undefined,
     StatusArtifact | undefined,
     FinishRound[],
-    { diffstat?: string; artifactSummary?: string },
+    DiffstatResult,
     string | undefined,
     string | null,
   ];
@@ -283,13 +289,13 @@ function buildStoriesSection(stories: FinishPrStory[]): string {
   return lines.join("\n");
 }
 
-function buildVerificationSection(
-  acceptance: string | undefined,
-  regression: string | undefined,
-  gatesRan: string[],
-  diffstat: string | undefined,
-  artifactSummary: string | undefined,
-): string | null {
+/**
+ * Takes the whole context rather than the five fields it reads: the section
+ * grew past the three-positional-parameter cap in the coding standards, and
+ * every field it wants is already on `FinishPrContext`.
+ */
+function buildVerificationSection(ctx: FinishPrContext): string | null {
+  const { acceptance, regression, gatesRan, diffstat, artifactSummary } = ctx;
   const lines: string[] = ["## Verification"];
   if (acceptance !== undefined) lines.push(`- Acceptance: ${acceptance}`);
   if (regression !== undefined) lines.push(`- Regression: ${regression}`);
@@ -368,13 +374,7 @@ export function buildFinishBody(ctx: FinishPrContext): string {
 
   if (ctx.stories.length > 0) sections.push(buildStoriesSection(ctx.stories));
 
-  const verification = buildVerificationSection(
-    ctx.acceptance,
-    ctx.regression,
-    ctx.gatesRan,
-    ctx.diffstat,
-    ctx.artifactSummary,
-  );
+  const verification = buildVerificationSection(ctx);
   if (verification !== null) sections.push(verification);
 
   const roundsSection = buildRoundsSection(ctx.rounds);

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -46,6 +46,11 @@ export interface FinishPrContext {
   regression?: string;
   gatesRan: string[];
   diffstat?: string;
+  /**
+   * `--shortstat` for the nax artifacts held out of `diffstat`. Absent when the
+   * branch touched none, so a repo that gitignores them renders nothing.
+   */
+  artifactSummary?: string;
   /** Repository PR/MR template, verbatim. Absent when none resolves. */
   template?: string;
   /** Resolved "What changed" prose. Absent when neither source produced text. */
@@ -121,7 +126,37 @@ function storiesFrom(prd: PrdArtifact | undefined): FinishPrStory[] {
 }
 
 /**
- * Run `git diff --stat <base>...HEAD` and return its stdout on success.
+ * Pathspec matching nax's own run artifacts, at any depth.
+ *
+ * `**` and the `glob` magic word are both load-bearing. nax writes artifacts
+ * to a repo-root `.nax/` *and* to a per-package `<pkg>/.nax/` — a root-anchored
+ * `:!.nax/**` silently keeps the per-package copy, which is routinely the
+ * largest file in the diff (587 of 2039 insertions on the run that motivated
+ * this). Without `glob`, git's default wildmatch lets `*` cross `/` and the
+ * two forms stop being distinguishable.
+ */
+const NAX_ARTIFACT_PATHSPEC = "**/.nax/**";
+
+/** Run `git diff <...args>` under `workdir`, or `undefined` on any non-happy path. */
+async function runGitDiff(workdir: string, args: string[]): Promise<string | undefined> {
+  try {
+    const res = await _prBodyDeps.run(["git", "diff", ...args], { cwd: workdir });
+    if (res.exitCode !== 0) return undefined;
+    return res.stdout;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Diffstat of the branch, excluding nax's own artifacts.
+ *
+ * The artifacts (`spec.md`, `prd.json`, the generated acceptance test) are
+ * committed and real, but they are the run's exhaust rather than the change
+ * under review, and they dominate the totals — quoting them in the headline
+ * advertises a 2039-line change where 791 lines are reviewable code.
+ * `artifactSummary` keeps them accounted for rather than silently dropped, so
+ * the body still reconciles against `gh pr diff`.
  *
  * Fail-open on every non-happy path — a non-zero exit (no commits, divergent
  * branch, base missing), a rejected run promise (forks too slow to start), or
@@ -129,18 +164,18 @@ function storiesFrom(prd: PrdArtifact | undefined): FinishPrStory[] {
  * optional, and a routine empty-branch finish must not lose `open_pr` to a
  * throw that the body can simply skip.
  */
-async function runDiffstat(workdir: string, base: string): Promise<string | undefined> {
+async function runDiffstat(workdir: string, base: string): Promise<{ diffstat?: string; artifactSummary?: string }> {
   // An empty `base` would interpolate to `...HEAD`, which git resolves as
   // `HEAD...HEAD` — exit 0, empty stdout — masking the missing-base case as
   // "no changes" instead of skipping explicitly.
-  if (!base) return undefined;
-  try {
-    const res = await _prBodyDeps.run(["git", "diff", "--stat", `${base}...HEAD`], { cwd: workdir });
-    if (res.exitCode !== 0) return undefined;
-    return res.stdout;
-  } catch {
-    return undefined;
-  }
+  if (!base) return {};
+  const range = `${base}...HEAD`;
+  const [diffstat, artifacts] = await Promise.all([
+    runGitDiff(workdir, ["--stat", range, "--", `:(glob,exclude)${NAX_ARTIFACT_PATHSPEC}`]),
+    runGitDiff(workdir, ["--shortstat", range, "--", `:(glob)${NAX_ARTIFACT_PATHSPEC}`]),
+  ]);
+  const summary = artifacts?.trim();
+  return { diffstat, artifactSummary: summary ? summary : undefined };
 }
 
 /**
@@ -168,7 +203,7 @@ export async function loadFinishPrContext(
   // [US-004] The audit trail (`rounds`), the diffstat, and the spec summary
   // are independent of the PRD/status reads — fetching them in parallel keeps
   // the loader's wall clock at max(readRounds, readJson×2, diffstat, spec).
-  const [prd, status, rounds, diffstat, template, specSummary] = (await Promise.all([
+  const [prd, status, rounds, stat, template, specSummary] = (await Promise.all([
     readJson(prdPath),
     readJson(join(dirname(prdPath), "status.json")),
     readRounds(input),
@@ -179,7 +214,7 @@ export async function loadFinishPrContext(
     PrdArtifact | undefined,
     StatusArtifact | undefined,
     FinishRound[],
-    string | undefined,
+    { diffstat?: string; artifactSummary?: string },
     string | undefined,
     string | null,
   ];
@@ -191,7 +226,8 @@ export async function loadFinishPrContext(
     regression: status?.postRun?.regression?.status,
     gatesRan: args.gatesRan,
     rounds,
-    diffstat,
+    diffstat: stat.diffstat,
+    artifactSummary: stat.artifactSummary,
     template,
     narrative: resolveNarrative(args.narrative, specSummary),
     run: {
@@ -252,12 +288,19 @@ function buildVerificationSection(
   regression: string | undefined,
   gatesRan: string[],
   diffstat: string | undefined,
+  artifactSummary: string | undefined,
 ): string | null {
   const lines: string[] = ["## Verification"];
   if (acceptance !== undefined) lines.push(`- Acceptance: ${acceptance}`);
   if (regression !== undefined) lines.push(`- Regression: ${regression}`);
   if (gatesRan.length > 0) lines.push(`- Gates: ${gatesRan.join(", ")}`);
   if (diffstat !== undefined && diffstat.length > 0) lines.push(`- Diffstat:\n\n\`\`\`\n${diffstat}\n\`\`\``);
+  // Stated even though the files are excluded above: a reviewer who diffs the
+  // branch themselves sees more than the diffstat quotes, and an unexplained
+  // mismatch reads as a stale body.
+  if (artifactSummary !== undefined && artifactSummary.length > 0) {
+    lines.push(`- Excluded from diffstat — nax run artifacts: ${artifactSummary}`);
+  }
   if (lines.length === 1) return null;
   return lines.join("\n");
 }
@@ -325,7 +368,13 @@ export function buildFinishBody(ctx: FinishPrContext): string {
 
   if (ctx.stories.length > 0) sections.push(buildStoriesSection(ctx.stories));
 
-  const verification = buildVerificationSection(ctx.acceptance, ctx.regression, ctx.gatesRan, ctx.diffstat);
+  const verification = buildVerificationSection(
+    ctx.acceptance,
+    ctx.regression,
+    ctx.gatesRan,
+    ctx.diffstat,
+    ctx.artifactSummary,
+  );
   if (verification !== null) sections.push(verification);
 
   const roundsSection = buildRoundsSection(ctx.rounds);

--- a/flows/nax-finish/steps/pr-narrative.ts
+++ b/flows/nax-finish/steps/pr-narrative.ts
@@ -9,7 +9,7 @@
  * Every failure is warned and swallowed for the same reason — a throw would
  * fail a flow whose real work already succeeded.
  */
-import { gateOutputs, inputOf, loadCtxOf, narrativeOf } from "../flow-ctx";
+import { gateOutputs, inputOf, loadCtxOf, narrativeOf, prTitleOf } from "../flow-ctx";
 import { detectForge } from "./forge";
 import { updatePrBody } from "./pr";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle, loadFinishPrContext } from "./pr-body";
@@ -19,9 +19,11 @@ export async function amendPrBodyNode(ctx: {
   outputs: unknown;
 }): Promise<{ route: "done"; amended: boolean }> {
   const narrative = narrativeOf(ctx);
+  const title = prTitleOf(ctx);
   // Nothing to add: the body already in place is correct, and rewriting it
-  // identically would spend a forge call to change nothing.
-  if (!narrative) return { route: "done", amended: false };
+  // identically would spend a forge call to change nothing. A title alone is
+  // still worth the call — it is the part a reviewer reads first.
+  if (!narrative && !title) return { route: "done", amended: false };
 
   const i = inputOf(ctx);
   const loadCtx = loadCtxOf(ctx);
@@ -33,6 +35,7 @@ export async function amendPrBodyNode(ctx: {
       forge,
       specPath: loadCtx.specPath,
       narrative,
+      title,
     });
     await updatePrBody(forge, i.workdir, i.branch, buildFinishTitle(prCtx), buildFinishBody(prCtx));
     return { route: "done", amended: true };

--- a/test/integration/flows/pr-diffstat.test.ts
+++ b/test/integration/flows/pr-diffstat.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The finish PR diffstat against a real git repository.
+ *
+ * `pr-body.test.ts` asserts the pathspec *string* the loader passes. That
+ * cannot catch the bug this exists for: the string was right in spirit and
+ * wrong in behaviour. nax writes run artifacts to a repo-root `.nax/` AND to a
+ * per-package `<pkg>/.nax/` in a monorepo, and a root-anchored `:!.nax/**`
+ * excludes only the first while reading as though it covers both — on the run
+ * that motivated this, the per-package copy it kept was the largest file in
+ * the diff.
+ *
+ * So these tests run real `git diff` over a real repo carrying artifacts at
+ * both depths, and pin git's matching semantics rather than our spelling of
+ * them.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadFinishPrContext } from "@flows/nax-finish/steps/pr-body";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+const ROOT_ARTIFACT = ".nax/features/f/spec.md";
+const PACKAGE_ARTIFACT = "packages/api/.nax/features/f/_nax_acceptance_test.py";
+const REAL_CODE = "packages/api/src/app.py";
+
+let testDir: string;
+let repo: string;
+let baseSha: string;
+
+async function git(args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], { cwd: repo, stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+  return (await new Response(proc.stdout).text()).trim();
+}
+
+function write(relPath: string, contents: string): void {
+  const abs = join(repo, relPath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+beforeEach(async () => {
+  testDir = makeTempDir("finish-diffstat-");
+  repo = join(testDir, "repo");
+  mkdirSync(repo, { recursive: true });
+
+  await git(["init"]);
+  await git(["config", "user.email", "test@example.com"]);
+  await git(["config", "user.name", "Test User"]);
+
+  write("README.md", "# fixture\n");
+  await git(["add", "."]);
+  await git(["commit", "-m", "initial"]);
+  // The base is the SHA, not a branch name: `git init` picks master or main
+  // depending on the host's git config, and this test cares about neither.
+  baseSha = await git(["rev-parse", "HEAD"]);
+
+  // One commit carrying artifacts at BOTH depths plus genuine source.
+  write(ROOT_ARTIFACT, "# spec\n".repeat(20));
+  write(PACKAGE_ARTIFACT, "assert True\n".repeat(30));
+  write(REAL_CODE, "def readyz():\n    return True\n");
+  await git(["add", "."]);
+  await git(["commit", "-m", "feat: work plus nax artifacts"]);
+});
+
+afterEach(() => {
+  cleanupTempDir(testDir);
+});
+
+const load = () =>
+  loadFinishPrContext(
+    { feature: "f", workdir: repo, branch: "feat/f", prdPath: "prd.json", escalateTelegram: false },
+    { base: baseSha, gatesRan: [] },
+  );
+
+describe("finish PR diffstat — nax artifact exclusion", () => {
+  test("excludes the repo-root .nax/ directory", async () => {
+    const ctx = await load();
+    expect(ctx.diffstat).toBeDefined();
+    expect(ctx.diffstat).not.toContain(".nax/features/f/spec.md");
+  });
+
+  test("excludes a per-package .nax/ directory — the monorepo case", async () => {
+    // The regression that shipped in rs-stock PR #446: a root-anchored
+    // pathspec leaves this file in the diffstat.
+    const ctx = await load();
+    expect(ctx.diffstat).not.toContain("_nax_acceptance_test.py");
+    expect(ctx.diffstat).not.toContain("packages/api/.nax");
+  });
+
+  test("keeps genuine source that merely sits beside a .nax/ directory", async () => {
+    // `packages/api/` contains an artifact dir; excluding the package wholesale
+    // would be just as wrong as excluding nothing.
+    const ctx = await load();
+    expect(ctx.diffstat).toContain("packages/api/src/app.py");
+  });
+
+  test("reports the excluded artifacts so the body still reconciles with the diff", async () => {
+    const ctx = await load();
+    expect(ctx.artifactSummary).toContain("2 files changed");
+  });
+
+  test("renders no artifact summary when the branch touched no .nax/ path", async () => {
+    write("packages/api/src/other.py", "x = 1\n");
+    await git(["add", "."]);
+    await git(["commit", "-m", "code only"]);
+    const onlyCode = await loadFinishPrContext(
+      { feature: "f", workdir: repo, branch: "feat/f", prdPath: "prd.json", escalateTelegram: false },
+      { base: await git(["rev-parse", "HEAD~1"]), gatesRan: [] },
+    );
+    expect(onlyCode.diffstat).toContain("other.py");
+    expect(onlyCode.artifactSummary).toBeUndefined();
+  });
+});

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -7,7 +7,7 @@ import { _gitDeps } from "@flows/nax-finish/steps/git";
 import { _prDeps } from "@flows/nax-finish/steps/pr";
 import { _qualityDeps } from "@flows/nax-finish/steps/quality";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
-import { narrativeOf } from "@flows/nax-finish/flow-ctx";
+import { narrativeOf, prTitleOf } from "@flows/nax-finish/flow-ctx";
 import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
 import { makeFlowCtx, makeFlowSteps } from "@test/helpers";
 
@@ -145,8 +145,21 @@ describe("nax-finish flow graph", () => {
     // while nothing is wired. `narrativeOf` reads `ctx.outputs.narrative`; the
     // node id below is what acpx keys that output by.
     expect(flow.nodes.narrative).toBeDefined();
-    expect(narrativeOf({ outputs: { narrative: "prose" } })).toBe("prose");
+    expect(narrativeOf({ outputs: { narrative: { narrative: "prose" } } })).toBe("prose");
     expect(narrativeOf({ outputs: {} })).toBeUndefined();
+  });
+
+  test("narrativeOf still reads the bare string a pre-title run journalled", () => {
+    // acpx replays a resumed run's outputs from its journal, so a run recorded
+    // before the node returned `{ narrative, title }` hands back the old shape.
+    expect(narrativeOf({ outputs: { narrative: "prose" } })).toBe("prose");
+  });
+
+  test("prTitleOf reads the title half, and is absent for the old shape", () => {
+    expect(prTitleOf({ outputs: { narrative: { narrative: "p", title: "fix: thing" } } })).toBe("fix: thing");
+    expect(prTitleOf({ outputs: { narrative: "prose" } })).toBeUndefined();
+    expect(prTitleOf({ outputs: { narrative: { narrative: "p" } } })).toBeUndefined();
+    expect(prTitleOf({ outputs: {} })).toBeUndefined();
   });
 });
 

--- a/test/unit/flows/nax-finish/narrative.test.ts
+++ b/test/unit/flows/nax-finish/narrative.test.ts
@@ -49,6 +49,65 @@ describe("parseNarrative", () => {
   test("never throws on an empty reply — a throw would fail the flow", () => {
     expect(parseNarrative("")).toBe("");
   });
+
+  test("never throws on a non-string reply", () => {
+    expect(parseNarrative(undefined as unknown as string)).toBe("");
+  });
+
+  test("keeps only what the sentinel wraps", () => {
+    const reply = "Let me read the diff first.\n<narrative>\nAdds a detector.\n</narrative>\n";
+    expect(parseNarrative(reply)).toBe("Adds a detector.");
+  });
+
+  test("preserves prose that would not survive a JSON contract", () => {
+    // Backticks, quotes and hard newlines are why this node uses a sentinel
+    // rather than the JSON the sibling review nodes use.
+    const prose = 'Wires `detect_schema_drift()` in.\n\nIt returns "ok" per {table, op} pair.';
+    expect(parseNarrative(`<narrative>${prose}</narrative>`)).toBe(prose);
+  });
+
+  test("takes the last opening tag, so narrating the tag does not win", () => {
+    const reply = "I will wrap it in <narrative> tags.\n<narrative>Real prose.</narrative>";
+    expect(parseNarrative(reply)).toBe("Real prose.");
+  });
+
+  test("recovers prose when the closing tag is missing", () => {
+    expect(parseNarrative("chatter\n<narrative>Adds a detector.")).toBe("Adds a detector.");
+  });
+
+  test("strips leaked preamble and a bold heading when the sentinel is absent", () => {
+    // The exact shape observed on rs-stock PR #446: acpx concatenates every
+    // agent message chunk of the turn, so between-tool-call narration lands in
+    // `parse`'s input with no separator at all.
+    const reply = [
+      "Now I have a clear picture. Let me check the remaining acceptance test",
+      'briefly, then write the PR body.I have enough context to write the "What changed" prose.',
+      "",
+      "**What changed**",
+      "",
+      "Adds a shared schema-drift detector.",
+    ].join("\n");
+    expect(parseNarrative(reply)).toBe("Adds a shared schema-drift detector.");
+  });
+
+  test("strips a markdown heading form too", () => {
+    expect(parseNarrative("Thinking out loud.\n\n## What changed\n\nAdds a gate.")).toBe("Adds a gate.");
+  });
+
+  test("returns the trimmed reply when no anchor is present at all", () => {
+    // Tier 3: preamble we cannot locate beats dropping the narrative entirely.
+    expect(parseNarrative("Adds a gate to readyz.")).toBe("Adds a gate to readyz.");
+  });
+
+  test("returns empty when the agent wrote a heading and nothing else", () => {
+    // Empty routes `resolveNarrative` to the spec summary rather than
+    // rendering a bare heading.
+    expect(parseNarrative("**What changed**")).toBe("");
+  });
+
+  test("falls through to the heading strip when the sentinel is empty", () => {
+    expect(parseNarrative("chatter\n**What changed**\n<narrative>  </narrative>")).toBe("");
+  });
 });
 
 describe("readSpecSummary", () => {
@@ -108,5 +167,13 @@ describe("buildNarrativePrompt", () => {
 
   test("states the length budget", () => {
     expect(buildNarrativePrompt({ base: "main" })).toContain(String(NARRATIVE_MAX_CHARS));
+  });
+
+  test("asks for the sentinel the parser anchors on", () => {
+    // The prompt and `parseNarrative` have to agree on the delimiter; nothing
+    // else ties them together, and a silent drift here reinstates the leak.
+    const prompt = buildNarrativePrompt({ base: "main" });
+    expect(prompt).toContain("<narrative>");
+    expect(prompt).toContain("</narrative>");
   });
 });

--- a/test/unit/flows/nax-finish/narrative.test.ts
+++ b/test/unit/flows/nax-finish/narrative.test.ts
@@ -11,6 +11,7 @@ import {
   NARRATIVE_MAX_CHARS,
   buildNarrativePrompt,
   parseNarrative,
+  parseNarrativeNode,
   readSpecSummary,
   resolveNarrative,
 } from "@flows/nax-finish/narrative";
@@ -175,5 +176,47 @@ describe("buildNarrativePrompt", () => {
     const prompt = buildNarrativePrompt({ base: "main" });
     expect(prompt).toContain("<narrative>");
     expect(prompt).toContain("</narrative>");
+  });
+
+  test("asks for a conventional-commit title in its own sentinel", () => {
+    const prompt = buildNarrativePrompt({ base: "main" });
+    expect(prompt).toContain("<title>");
+    expect(prompt).toContain("</title>");
+    expect(prompt).toContain("conventional-commit");
+  });
+});
+
+describe("parseNarrativeNode", () => {
+  test("splits a well-formed reply into title and prose", () => {
+    const reply = "<title>fix: repair the gate</title>\n<narrative>Adds a detector.</narrative>";
+    expect(parseNarrativeNode(reply)).toEqual({ title: "fix: repair the gate", narrative: "Adds a detector." });
+  });
+
+  test("keeps the title block out of the prose when the narrative sentinel is missing", () => {
+    // Tier 2: without this the `<title>` block would be rendered as part of
+    // the "What changed" section.
+    const out = parseNarrativeNode("<title>fix: repair the gate</title>\n\nAdds a detector.");
+    expect(out.title).toBe("fix: repair the gate");
+    expect(out.narrative).toBe("Adds a detector.");
+    expect(out.narrative).not.toContain("<title>");
+  });
+
+  test("returns prose with no title when the model omitted the title block", () => {
+    expect(parseNarrativeNode("<narrative>Adds a detector.</narrative>")).toEqual({
+      title: undefined,
+      narrative: "Adds a detector.",
+    });
+  });
+
+  test("returns a title with empty prose rather than throwing", () => {
+    // A title alone is still worth amending the PR for.
+    const out = parseNarrativeNode("<title>fix: repair the gate</title>");
+    expect(out.title).toBe("fix: repair the gate");
+    expect(out.narrative).toBe("");
+  });
+
+  test("never throws on junk", () => {
+    expect(parseNarrativeNode("")).toEqual({ title: undefined, narrative: "" });
+    expect(parseNarrativeNode(undefined as unknown as string)).toEqual({ title: undefined, narrative: "" });
   });
 });

--- a/test/unit/flows/nax-finish/pr-body.test.ts
+++ b/test/unit/flows/nax-finish/pr-body.test.ts
@@ -9,6 +9,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle, loadFinishPrContext } from "@flows/nax-finish/steps/pr-body";
 import type { FinishPrContext, FinishPrStory } from "@flows/nax-finish/steps/pr-body";
+import { resolveTitle } from "@flows/nax-finish/pr-title";
 import type { Finding, FinishRound } from "@flows/nax-finish/types";
 
 const story = (over: Partial<FinishPrStory> = {}): FinishPrStory => ({
@@ -44,17 +45,22 @@ const baseCtx = (over: Partial<FinishPrContext> = {}): FinishPrContext => ({
   gatesRan: [],
   rounds: [],
   run: {},
+  title: "feat: auto-pr-plugin",
   ...over,
 });
 
 describe("buildFinishTitle (US-002 AC1)", () => {
-  test("returns 'feat: <feature>' for the supplied feature", () => {
-    expect(buildFinishTitle(baseCtx({ feature: "auto-pr-plugin" }))).toBe("feat: auto-pr-plugin");
+  test("renders the resolved conventional-commit title", () => {
+    const ctx = baseCtx({ feature: "schema-drift-gate", title: "fix: make the Alembic drift gate able to fail" });
+    expect(buildFinishTitle(ctx)).toBe("fix: make the Alembic drift gate able to fail");
   });
 
-  test("matches the buildTitle format used by the auto-PR plugin", () => {
-    // Identical title shape so finish-opened and auto-PR-opened PRs read the same.
-    expect(buildFinishTitle(baseCtx({ feature: "pipeline-run-outcome" }))).toBe("feat: pipeline-run-outcome");
+  test("renders the 'feat: <feature>' fallback that resolveTitle supplies", () => {
+    // The floor is still the auto-PR plugin's shape, so a finish run whose
+    // narrative node never spoke reads the same as an auto-PR-opened one.
+    expect(buildFinishTitle(baseCtx({ title: resolveTitle(undefined, "pipeline-run-outcome") }))).toBe(
+      "feat: pipeline-run-outcome",
+    );
   });
 });
 

--- a/test/unit/flows/nax-finish/pr-body.test.ts
+++ b/test/unit/flows/nax-finish/pr-body.test.ts
@@ -6,8 +6,8 @@
  * title cannot break its row, and mirrors `buildTitle` so finish-opened and
  * auto-PR-opened PRs read the same.
  */
-import { describe, expect, test } from "bun:test";
-import { buildFinishBody, buildFinishTitle } from "@flows/nax-finish/steps/pr-body";
+import { afterEach, describe, expect, test } from "bun:test";
+import { _prBodyDeps, buildFinishBody, buildFinishTitle, loadFinishPrContext } from "@flows/nax-finish/steps/pr-body";
 import type { FinishPrContext, FinishPrStory } from "@flows/nax-finish/steps/pr-body";
 import type { Finding, FinishRound } from "@flows/nax-finish/types";
 
@@ -105,6 +105,16 @@ describe("buildFinishBody — Verification block (US-002 AC4-AC7)", () => {
     const stat = " src/foo.ts | 12 ++++--\n 1 file changed, 9 insertions(+), 3 deletions(-)";
     const body = buildFinishBody(baseCtx({ diffstat: stat }));
     expect(body).toContain(stat);
+  });
+
+  test("accounts for the held-out nax artifacts so the body reconciles with the real diff", () => {
+    const body = buildFinishBody(baseCtx({ artifactSummary: "5 files changed, 1248 insertions(+)" }));
+    expect(body).toContain("Excluded from diffstat — nax run artifacts: 5 files changed, 1248 insertions(+)");
+  });
+
+  test("renders no exclusion line when the branch touched no artifacts", () => {
+    const body = buildFinishBody(baseCtx({ diffstat: " src/foo.ts | 1 +" }));
+    expect(body).not.toContain("Excluded from diffstat");
   });
 });
 
@@ -264,5 +274,78 @@ describe("buildFinishBody — What changed section (#1477)", () => {
   test("treats a whitespace-only narrative as absent", () => {
     const body = buildFinishBody(baseCtx({ stories: [story()], narrative: "  \n " }));
     expect(body).not.toContain("## What changed");
+  });
+});
+
+describe("loadFinishPrContext — diffstat scope", () => {
+  const origRun = _prBodyDeps.run;
+  const origReadText = _prBodyDeps.readText;
+  afterEach(() => {
+    _prBodyDeps.run = origRun;
+    _prBodyDeps.readText = origReadText;
+  });
+
+  const INPUT = { feature: "f", workdir: "/repo", branch: "feat/f", prdPath: "p.json", escalateTelegram: false };
+
+  /** Capture every argv the loader issues, answering each `git diff` distinctly. */
+  const captureRun = (stdoutFor: (cmd: string[]) => string = () => "") => {
+    const calls: string[][] = [];
+    _prBodyDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return { exitCode: 0, stdout: stdoutFor(cmd), stderr: "" };
+    };
+    return calls;
+  };
+
+  test("excludes nax artifacts at any depth, not just the repo root", async () => {
+    // The `**/` prefix and the `glob` magic word are both load-bearing: nax
+    // writes to `.nax/` AND `<pkg>/.nax/`, and a root-anchored `:!.nax/**`
+    // silently keeps the per-package copy — the largest file in the diff on
+    // the run that motivated this.
+    const calls = captureRun();
+    _prBodyDeps.readText = async () => null;
+    await loadFinishPrContext(INPUT, { base: "origin/main", gatesRan: [] });
+
+    const stat = calls.find((c) => c.includes("--stat"));
+    expect(stat).toBeDefined();
+    expect(stat).toContain(":(glob,exclude)**/.nax/**");
+  });
+
+  test("reports the excluded artifacts as a shortstat rather than dropping them", async () => {
+    const calls = captureRun((cmd) => (cmd.includes("--shortstat") ? " 5 files changed, 1248 insertions(+)\n" : " a.ts | 1 +\n"));
+    _prBodyDeps.readText = async () => null;
+    const ctx = await loadFinishPrContext(INPUT, { base: "origin/main", gatesRan: [] });
+
+    const short = calls.find((c) => c.includes("--shortstat"));
+    expect(short).toContain(":(glob)**/.nax/**");
+    expect(ctx.artifactSummary).toBe("5 files changed, 1248 insertions(+)");
+    expect(ctx.diffstat).toBe(" a.ts | 1 +\n");
+  });
+
+  test("omits the artifact summary when the branch touched none", async () => {
+    captureRun((cmd) => (cmd.includes("--shortstat") ? "" : " a.ts | 1 +\n"));
+    _prBodyDeps.readText = async () => null;
+    const ctx = await loadFinishPrContext(INPUT, { base: "origin/main", gatesRan: [] });
+    expect(ctx.artifactSummary).toBeUndefined();
+  });
+
+  test("issues no git diff at all when the base is unresolved", async () => {
+    const calls = captureRun();
+    _prBodyDeps.readText = async () => null;
+    const ctx = await loadFinishPrContext(INPUT, { base: "", gatesRan: [] });
+    expect(calls.filter((c) => c[1] === "diff")).toEqual([]);
+    expect(ctx.diffstat).toBeUndefined();
+    expect(ctx.artifactSummary).toBeUndefined();
+  });
+
+  test("survives a git failure without losing the rest of the context", async () => {
+    _prBodyDeps.run = async () => {
+      throw new Error("git exploded");
+    };
+    _prBodyDeps.readText = async () => null;
+    const ctx = await loadFinishPrContext(INPUT, { base: "origin/main", gatesRan: ["lint"] });
+    expect(ctx.diffstat).toBeUndefined();
+    expect(ctx.artifactSummary).toBeUndefined();
+    expect(ctx.gatesRan).toEqual(["lint"]);
   });
 });

--- a/test/unit/flows/nax-finish/pr-narrative.test.ts
+++ b/test/unit/flows/nax-finish/pr-narrative.test.ts
@@ -24,6 +24,16 @@ const ctxWith = (narrative?: unknown) =>
     outputs: { load_ctx: { route: "proceed", base: "origin/main" }, narrative },
   });
 
+/**
+ * A `run` that satisfies `detectForge` (GitHub remote) and records every argv,
+ * so the amend path actually reaches `gh pr edit` instead of failing detection.
+ */
+const githubRun = (calls: string[][] = []) => async (cmd: string[]) => {
+  calls.push(cmd);
+  const isRemote = cmd.includes("remote");
+  return { exitCode: 0, stdout: isRemote ? "git@github.com:acme/repo.git" : "", stderr: "" };
+};
+
 describe("amendPrBodyNode", () => {
   test("issues no forge call when the narrative node produced nothing", async () => {
     const calls: string[][] = [];
@@ -31,14 +41,38 @@ describe("amendPrBodyNode", () => {
       calls.push(cmd);
       return { exitCode: 0, stdout: "", stderr: "" };
     };
-    const out = await amendPrBodyNode(ctxWith(undefined));
+    const out = await amendPrBodyNode(ctxWith({ narrative: "" }));
     expect(out).toEqual({ route: "done", amended: false });
     expect(calls).toEqual([]);
   });
 
   test("treats a whitespace-only narrative as nothing", async () => {
-    const out = await amendPrBodyNode(ctxWith("   \n  "));
+    const out = await amendPrBodyNode(ctxWith({ narrative: "   \n  " }));
     expect(out.amended).toBe(false);
+  });
+
+  test("amends for a title even when the prose is empty", async () => {
+    // The title is the part a reviewer reads first, so it alone justifies the
+    // forge call that an empty narrative would otherwise skip.
+    _prBodyDeps.run = githubRun();
+    const out = await amendPrBodyNode(ctxWith({ narrative: "", title: "fix: repair the gate" }));
+    expect(out.amended).toBe(true);
+  });
+
+  test("writes the model's title onto the PR", async () => {
+    const calls: string[][] = [];
+    _prBodyDeps.run = githubRun(calls);
+    await amendPrBodyNode(ctxWith({ narrative: "Prose.", title: "fix: repair the gate" }));
+    const edit = calls.find((c) => c.includes("--title"));
+    expect(edit?.[edit.indexOf("--title") + 1]).toBe("fix: repair the gate");
+  });
+
+  test("falls back to 'feat: <feature>' when the node produced no title", async () => {
+    const calls: string[][] = [];
+    _prBodyDeps.run = githubRun(calls);
+    await amendPrBodyNode(ctxWith({ narrative: "Prose." }));
+    const edit = calls.find((c) => c.includes("--title"));
+    expect(edit?.[edit.indexOf("--title") + 1]).toBe("feat: x");
   });
 
   test("warns instead of throwing when the forge edit fails", async () => {
@@ -47,7 +81,7 @@ describe("amendPrBodyNode", () => {
     _prBodyDeps.run = async () => {
       throw new Error("gh exploded");
     };
-    const out = await amendPrBodyNode(ctxWith("real prose"));
+    const out = await amendPrBodyNode(ctxWith({ narrative: "real prose" }));
     expect(out).toEqual({ route: "done", amended: false });
     expect(warnings.length).toBe(1);
   });

--- a/test/unit/flows/nax-finish/pr-title.test.ts
+++ b/test/unit/flows/nax-finish/pr-title.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The PR title — the one piece of PR metadata derived from a model, and so the
+ * one that has to assume the reply is junk.
+ *
+ * Every guarantee here is on a pure function: the acp node that produces the
+ * text cannot be executed in tests, so the sanitiser and its fallback chain
+ * live where a test can reach them.
+ */
+import { describe, expect, test } from "bun:test";
+import { TITLE_MAX_CHARS, parseTitle, resolveTitle, sanitizeTitle } from "@flows/nax-finish/pr-title";
+
+describe("sanitizeTitle", () => {
+  test("keeps a well-formed conventional-commit subject unchanged", () => {
+    expect(sanitizeTitle("fix: make the Alembic drift gate able to fail")).toBe(
+      "fix: make the Alembic drift gate able to fail",
+    );
+  });
+
+  test.each([
+    ["feat", "feat: add a thing"],
+    ["fix", "fix: repair a thing"],
+    ["refactor", "refactor: move a thing"],
+    ["perf", "perf: speed a thing"],
+    ["chore", "chore: bump a thing"],
+    ["revert", "revert: undo a thing"],
+  ])("accepts the %s type as an existing prefix", (_type, title) => {
+    expect(sanitizeTitle(title)).toBe(title);
+  });
+
+  test("accepts a scope and a breaking-change marker", () => {
+    expect(sanitizeTitle("feat(readyz)!: return 503 on schema drift")).toBe("feat(readyz)!: return 503 on schema drift");
+  });
+
+  test("prefixes a bare subject rather than rejecting it", () => {
+    // The prose is usually right even when the model forgets the ceremony.
+    expect(sanitizeTitle("make the drift gate able to fail")).toBe("feat: make the drift gate able to fail");
+  });
+
+  test("keeps only the first line, dropping a rationale written below it", () => {
+    expect(sanitizeTitle("fix: repair the gate\n\nBecause it could never fail.")).toBe("fix: repair the gate");
+  });
+
+  test.each([
+    ['"fix: repair the gate"', "double quotes"],
+    ["'fix: repair the gate'", "single quotes"],
+    ["`fix: repair the gate`", "backticks"],
+    ["**fix: repair the gate**", "bold markers"],
+    ['"`fix: repair the gate`"', "nested quoting"],
+  ])("strips %s (%s)", (raw) => {
+    expect(sanitizeTitle(raw)).toBe("fix: repair the gate");
+  });
+
+  test("strips a markdown heading mark", () => {
+    expect(sanitizeTitle("## fix: repair the gate")).toBe("fix: repair the gate");
+  });
+
+  test("strips trailing sentence punctuation", () => {
+    expect(sanitizeTitle("fix: repair the gate.")).toBe("fix: repair the gate");
+  });
+
+  test("collapses internal whitespace so the length cap matches what a reader sees", () => {
+    expect(sanitizeTitle("fix:   repair    the gate")).toBe("fix: repair the gate");
+  });
+
+  test("clamps an over-long title on a word boundary", () => {
+    const long = `fix: ${"repair ".repeat(30)}gate`;
+    const out = sanitizeTitle(long) as string;
+    expect(out.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+    // A mid-word cut reads as corruption rather than brevity.
+    expect(out.endsWith("repair")).toBe(true);
+  });
+
+  test("clamps a title with no spaces at all rather than returning nothing", () => {
+    const out = sanitizeTitle(`fix: ${"x".repeat(200)}`) as string;
+    expect(out.length).toBe(TITLE_MAX_CHARS);
+  });
+
+  test.each([
+    ["", "empty"],
+    ["   \n  ", "whitespace only"],
+    ["feat:", "a bare type with no subject"],
+    ["**  **", "only wrapping markers"],
+  ])("returns undefined for %s input (%s)", (raw) => {
+    expect(sanitizeTitle(raw)).toBeUndefined();
+  });
+
+  test("returns undefined for a non-string, and never throws", () => {
+    expect(sanitizeTitle(undefined)).toBeUndefined();
+    expect(sanitizeTitle(42 as unknown as string)).toBeUndefined();
+  });
+});
+
+describe("parseTitle", () => {
+  test("reads the sentinel out of a reply that also carries prose", () => {
+    const reply = "Let me look at the diff.\n<title>fix: repair the gate</title>\n<narrative>Prose.</narrative>";
+    expect(parseTitle(reply)).toBe("fix: repair the gate");
+  });
+
+  test("takes the last opening tag, so narrating the tag does not win", () => {
+    expect(parseTitle("I'll put it in <title> tags.\n<title>fix: real one</title>")).toBe("fix: real one");
+  });
+
+  test("recovers a title when the closing tag is missing", () => {
+    expect(parseTitle("<title>fix: repair the gate")).toBe("fix: repair the gate");
+  });
+
+  test("returns undefined when the sentinel is absent entirely", () => {
+    expect(parseTitle("fix: repair the gate")).toBeUndefined();
+  });
+
+  test("returns undefined for an empty sentinel", () => {
+    expect(parseTitle("<title>   </title>")).toBeUndefined();
+  });
+});
+
+describe("resolveTitle", () => {
+  test("prefers the model's subject", () => {
+    expect(resolveTitle("fix: repair the gate", "schema-drift-gate")).toBe("fix: repair the gate");
+  });
+
+  test.each([
+    [undefined, "nothing"],
+    ["   ", "whitespace"],
+    ["feat:", "an unusable subject"],
+  ])("falls back to 'feat: <feature>' given %s (%s)", (raw) => {
+    // The floor is what shipped before, and what the auto-PR plugin opens with.
+    expect(resolveTitle(raw, "schema-drift-gate")).toBe("feat: schema-drift-gate");
+  });
+});

--- a/test/unit/flows/nax-finish/steps/pr.test.ts
+++ b/test/unit/flows/nax-finish/steps/pr.test.ts
@@ -257,8 +257,21 @@ describe("loadFinishPrContext (US-004 AC1-AC6)", () => {
 
     await loadFinishPrContext(input(), { base: "origin/release/2026.08", gatesRan: [] });
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual(["git", "diff", "--stat", "origin/release/2026.08...HEAD"]);
+    // Two calls since the artifact exclusion landed: the reviewable diffstat,
+    // and the `--shortstat` that accounts for the nax artifacts held out of it.
+    // Both must carry the caller's base — the point of this AC.
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call).toContain("origin/release/2026.08...HEAD");
+    }
+    expect(calls.find((c) => c.includes("--stat"))).toEqual([
+      "git",
+      "diff",
+      "--stat",
+      "origin/release/2026.08...HEAD",
+      "--",
+      ":(glob,exclude)**/.nax/**",
+    ]);
   });
 
   // US-004 AC4 — the diffstat text is rendered verbatim into the Verification


### PR DESCRIPTION
## What changed

Three fixes to the `nax-finish` flow's PR metadata, all observed on the same finish run — a clean 2/2-story run whose output was fine and whose PR metadata was not.

### 1. Agent narration leaked into "What changed"

The narrative section opened with the agent thinking out loud:

> Now I have a clear picture. Let me check the remaining acceptance test and the readyz test file briefly for coverage detail, then write the PR body.**I have enough context to write the "What changed" prose.**
>
> \*\*What changed\*\*
>
> Adds a shared schema-drift detector and…

Note `…write the PR body.` + `I have enough context…` with no separator. acpx hands an acp node's `parse` the concatenation of **every** agent message chunk in the turn — `chunks.join("")` in its `createQuietCaptureOutput`. The narrative node reads the branch diff with tools, so its between-tool-call narration is structurally part of `parseNarrative`'s input. That function only trimmed:

```ts
export function parseNarrative(text: string): string {
  return typeof text === "string" ? text.trim() : "";
}
```

The prompt already said "no preamble" and "do not write a heading"; nothing enforced either, and both were ignored. Every sibling node in this flow is immune only because it parses JSON via `extractJsonObject`, which discards preamble structurally — `narrative` is the lone free-prose node and had the weakest parser.

**Fix:** wrap the prose in a `<narrative>` sentinel and parse between the tags. A sentinel rather than the siblings' JSON contract, deliberately: this payload is multi-paragraph prose *about code*, full of backticks, quotes and hard newlines — literal newlines inside a JSON string are invalid JSON, so a JSON contract would fail on exactly the inputs this node exists to carry, and fall back to a spec-derived narrative that describes intent rather than what shipped.

Degrades in three tiers, none of which throw (a throw in `parse` fails the node, and `open_pr` has already opened the PR by then):

1. sentinel — the contract the prompt asks for
2. strip a leaked `**What changed**` / `## What changed` heading and everything before it — the observed failure, and the anchor that survives an ignored sentinel
3. bare trim — preamble beats no narrative at all

Tier 2 also strips residual tag markers, so a malformed sentinel cannot put `<narrative>` markup into a PR body. That case came from writing the test, which failed on the first implementation.

### 2. nax's own artifacts dominated the diffstat

`runDiffstat` ran `git diff --stat <base>...HEAD` with no pathspec, so the run's own exhaust — `spec.md`, `prd.json`, `acceptance-refined.json`, the generated acceptance test — landed in the headline:

| Diffstat | Files | Insertions | Deletions |
|:---|---:|---:|---:|
| What the PR reported | 13 | 2,039 | 417 |
| Real reviewable code | 8 | **791** | 417 |

61% of the advertised size was artifacts.

**Fix:** exclude them with `:(glob,exclude)**/.nax/**`. Both the `**/` prefix and the `glob` magic word are load-bearing — nax writes to a repo-root `.nax/` **and** a per-package `<pkg>/.nax/`, so the obvious root-anchored form silently keeps the per-package copy, which was the single largest file in that diff:

```
:!.nax/**                  → 9 files, 1378 insertions   ✗ still 587 lines of artifact
:(glob,exclude)**/.nax/**  → 8 files,  791 insertions   ✓
```

The held-out files are reported as a `--shortstat` line rather than dropped silently — a reviewer who runs `gh pr diff` sees more than the body quotes, and an unexplained mismatch reads as a stale body:

```
- Excluded from diffstat — nax run artifacts: 5 files changed, 1248 insertions(+)
```

Absent when the branch touched no artifacts, so a repo that gitignores them renders nothing. Both git calls stay fail-open — `open_pr` must not die for an optional block.

### 3. The title was the feature slug

`buildFinishTitle` returned `feat: <feature>` unconditionally, so every finish-opened PR was titled with its feature slug — the name of the run, not the change.

No deterministic source can replace it: a spec's H1 is typically the slug in prose (`# SPEC: Schema drift gate`), the PRD carries no feature-level title, and concatenating story titles reads worse than the slug. But the narrative node has already read the whole diff by the time the body is amended, so a real subject costs one extra sentinel in a prompt that was being sent anyway.

The node now returns `{ narrative, title }` and `amend_body` writes both.

`feat: <feature>` remains the **floor**, not a rejected option: a run whose narrative node is disabled by config, dies, or returns junk is titled exactly as before — and so is the window between `open_pr` and the node speaking. That is why the fallback still matches `buildTitle` in the auto-PR plugin; the two diverge only once there is something better to say.

Everything downstream assumes the reply is junk. `sanitizeTitle` takes the first non-empty line, strips wrapping quotes/backticks/bold and markdown heading marks, collapses whitespace, drops trailing punctuation, normalises or adds the conventional-commit prefix, and clamps to 72 characters on a word boundary. Anything left without a subject falls back. Titles reach `gh`/`glab` via `runArgv`, which spawns argv directly with no shell — no injection surface.

`narrativeOf` still accepts the bare string the node used to return, since acpx replays a resumed run's outputs from its journal and a run recorded before this change hands back the old shape.

## Verification

- `bun run test` — 11,960 unit + 1,097 integration + 24 UI, **0 fail**
- `bun run typecheck` — clean
- `bun run lint` — clean, all 9 check scripts at baseline

New coverage:

- **`test/integration/flows/pr-diffstat.test.ts`** — real `git diff` over a fixture carrying artifacts at *both* depths plus source under the same package. The unit test asserts the pathspec string; only this pins git's actual matching semantics. **Verified to fail on the root-anchored form** (2 of 5 red) and pass on `**/.nax/**`, so it genuinely guards the bug rather than restating the implementation.
- **`test/unit/flows/nax-finish/pr-title.test.ts`** — 34 cases over `sanitizeTitle` / `parseTitle` / `resolveTitle`: every accepted type, scopes and `!` markers, each quoting form, clamping on and off a word boundary, and every route to the fallback.
- `parseNarrative` / `parseNarrativeNode` — the verbatim leaked-preamble shape, prose that would not survive a JSON contract, a narrated-then-real tag, a missing closing tag, a title block leaking into the prose, and heading-only input.
- `buildFinishBody` / `loadFinishPrContext` / `amend_body` — exclusion argv, artifact summary present/absent, unresolved base, git failure, title written, title fallback, and amending for a title with no prose.

## Review notes

Two bugs were found **by writing the tests**, not before:

- The narrative fallback left literal `<narrative>` markup in the body when the sentinel was empty or malformed — worse than the preamble being fixed.
- `feat:` failed the old prefix test (which required trailing whitespace), got prefixed again, and produced `feat: feat:`. The prefix is now captured and rejoined rather than merely tested, which also normalises `feat:no-space`.

One pre-existing test changed: `US-004 AC3` in `steps/pr.test.ts` pinned the old single-call argv. Its intent — the caller's base is used verbatim, never a silent `main` — is preserved and now asserted across both calls.

Self-review of my own diff caught two more, fixed in the third commit: `buildVerificationSection` had grown to five positional parameters (standards cap is three) and now takes the context it was destructuring anyway; and the `{ diffstat?, artifactSummary? }` shape appeared three times inline, now named `DiffstatResult`.

## Out of scope

- **Repairing the body of the PR that surfaced this.** This fixes the generator, not the artifact it already produced.
- **Whether a generated acceptance test under `<pkg>/.nax/` should be committed at all.** That is a consuming repo's `.gitignore`/`.naxignore` question, not something nax should decide here.
