### PR TITLE
fix(plan): apply spec->PRD fidelity repairs on every write path, and surface degraded plans

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -80,6 +80,7 @@ import { DEFAULT_CONFIG, findProjectDir, loadConfig, validateDirectory } from ".
 import { run } from "../src/execution";
 import { loadHooksConfig } from "../src/hooks";
 import { type LogLevel, initLogger, resetLogger } from "../src/logger";
+import type { PlanResult } from "../src/plan/strategies";
 import { countStories, loadPRD } from "../src/prd";
 import { AgentStreamEventBus, projectOutputDir } from "../src/runtime";
 import { resolveScheduleGate, waitForSchedule } from "../src/schedule";
@@ -102,6 +103,20 @@ program.name("nax").description("AI Coding Agent Orchestrator — loops until do
  */
 function collectProfile(value: string, previous: string[]): string[] {
   return previous.concat(value);
+}
+
+/**
+ * Surface a degraded plan. `nax plan` is deliberately recovery-tolerant — it
+ * yields a usable PRD rather than failing — but a recovered PRD came from the
+ * agent's own on-disk output after a throw, not from the strategy's normal
+ * path. It used to be indistinguishable from a clean plan at every layer, so
+ * `[OK] PRD generated` + exit 0 was the only signal the user ever saw (#1494).
+ */
+function warnIfPlanDegraded(result: PlanResult): void {
+  if (!result.degraded) return;
+  console.log(chalk.yellow("\n[WARN] PRD recovered after a plan failure — this is a degraded result"));
+  console.log(chalk.dim(`   Cause: ${result.degraded.reason}`));
+  console.log(chalk.dim("   Deterministic spec->PRD repairs were re-applied, but review the PRD before running."));
 }
 
 /**
@@ -564,12 +579,14 @@ program
         console.log(chalk.dim(`   [Plan log: ${planLogPath}]`));
 
         console.log(chalk.dim("   [Planning phase: generating PRD from spec]"));
-        const generatedPrdPath = await planCommand(workdir, config, {
+        const planResult = await planCommand(workdir, config, {
           from: options.from,
           feature: options.feature,
           auto: options.oneShot ?? false, // interactive by default; --one-shot skips Q&A
           branch: undefined,
         });
+        const generatedPrdPath = planResult.outputPath;
+        warnIfPlanDegraded(planResult);
 
         // Load the generated PRD to display confirmation gate
         const generatedPrd = await loadPRD(generatedPrdPath);
@@ -1126,15 +1143,16 @@ program
           console.error(chalk.red("Error: --from <spec-path> is required unless --decompose is used"));
           process.exit(1);
         }
-        const prdPath = await planCommand(workdir, config, {
+        const planResult = await planCommand(workdir, config, {
           from: options.from,
           feature: options.feature,
           auto: options.auto || options.oneShot, // --auto and --one-shot are aliases
           branch: options.branch,
         });
 
+        warnIfPlanDegraded(planResult);
         console.log(chalk.green("\n[OK] PRD generated"));
-        console.log(chalk.dim(`   PRD: ${prdPath}`));
+        console.log(chalk.dim(`   PRD: ${planResult.outputPath}`));
         console.log(chalk.dim(`   Log: ${planLogPath}`));
         console.log(chalk.dim(`\nNext: nax run -f ${options.feature}`));
       }

--- a/src/cli/plan-command.ts
+++ b/src/cli/plan-command.ts
@@ -14,7 +14,7 @@ import { renderManifestSection } from "../debate";
 import { NaxError } from "../errors";
 import { callOp, groundOp, planDraftOp } from "../operations";
 import type { PlanDraftInput } from "../operations";
-import { buildPlanModeContext, createPlanStrategy, finalizePrdRouting } from "../plan/strategies";
+import { buildPlanModeContext, createPlanStrategy, finalizeAndWritePrd } from "../plan/strategies";
 export { assertIsValidPrd, buildPlanComposition } from "../plan/strategies";
 import { buildPackageSummary, buildSourceRootsSection } from "./plan-helpers";
 import { _planDeps, createPlanRuntime } from "./plan-runtime";
@@ -198,15 +198,20 @@ export async function runPlanPipeline(
     });
 
     if (verdict.outcome === "passed") {
-      // Delta C4 + ADR-025: finalizePrdRouting resolves agentProfileId → agent,
-      // stamps origin fields, and records the loader-resolved config profile name
-      // so nax run can detect ladder drift.
-      const prdToWrite = finalizePrdRouting(
-        { ...verdict.prd, project: projectName },
-        config.routing?.agents,
-        config.profile,
-      );
-      await _planDeps.writeFile(outputPath, JSON.stringify(prdToWrite, null, 2));
+      // Delta C4 + ADR-025: finalizeAndWritePrd re-applies the spec→PRD fidelity
+      // repairs, resolves agentProfileId → agent, stamps origin fields, and
+      // records the loader-resolved config profile name so nax run can detect
+      // ladder drift.
+      await finalizeAndWritePrd({
+        prd: verdict.prd,
+        specContent,
+        featureName: options.feature,
+        projectName,
+        agentRouting: config.routing?.agents,
+        profileName: config.profile,
+        outputPath,
+        writeFile: _planDeps.writeFile,
+      });
       logger?.info("plan", "[OK] PRD written via pipeline", { outputPath });
       return outputPath;
     }

--- a/src/cli/plan-command.ts
+++ b/src/cli/plan-command.ts
@@ -15,6 +15,8 @@ import { NaxError } from "../errors";
 import { callOp, groundOp, planDraftOp } from "../operations";
 import type { PlanDraftInput } from "../operations";
 import { buildPlanModeContext, createPlanStrategy, finalizeAndWritePrd } from "../plan/strategies";
+import type { PlanResult } from "../plan/strategies";
+
 export { assertIsValidPrd, buildPlanComposition } from "../plan/strategies";
 import { buildPackageSummary, buildSourceRootsSection } from "./plan-helpers";
 import { _planDeps, createPlanRuntime } from "./plan-runtime";
@@ -70,9 +72,14 @@ export interface PlanCommandOptions {
  * @param workdir - Project root directory
  * @param config  - Nax configuration
  * @param options - Command options
- * @returns Path to generated prd.json
+ * @returns The generated prd.json path, plus `degraded` when the plan threw and
+ *          the PRD had to be recovered from disk.
  */
-export async function planCommand(workdir: string, config: NaxConfig, options: PlanCommandOptions): Promise<string> {
+export async function planCommand(
+  workdir: string,
+  config: NaxConfig,
+  options: PlanCommandOptions,
+): Promise<PlanResult> {
   const ctx = await buildPlanModeContext(workdir, config, options, _planDeps);
   try {
     const mode = resolvePlanMode(config);

--- a/src/plan/strategies/debate.ts
+++ b/src/plan/strategies/debate.ts
@@ -1,9 +1,8 @@
 import type { DebateStageConfig } from "@/debate/types";
 import { NaxError } from "@/errors";
-import { applyPlanFidelity, callOp, planInteractiveOp } from "@/operations";
+import { callOp, planInteractiveOp } from "@/operations";
 import type { CallContext, PlanInteractiveInput } from "@/operations";
 import { validatePlanOutput } from "@/prd";
-import type { PRD } from "@/prd/types";
 import { PlanPromptBuilder } from "@/prompts";
 import { assertIsValidPrd } from "./assert";
 import { buildPlanComposition } from "./debate-composition";
@@ -82,10 +81,9 @@ export class DebatePlanStrategy implements IPlanStrategy {
         const prd = validatePlanOutput(debateResult.output, ctx.options.feature, ctx.branchName);
         // Debate synthesis merges debater candidates and can drop a feature-level
         // exclusion. Repairable rather than merely reportable — an exclusion has
-        // exactly one home, so restore it. spec-review --prd remains the gate.
-        const scoped = applyPlanFidelity(prd, ctx.specContent, ctx.options.feature);
-        const withProject = { ...scoped, project: ctx.projectName } satisfies PRD;
-        return _debatePlanDeps.writeOrRecoverPrd(ctx, withProject);
+        // exactly one home, and persistPrd restores it. spec-review --prd remains
+        // the gate.
+        return _debatePlanDeps.writeOrRecoverPrd(ctx, prd);
       }
 
       const prd = await callOp(
@@ -107,8 +105,7 @@ export class DebatePlanStrategy implements IPlanStrategy {
         } satisfies PlanInteractiveInput,
       );
       assertIsValidPrd(prd);
-      const withProject = { ...prd, project: ctx.projectName } satisfies PRD;
-      return _debatePlanDeps.writeOrRecoverPrd(ctx, withProject);
+      return _debatePlanDeps.writeOrRecoverPrd(ctx, prd);
     } catch (err) {
       return _debatePlanDeps.writeOrRecoverPrd(ctx, null, err);
     } finally {

--- a/src/plan/strategies/debate.ts
+++ b/src/plan/strategies/debate.ts
@@ -6,7 +6,7 @@ import { validatePlanOutput } from "@/prd";
 import { PlanPromptBuilder } from "@/prompts";
 import { assertIsValidPrd } from "./assert";
 import { buildPlanComposition } from "./debate-composition";
-import type { IPlanStrategy, PlanModeContext } from "./types";
+import type { IPlanStrategy, PlanModeContext, PlanResult } from "./types";
 import { writeOrRecoverPrd } from "./write-prd";
 
 export const _debatePlanDeps = {
@@ -20,7 +20,7 @@ export const _debatePlanDeps = {
 export class DebatePlanStrategy implements IPlanStrategy {
   readonly mode = "debate" as const;
 
-  async execute(ctx: PlanModeContext): Promise<string> {
+  async execute(ctx: PlanModeContext): Promise<PlanResult> {
     const agentRouting = ctx.config.routing?.agents;
     const profiles = agentRouting?.enabled === true ? (agentRouting.profiles ?? []) : [];
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(

--- a/src/plan/strategies/index.ts
+++ b/src/plan/strategies/index.ts
@@ -9,3 +9,5 @@ export { DebatePlanStrategy, _debatePlanDeps } from "./debate";
 export { RefinePlanStrategy, _refinePlanDeps } from "./refine";
 export { buildPlanComposition } from "./debate-composition";
 export { finalizePrdRouting } from "./finalize-routing";
+export { finalizeAndWritePrd, persistPrd } from "./persist-prd";
+export type { PersistPrdArgs } from "./persist-prd";

--- a/src/plan/strategies/index.ts
+++ b/src/plan/strategies/index.ts
@@ -1,4 +1,11 @@
-export type { IPlanStrategy, PlanCommandOptions, PlanDeps, PlanModeContext } from "./types";
+export type {
+  IPlanStrategy,
+  PlanCommandOptions,
+  PlanDegradation,
+  PlanDeps,
+  PlanModeContext,
+  PlanResult,
+} from "./types";
 export { buildPlanModeContext } from "./context-builder";
 export { createPlanStrategy } from "./factory";
 export { writeOrRecoverPrd } from "./write-prd";

--- a/src/plan/strategies/persist-prd.ts
+++ b/src/plan/strategies/persist-prd.ts
@@ -1,0 +1,60 @@
+/**
+ * The single pre-write invariant for every PRD `nax plan` persists.
+ *
+ * `applyPlanFidelity` used to be invoked per-strategy — inside `planOp.parse`
+ * for single, `planRefineOp.verify` for refine, and in the strategy body for
+ * pipeline and debate. Every one of those sites sits on the *happy* path, so a
+ * throw that diverted a strategy onto its disk-recovery branch persisted the
+ * agent-written PRD raw, silently discarding the deterministic spec→PRD repairs
+ * (#1494). `modifiedFiles` was the canary: unlike `outOfScope` it has no
+ * prompt-side self-heal turn, so the backfill is its only channel.
+ *
+ * Routing them all through here makes the repair a property of *writing a PRD*
+ * rather than of any one code path, which is what `applyPlanFidelity`'s own
+ * contract already claimed ("the four plan strategies cannot drift on which
+ * repairs they apply"). Re-application is safe: `backfillOutOfScope` early-returns
+ * once nothing is missing, and `applyModifiedFiles` merges deduped by path.
+ */
+import type { AgentRoutingConfig } from "@/config";
+import { applyPlanFidelity } from "@/operations";
+import type { PRD } from "@/prd/types";
+import { finalizePrdRouting } from "./finalize-routing";
+import type { PlanModeContext } from "./types";
+
+export interface PersistPrdArgs {
+  readonly prd: PRD;
+  readonly specContent: string;
+  readonly featureName: string;
+  readonly projectName: string;
+  readonly agentRouting: AgentRoutingConfig | undefined;
+  readonly profileName: string | undefined;
+  readonly outputPath: string;
+  readonly writeFile: (path: string, content: string) => Promise<void>;
+}
+
+/**
+ * Repair → finalize routing → write. Returns the path written.
+ *
+ * Context-free so `runPlanPipeline`, which never builds a `PlanModeContext`,
+ * shares the same invariant as the four strategies.
+ */
+export async function finalizeAndWritePrd(args: PersistPrdArgs): Promise<string> {
+  const repaired = applyPlanFidelity(args.prd, args.specContent, args.featureName);
+  const finalized = finalizePrdRouting({ ...repaired, project: args.projectName }, args.agentRouting, args.profileName);
+  await args.writeFile(args.outputPath, JSON.stringify(finalized, null, 2));
+  return args.outputPath;
+}
+
+/** `finalizeAndWritePrd` for the four strategies, which all carry a full context. */
+export async function persistPrd(ctx: PlanModeContext, prd: PRD): Promise<string> {
+  return finalizeAndWritePrd({
+    prd,
+    specContent: ctx.specContent,
+    featureName: ctx.options.feature,
+    projectName: ctx.projectName,
+    agentRouting: ctx.config.routing?.agents,
+    profileName: ctx.profileName,
+    outputPath: ctx.outputPath,
+    writeFile: ctx.deps.writeFile,
+  });
+}

--- a/src/plan/strategies/pipeline.ts
+++ b/src/plan/strategies/pipeline.ts
@@ -1,10 +1,10 @@
 import { renderManifestSection } from "@/debate";
 import type { FactsManifest } from "@/debate/facts-manifest";
 import { NaxError } from "@/errors";
-import { applyPlanFidelity, callOp, groundOp, planDraftOp } from "@/operations";
+import { callOp, groundOp, planDraftOp } from "@/operations";
 import type { CallContext, PlanDraftInput } from "@/operations";
 import { runPlanCritic } from "../critic";
-import { finalizePrdRouting } from "./finalize-routing";
+import { persistPrd } from "./persist-prd";
 import type { IPlanStrategy, PlanModeContext } from "./types";
 
 export const _pipelinePlanDeps = {
@@ -85,16 +85,9 @@ export class PipelinePlanStrategy implements IPlanStrategy {
         );
       }
 
-      // The critic can drop feature-level exclusions the draft carried; this path
-      // has no op verify, so restore them here for parity with single/refine.
-      const scoped = applyPlanFidelity(verdict.prd, ctx.specContent, ctx.options.feature);
-      const prdToWrite = finalizePrdRouting(
-        { ...scoped, project: ctx.projectName },
-        ctx.config.routing?.agents,
-        ctx.profileName,
-      );
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(prdToWrite, null, 2));
-      return ctx.outputPath;
+      // The critic can drop feature-level exclusions the draft carried; persistPrd
+      // restores them, as it now does for every strategy on every path.
+      return await persistPrd(ctx, verdict.prd);
     } finally {
       await ctx.runtime.close().catch(() => {});
     }

--- a/src/plan/strategies/pipeline.ts
+++ b/src/plan/strategies/pipeline.ts
@@ -5,7 +5,7 @@ import { callOp, groundOp, planDraftOp } from "@/operations";
 import type { CallContext, PlanDraftInput } from "@/operations";
 import { runPlanCritic } from "../critic";
 import { persistPrd } from "./persist-prd";
-import type { IPlanStrategy, PlanModeContext } from "./types";
+import type { IPlanStrategy, PlanModeContext, PlanResult } from "./types";
 
 export const _pipelinePlanDeps = {
   callOp,
@@ -17,7 +17,7 @@ export const _pipelinePlanDeps = {
 export class PipelinePlanStrategy implements IPlanStrategy {
   readonly mode = "pipeline" as const;
 
-  async execute(ctx: PlanModeContext): Promise<string> {
+  async execute(ctx: PlanModeContext): Promise<PlanResult> {
     if (ctx.config.debate?.enabled === true) {
       ctx.deps.getLogger()?.warn("plan", "pipeline mode active; debate config ignored", {
         storyId: ctx.options.feature,
@@ -87,7 +87,7 @@ export class PipelinePlanStrategy implements IPlanStrategy {
 
       // The critic can drop feature-level exclusions the draft carried; persistPrd
       // restores them, as it now does for every strategy on every path.
-      return await persistPrd(ctx, verdict.prd);
+      return { outputPath: await persistPrd(ctx, verdict.prd) };
     } finally {
       await ctx.runtime.close().catch(() => {});
     }

--- a/src/plan/strategies/refine.ts
+++ b/src/plan/strategies/refine.ts
@@ -1,6 +1,6 @@
 import { callOp, planRefineOp } from "@/operations";
 import type { PlanRefineInput } from "@/operations";
-import type { IPlanStrategy, PlanModeContext } from "./types";
+import type { IPlanStrategy, PlanModeContext, PlanResult } from "./types";
 import { writeOrRecoverPrd } from "./write-prd";
 
 export const _refinePlanDeps = {
@@ -11,7 +11,7 @@ export const _refinePlanDeps = {
 export class RefinePlanStrategy implements IPlanStrategy {
   readonly mode = "refine" as const;
 
-  async execute(ctx: PlanModeContext): Promise<string> {
+  async execute(ctx: PlanModeContext): Promise<PlanResult> {
     try {
       const prd = await _refinePlanDeps.callOp(
         {

--- a/src/plan/strategies/single.ts
+++ b/src/plan/strategies/single.ts
@@ -1,8 +1,9 @@
+import { getSafeLogger } from "@/logger";
 import { callOp, planInteractiveOp } from "@/operations";
 import type { PlanInteractiveInput } from "@/operations";
 import { validatePlanOutput } from "@/prd";
 import { assertIsValidPrd } from "./assert";
-import { finalizePrdRouting } from "./finalize-routing";
+import { persistPrd } from "./persist-prd";
 import type { IPlanStrategy, PlanModeContext } from "./types";
 
 export const _singlePlanDeps = {
@@ -39,24 +40,20 @@ export class SinglePlanStrategy implements IPlanStrategy {
         } satisfies PlanInteractiveInput,
       );
       assertIsValidPrd(prd);
-      const finalized = finalizePrdRouting(
-        { ...prd, project: ctx.projectName },
-        ctx.config.routing?.agents,
-        ctx.profileName,
-      );
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
-      return ctx.outputPath;
+      return await persistPrd(ctx, prd);
     } catch (err) {
       if (ctx.deps.existsSync(ctx.outputPath)) {
         const rawContent = await ctx.deps.readFile(ctx.outputPath);
         const recoveredPrd = validatePlanOutput(rawContent, ctx.options.feature, ctx.branchName);
-        const finalizedRecovered = finalizePrdRouting(
-          { ...recoveredPrd, project: ctx.projectName },
-          ctx.config.routing?.agents,
-          ctx.profileName,
-        );
-        await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalizedRecovered, null, 2));
-        return ctx.outputPath;
+        // Same degraded-result contract as writeOrRecoverPrd — single hand-rolls
+        // its own recovery rather than sharing that helper, which is exactly how
+        // it escaped #1494's original scope table.
+        getSafeLogger()?.warn("plan", "PRD recovered from disk after a plan failure — result is degraded", {
+          featureName: ctx.options.feature,
+          outputPath: ctx.outputPath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return await persistPrd(ctx, recoveredPrd);
       }
       throw err;
     } finally {

--- a/src/plan/strategies/single.ts
+++ b/src/plan/strategies/single.ts
@@ -4,7 +4,7 @@ import type { PlanInteractiveInput } from "@/operations";
 import { validatePlanOutput } from "@/prd";
 import { assertIsValidPrd } from "./assert";
 import { persistPrd } from "./persist-prd";
-import type { IPlanStrategy, PlanModeContext } from "./types";
+import type { IPlanStrategy, PlanModeContext, PlanResult } from "./types";
 
 export const _singlePlanDeps = {
   callOp,
@@ -14,7 +14,7 @@ export const _singlePlanDeps = {
 export class SinglePlanStrategy implements IPlanStrategy {
   readonly mode = "single" as const;
 
-  async execute(ctx: PlanModeContext): Promise<string> {
+  async execute(ctx: PlanModeContext): Promise<PlanResult> {
     try {
       const prd = await _singlePlanDeps.callOp(
         {
@@ -40,7 +40,7 @@ export class SinglePlanStrategy implements IPlanStrategy {
         } satisfies PlanInteractiveInput,
       );
       assertIsValidPrd(prd);
-      return await persistPrd(ctx, prd);
+      return { outputPath: await persistPrd(ctx, prd) };
     } catch (err) {
       if (ctx.deps.existsSync(ctx.outputPath)) {
         const rawContent = await ctx.deps.readFile(ctx.outputPath);
@@ -48,12 +48,13 @@ export class SinglePlanStrategy implements IPlanStrategy {
         // Same degraded-result contract as writeOrRecoverPrd — single hand-rolls
         // its own recovery rather than sharing that helper, which is exactly how
         // it escaped #1494's original scope table.
+        const reason = err instanceof Error ? err.message : String(err);
         getSafeLogger()?.warn("plan", "PRD recovered from disk after a plan failure — result is degraded", {
           featureName: ctx.options.feature,
           outputPath: ctx.outputPath,
-          error: err instanceof Error ? err.message : String(err),
+          error: reason,
         });
-        return await persistPrd(ctx, recoveredPrd);
+        return { outputPath: await persistPrd(ctx, recoveredPrd), degraded: { reason } };
       }
       throw err;
     } finally {

--- a/src/plan/strategies/types.ts
+++ b/src/plan/strategies/types.ts
@@ -52,7 +52,26 @@ export interface PlanModeContext {
   readonly deps: PlanDeps;
 }
 
+/**
+ * Why a PRD is a degraded result — the plan threw and was recovered from the
+ * agent-written file on disk rather than produced by the strategy's own path.
+ */
+export interface PlanDegradation {
+  /** The original error that diverted the strategy onto its recovery branch. */
+  readonly reason: string;
+}
+
+/**
+ * A strategy's outcome. Carries `degraded` so the CLI can say so — a recovered
+ * PRD used to be indistinguishable from a clean one at every layer above the
+ * strategy, which is half of why #1494 went unnoticed.
+ */
+export interface PlanResult {
+  readonly outputPath: string;
+  readonly degraded?: PlanDegradation;
+}
+
 export interface IPlanStrategy {
   readonly mode: "single" | "pipeline" | "debate" | "refine";
-  execute(ctx: PlanModeContext): Promise<string>;
+  execute(ctx: PlanModeContext): Promise<PlanResult>;
 }

--- a/src/plan/strategies/write-prd.ts
+++ b/src/plan/strategies/write-prd.ts
@@ -1,7 +1,8 @@
 import { NaxError } from "@/errors";
+import { getSafeLogger } from "@/logger";
 import { validatePlanOutput } from "@/prd";
 import type { PRD } from "@/prd/types";
-import { finalizePrdRouting } from "./finalize-routing";
+import { persistPrd } from "./persist-prd";
 import type { PlanModeContext } from "./types";
 
 export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, err?: unknown): Promise<string> {
@@ -27,24 +28,12 @@ export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, e
 
   if (prd !== null) {
     if (Array.isArray((prd as { userStories?: unknown }).userStories)) {
-      const finalized = finalizePrdRouting(
-        { ...prd, project: ctx.projectName },
-        ctx.config.routing?.agents,
-        ctx.profileName,
-      );
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
-      return ctx.outputPath;
+      return persistPrd(ctx, prd);
     }
 
     const normalizedPrd = tryExtractPrd(prd);
     if (normalizedPrd !== null) {
-      const finalized = finalizePrdRouting(
-        { ...normalizedPrd, project: ctx.projectName },
-        ctx.config.routing?.agents,
-        ctx.profileName,
-      );
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
-      return ctx.outputPath;
+      return persistPrd(ctx, normalizedPrd);
     }
   }
 
@@ -65,13 +54,15 @@ export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, e
       }
     }
     recoveredPrd = recoveredPrd ?? validatePlanOutput(rawContent, ctx.options.feature, ctx.branchName);
-    const finalized = finalizePrdRouting(
-      { ...recoveredPrd, project: ctx.projectName },
-      ctx.config.routing?.agents,
-      ctx.profileName,
-    );
-    await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(finalized, null, 2));
-    return ctx.outputPath;
+    // Recovery is deliberate — `nax plan` produces a usable PRD rather than
+    // failing — but it is a degraded result, so say so. Silence here is what
+    // made #1494 take hours to attribute: exit 0, no console line, no JSONL record.
+    getSafeLogger()?.warn("plan", "PRD recovered from disk after a plan failure — result is degraded", {
+      featureName: ctx.options.feature,
+      outputPath: ctx.outputPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return persistPrd(ctx, recoveredPrd);
   } catch {
     throw err;
   }

--- a/src/plan/strategies/write-prd.ts
+++ b/src/plan/strategies/write-prd.ts
@@ -3,9 +3,9 @@ import { getSafeLogger } from "@/logger";
 import { validatePlanOutput } from "@/prd";
 import type { PRD } from "@/prd/types";
 import { persistPrd } from "./persist-prd";
-import type { PlanModeContext } from "./types";
+import type { PlanModeContext, PlanResult } from "./types";
 
-export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, err?: unknown): Promise<string> {
+export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, err?: unknown): Promise<PlanResult> {
   const tryExtractPrd = (value: unknown): PRD | null => {
     if (value === null || typeof value !== "object") return null;
 
@@ -28,12 +28,12 @@ export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, e
 
   if (prd !== null) {
     if (Array.isArray((prd as { userStories?: unknown }).userStories)) {
-      return persistPrd(ctx, prd);
+      return { outputPath: await persistPrd(ctx, prd) };
     }
 
     const normalizedPrd = tryExtractPrd(prd);
     if (normalizedPrd !== null) {
-      return persistPrd(ctx, normalizedPrd);
+      return { outputPath: await persistPrd(ctx, normalizedPrd) };
     }
   }
 
@@ -57,12 +57,13 @@ export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, e
     // Recovery is deliberate — `nax plan` produces a usable PRD rather than
     // failing — but it is a degraded result, so say so. Silence here is what
     // made #1494 take hours to attribute: exit 0, no console line, no JSONL record.
+    const reason = err instanceof Error ? err.message : String(err);
     getSafeLogger()?.warn("plan", "PRD recovered from disk after a plan failure — result is degraded", {
       featureName: ctx.options.feature,
       outputPath: ctx.outputPath,
-      error: err instanceof Error ? err.message : String(err),
+      error: reason,
     });
-    return persistPrd(ctx, recoveredPrd);
+    return { outputPath: await persistPrd(ctx, recoveredPrd), degraded: { reason } };
   } catch {
     throw err;
   }

--- a/test/integration/cli/plan-agent-selection.test.ts
+++ b/test/integration/cli/plan-agent-selection.test.ts
@@ -210,8 +210,8 @@ describe("planCommand — plan-time agent selection (ADR-025 Part C)", () => {
     });
 
     // planCommand must return the prd.json path
-    expect(result).toContain("prd.json");
-    expect(result).toContain("plan-agent-selection");
+    expect(result.outputPath).toContain("prd.json");
+    expect(result.outputPath).toContain("plan-agent-selection");
 
     // Read the written prd.json from disk
     const written = await Bun.file(outputPath).text();

--- a/test/integration/plan/plan-callop-migration.test.ts
+++ b/test/integration/plan/plan-callop-migration.test.ts
@@ -157,8 +157,8 @@ describe("planCommand callOp migration (US-003)", () => {
       feature: "test-feature",
     });
 
-    expect(result).toContain("prd.json");
-    expect(result).toContain("test-feature");
+    expect(result.outputPath).toContain("prd.json");
+    expect(result.outputPath).toContain("test-feature");
   });
 
   // Test that spec is read correctly

--- a/test/integration/plan/plan-callop.test.ts
+++ b/test/integration/plan/plan-callop.test.ts
@@ -191,8 +191,8 @@ describe("planCommand integration — callOp + planInteractiveOp", () => {
 
     // After migration, planCommand should have called callOp internally
     // Result should be the path to the generated prd.json
-    expect(result).toContain("prd.json");
-    expect(result).toContain("authentication");
+    expect(result.outputPath).toContain("prd.json");
+    expect(result.outputPath).toContain("authentication");
   });
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -273,7 +273,7 @@ describe("planCommand integration — callOp + planInteractiveOp", () => {
 
     // After migration, maxInteractionTurns should be threaded through CallContext
     // Verification happens indirectly through successful completion
-    expect(result).toContain("prd.json");
+    expect(result.outputPath).toContain("prd.json");
   });
 
   test("uses default maxInteractionTurns when config is undefined", async () => {
@@ -291,7 +291,7 @@ describe("planCommand integration — callOp + planInteractiveOp", () => {
 
     // When config.agent is undefined, maxInteractionTurns should be undefined
     // callOp uses its own defaults
-    expect(result).toContain("prd.json");
+    expect(result.outputPath).toContain("prd.json");
   });
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -322,7 +322,7 @@ describe("planCommand integration — callOp + planInteractiveOp", () => {
 
     // After migration, even if callOp fails but PRD is on disk, should return path
     expect(result).toBeDefined();
-    expect(result).toContain("prd.json");
+    expect(result.outputPath).toContain("prd.json");
   });
 
   test("throws error when callOp fails and outputPath doesn't exist on disk", async () => {
@@ -409,7 +409,7 @@ describe("planCommand integration — callOp + planInteractiveOp", () => {
     // 3. CallContext should have maxInteractionTurns from config
     // 4. Result should be path to generated prd.json
     expect(result).toBeDefined();
-    expect(typeof result).toBe("string");
-    expect(result).toContain("prd.json");
+    expect(typeof result.outputPath).toBe("string");
+    expect(result.outputPath).toContain("prd.json");
   });
 });

--- a/test/unit/cli/plan-callop.test.ts
+++ b/test/unit/cli/plan-callop.test.ts
@@ -317,9 +317,9 @@ describe("planCommand — callOp + planInteractiveOp migration", () => {
     });
 
     // Result should be a string path to prd.json
-    expect(typeof result).toBe("string");
-    expect(result).toContain("prd.json");
-    expect(result).toContain("url-shortener");
+    expect(typeof result.outputPath).toBe("string");
+    expect(result.outputPath).toContain("prd.json");
+    expect(result.outputPath).toContain("url-shortener");
   });
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -416,7 +416,7 @@ describe("planCommand — callOp + planInteractiveOp migration", () => {
       // No auto: true
     });
 
-    expect(typeof result).toBe("string");
+    expect(typeof result.outputPath).toBe("string");
   });
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -467,7 +467,7 @@ describe("planCommand — callOp + planInteractiveOp migration", () => {
     });
 
     // After migration, planCommand should work using planInteractiveOp
-    expect(result).toContain("prd.json");
+    expect(result.outputPath).toContain("prd.json");
   });
 
   // ────────────────────────────────────────────────────────────────────────────

--- a/test/unit/cli/plan-interactive.test.ts
+++ b/test/unit/cli/plan-interactive.test.ts
@@ -292,7 +292,7 @@ describe("planCommand — interactive mode (PLN-002)", () => {
     });
 
     const expectedPath = join(tmpDir, ".nax", "features", "url-shortener", "prd.json");
-    expect(result).toBe(expectedPath);
+    expect(result.outputPath).toBe(expectedPath);
     expect(capturedWriteArgs[0][0]).toBe(expectedPath);
 
     const [_path, content] = capturedWriteArgs[0];
@@ -418,7 +418,7 @@ describe("planCommand — interactive mode (PLN-002)", () => {
       feature: "url-shortener",
     });
 
-    expect(result).toContain("prd.json");
+    expect(result.outputPath).toContain("prd.json");
     expect(planCalled).toBe(true);
   });
 

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -378,7 +378,7 @@ describe("planCommand", () => {
     });
 
     const expectedPath = join(tmpDir, ".nax", "features", "url-shortener", "prd.json");
-    expect(result).toBe(expectedPath);
+    expect(result.outputPath).toBe(expectedPath);
     expect(capturedWriteArgs[0][0]).toBe(expectedPath);
     const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
@@ -739,8 +739,8 @@ describe("assertIsValidPrd guard (#993)", () => {
       feature: "url-shortener",
     });
 
-    expect(result).toContain("url-shortener");
-    expect(result).toContain("prd.json");
+    expect(result.outputPath).toContain("url-shortener");
+    expect(result.outputPath).toContain("prd.json");
     expect(capturedWrites993.length).toBeGreaterThan(0);
     const written = JSON.parse(capturedWrites993[capturedWrites993.length - 1]?.[1] ?? "{}");
     const writtenIds = (written.userStories as Array<{ id: string; title: string }>).map((s) => s.id);
@@ -1079,9 +1079,9 @@ describe("runPlanPipeline (US-005)", () => {
         feature: "test-feature",
       });
 
-      expect(result).toBe(join(tempWorkdir, ".nax", "features", "test-feature", "prd.json"));
+      expect(result.outputPath).toBe(join(tempWorkdir, ".nax", "features", "test-feature", "prd.json"));
       // Verify no PLAN_PIPELINE_NOT_IMPLEMENTED was thrown (success path reached)
-      expect(typeof result).toBe("string");
+      expect(typeof result.outputPath).toBe("string");
     });
   });
 });

--- a/test/unit/plan/debate-strategy.test.ts
+++ b/test/unit/plan/debate-strategy.test.ts
@@ -155,7 +155,7 @@ describe("DebatePlanStrategy", () => {
 
     const result = await new DebatePlanStrategy().execute(ctx);
 
-    expect(result).toBe(ctx.outputPath);
+    expect(result.outputPath).toBe(ctx.outputPath);
     expect(buildPromptSpy).toHaveBeenCalledWith(
       ctx.specContent,
       ctx.codebaseContext,
@@ -209,7 +209,9 @@ describe("DebatePlanStrategy", () => {
     const createDebateRunnerMock = mock(() => ({ runPlan: runPlanMock }));
     const callOpSpy = spyOn(operationsModule, "callOp").mockResolvedValue(fallbackPrd as never);
     const origWriteOrRecoverPrd = _debatePlanDeps.writeOrRecoverPrd;
-    _debatePlanDeps.writeOrRecoverPrd = mock(async () => "/tmp/workdir/.nax/features/feat-debate/prd.json");
+    _debatePlanDeps.writeOrRecoverPrd = mock(async () => ({
+      outputPath: "/tmp/workdir/.nax/features/feat-debate/prd.json",
+    }));
     const ctx = makeContext({
       deps: makeDeps({ createDebateRunner: createDebateRunnerMock }),
     });
@@ -217,7 +219,7 @@ describe("DebatePlanStrategy", () => {
     try {
       const result = await new DebatePlanStrategy().execute(ctx);
 
-      expect(result).toBe(ctx.outputPath);
+      expect(result.outputPath).toBe(ctx.outputPath);
       expect(callOpSpy).toHaveBeenCalledTimes(1);
       const [callCtx, op, input] = callOpSpy.mock.calls[0] as [Record<string, unknown>, unknown, Record<string, unknown>];
       expect(op).toBe(planInteractiveOp);

--- a/test/unit/plan/fidelity-survives-recovery.test.ts
+++ b/test/unit/plan/fidelity-survives-recovery.test.ts
@@ -138,7 +138,9 @@ describe("#1494 — fidelity repairs survive the disk-recovery path", () => {
     }) as typeof _refinePlanDeps.callOp;
 
     try {
-      expect(await new RefinePlanStrategy().execute(ctx)).toBe(ctx.outputPath);
+      const result = await new RefinePlanStrategy().execute(ctx);
+      expect(result.outputPath).toBe(ctx.outputPath);
+      expect(result.degraded?.reason).toBe("agent call failed");
     } finally {
       _refinePlanDeps.callOp = original;
     }
@@ -154,7 +156,9 @@ describe("#1494 — fidelity repairs survive the disk-recovery path", () => {
     }) as typeof _singlePlanDeps.callOp;
 
     try {
-      expect(await new SinglePlanStrategy().execute(ctx)).toBe(ctx.outputPath);
+      const result = await new SinglePlanStrategy().execute(ctx);
+      expect(result.outputPath).toBe(ctx.outputPath);
+      expect(result.degraded?.reason).toBe("agent call failed");
     } finally {
       _singlePlanDeps.callOp = original;
     }
@@ -171,7 +175,9 @@ describe("#1494 — fidelity repairs survive the disk-recovery path", () => {
       config: { ...ctx.config, plan: { specGuard: false }, debate: { stages: { plan: { enabled: true } } } },
     } as unknown as PlanModeContext;
 
-    expect(await new DebatePlanStrategy().execute(ctxWithStage)).toBe(ctx.outputPath);
+    const result = await new DebatePlanStrategy().execute(ctxWithStage);
+    expect(result.outputPath).toBe(ctx.outputPath);
+    expect(result.degraded?.reason).toBe("debate stage failed");
     expectModifiedFilesSurvived(written);
   });
 
@@ -182,7 +188,11 @@ describe("#1494 — fidelity repairs survive the disk-recovery path", () => {
     _refinePlanDeps.callOp = (async () => JSON.parse(DISK_PRD)) as typeof _refinePlanDeps.callOp;
 
     try {
-      expect(await new RefinePlanStrategy().execute(ctx)).toBe(ctx.outputPath);
+      const result = await new RefinePlanStrategy().execute(ctx);
+      expect(result.outputPath).toBe(ctx.outputPath);
+      // A clean plan must NOT be labelled degraded — otherwise the CLI warning
+      // becomes noise the user learns to ignore.
+      expect(result.degraded).toBeUndefined();
     } finally {
       _refinePlanDeps.callOp = original;
     }

--- a/test/unit/plan/fidelity-survives-recovery.test.ts
+++ b/test/unit/plan/fidelity-survives-recovery.test.ts
@@ -1,0 +1,191 @@
+/**
+ * #1494 — a throw inside a plan strategy diverts it onto its disk-recovery
+ * branch, which used to persist the agent-written PRD raw and silently discard
+ * every deterministic spec→PRD fidelity repair while still reporting success.
+ *
+ * `modifiedFiles` is the canary: unlike `outOfScope` it has no prompt-side
+ * self-heal turn, so the `applyPlanFidelity` backfill is its only channel. These
+ * tests drive the real strategies with a throwing `callOp` and assert the spec's
+ * `### Modifies` authority still reaches disk.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  DebatePlanStrategy,
+  RefinePlanStrategy,
+  SinglePlanStrategy,
+  _refinePlanDeps,
+  _singlePlanDeps,
+} from "@/plan";
+import type { PlanDeps, PlanModeContext } from "@/plan/strategies";
+import type { PackageSummary } from "@/prompts";
+import type { NaxRuntime } from "@/runtime";
+import { makeMockAgentManager } from "@test/helpers";
+
+const SPEC = `# SPEC-x
+
+## Stories
+
+**US-001**: do a thing
+
+### Modifies
+
+**US-001**
+- \`src/alpha.ts\` — add the alpha seam
+- \`src/beta.ts\` — wire beta
+
+**US-002**
+- \`src/gamma.ts\` — gamma path
+
+## Acceptance Criteria
+`;
+
+/** The agent-written PRD as it lands on disk: fidelity repairs not yet applied. */
+const DISK_PRD = JSON.stringify({
+  userStories: [
+    {
+      id: "US-001",
+      title: "Do a thing",
+      description: "A story the spec grants modification authority for",
+      acceptanceCriteria: ["AC1: should pass"],
+      complexity: "simple",
+    },
+    {
+      id: "US-002",
+      title: "Do another thing",
+      description: "A second story the spec grants modification authority for",
+      acceptanceCriteria: ["AC1: should pass"],
+      complexity: "simple",
+    },
+  ],
+});
+
+function makeCtx(written: { value: string | null }): PlanModeContext {
+  const deps = {
+    readFile: async () => DISK_PRD,
+    writeFile: async (_path: string, content: string) => {
+      written.value = content;
+    },
+    mkdirp: async () => {},
+    existsSync: () => true,
+    readPackageJson: async () => null,
+    readPackageJsonAt: async () => null,
+    scanSourceRoots: async () => [],
+    spawnSync: () => ({ stdout: Buffer.from(""), exitCode: 0 }),
+    initInteractionChain: async () => null,
+    createInteractionBridge: () => ({ detectQuestion: async () => false, onQuestionDetected: async () => "" }),
+    createDebateRunner: () => ({
+      runPlan: async () => {
+        throw new Error("debate stage failed");
+      },
+    }),
+    getLogger: () => null,
+  } as unknown as PlanDeps;
+
+  return {
+    workdir: "/tmp/workdir",
+    naxDir: "/tmp/workdir/.nax",
+    outputDir: "/tmp/workdir/.nax/features/feat-x",
+    outputPath: "/tmp/workdir/.nax/features/feat-x/prd.json",
+    specContent: SPEC,
+    codebaseContext: "context",
+    normalizedRoots: [],
+    relativePackages: ["packages/api"],
+    packageDetails: [
+      {
+        path: "packages/api",
+        packageName: "@acme/api",
+        stackSummary: "TypeScript",
+        keyDeps: [],
+      } as unknown as PackageSummary,
+    ],
+    projectName: "acme",
+    branchName: "feat/feat-x",
+    timeoutSeconds: 30,
+    config: { plan: { specGuard: false }, timeoutSeconds: 30 } as never,
+    profileName: undefined,
+    options: { from: "/tmp/spec.md", feature: "feat-x" },
+    runtime: {
+      runId: "run-1494",
+      configLoader: { current: () => ({}) },
+      packages: { resolve: () => ({}) },
+      sessionManager: { nameFor: () => "session" },
+      agentManager: makeMockAgentManager({ getDefaultAgent: "agent-x" }),
+      close: async () => {},
+    } as unknown as NaxRuntime,
+    interactionChain: null,
+    interactionBridge: {} as never,
+    deps,
+  } as unknown as PlanModeContext;
+}
+
+function expectModifiedFilesSurvived(written: { value: string | null }): void {
+  expect(written.value).not.toBeNull();
+  const persisted = JSON.parse(written.value as string);
+  expect(persisted.userStories[0].modifiedFiles?.map((entry: { path: string }) => entry.path)).toEqual([
+    "src/alpha.ts",
+    "src/beta.ts",
+  ]);
+  expect(persisted.userStories[1].modifiedFiles?.map((entry: { path: string }) => entry.path)).toEqual(["src/gamma.ts"]);
+}
+
+describe("#1494 — fidelity repairs survive the disk-recovery path", () => {
+  test("refine: a throw still persists the spec's Modifies authority", async () => {
+    const written = { value: null as string | null };
+    const ctx = makeCtx(written);
+    const original = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = (async () => {
+      throw new Error("agent call failed");
+    }) as typeof _refinePlanDeps.callOp;
+
+    try {
+      expect(await new RefinePlanStrategy().execute(ctx)).toBe(ctx.outputPath);
+    } finally {
+      _refinePlanDeps.callOp = original;
+    }
+    expectModifiedFilesSurvived(written);
+  });
+
+  test("single: a throw still persists the spec's Modifies authority", async () => {
+    const written = { value: null as string | null };
+    const ctx = makeCtx(written);
+    const original = _singlePlanDeps.callOp;
+    _singlePlanDeps.callOp = (async () => {
+      throw new Error("agent call failed");
+    }) as typeof _singlePlanDeps.callOp;
+
+    try {
+      expect(await new SinglePlanStrategy().execute(ctx)).toBe(ctx.outputPath);
+    } finally {
+      _singlePlanDeps.callOp = original;
+    }
+    expectModifiedFilesSurvived(written);
+  });
+
+  test("debate: a throw still persists the spec's Modifies authority", async () => {
+    const written = { value: null as string | null };
+    const ctx = makeCtx(written);
+    // The debate runner throws inside execute's try — the same recovery branch
+    // refine takes, reached through writeOrRecoverPrd.
+    const ctxWithStage = {
+      ...ctx,
+      config: { ...ctx.config, plan: { specGuard: false }, debate: { stages: { plan: { enabled: true } } } },
+    } as unknown as PlanModeContext;
+
+    expect(await new DebatePlanStrategy().execute(ctxWithStage)).toBe(ctx.outputPath);
+    expectModifiedFilesSurvived(written);
+  });
+
+  test("the repair is applied on the happy path too", async () => {
+    const written = { value: null as string | null };
+    const ctx = makeCtx(written);
+    const original = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = (async () => JSON.parse(DISK_PRD)) as typeof _refinePlanDeps.callOp;
+
+    try {
+      expect(await new RefinePlanStrategy().execute(ctx)).toBe(ctx.outputPath);
+    } finally {
+      _refinePlanDeps.callOp = original;
+    }
+    expectModifiedFilesSurvived(written);
+  });
+});

--- a/test/unit/plan/pipeline-strategy.test.ts
+++ b/test/unit/plan/pipeline-strategy.test.ts
@@ -80,7 +80,7 @@ describe("PipelinePlanStrategy", () => {
     }) as typeof _pipelinePlanDeps.runPlanCritic;
 
     try {
-      const outputPath = await strategy.execute(ctx);
+      const { outputPath } = await strategy.execute(ctx);
       expect(outputPath).toBe(ctx.outputPath);
       expect(sequence).toEqual(["ground", "draft", "critic"]);
     } finally {

--- a/test/unit/plan/refine-strategy.test.ts
+++ b/test/unit/plan/refine-strategy.test.ts
@@ -86,7 +86,7 @@ describe("RefinePlanStrategy", () => {
 
     try {
       const result = await strategy.execute(ctx);
-      expect(result).toBe(ctx.outputPath);
+      expect(result.outputPath).toBe(ctx.outputPath);
       expect(callOpMock).toHaveBeenCalledTimes(1);
       const [callCtx, operation, input] = callOpMock.mock.calls[0] as [Record<string, unknown>, unknown, Record<string, unknown>];
       expect(callCtx.runtime).toBe(ctx.runtime);
@@ -125,7 +125,7 @@ describe("RefinePlanStrategy", () => {
     }) as typeof _refinePlanDeps.callOp;
 
     try {
-      await expect(strategy.execute(ctx)).resolves.toBe(ctx.outputPath);
+      await expect(strategy.execute(ctx)).resolves.toMatchObject({ outputPath: ctx.outputPath });
       expect(closeSpy).toHaveBeenCalledTimes(1);
     } finally {
       _refinePlanDeps.callOp = originalCallOp;

--- a/test/unit/plan/single-strategy.test.ts
+++ b/test/unit/plan/single-strategy.test.ts
@@ -79,7 +79,7 @@ describe("SinglePlanStrategy", () => {
 
     try {
       const result = await strategy.execute(ctx);
-      expect(result).toBe(ctx.outputPath);
+      expect(result.outputPath).toBe(ctx.outputPath);
       expect(callOpMock).toHaveBeenCalledTimes(1);
       const [callCtx, operation, input] = callOpMock.mock.calls[0] as [Record<string, unknown>, unknown, Record<string, unknown>];
       expect(callCtx.runtime).toBe(ctx.runtime);
@@ -116,7 +116,7 @@ describe("SinglePlanStrategy", () => {
     }) as typeof _singlePlanDeps.callOp;
 
     try {
-      await expect(strategy.execute(ctx)).resolves.toBe(ctx.outputPath);
+      await expect(strategy.execute(ctx)).resolves.toMatchObject({ outputPath: ctx.outputPath });
     } finally {
       _singlePlanDeps.callOp = originalCallOp;
     }

--- a/test/unit/plan/strategies.test.ts
+++ b/test/unit/plan/strategies.test.ts
@@ -197,7 +197,7 @@ describe("writeOrRecoverPrd", () => {
 
     const result = await writeOrRecoverPrd(ctx, SAMPLE_PRD);
 
-    expect(result).toBe(ctx.outputPath);
+    expect(result.outputPath).toBe(ctx.outputPath);
     const writeCall = (deps.writeFile as ReturnType<typeof mock>).mock.calls.at(-1);
     expect(writeCall?.[0]).toBe(ctx.outputPath);
     const writtenPrd = JSON.parse(String(writeCall?.[1])) as PRD;
@@ -215,7 +215,7 @@ describe("writeOrRecoverPrd", () => {
 
     const result = await writeOrRecoverPrd(ctx, null, err);
 
-    expect(result).toBe(ctx.outputPath);
+    expect(result.outputPath).toBe(ctx.outputPath);
     expect(deps.readFile).toHaveBeenCalledWith(ctx.outputPath);
     const writeCall = (deps.writeFile as ReturnType<typeof mock>).mock.calls.at(-1);
     expect(writeCall?.[0]).toBe(ctx.outputPath);


### PR DESCRIPTION
Fixes #1494.

## The bug

`applyPlanFidelity` was invoked per-strategy — `planInteractiveOp.parse` for single, `planRefineOp.verify` for refine, the strategy body for pipeline and debate. Every one of those sites sits on the **happy path**. A throw diverts a strategy onto its disk-recovery branch, which re-read the agent-written PRD and persisted it raw, discarding every deterministic spec→PRD repair while still returning a path and printing `[OK] PRD generated` + exit 0.

`modifiedFiles` is the canary. Unlike `outOfScope` it has no prompt-side self-heal turn, so the `applyPlanFidelity` backfill is its only channel — a spec's `### Modifies` block reached the PRD as `modifiedFiles: []`, stripping the modification authority the spec intended to grant, with nothing on stdout or in the JSONL to explain it.

## Scope correction

The issue's scope table lists `single` as unaffected. It is affected. `single.ts` hand-rolls its own `catch` → `existsSync` → read → validate → write recovery instead of sharing `writeOrRecoverPrd`, which is exactly how it escaped the original analysis. The regression test drives it and it loses the repair identically.

Confirmed affected: `refine`, `debate`, `single`. Only `pipeline` was clean — its `try` has a `finally` and no `catch`, so a throw propagates.

## Commit 1 — repair on every path

All seven PRD write sites now go through `finalizeAndWritePrd` (repair → finalize routing → write). Fidelity becomes a property of *writing a PRD* rather than of any one code path, which is what `applyPlanFidelity`'s own docstring already claimed:

> One entry point so the four plan strategies (single, refine, pipeline, debate) cannot drift on which repairs they apply — the class of bug that let `### Modifies` reach only some paths would otherwise recur per-field.

Re-application is safe, which is what makes this additive rather than a rip-out: `backfillOutOfScope` early-returns once nothing is missing, and `applyModifiedFiles` merges deduped by path (`mergeEntries`). The redundant explicit calls in `pipeline.ts` and `debate.ts` are dropped; the in-op calls in `plan.ts` and `plan-refine.ts` stay, since downstream logic in those ops consumes the scoped PRD.

Both recovery sites now `logger.warn` with the original error. The silence is half of why this took hours to attribute.

## Commit 2 — make exit 0 honest

`IPlanStrategy.execute` returned a bare path, so a recovered PRD was indistinguishable from a clean one at every layer above the strategy. It now returns `PlanResult { outputPath, degraded? }`, and the CLI prints a `[WARN]` line naming the cause.

Recovery still exits 0 — `nax plan` is deliberately recovery-tolerant, producing a usable PRD rather than failing. The change is that a degraded result now says so, and (per commit 1) the repairs have been re-applied before it is written, so the warning means "review this", not "your `modifiedFiles` are gone".

## Verification

`test/unit/plan/fidelity-survives-recovery.test.ts` drives the real strategies with a throwing `callOp` / debate runner and asserts the spec's `### Modifies` authority reaches disk, plus that `degraded` is set on recovery and **absent** on a clean plan.

**Negative control:** with `src/` reverted to `main` and the test file kept, all 4 fail (`modifiedFiles` → `undefined`). With the fix, 4/4 pass.

Full suite green: 11964 unit + 1097 integration + 24 ui, 0 fail. `typecheck` and `lint` clean.

## Reviewer notes

- The remaining test churn is mechanical — `expect(result)` → `expect(result.outputPath)` where the assertion targeted the returned path.
- `finalizeAndWritePrd` is context-free so `runPlanPipeline`, which never builds a `PlanModeContext`, shares the same invariant; `persistPrd` is the `ctx` convenience for the four strategies.
- Two commits are kept separate: the first is the data-loss fix and stands alone; the second is the user-visible signal and changes a return type.
