### PR TITLE
fix(rules-export): carry package scope into the Claude rules frontmatter

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -1752,6 +1752,11 @@ rules
       process.exit(1);
       return;
     }
+    // Without this the export's warnings — a scope it could not carry across, a
+    // generated file with no canonical source — resolve through `getLogger()`
+    // to the noop logger and are discarded, so the command silently loses
+    // information it believes it is reporting. `rules lint` already does this.
+    initLogger({ level: "info", useChalk: true });
     try {
       await rulesExportCommand({
         dir: workdir,

--- a/docs/superpowers/specs/2026-08-03-rules-export-claude-dir-design.md
+++ b/docs/superpowers/specs/2026-08-03-rules-export-claude-dir-design.md
@@ -70,6 +70,14 @@ The key means different things in each store:
 
 Getting this wrong reproduces the original bug in the opposite direction, which is why it is called out here rather than left to the implementer.
 
+> **Superseded by #1503.** Dropping canonical `paths:` was itself the bug: a rule
+> using `paths:` with no `appliesTo:` produced no globs, so the frontmatter block
+> was omitted entirely and Claude loaded the rule *globally* — the widest possible
+> reading of a rule that asked to be narrow. Package scope is now translated to
+> the equivalent file glob (`packages/api/*` → `packages/api/**`) rather than
+> dropped. The warning survives only for a rule that sets **both** scopes, which
+> Claude's single disjunctive `paths:` list cannot express as an intersection.
+
 ## Sequencing constraint (hard)
 
 **This must not ship before US-004 of `context-budget-truth` lands.** That story restores `appliesTo:` on the three files that lost scoping. Today `.nax/rules/` has no scoping for them and `.claude/rules/` holds the only copy — so exporting now would overwrite the survivors with unscoped versions and destroy the scoping in both stores at once, silently unscoping rules Claude Code currently honours.

--- a/src/cli/rules.ts
+++ b/src/cli/rules.ts
@@ -147,7 +147,13 @@ export interface RulesExportOptions {
  * strictly less than it did.
  */
 function packageGlobToFileGlob(pattern: string): string {
-  const base = pattern.replace(/\/+\*{1,2}$/, "").replace(/\/+$/, "");
+  // Trailing slashes come off FIRST: `packages/api/*/` and `packages/api/*`
+  // name the same directory, but a star-strip anchored at end-of-string sees
+  // only the second, so the order below is what keeps them from diverging.
+  const base = pattern
+    .replace(/\/+$/, "")
+    .replace(/\/+\*{1,2}$/, "")
+    .replace(/\/+$/, "");
   // A pattern that selects every package maps to every file.
   if (base === "" || base === "**") return "**";
   return `${base}/**`;

--- a/src/cli/rules.ts
+++ b/src/cli/rules.ts
@@ -136,27 +136,53 @@ export interface RulesExportOptions {
 }
 
 /**
+ * Read a canonical PACKAGE-scope glob as a Claude FILE glob.
+ *
+ * `ruleMatchesPackage` (static-rules.ts) tests each canonical pattern against a
+ * package directory path relative to the repo root, so the faithful file-glob
+ * reading is "every file beneath a directory this pattern selects". A trailing
+ * `/*` or `/**` is part of how the package form spells "this directory", not an
+ * extra level, so it is normalised away before the file-matching `/**` is added
+ * — otherwise `packages/api/**` would become `packages/api/**\/**` and match
+ * strictly less than it did.
+ */
+function packageGlobToFileGlob(pattern: string): string {
+  const base = pattern.replace(/\/+\*{1,2}$/, "").replace(/\/+$/, "");
+  // A pattern that selects every package maps to every file.
+  if (base === "" || base === "**") return "**";
+  return `${base}/**`;
+}
+
+/**
  * Rebuild an agent-facing frontmatter block from a canonical rule.
  *
  * The key means different things in each store: nax's `appliesTo:` is the FILE
  * glob and its `paths:` is PACKAGE scope, whereas Claude's `paths:` is the file
  * glob. `nax rules migrate` translates Claude `paths:` -> nax `appliesTo:` on
  * the way in (see translateLegacyFrontmatter); this is the same translation on
- * the way out. Canonical `paths:` has no Claude equivalent and is dropped.
+ * the way out. Canonical `paths:` is read as a file glob via
+ * {@link packageGlobToFileGlob} so a package-scoped rule keeps its scope.
  *
  * Returns "" for an unscoped rule so no empty block is emitted.
  */
 function claudeFrontmatter(rule: CanonicalRule): string {
-  // Canonical `paths:` is PACKAGE scope and has no Claude equivalent. Dropping
-  // it silently WIDENS the rule — a rule scoped to one package becomes globally
-  // loaded — so it is warned about rather than quietly discarded.
-  if (rule.paths?.length) {
-    _rulesCLIDeps.getLogger().warn("rules-export", "Dropping package scope — Claude has no equivalent", {
+  const fileGlobs = rule.appliesTo ?? [];
+  const packageGlobs = rule.paths ?? [];
+
+  // nax applies `appliesTo` AND `paths` as a conjunction, but Claude's single
+  // `paths:` list is a disjunction — emitting both would WIDEN the rule rather
+  // than narrow it, which is the opposite of what either scope asked for. Keep
+  // the file glob, the more specific of the two, and report the package scope
+  // instead of quietly unioning it in.
+  if (fileGlobs.length > 0 && packageGlobs.length > 0) {
+    _rulesCLIDeps.getLogger().warn("rules-export", "Dropping package scope — Claude cannot express both scopes", {
       rule: rule.path ?? rule.fileName,
-      droppedPaths: rule.paths,
+      droppedPaths: packageGlobs,
+      keptAppliesTo: fileGlobs,
     });
   }
-  const globs = rule.appliesTo ?? [];
+
+  const globs = fileGlobs.length > 0 ? fileGlobs : [...new Set(packageGlobs.map(packageGlobToFileGlob))];
   if (globs.length === 0) return "";
   // JSON.stringify escapes quotes/backslashes — a raw interpolation would
   // emit invalid YAML for a glob containing either (cf. toYamlListLiteral).

--- a/test/unit/cli/rules-export-scope.test.ts
+++ b/test/unit/cli/rules-export-scope.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `nax rules export --agent=claude` — package scope survives the export.
+ *
+ * Canonical `paths:` is PACKAGE scope; Claude's `paths:` is a FILE glob. These
+ * used to be treated as having no correspondence, so a package-scoped rule was
+ * exported with its scope dropped — and because `claudeFrontmatter` derives the
+ * block solely from `appliesTo`, such a rule emitted no frontmatter at all and
+ * Claude then loaded it globally. A rule written for one package silently
+ * applied to the whole monorepo.
+ *
+ * A package glob does have a faithful file-glob reading: "every file beneath a
+ * directory this pattern selects". These tests pin that translation, and pin
+ * that the lossy case that remains (both scopes set, which Claude cannot express
+ * as an intersection) still warns.
+ *
+ * Split from rules.test.ts, which is at 747 of the 800-line limit.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _rulesCLIDeps, rulesExportCommand } from "../../../src/cli/rules";
+
+let origWriteFile: typeof _rulesCLIDeps.writeFile;
+let origGlobInDir: typeof _rulesCLIDeps.globInDir;
+let origMkdir: typeof _rulesCLIDeps.mkdir;
+let origLoadCanonicalRules: typeof _rulesCLIDeps.loadCanonicalRules;
+let origGetLogger: typeof _rulesCLIDeps.getLogger;
+
+const written: Record<string, string> = {};
+let warnings: Array<{ msg: string; data: unknown }> = [];
+
+beforeEach(() => {
+  origWriteFile = _rulesCLIDeps.writeFile;
+  origGlobInDir = _rulesCLIDeps.globInDir;
+  origMkdir = _rulesCLIDeps.mkdir;
+  origLoadCanonicalRules = _rulesCLIDeps.loadCanonicalRules;
+  origGetLogger = _rulesCLIDeps.getLogger;
+
+  Object.keys(written).forEach((k) => delete written[k]);
+  warnings = [];
+
+  _rulesCLIDeps.writeFile = async (path, content) => {
+    written[path] = content;
+  };
+  _rulesCLIDeps.globInDir = () => [];
+  _rulesCLIDeps.mkdir = async () => {};
+  _rulesCLIDeps.loadCanonicalRules = async () => [];
+  _rulesCLIDeps.getLogger = () =>
+    ({ warn: (_s: string, msg: string, data: unknown) => warnings.push({ msg, data }) }) as never;
+});
+
+afterEach(() => {
+  _rulesCLIDeps.writeFile = origWriteFile;
+  _rulesCLIDeps.globInDir = origGlobInDir;
+  _rulesCLIDeps.mkdir = origMkdir;
+  _rulesCLIDeps.loadCanonicalRules = origLoadCanonicalRules;
+  _rulesCLIDeps.getLogger = origGetLogger;
+});
+
+/** Export one rule and return the generated file body. */
+async function exportOne(rule: Record<string, unknown>): Promise<string> {
+  _rulesCLIDeps.loadCanonicalRules = async () => [{ fileName: "r.md", content: "Body.", ...rule } as never];
+  await rulesExportCommand({ dir: "/project", agent: "claude" });
+  return written["/project/.claude/rules/r.md"] ?? "";
+}
+
+describe("rules export (claude) — package scope becomes a file glob", () => {
+  test.each([
+    // [canonical paths:, expected Claude paths:]
+    ["packages/nestjs-oauth/*", "packages/nestjs-oauth/**"],
+    ["packages/api/**", "packages/api/**"],
+    ["apps/web", "apps/web/**"],
+    ["packages/*/core", "packages/*/core/**"],
+  ])("canonical paths %p exports as Claude glob %p", async (canonical, expected) => {
+    const out = await exportOne({ paths: [canonical] });
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain(`  - ${JSON.stringify(expected)}`);
+  });
+
+  test("a package-scoped rule is no longer emitted without frontmatter", async () => {
+    const out = await exportOne({ paths: ["packages/nestjs-oauth/*"] });
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain("paths:");
+  });
+
+  test("translating is not a drop, so nothing warns about lost package scope", async () => {
+    await exportOne({ paths: ["packages/nestjs-oauth/*"] });
+    expect(warnings.find((w) => w.msg.includes("package scope"))).toBeUndefined();
+  });
+
+  test("every canonical path is carried, not just the first", async () => {
+    const out = await exportOne({ paths: ["packages/a/*", "packages/b/*"] });
+    expect(out).toContain('  - "packages/a/**"');
+    expect(out).toContain('  - "packages/b/**"');
+  });
+
+  test("nax's own paths: spelling never reaches the generated file", async () => {
+    const out = await exportOne({ paths: ["packages/api/*"] });
+    expect(out).not.toContain("appliesTo:");
+    // Claude reads `paths:`; the canonical key name means nothing to it.
+    expect(out.split("---")[1]).toContain("paths:");
+  });
+});
+
+describe("rules export (claude) — the scopes that cannot be combined", () => {
+  /**
+   * nax applies `appliesTo` AND `paths` as a conjunction; Claude's single
+   * `paths:` list is a disjunction, so emitting both would WIDEN the rule
+   * rather than narrow it. The file glob is kept and the package scope is
+   * reported instead of being silently unioned in.
+   */
+  test("keeps the file glob and warns when both scopes are set", async () => {
+    const out = await exportOne({ appliesTo: ["src/**/*.ts"], paths: ["packages/api/*"] });
+    expect(out).toContain('  - "src/**/*.ts"');
+    expect(out).not.toContain("packages/api");
+
+    const w = warnings.find((x) => x.msg.includes("package scope"));
+    expect(w).toBeDefined();
+    expect(JSON.stringify(w?.data)).toContain("packages/api/*");
+  });
+
+  test("an unscoped rule still gets no frontmatter block", async () => {
+    const out = await exportOne({});
+    expect(out.startsWith("---")).toBe(false);
+    expect(out).toContain("Body.");
+  });
+});

--- a/test/unit/cli/rules-export-scope.test.ts
+++ b/test/unit/cli/rules-export-scope.test.ts
@@ -70,6 +70,9 @@ describe("rules export (claude) — package scope becomes a file glob", () => {
     ["packages/api/**", "packages/api/**"],
     ["apps/web", "apps/web/**"],
     ["packages/*/core", "packages/*/core/**"],
+    // A trailing slash names the same directory and must not change the result.
+    ["packages/api/", "packages/api/**"],
+    ["packages/api/*/", "packages/api/**"],
   ])("canonical paths %p exports as Claude glob %p", async (canonical, expected) => {
     const out = await exportOne({ paths: [canonical] });
     expect(out.startsWith("---\n")).toBe(true);

--- a/test/unit/cli/rules.test.ts
+++ b/test/unit/cli/rules.test.ts
@@ -255,7 +255,12 @@ describe("rulesExportCommand", () => {
     });
   });
 
-  test("warns when canonical package scope is dropped, instead of widening silently", async () => {
+  // Package scope used to be dropped here (warned about, but dropped), which
+  // left the rule with no frontmatter at all and therefore globally loaded.
+  // It is now carried across as the equivalent file glob. The lossy case that
+  // remains — both scopes set, which Claude cannot express as an intersection —
+  // is covered in rules-export-scope.test.ts.
+  test("carries canonical package scope across instead of widening the rule", async () => {
     const warnings: Array<{ msg: string; data: unknown }> = [];
     _rulesCLIDeps.getLogger = () =>
       ({ warn: (_s: string, msg: string, data: unknown) => warnings.push({ msg, data }) }) as never;
@@ -263,9 +268,10 @@ describe("rulesExportCommand", () => {
 
     await rulesExportCommand({ dir: "/project", agent: "claude" });
 
-    const w = warnings.find((x) => x.msg.includes("package scope"));
-    expect(w).toBeDefined();
-    expect(JSON.stringify(w?.data)).toContain("apps/api/**");
+    const out = written["/project/.claude/rules/pkg.md"] ?? "";
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain('  - "apps/api/**"');
+    expect(warnings.find((x) => x.msg.includes("package scope"))).toBeUndefined();
   });
 
   test("warns about a generated rule file with no canonical source", async () => {


### PR DESCRIPTION
## What

A rule scoped with canonical `paths:` exported to `.claude/rules/` **with no
frontmatter at all**, so Claude loaded it globally.

## Why it happened

`claudeFrontmatter` builds the block solely from `appliesTo`:

```ts
const globs = rule.appliesTo ?? [];
if (globs.length === 0) return "";
```

Canonical `paths:` is PACKAGE scope and was dropped on the way out. For a rule
that used `paths:` and no `appliesTo`, that left zero globs, so the function
returned `""` — no frontmatter — and a rule written for one package silently
applied to the whole monorepo.

Observed on `nathapp-nestjs-platform`: `nestjs-oauth-controllers.md` and
`nestjs-oauth-safety.md` both declare `paths: packages/nestjs-oauth/*`, and
both exported unscoped.

### The mitigation was dead

The drop was supposed to be warned about — the comment said so explicitly. It
was not. The warning resolves through `getLogger()`, and the `rules export`
action never called `initLogger` (only `rules lint` did), so `getLogger()`
returned the noop logger and the record was discarded. `--dry-run` on the
affected repo printed nothing for either rule.

## How

**Translate rather than drop.** The two scopes were treated as having no
correspondence, but a package glob has a faithful file-glob reading.
`ruleMatchesPackage` (static-rules.ts) tests each canonical pattern against a
package directory path relative to the repo root, so the equivalent file glob
is "every file beneath a directory that pattern selects":

| canonical `paths:` | Claude `paths:` |
|---|---|
| `packages/nestjs-oauth/*` | `packages/nestjs-oauth/**` |
| `packages/api/**` | `packages/api/**` |
| `apps/web` | `apps/web/**` |
| `packages/*/core` | `packages/*/core/**` |

A trailing `/*` or `/**` is how the package form spells "this directory", so it
is normalised away rather than stacked — otherwise `packages/api/**` would
become `packages/api/**/**` and match strictly less than before.

**The one genuinely lossy case stays lossy, and now says so.** nax applies
`appliesTo` AND `paths` as a conjunction; Claude's single `paths:` list is a
disjunction, so emitting both would widen the rule rather than narrow it. The
file glob is kept and the package scope is reported.

**`initLogger` in the export action**, mirroring `rules lint`, so that report —
and the pre-existing "generated file with no canonical source" warning —
actually reach the operator.

## Testing

- [x] `bun run test` — 12102 unit / 1097 integration / 24 ui, 0 fail
- [x] `bun run typecheck`, `bun run lint`, `bun run build`
- [x] New `test/unit/cli/rules-export-scope.test.ts` (split out; rules.test.ts
      is at 747 of the 800-line limit) covering the translation table, multiple
      paths, no spurious warning, the both-scopes case, and unscoped rules
      still emitting no block
- [x] One pre-existing test pinned the old drop-and-warn contract and
      necessarily failed; rewritten to assert the scope is carried across,
      which is what its own title ("instead of widening silently") wanted
- [x] End-to-end against the real nestjs-platform rules copied into a temp
      dir: both oauth rules now emit `paths: ["packages/nestjs-oauth/**"]`,
      and the genuinely unscoped `pagination.md` still emits no block
- [x] Warning verified visible before/after the `initLogger` fix
- [x] `nax rules export --agent=claude --check` clean in this repo — the 12
      generated rules here are unchanged

## Note

This is the third instance of scoping that silently did nothing in this
subsystem, after #1463 (`appliesTo:` inert, docstring wrong) and #1465
(comment-displaced frontmatter dropping the whole block). Worth considering a
`rules lint` check that flags a canonical rule whose scope cannot survive
export for the target agent.
