### PR TITLE
feat(mutation-check): persist outcome counts to the run log

### DIFF
--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -146,12 +146,21 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       checked: false,
     };
     const logger = getLogger();
-    const record = (result: {
-      survivors: readonly SurvivingMutant[];
-      outcomes: MutationOutcomeSummary;
-      candidates: number;
-      checked: boolean;
-    }) => {
+    const record = (
+      result: {
+        survivors: readonly SurvivingMutant[];
+        outcomes: MutationOutcomeSummary;
+        candidates: number;
+        checked: boolean;
+        revertFailed?: true;
+      },
+      /**
+       * Why nothing was measured, when the gate exited after the enabled check
+       * but before mutating anything. Absent on a completed check. Kept off
+       * `result` so it stays out of the stored `MutationStorySummary`.
+       */
+      skipReason?: string,
+    ) => {
       if (ctx.storyId) {
         ctx.runtime?.mutationSummaries?.set(ctx.storyId, { storyId: ctx.storyId, ...result });
       }
@@ -171,6 +180,12 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
           survived: result.outcomes.survived,
           errored: result.outcomes.errored,
           candidates: result.candidates,
+          // An all-zero row means "bailed" or "nothing to mutate" — without this
+          // the two are indistinguishable, and a bail would be counted as a real
+          // zero-candidate measurement.
+          ...(skipReason ? { skipReason } : {}),
+          // The counts describe a tree this op did not leave clean.
+          ...(result.revertFailed ? { revertFailed: true } : {}),
         });
       }
     };
@@ -266,7 +281,7 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       logger.warn("mutation-check", "Failed to obtain changed-line ranges — skipping mutation spot-check", {
         storyId: input.storyId,
       });
-      record({ ...emptyOutput, checked: true });
+      record({ ...emptyOutput, checked: true }, "changed-line-ranges-unavailable");
       return { success: true as const, ...emptyOutput, checked: true };
     }
 

--- a/src/operations/mutation-check.ts
+++ b/src/operations/mutation-check.ts
@@ -145,6 +145,7 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       candidates: 0,
       checked: false,
     };
+    const logger = getLogger();
     const record = (result: {
       survivors: readonly SurvivingMutant[];
       outcomes: MutationOutcomeSummary;
@@ -154,8 +155,25 @@ export const mutationCheckOp: DeterministicOperation<MutationCheckInput, Mutatio
       if (ctx.storyId) {
         ctx.runtime?.mutationSummaries?.set(ctx.storyId, { storyId: ctx.storyId, ...result });
       }
+      // `mutationSummaries` is in-memory and the run-end summary is stdout-only,
+      // so without this line a run where every mutant was killed leaves no trace
+      // on disk at all — survivors were the only outcome ever persisted. The
+      // kill rate needs its denominator (`candidates`) recorded next to it, or
+      // the soft-gate decision cannot be made from run artifacts.
+      //
+      // Only when the gate actually ran: the feature is default-off everywhere
+      // but nax's own repo, and a row of zeroes from a disabled gate would read
+      // as a real all-errored measurement.
+      if (result.checked) {
+        logger.info("mutation-check", "Mutation spot-check outcomes", {
+          storyId: input.storyId,
+          killed: result.outcomes.killed,
+          survived: result.outcomes.survived,
+          errored: result.outcomes.errored,
+          candidates: result.candidates,
+        });
+      }
     };
-    const logger = getLogger();
     // A mutation left behind by an interrupted run must still be restored if
     // the feature is turned off afterwards, so the sweep precedes the enabled
     // gate. Resolving the anchor costs a `git rev-parse` subprocess though, and

--- a/test/unit/config/schemas.test.ts
+++ b/test/unit/config/schemas.test.ts
@@ -677,6 +677,24 @@ describe("RectificationConfigSchema — no-progress fields (US-1496)", () => {
     const rectification = execution.rectification as Record<string, unknown>;
     expect(rectification["abortOnNoProgress"]).toBe(false);
   });
+
+  /**
+   * The default is declared in TWO places that Zod never reconciles: the parent
+   * literal in `schemas.ts` (which `parse({})` resolves) and `.default(true)` on
+   * the nested field in `schemas-execution.ts` (which only a PARTIAL
+   * `execution.rectification` reaches). AC 1 above covers the first; without
+   * this the second can be flipped and every test still passes, letting the two
+   * sites drift silently.
+   *
+   * Found by the mutation spot-check: a `ts:bool-flip` on the nested default
+   * survived a real run.
+   */
+  test("abortOnNoProgress defaults to true when rectification is present but omits it", () => {
+    const config = NaxConfigSchema.parse(rectificationConfig({ maxAttemptsTotal: 5 }));
+    const execution = config.execution as Record<string, unknown>;
+    const rectification = execution.rectification as Record<string, unknown>;
+    expect(rectification["abortOnNoProgress"]).toBe(true);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/operations/mutation-check-telemetry.test.ts
+++ b/test/unit/operations/mutation-check-telemetry.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Outcome telemetry for the mutation spot-check (G12).
+ *
+ * The gate computes `outcomes {killed, survived, errored}` and `candidates`, but
+ * before this they reached only an in-memory `NaxRuntime.mutationSummaries` map
+ * and stdout. Only survivors were ever written to the run JSONL, so a run where
+ * every mutant was killed left no durable trace at all — leaving the kill rate
+ * and the false-alarm rate uncomputable from run artifacts, which is exactly
+ * what the soft-gate decision needs.
+ *
+ * These tests pin the durable record: emitted with the full counts whenever the
+ * gate actually ran, and silent when it did not.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { _mutationCheckDeps, mutationCheckOp } from "@/operations";
+import type { MutationCheckDeps } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+import { cleanupTempDir, makeTempDir, withInfoSpy } from "@test/helpers";
+
+const FAKE_STORY = { id: "US-004", title: "mutation-check telemetry" } as any;
+const ENABLED = { enabled: true, maxMutants: 3, timeoutSeconds: 60 };
+
+function ctxWithConfig(execution: Record<string, unknown> = {}, runtime: Partial<NaxRuntime> = {}): any {
+  const config = { execution, quality: { commands: { test: "bun test" } } } as any;
+  return {
+    runtime: { mutationSummaries: new Map(), ...runtime },
+    storyId: "US-004",
+    packageView: {
+      packageDir: "packages/agent",
+      repoRoot: "/repo",
+      hasOverride: false,
+      config,
+      select: (s: any) => s.select(config),
+    },
+  } as any;
+}
+
+const originalMutationCheckDeps = { ..._mutationCheckDeps };
+afterEach(() => Object.assign(_mutationCheckDeps, originalMutationCheckDeps));
+
+function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps {
+  return {
+    detectLanguage: async () => "typescript" as any,
+    getChangedNonTestFiles: async () => [],
+    getChangedLineRanges: async () => new Map(),
+    getGitRoot: async () => null,
+    selectScopedTests: async () => ({
+      effectiveCommand: "bun test",
+      isFullSuite: true,
+      thresholdFallback: false,
+      isMonorepoOrchestrator: false,
+    }),
+    regression: async () => ({
+      status: "SUCCESS" as const,
+      success: true,
+      countsTowardEscalation: true,
+      output: "",
+    }),
+    ...overrides,
+  };
+}
+
+/**
+ * Drive the op to completion against a single one-line mutable source file, and
+ * return the `mutation-check` info records it emitted.
+ */
+async function runAndCaptureInfo(
+  regressionResult: {
+    status: "SUCCESS" | "TEST_FAILURE" | "TIMEOUT" | "ENVIRONMENTAL_FAILURE" | "ASSET_CHECK_FAILED";
+    passCount?: number;
+    failCount?: number;
+  },
+  mutationsConfig: Record<string, unknown> = ENABLED,
+): Promise<{ calls: unknown[][]; out: any }> {
+  const dir = makeTempDir("nax-mutation-telemetry-");
+  try {
+    const file = join(dir, "src", "foo.ts");
+    await Bun.write(file, "if (a == b) { return 1; }\n");
+
+    const deps = fakeDeps({
+      getChangedNonTestFiles: async () => [file],
+      getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 1 }]]]),
+      selectScopedTests: async () => ({
+        effectiveCommand: "bun test src/foo.test.ts",
+        isFullSuite: false,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: false,
+      }),
+      regression: async () => ({
+        ...regressionResult,
+        success: regressionResult.status === "SUCCESS",
+        countsTowardEscalation: true,
+        output: "",
+      }),
+    });
+
+    return await withInfoSpy(async (infoSpy) => {
+      const out = await mutationCheckOp.execute(
+        {
+          story: FAKE_STORY,
+          workdir: dir,
+          storyId: "US-004",
+          storyGitRef: "abc123",
+          repoRoot: dir,
+          resolvedTestPatterns: {
+            globs: ["**/*.test.ts"],
+            regex: [/\.test\.ts$/],
+            pathspec: [":!*.test.ts"],
+            testDirs: ["test"],
+          },
+        },
+        ctxWithConfig({ mutationCheck: mutationsConfig }),
+        deps,
+      );
+      const calls = infoSpy.mock.calls.filter((c) => c[0] === "mutation-check");
+      return { calls, out };
+    });
+  } finally {
+    cleanupTempDir(dir);
+  }
+}
+
+describe("mutationCheckOp — outcome telemetry is durable (G12)", () => {
+  test("emits one mutation-check info record when the gate ran", async () => {
+    const { calls } = await runAndCaptureInfo({ status: "TEST_FAILURE", failCount: 1 });
+    expect(calls.length).toBe(1);
+  });
+
+  test("the record carries the full outcome counts and the candidate denominator", async () => {
+    const { calls, out } = await runAndCaptureInfo({ status: "TEST_FAILURE", failCount: 1 });
+    const data = calls[0]?.[2] as Record<string, unknown>;
+    expect(data).toMatchObject({
+      killed: out.outcomes.killed,
+      survived: out.outcomes.survived,
+      errored: out.outcomes.errored,
+      candidates: out.candidates,
+    });
+  });
+
+  /**
+   * The whole point of the change: an all-killed run previously wrote NOTHING to
+   * disk, because only survivors were logged. Without this the numerator has no
+   * denominator and the kill rate cannot be computed.
+   */
+  test("emits even when every mutant was killed and there are no survivors", async () => {
+    const { calls, out } = await runAndCaptureInfo({ status: "TEST_FAILURE", failCount: 1 });
+    expect(out.survivors.length).toBe(0);
+    expect(out.outcomes.killed).toBeGreaterThan(0);
+    expect(calls.length).toBe(1);
+    expect((calls[0]?.[2] as { killed: number }).killed).toBe(out.outcomes.killed);
+  });
+
+  test("storyId is the first key in the record's data object", async () => {
+    const { calls } = await runAndCaptureInfo({ status: "TEST_FAILURE", failCount: 1 });
+    expect(Object.keys(calls[0]?.[2] as object)[0]).toBe("storyId");
+  });
+
+  /**
+   * The inverse direction. `mutationCheck` is default-off for every repo but
+   * nax's own, so a disabled gate must stay silent rather than emit a row of
+   * zeroes that would read as a real all-errored measurement.
+   */
+  test("stays silent when the gate is disabled", async () => {
+    const { calls, out } = await runAndCaptureInfo({ status: "SUCCESS" }, { enabled: false });
+    expect(out.checked).toBe(false);
+    expect(calls.length).toBe(0);
+  });
+});

--- a/test/unit/operations/mutation-check-telemetry.test.ts
+++ b/test/unit/operations/mutation-check-telemetry.test.ts
@@ -22,10 +22,14 @@ import { cleanupTempDir, makeTempDir, withInfoSpy } from "@test/helpers";
 const FAKE_STORY = { id: "US-004", title: "mutation-check telemetry" } as any;
 const ENABLED = { enabled: true, maxMutants: 3, timeoutSeconds: 60 };
 
-function ctxWithConfig(execution: Record<string, unknown> = {}, runtime: Partial<NaxRuntime> = {}): any {
-  const config = { execution, quality: { commands: { test: "bun test" } } } as any;
+function ctxWithConfig(
+  execution: Record<string, unknown> = {},
+  runtime: Partial<NaxRuntime> = {},
+  quality: Record<string, unknown> = { commands: { test: "bun test" } },
+): any {
+  const config = { execution, quality } as any;
   return {
-    runtime: { mutationSummaries: new Map(), ...runtime },
+    runtime: { mutationSummaries: new Map(), dirtyWorktrees: new Set<string>(), ...runtime },
     storyId: "US-004",
     packageView: {
       packageDir: "packages/agent",
@@ -73,6 +77,7 @@ async function runAndCaptureInfo(
     failCount?: number;
   },
   mutationsConfig: Record<string, unknown> = ENABLED,
+  opts: { depsOverrides?: Partial<MutationCheckDeps>; quality?: Record<string, unknown> } = {},
 ): Promise<{ calls: unknown[][]; out: any }> {
   const dir = makeTempDir("nax-mutation-telemetry-");
   try {
@@ -94,6 +99,7 @@ async function runAndCaptureInfo(
         countsTowardEscalation: true,
         output: "",
       }),
+      ...(opts.depsOverrides ?? {}),
     });
 
     return await withInfoSpy(async (infoSpy) => {
@@ -111,7 +117,7 @@ async function runAndCaptureInfo(
             testDirs: ["test"],
           },
         },
-        ctxWithConfig({ mutationCheck: mutationsConfig }),
+        ctxWithConfig({ mutationCheck: mutationsConfig }, {}, opts.quality),
         deps,
       );
       const calls = infoSpy.mock.calls.filter((c) => c[0] === "mutation-check");
@@ -166,5 +172,92 @@ describe("mutationCheckOp — outcome telemetry is durable (G12)", () => {
     const { calls, out } = await runAndCaptureInfo({ status: "SUCCESS" }, { enabled: false });
     expect(out.checked).toBe(false);
     expect(calls.length).toBe(0);
+  });
+
+  test("stays silent when no test command is configured", async () => {
+    const { calls, out } = await runAndCaptureInfo({ status: "SUCCESS" }, ENABLED, { quality: {} });
+    expect(out.checked).toBe(false);
+    expect(calls.length).toBe(0);
+  });
+
+  /**
+   * The gate got past the enabled check but bailed before mutating anything, so
+   * it reports `checked: true` with nothing measured. The record still has to be
+   * emitted — an absent row is indistinguishable from a story the gate never
+   * reached — but it must say WHY, or a bail is silently counted as a real
+   * zero-candidate measurement.
+   */
+  test("emits with a skipReason when the gate bailed before mutating anything", async () => {
+    const { calls, out } = await runAndCaptureInfo({ status: "SUCCESS" }, ENABLED, {
+      depsOverrides: { getChangedLineRanges: async () => null },
+    });
+    expect(out.checked).toBe(true);
+    expect(out.candidates).toBe(0);
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.[2]).toMatchObject({
+      killed: 0,
+      survived: 0,
+      errored: 0,
+      candidates: 0,
+      skipReason: "changed-line-ranges-unavailable",
+    });
+  });
+
+  test("a completed check carries no skipReason", async () => {
+    const { calls } = await runAndCaptureInfo({ status: "TEST_FAILURE", failCount: 1 });
+    expect(calls[0]?.[2]).not.toHaveProperty("skipReason");
+  });
+});
+
+/**
+ * A story whose worktree was left holding an injected mutation is exactly the
+ * context an analyst needs beside the counts — the numbers describe a tree that
+ * is not the one the tests were written against.
+ */
+describe("mutationCheckOp — outcome telemetry flags an unrestored worktree", () => {
+  test("carries revertFailed when a revert could not be confirmed", async () => {
+    const dir = makeTempDir("nax-mutation-telemetry-dirty-");
+    try {
+      const file = join(dir, "src", "foo.ts");
+      await Bun.write(file, "if (a == b) { return 1; }\n");
+      const hijacked = "SOMEONE ELSE WROTE THIS\n";
+
+      const deps = fakeDeps({
+        getChangedNonTestFiles: async () => [file],
+        getChangedLineRanges: async () => new Map([[file, [{ start: 1, end: 1 }]]]),
+        regression: async () => {
+          // Simulate a formatter rewriting the mutated line mid-check.
+          await Bun.write(file, hijacked);
+          return { status: "FAILURE" as const, success: false, countsTowardEscalation: true, output: "1 fail" };
+        },
+      });
+
+      const { calls, out } = await withInfoSpy(async (infoSpy) => {
+        const out = await mutationCheckOp.execute(
+          {
+            story: FAKE_STORY,
+            workdir: dir,
+            storyId: "US-004",
+            storyGitRef: "abc123",
+            repoRoot: dir,
+            resolvedTestPatterns: {
+              globs: ["**/*.test.ts"],
+              regex: [/\.test\.ts$/],
+              pathspec: [":!*.test.ts"],
+              testDirs: ["test"],
+            },
+          },
+          ctxWithConfig({ mutationCheck: ENABLED }),
+          deps,
+        );
+        return { calls: infoSpy.mock.calls.filter((c) => c[0] === "mutation-check"), out };
+      });
+
+      expect(out.revertFailed).toBe(true);
+      expect(calls.length).toBe(1);
+      expect(calls[0]?.[2]).toMatchObject({ revertFailed: true });
+    } finally {
+      cleanupTempDir(dir);
+    }
   });
 });


### PR DESCRIPTION
## What

Persists the mutation spot-check's outcome counts to the run log, and pins a
config default the gate itself flagged as untested.

Closes the blocker on **G12** of the mutation-check gap analysis.

## Why

The gate already computed `outcomes {killed, survived, errored}` and
`candidates`, but they reached only an in-memory `NaxRuntime.mutationSummaries`
map and stdout via `outputMutationSummary` (which also returns early in `json`
mode). Survivors were the **only** outcome ever written to the run JSONL.

So a run where every mutant was killed left no durable trace at all — a
numerator with no denominator. Kill rate and false-alarm rate were both
uncomputable from run artifacts, which is precisely what the deferred
soft-gate-to-rectification decision needs in order to be made at all.

Field check across the three runs since the gate was enabled: all three
produced survivors, across four distinct operators (`ts:arith-flip`,
`ts:cmp-bracket-flip`, `ts:bool-flip`, `ts:cmp-flip`). The gate is doing real
work; it just was not recording most of what it found.

## How

**1. Durable outcome record.** Emit one structured `logger.info` per story from
`record()` — the single helper all four exit paths already funnel through —
carrying the counts next to the `candidates` denominator. Gated on `checked`,
so a disabled gate stays silent instead of writing zeroes that would read as a
real all-errored measurement. `getLogger()` is hoisted above `record` so the
closure does not depend on call-time ordering.

**2. Disambiguated.** `record()` has four call sites and they do not all mean
the same thing. `:269` (changed-line ranges unavailable) reports `checked: true`
having measured nothing, so it emitted an all-zero row indistinguishable from a
genuine zero-candidate run — a bail counted as a real measurement. It now
carries `skipReason`, passed as a second argument so it stays off the stored
`MutationStorySummary`. The record also now carries `revertFailed`, which the
summary already had: the counts describe a tree the op did not leave clean, and
that belongs beside them.

**3. The survivor it found.** `ts:bool-flip` survived on
`schemas-execution.ts`'s `abortOnNoProgress: z.boolean().default(true)`.

That default is declared in **two** places Zod never reconciles: the parent
literal in `schemas.ts` (what `NaxConfigSchema.parse({})` resolves) and
`.default(true)` on the nested field (reached only by a *partial*
`execution.rectification`). US-1496 AC 1 covers the first site; nothing covered
the second, so flipping it left all 67 tests in that file green and the two
sites free to drift. Added a test for the partial path, verified it kills the
mutant.

## Testing

- [x] `bun run test` — 12092 unit + 1097 integration + 24 ui, 0 fail
- [x] `bun run typecheck`, `bun run lint`, `bun run build`
- [x] All four `record()` call sites covered: `:186` and `:211` silent,
      `:269` emits with a reason, `:437` emits complete
- [x] **Negative controls, one per behaviour** — each of these makes exactly
      its own test fail: removing the `checked` gate, dropping the
      `skipReason` argument, dropping the `revertFailed` spread, and flipping
      the nested config default

## Notes

Per-survivor detail already had its own warn record and is unchanged.

Known and deliberately out of scope: `fakeDeps` / `ctxWithConfig` are now
duplicated across seven test files under `test/unit/operations/`, past the
"3+ files" threshold in `.claude/rules/test-helpers.md`. Extracting them
touches unrelated test files and belongs in its own chore.
