### PR TITLE
chore(test): extract the shared mutationCheckOp test fixtures

### DIFF
--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -42,3 +42,5 @@ export { makeScriptedAgent, runOrchestratorE2E } from "./e2e";
 export type { ScriptedAgentSpec, ScriptedTurn, E2EOptions, E2EResult, E2EGates } from "./e2e";
 export { DEFAULT_TEST_ROUTING, makeTestContext, makeTestPRD, makeTestStory } from "./pipeline-context";
 export { makeFlowCtx, makeFlowStep, makeFlowSteps, reviewRounds } from "./flow-steps";
+export { makeMutationCheckCtx, makeMutationCheckDeps } from "./mutation-check";
+export type { MutationCheckCtxOptions } from "./mutation-check";

--- a/test/helpers/mutation-check.ts
+++ b/test/helpers/mutation-check.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared fixtures for `mutationCheckOp` unit tests.
+ *
+ * The deps object and the `CallContext` shape were duplicated verbatim across
+ * five files under `test/unit/operations/` (`mutation-check`, `-selection`,
+ * `-revert`, `-diff-scope`, `-telemetry`), which is well past the "same mock in
+ * 3+ test files" threshold in `.claude/rules/test-helpers.md`.
+ *
+ * Deliberately NOT shared with `full-suite-gate` / `verify-scoped`: those name
+ * their locals the same way but build a different context (config passed whole
+ * rather than under `execution`, no mutation runtime) against a different deps
+ * type. Merging them would be an abstraction over a coincidence of naming.
+ */
+
+import type { MutationCheckDeps } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+
+/**
+ * `MutationCheckDeps` with every collaborator stubbed to a benign success: no
+ * changed files, no line ranges, a full-suite selection, and a passing
+ * regression run. Override only what the test is about.
+ */
+export function makeMutationCheckDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps {
+  return {
+    detectLanguage: async () => "typescript" as any,
+    getChangedNonTestFiles: async () => [],
+    getChangedLineRanges: async () => new Map(),
+    getGitRoot: async () => null,
+    selectScopedTests: async () => ({
+      effectiveCommand: "bun test",
+      isFullSuite: true,
+      thresholdFallback: false,
+      isMonorepoOrchestrator: false,
+    }),
+    regression: async () => ({
+      status: "SUCCESS" as const,
+      success: true,
+      countsTowardEscalation: true,
+      output: "",
+    }),
+    ...overrides,
+  };
+}
+
+export interface MutationCheckCtxOptions {
+  /** Extra `NaxRuntime` fields, merged over the mutation-aware defaults. */
+  readonly runtime?: Partial<NaxRuntime>;
+  /** Replaces the default `{ commands: { test: "bun test" } }` wholesale. */
+  readonly quality?: Record<string, unknown>;
+  readonly storyId?: string;
+  readonly packageDir?: string;
+  readonly repoRoot?: string;
+}
+
+/**
+ * A `CallContext` for `mutationCheckOp`, with `execution` as the first argument
+ * because that is the slice almost every test varies.
+ *
+ * The runtime always carries both `mutationSummaries` and `dirtyWorktrees`.
+ * The op reaches each through optional chaining, so supplying them is
+ * harmless for tests that ignore them and removes a footgun for tests that
+ * exercise the revert path and would otherwise fail on an absent `Set`.
+ */
+export function makeMutationCheckCtx(
+  execution: Record<string, unknown> = {},
+  options: MutationCheckCtxOptions = {},
+): any {
+  const {
+    runtime = {},
+    quality = { commands: { test: "bun test" } },
+    storyId = "US-004",
+    packageDir = "packages/agent",
+    repoRoot = "/repo",
+  } = options;
+  const config = { execution, quality } as any;
+  return {
+    runtime: { mutationSummaries: new Map(), dirtyWorktrees: new Set<string>(), ...runtime },
+    storyId,
+    packageView: {
+      packageDir,
+      repoRoot,
+      hasOverride: false,
+      config,
+      select: (s: any) => s.select(config),
+    },
+  } as any;
+}

--- a/test/unit/operations/mutation-check-diff-scope.test.ts
+++ b/test/unit/operations/mutation-check-diff-scope.test.ts
@@ -10,48 +10,18 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import * as loggerModule from "@/logger";
 import { mutationCheckOp } from "@/operations";
-import type { MutationCheckDeps } from "@/operations";
-import { cleanupTempDir, makeTempDir } from "@test/helpers";
+import {
+  cleanupTempDir,
+  makeMutationCheckCtx,
+  makeMutationCheckDeps as fakeDeps,
+  makeTempDir,
+} from "@test/helpers";
 import * as mutationModule from "@/verification/mutation";
 
 const FAKE_STORY = { id: "US-003", title: "scope mutation candidates" } as any;
 
-function ctxWithConfig(execution: Record<string, unknown> = {}): any {
-  const config = { execution, quality: { commands: { test: "bun test" } } } as any;
-  return {
-    runtime: { mutationSummaries: new Map() },
-    storyId: "US-003",
-    packageView: {
-      packageDir: "packages/agent",
-      repoRoot: "/repo",
-      hasOverride: false,
-      config,
-      select: (s: any) => s.select(config),
-    },
-  } as any;
-}
-
-function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps {
-  return {
-    detectLanguage: async () => "typescript" as any,
-    getChangedNonTestFiles: async () => [],
-    getChangedLineRanges: async () => new Map(),
-    getGitRoot: async () => null,
-    selectScopedTests: async () => ({
-      effectiveCommand: "bun test",
-      isFullSuite: true,
-      thresholdFallback: false,
-      isMonorepoOrchestrator: false,
-    }),
-    regression: async () => ({
-      status: "SUCCESS" as const,
-      success: true,
-      countsTowardEscalation: true,
-      output: "",
-    }),
-    ...overrides,
-  };
-}
+const ctxWithConfig = (execution: Record<string, unknown> = {}) =>
+  makeMutationCheckCtx(execution, { storyId: "US-003" });
 
 describe("mutationCheckOp — US-003 AC7: getChangedLineRanges resolves to null", () => {
   test("returns success:true with outcomes { killed: 0, survived: 0, errored: 0 }", async () => {

--- a/test/unit/operations/mutation-check-revert.test.ts
+++ b/test/unit/operations/mutation-check-revert.test.ts
@@ -1,52 +1,22 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { _mutationCheckDeps, mutationCheckOp } from "@/operations";
-import type { MutationCheckDeps } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
 import { applyMutant, journalPathFor, recordInFlight } from "@/verification";
-import { cleanupTempDir, makeTempDir } from "@test/helpers";
+import {
+  cleanupTempDir,
+  makeMutationCheckCtx,
+  makeMutationCheckDeps as fakeDeps,
+  makeTempDir,
+} from "@test/helpers";
 
 const FAKE_STORY = { id: "US-004", title: "mutation-check op" } as any;
 
-function ctxWithConfig(execution: Record<string, unknown> = {}, runtime: Partial<NaxRuntime> = {}): any {
-  const config = { execution, quality: { commands: { test: "bun test" } } } as any;
-  return {
-    runtime: { mutationSummaries: new Map(), dirtyWorktrees: new Set<string>(), ...runtime },
-    storyId: "US-004",
-    packageView: {
-      packageDir: "packages/agent",
-      repoRoot: "/repo",
-      hasOverride: false,
-      config,
-      select: (s: any) => s.select(config),
-    },
-  } as any;
-}
+const ctxWithConfig = (execution: Record<string, unknown> = {}, runtime: Partial<NaxRuntime> = {}) =>
+  makeMutationCheckCtx(execution, { runtime });
 
 const originalMutationCheckDeps = { ..._mutationCheckDeps };
 afterEach(() => Object.assign(_mutationCheckDeps, originalMutationCheckDeps));
-
-function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps {
-  return {
-    detectLanguage: async () => "typescript" as any,
-    getChangedNonTestFiles: async () => [],
-    getChangedLineRanges: async () => new Map(),
-    getGitRoot: async () => null,
-    selectScopedTests: async () => ({
-      effectiveCommand: "bun test",
-      isFullSuite: true,
-      thresholdFallback: false,
-      isMonorepoOrchestrator: false,
-    }),
-    regression: async () => ({
-      status: "SUCCESS" as const,
-      success: true,
-      countsTowardEscalation: true,
-      output: "",
-    }),
-    ...overrides,
-  };
-}
 
 describe("mutationCheckOp — AC9: regression throw still reverts and reports success", () => {
   test("restores file when regression throws and returns success=true", async () => {

--- a/test/unit/operations/mutation-check-selection.test.ts
+++ b/test/unit/operations/mutation-check-selection.test.ts
@@ -8,58 +8,25 @@
  *  - never invokes regression when no candidates are produced (AC13)
  *  - returns the all-zero outcomes contract for an empty selection (AC14)
  *
- * Mirrors the helpers in mutation-check.test.ts rather than co-locating,
- * because this file would otherwise push the parent over the 800-line
- * test file limit.
+ * Separate from mutation-check.test.ts because co-locating would push that
+ * file over the 800-line test limit; the shared fixtures both use live in
+ * test/helpers/mutation-check.ts.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { mutationCheckOp, _mutationCheckDeps } from "@/operations";
-import type { MutationCheckDeps } from "@/operations";
-import { cleanupTempDir, makeTempDir } from "@test/helpers";
+import {
+  cleanupTempDir,
+  makeMutationCheckCtx as ctxWithConfig,
+  makeMutationCheckDeps as fakeDeps,
+  makeTempDir,
+} from "@test/helpers";
 
 const FAKE_STORY = { id: "US-004", title: "mutation-check op" } as any;
 
-function ctxWithConfig(execution: Record<string, unknown> = {}): any {
-  const config = { execution, quality: { commands: { test: "bun test" } } } as any;
-  return {
-    runtime: {},
-    storyId: "US-004",
-    packageView: {
-      packageDir: "packages/agent",
-      repoRoot: "/repo",
-      hasOverride: false,
-      config,
-      select: (s: any) => s.select(config),
-    },
-  } as any;
-}
-
 const originalMutationCheckDeps = { ..._mutationCheckDeps };
 afterEach(() => Object.assign(_mutationCheckDeps, originalMutationCheckDeps));
-
-function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps {
-  return {
-    detectLanguage: async () => "typescript" as any,
-    getChangedNonTestFiles: async () => [],
-    getChangedLineRanges: async () => new Map(),
-    getGitRoot: async () => null,
-    selectScopedTests: async () => ({
-      effectiveCommand: "bun test",
-      isFullSuite: true,
-      thresholdFallback: false,
-      isMonorepoOrchestrator: false,
-    }),
-    regression: async () => ({
-      status: "SUCCESS" as const,
-      success: true,
-      countsTowardEscalation: true,
-      output: "",
-    }),
-    ...overrides,
-  };
-}
 
 describe("mutationCheckOp — US-002 AC11: regression capped to maxMutants even with many candidates in one file", () => {
   test("maxMutants 2, one file with 8 candidates, regression TEST_FAILURE failCount 1 — regression invoked exactly twice", async () => {

--- a/test/unit/operations/mutation-check-telemetry.test.ts
+++ b/test/unit/operations/mutation-check-telemetry.test.ts
@@ -17,54 +17,25 @@ import { join } from "node:path";
 import { _mutationCheckDeps, mutationCheckOp } from "@/operations";
 import type { MutationCheckDeps } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
-import { cleanupTempDir, makeTempDir, withInfoSpy } from "@test/helpers";
+import {
+  cleanupTempDir,
+  makeMutationCheckCtx,
+  makeMutationCheckDeps as fakeDeps,
+  makeTempDir,
+  withInfoSpy,
+} from "@test/helpers";
 
 const FAKE_STORY = { id: "US-004", title: "mutation-check telemetry" } as any;
 const ENABLED = { enabled: true, maxMutants: 3, timeoutSeconds: 60 };
 
-function ctxWithConfig(
+const ctxWithConfig = (
   execution: Record<string, unknown> = {},
   runtime: Partial<NaxRuntime> = {},
-  quality: Record<string, unknown> = { commands: { test: "bun test" } },
-): any {
-  const config = { execution, quality } as any;
-  return {
-    runtime: { mutationSummaries: new Map(), dirtyWorktrees: new Set<string>(), ...runtime },
-    storyId: "US-004",
-    packageView: {
-      packageDir: "packages/agent",
-      repoRoot: "/repo",
-      hasOverride: false,
-      config,
-      select: (s: any) => s.select(config),
-    },
-  } as any;
-}
+  quality?: Record<string, unknown>,
+) => makeMutationCheckCtx(execution, { runtime, ...(quality ? { quality } : {}) });
 
 const originalMutationCheckDeps = { ..._mutationCheckDeps };
 afterEach(() => Object.assign(_mutationCheckDeps, originalMutationCheckDeps));
-
-function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps {
-  return {
-    detectLanguage: async () => "typescript" as any,
-    getChangedNonTestFiles: async () => [],
-    getChangedLineRanges: async () => new Map(),
-    getGitRoot: async () => null,
-    selectScopedTests: async () => ({
-      effectiveCommand: "bun test",
-      isFullSuite: true,
-      thresholdFallback: false,
-      isMonorepoOrchestrator: false,
-    }),
-    regression: async () => ({
-      status: "SUCCESS" as const,
-      success: true,
-      countsTowardEscalation: true,
-      output: "",
-    }),
-    ...overrides,
-  };
-}
 
 /**
  * Drive the op to completion against a single one-line mutable source file, and

--- a/test/unit/operations/mutation-check.test.ts
+++ b/test/unit/operations/mutation-check.test.ts
@@ -1,51 +1,21 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { _mutationCheckDeps, mutationCheckOp } from "@/operations";
-import type { MutationCheckDeps } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
-import { cleanupTempDir, makeTempDir } from "@test/helpers";
+import {
+  cleanupTempDir,
+  makeMutationCheckCtx,
+  makeMutationCheckDeps as fakeDeps,
+  makeTempDir,
+} from "@test/helpers";
 
 const FAKE_STORY = { id: "US-004", title: "mutation-check op" } as any;
 
-function ctxWithConfig(execution: Record<string, unknown> = {}, runtime: Partial<NaxRuntime> = {}): any {
-  const config = { execution, quality: { commands: { test: "bun test" } } } as any;
-  return {
-    runtime: { mutationSummaries: new Map(), ...runtime },
-    storyId: "US-004",
-    packageView: {
-      packageDir: "packages/agent",
-      repoRoot: "/repo",
-      hasOverride: false,
-      config,
-      select: (s: any) => s.select(config),
-    },
-  } as any;
-}
+const ctxWithConfig = (execution: Record<string, unknown> = {}, runtime: Partial<NaxRuntime> = {}) =>
+  makeMutationCheckCtx(execution, { runtime });
 
 const originalMutationCheckDeps = { ..._mutationCheckDeps };
 afterEach(() => Object.assign(_mutationCheckDeps, originalMutationCheckDeps));
-
-function fakeDeps(overrides: Partial<MutationCheckDeps> = {}): MutationCheckDeps {
-  return {
-    detectLanguage: async () => "typescript" as any,
-    getChangedNonTestFiles: async () => [],
-    getChangedLineRanges: async () => new Map(),
-    getGitRoot: async () => null,
-    selectScopedTests: async () => ({
-      effectiveCommand: "bun test",
-      isFullSuite: true,
-      thresholdFallback: false,
-      isMonorepoOrchestrator: false,
-    }),
-    regression: async () => ({
-      status: "SUCCESS" as const,
-      success: true,
-      countsTowardEscalation: true,
-      output: "",
-    }),
-    ...overrides,
-  };
-}
 
 describe("mutationCheckOp — AC1: DeterministicOperation shape", () => {
   test("kind is deterministic", () => {


### PR DESCRIPTION
## What

Extracts the duplicated `mutationCheckOp` test fixtures into
`test/helpers/mutation-check.ts`.

Follow-up to #1501, where this was raised in review and deliberately deferred
so it would not bury that PR's diff.

## Why

`fakeDeps` and `ctxWithConfig` were duplicated across five files under
`test/unit/operations/`: `mutation-check`, `-selection`, `-revert`,
`-diff-scope`, `-telemetry`. All five `fakeDeps` bodies were **byte-identical**
(verified by diff); the context builders differed only in which runtime fields
they carried and which `storyId` they used.

`.claude/rules/test-helpers.md` puts the threshold at 3+ files:

> When you find yourself writing the same mock in 3+ test files, add it to
> `test/helpers/` with a `make*(overrides?)` signature.

## How

New `test/helpers/mutation-check.ts` exporting
`makeMutationCheckDeps(overrides?)` and
`makeMutationCheckCtx(execution?, options?)`, both barrel-exported.

Each test file keeps a one-line local binding (or an aliased import) so **no
call site changes** — there are 52 of each across the five files, and churning
them would be diff noise with real regression risk for no benefit. What is
removed is the duplicated fixture bodies, not the per-file ergonomics.

The shared runtime always carries both `mutationSummaries` and
`dirtyWorktrees`. The op reaches each through optional chaining
(`ctx.runtime?.dirtyWorktrees?.add`), so supplying them is inert for tests that
ignore them and removes a footgun for tests that exercise the revert path and
would otherwise fail on an absent `Set`.

### Not included

`full-suite-gate.test.ts` and `verify-scoped.test.ts` also declare locals named
`ctxWithConfig` / `fakeDeps`, and an earlier count of "seven files" included
them. They are **not** the same fixture: `full-suite-gate` takes `config` whole
rather than under `execution` and has no deps factory at all, and
`verify-scoped`'s `fakeDeps` builds `VerifyScopedDeps`, a different type. They
matched a grep, not a shape. Merging them would be an abstraction over a naming
coincidence, so they are left alone.

## Testing

- [x] `bun run test` — **12092 unit / 1097 integration / 24 ui**, identical to
      the totals before the refactor, so no test was silently dropped
- [x] `bun run typecheck`, `bun run lint`, `bun run build`
- [x] The #1501 telemetry negative controls were re-run against the refactored
      fixtures and still fail their own tests — removing the `checked` gate or
      the `skipReason` argument is still caught, so the shared context did not
      weaken the assertions

Net **-150 lines**.
