### PR TITLE
fix(pr-body): merge the repo PR template instead of appending it blank

### DIFF
--- a/flows/nax-finish/pr-template-merge.ts
+++ b/flows/nax-finish/pr-template-merge.ts
@@ -117,6 +117,8 @@ const FRONTMATTER_RE = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/;
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
 /** `Closes #`, `Fixes # (issue)` — an issue reference with no issue. */
 const DANGLING_ISSUE_RE = /^[ \t]*(?:closes?|fixe?s?|resolves?)[ \t]*:?[ \t]*#[ \t]*(?:\([^)]*\))?[ \t]*$/i;
+/** An unticked task-list item — an unfilled field wherever it appears. */
+const UNCHECKED_BOX_RE = /^[ \t]*[-*+][ \t]+\[[ \t]\]/;
 
 interface TemplateSection {
   heading: string;
@@ -141,23 +143,32 @@ function normalizeHeading(heading: string): string {
 /**
  * Strip placeholders from template-derived prose.
  *
- * Only ever applied to text nax is *keeping* (the preamble). Text under a
- * matched heading is replaced wholesale and text under an unmatched one is
- * discarded, so a checkbox list or a stale `Closes #` inside a section never
- * reaches this function — which is why there is no checkbox-versus-gate
- * reconciliation anywhere in this module.
+ * Only ever applied to the preamble — the one template region that survives
+ * into the body. Text under a matched heading is replaced wholesale and text
+ * under an unmatched one is discarded, so a checklist or a stale `Closes #`
+ * *inside a section* never reaches this function, which is why there is no
+ * checkbox-versus-gate reconciliation anywhere in this module.
+ *
+ * The preamble is the exception, because a template may open with a
+ * contributor checklist before its first heading. An unticked box there is an
+ * unfilled field like any other, so it is dropped while the prose around it is
+ * kept.
  */
 function cleanTemplateText(text: string): string {
   return text
     .replace(HTML_COMMENT_RE, "")
     .split("\n")
-    .filter((line) => !DANGLING_ISSUE_RE.test(line))
+    .filter((line) => !DANGLING_ISSUE_RE.test(line) && !UNCHECKED_BOX_RE.test(line))
     .map((line) => line.trimEnd())
     .join("\n")
     .trim();
 }
 
-function parseTemplate(text: string): ParsedTemplate {
+function parseTemplate(rawText: string): ParsedTemplate {
+  // Normalised up front so a CRLF template (anything authored on Windows, or
+  // fetched through a forge web editor) cannot leak a stray carriage return
+  // into a heading this module re-emits.
+  const text = rawText.replace(/\r\n/g, "\n");
   const frontmatterMatch = FRONTMATTER_RE.exec(text);
   const frontmatter = frontmatterMatch ? frontmatterMatch[0].trimEnd() : "";
   const rest = frontmatterMatch ? text.slice(frontmatterMatch[0].length) : text;
@@ -209,7 +220,11 @@ export function mergeTemplate(
   // this module removes — so fall back to the body nax would have written.
   if (parsed.sections.length === 0) return renderSections(sections);
 
-  const aliases = { ...DEFAULT_SECTION_ALIASES, ...(opts.sectionMap ?? {}) };
+  // Override keys go through the same normalisation as the template headings
+  // they are matched against, so a repo pins a heading by pasting it —
+  // `"What does this MR do and why?"` — not by hand-normalising it first.
+  const aliases = { ...DEFAULT_SECTION_ALIASES };
+  for (const [heading, key] of Object.entries(opts.sectionMap ?? {})) aliases[normalizeHeading(heading)] = key;
   const fillable = sections.filter((s) => s.heading.length > 0 && s.body.trim().length > 0);
   const consumed = new Set<string>();
   const parts: string[] = [];

--- a/flows/nax-finish/pr-template-merge.ts
+++ b/flows/nax-finish/pr-template-merge.ts
@@ -1,0 +1,238 @@
+/**
+ * Merge nax's generated PR/MR body into the repository's own PR template.
+ *
+ * ## Why this exists
+ *
+ * `gh pr create --body` / `glab mr create --description` suppress the repo's
+ * template, so a generated body has to account for it. The first attempt
+ * appended the template verbatim after the generated content, which shipped a
+ * *blank form* below a filled one: placeholder comments, a dangling `Closes #`,
+ * duplicated headings, and an unchecked "`bun test` passes" box sitting under a
+ * Verification section that already said the gates were green (nax#1504).
+ *
+ * A PR template is an input form, not decoration. So the template is treated as
+ * **shape** and nax's content as **fill**:
+ *
+ * - a template heading nax can fill  → keep the heading, replace its body
+ * - a template heading nax cannot    → drop it (`merge`) or empty it (`strict`)
+ * - nax content with no home         → append under nax's own heading
+ *
+ * The governing invariant is **never emit a field that was not filled**. That
+ * is the same rule `buildFinishBody` already followed for its own sections
+ * (nax#1477 forbids a bare heading with nothing under it); this module extends
+ * it to template-derived text. `strict` mode is the one deliberate exception,
+ * for repos whose CI asserts a set of headings exists.
+ *
+ * ## Why deterministic
+ *
+ * Placement is decided by a heading-alias table, not by a model. The facts in
+ * the body — gate results, story counts, diffstat, review rounds — stay a pure
+ * string join, which is what keeps a finish body greppable in PR history. A
+ * repo whose headings the table does not know loses nothing: its sections are
+ * dropped and nax's own headings are used instead, and `sectionMap` pins the
+ * mapping explicitly when a team wants its headings honoured.
+ *
+ * Lives under `flows/` (and is imported from `src/` via `@flows/*`, not
+ * re-implemented) because `flows/` is the more constrained runtime — acpx runs
+ * it in its own Node process where `Bun` and the `@/*` alias do not exist. Code
+ * that satisfies that constraint runs in both places; the reverse is not true.
+ */
+
+/** One nax-authored section of the body. */
+export interface BodySection {
+  /**
+   * Stable id matched against the alias table. Independent of `heading` so
+   * renaming nax's own heading does not silently break template matching.
+   */
+  key: string;
+  /**
+   * nax's H2 text, used when the section is appended rather than merged.
+   * Empty means headingless (the run footer) — such a section is rendered as
+   * bare text and is never matched to a template heading, so a stray alias
+   * cannot bury the footer under someone's `## Notes`.
+   */
+  heading: string;
+  /** Markdown body without its heading line. Callers omit empty sections. */
+  body: string;
+}
+
+/**
+ * - `merge`  — template headings nax cannot fill are dropped. Default.
+ * - `strict` — they are kept, empty, for repos with heading-checking CI.
+ * - `ignore` — the template is not consulted at all.
+ */
+export type TemplateMode = "merge" | "strict" | "ignore";
+
+export interface MergeOptions {
+  mode?: TemplateMode;
+  /**
+   * Normalised template heading → `BodySection.key`, layered over
+   * `DEFAULT_SECTION_ALIASES`. An empty value suppresses a default alias,
+   * which is how a repo says "do not put anything under this heading".
+   */
+  sectionMap?: Record<string, string>;
+}
+
+/**
+ * Normalised heading → section key.
+ *
+ * Deliberately partial. `why`, `notes`, `screenshots` and friends are absent
+ * because nax has nothing truthful to put under them — an alias that mapped
+ * them to some loosely-related section would reintroduce exactly the
+ * unfilled-field problem this module exists to remove.
+ */
+export const DEFAULT_SECTION_ALIASES: Record<string, string> = {
+  // → narrative
+  what: "narrative",
+  "what changed": "narrative",
+  "whats changed": "narrative",
+  summary: "narrative",
+  description: "narrative",
+  overview: "narrative",
+  changes: "narrative",
+  "what does this do": "narrative",
+  "what does this mr do and why": "narrative",
+  "what does this pr do": "narrative",
+  // → stories
+  how: "stories",
+  implementation: "stories",
+  "implementation details": "stories",
+  "changes made": "stories",
+  approach: "stories",
+  design: "stories",
+  // → verification
+  testing: "verification",
+  tests: "verification",
+  "test plan": "verification",
+  verification: "verification",
+  qa: "verification",
+  validation: "verification",
+  "how to test": "verification",
+  "how has this been tested": "verification",
+  "how to set up and validate locally": "verification",
+};
+
+const HEADING_RE = /^##[ \t]+(.+?)[ \t]*$/;
+const FRONTMATTER_RE = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/;
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+/** `Closes #`, `Fixes # (issue)` — an issue reference with no issue. */
+const DANGLING_ISSUE_RE = /^[ \t]*(?:closes?|fixe?s?|resolves?)[ \t]*:?[ \t]*#[ \t]*(?:\([^)]*\))?[ \t]*$/i;
+
+interface TemplateSection {
+  heading: string;
+  body: string;
+}
+
+interface ParsedTemplate {
+  frontmatter: string;
+  preamble: string;
+  sections: TemplateSection[];
+}
+
+/** Lowercase, drop punctuation, collapse whitespace — so `## Testing:` matches `testing`. */
+function normalizeHeading(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Strip placeholders from template-derived prose.
+ *
+ * Only ever applied to text nax is *keeping* (the preamble). Text under a
+ * matched heading is replaced wholesale and text under an unmatched one is
+ * discarded, so a checkbox list or a stale `Closes #` inside a section never
+ * reaches this function — which is why there is no checkbox-versus-gate
+ * reconciliation anywhere in this module.
+ */
+function cleanTemplateText(text: string): string {
+  return text
+    .replace(HTML_COMMENT_RE, "")
+    .split("\n")
+    .filter((line) => !DANGLING_ISSUE_RE.test(line))
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+}
+
+function parseTemplate(text: string): ParsedTemplate {
+  const frontmatterMatch = FRONTMATTER_RE.exec(text);
+  const frontmatter = frontmatterMatch ? frontmatterMatch[0].trimEnd() : "";
+  const rest = frontmatterMatch ? text.slice(frontmatterMatch[0].length) : text;
+
+  const preambleLines: string[] = [];
+  const sections: TemplateSection[] = [];
+  let current: { heading: string; lines: string[] } | null = null;
+
+  for (const line of rest.split("\n")) {
+    const heading = HEADING_RE.exec(line);
+    if (heading) {
+      if (current) sections.push({ heading: current.heading, body: current.lines.join("\n") });
+      current = { heading: heading[1], lines: [] };
+      continue;
+    }
+    if (current) current.lines.push(line);
+    else preambleLines.push(line);
+  }
+  if (current) sections.push({ heading: current.heading, body: current.lines.join("\n") });
+
+  return { frontmatter, preamble: preambleLines.join("\n"), sections };
+}
+
+function renderSection(heading: string, body: string): string {
+  if (heading.length === 0) return body;
+  return body.length === 0 ? `## ${heading}` : `## ${heading}\n\n${body}`;
+}
+
+/** Nax-only body: every section under its own heading, in the order given. */
+function renderSections(sections: BodySection[]): string {
+  return sections
+    .filter((s) => s.body.trim().length > 0)
+    .map((s) => renderSection(s.heading, s.body.trim()))
+    .join("\n\n")
+    .trim();
+}
+
+export function mergeTemplate(
+  template: string | null | undefined,
+  sections: BodySection[],
+  opts: MergeOptions = {},
+): string {
+  const mode = opts.mode ?? "merge";
+  if (mode === "ignore" || !template || template.trim().length === 0) return renderSections(sections);
+
+  const parsed = parseTemplate(template);
+  // No H2 anywhere: the template is prose, or nests everything under H1/H3.
+  // There is no shape to merge into, and appending it unparsed is the defect
+  // this module removes — so fall back to the body nax would have written.
+  if (parsed.sections.length === 0) return renderSections(sections);
+
+  const aliases = { ...DEFAULT_SECTION_ALIASES, ...(opts.sectionMap ?? {}) };
+  const fillable = sections.filter((s) => s.heading.length > 0 && s.body.trim().length > 0);
+  const consumed = new Set<string>();
+  const parts: string[] = [];
+
+  if (parsed.frontmatter.length > 0) parts.push(parsed.frontmatter);
+  const preamble = cleanTemplateText(parsed.preamble);
+  if (preamble.length > 0) parts.push(preamble);
+
+  for (const templateSection of parsed.sections) {
+    const key = aliases[normalizeHeading(templateSection.heading)];
+    const match = key ? fillable.find((s) => s.key === key && !consumed.has(s.key)) : undefined;
+    if (match) {
+      consumed.add(match.key);
+      parts.push(renderSection(templateSection.heading, match.body.trim()));
+    } else if (mode === "strict") {
+      parts.push(renderSection(templateSection.heading, ""));
+    }
+  }
+
+  for (const section of sections) {
+    if (consumed.has(section.key) || section.body.trim().length === 0) continue;
+    parts.push(renderSection(section.heading, section.body.trim()));
+  }
+
+  return parts.join("\n\n").trim();
+}

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -23,6 +23,7 @@ import { dirname, isAbsolute, join } from "node:path";
 import { runArgv } from "../exec";
 import { readSpecSummary, resolveNarrative } from "../narrative";
 import { findPrTemplate } from "../pr-template";
+import { type BodySection, type TemplateMode, mergeTemplate } from "../pr-template-merge";
 import { resolveTitle } from "../pr-title";
 import type { Finding, FinishInput, FinishRound, RunFn } from "../types";
 import type { Forge } from "./forge";
@@ -57,6 +58,10 @@ export interface FinishPrContext {
   artifactSummary?: string;
   /** Repository PR/MR template, verbatim. Absent when none resolves. */
   template?: string;
+  /** How `template` is honoured. Absent → `merge`. See `pr-template-merge.ts`. */
+  templateMode?: TemplateMode;
+  /** Repo overrides for the template-heading → section-key table. */
+  templateSectionMap?: Record<string, string>;
   /** Resolved "What changed" prose. Absent when neither source produced text. */
   narrative?: string;
   /**
@@ -244,6 +249,8 @@ export async function loadFinishPrContext(
     diffstat: stat.diffstat,
     artifactSummary: stat.artifactSummary,
     template,
+    ...(input.prBody?.template !== undefined ? { templateMode: input.prBody.template } : {}),
+    ...(input.prBody?.sectionMap !== undefined ? { templateSectionMap: input.prBody.sectionMap } : {}),
     narrative: resolveNarrative(args.narrative, specSummary),
     title: resolveTitle(args.title, input.feature),
     run: {
@@ -296,7 +303,6 @@ function formatDuration(durationMs: number): string {
 
 function buildStoriesSection(stories: FinishPrStory[]): string {
   const lines: string[] = [];
-  lines.push("## Stories");
   lines.push("| Story | Title | ACs |");
   lines.push("|-------|-------|-----|");
   for (const story of stories) {
@@ -312,7 +318,7 @@ function buildStoriesSection(stories: FinishPrStory[]): string {
  */
 function buildVerificationSection(ctx: FinishPrContext): string | null {
   const { acceptance, regression, gatesRan, diffstat, artifactSummary } = ctx;
-  const lines: string[] = ["## Verification"];
+  const lines: string[] = [];
   if (acceptance !== undefined) lines.push(`- Acceptance: ${acceptance}`);
   if (regression !== undefined) lines.push(`- Regression: ${regression}`);
   if (gatesRan.length > 0) lines.push(`- Gates: ${gatesRan.join(", ")}`);
@@ -323,7 +329,7 @@ function buildVerificationSection(ctx: FinishPrContext): string | null {
   if (artifactSummary !== undefined && artifactSummary.length > 0) {
     lines.push(`- Excluded from diffstat — nax run artifacts: ${artifactSummary}`);
   }
-  if (lines.length === 1) return null;
+  if (lines.length === 0) return null;
   return lines.join("\n");
 }
 
@@ -346,8 +352,7 @@ function buildRoundBlock(round: FinishRound): string {
 
 function buildRoundsSection(rounds: FinishRound[]): string | null {
   if (rounds.length === 0) return null;
-  const blocks = rounds.map(buildRoundBlock);
-  return ["## Review rounds", ...blocks].join("\n\n");
+  return rounds.map(buildRoundBlock).join("\n\n");
 }
 
 function renderFinding(finding: Finding): string {
@@ -355,20 +360,17 @@ function renderFinding(finding: Finding): string {
 }
 
 /**
- * Heading and text are produced together, so "no text" cannot render a bare
- * `## What changed` heading — the empty-heading case #1477 forbids.
+ * Body only — the heading is attached by `buildFinishBody`, which drops any
+ * section whose body is null. "No text" therefore cannot render a bare
+ * `## What changed` heading, the empty-heading case #1477 forbids.
  */
 function buildNarrativeSection(narrative: string | undefined): string | null {
-  const text = narrative?.trim();
-  if (!text) return null;
-  return ["## What changed", text].join("\n\n");
+  return narrative?.trim() || null;
 }
 
 function buildOutOfScopeSection(outOfScope: string[]): string | null {
   if (outOfScope.length === 0) return null;
-  const lines: string[] = ["## Out of scope"];
-  for (const item of outOfScope) lines.push(`- ${item}`);
-  return lines.join("\n");
+  return outOfScope.map((item) => `- ${item}`).join("\n");
 }
 
 function buildFooter(run: FinishPrContext["run"]): string | null {
@@ -382,29 +384,38 @@ function buildFooter(run: FinishPrContext["run"]): string | null {
   return parts.join(" · ");
 }
 
+/**
+ * The nax-authored sections, in canonical order — the order they appear in
+ * when the repo has no template, and the order the leftovers are appended in
+ * when it has one. `key` is what `mergeTemplate` matches against the repo's
+ * headings; the run footer carries an empty heading so it stays unmatchable
+ * and last.
+ */
+function buildBodySections(ctx: FinishPrContext): BodySection[] {
+  const candidates: { key: string; heading: string; body: string | null }[] = [
+    { key: "narrative", heading: "What changed", body: buildNarrativeSection(ctx.narrative) },
+    { key: "stories", heading: "Stories", body: ctx.stories.length > 0 ? buildStoriesSection(ctx.stories) : null },
+    { key: "verification", heading: "Verification", body: buildVerificationSection(ctx) },
+    { key: "rounds", heading: "Review rounds", body: buildRoundsSection(ctx.rounds) },
+    { key: "outOfScope", heading: "Out of scope", body: buildOutOfScopeSection(ctx.outOfScope) },
+    { key: "footer", heading: "", body: buildFooter(ctx.run) },
+  ];
+  return candidates
+    .filter((c): c is { key: string; heading: string; body: string } => c.body !== null)
+    .map(({ key, heading, body }) => ({ key, heading, body }));
+}
+
+/**
+ * Assemble the body, merged into the repo's own PR template when it has one.
+ *
+ * The template supplies the *shape* (which headings, in what order) and these
+ * sections supply the *content* — see `pr-template-merge.ts` for why appending
+ * it verbatim, which is what this used to do, shipped a blank form under a
+ * filled one (nax#1504).
+ */
 export function buildFinishBody(ctx: FinishPrContext): string {
-  const sections: string[] = [];
-
-  const narrativeSection = buildNarrativeSection(ctx.narrative);
-  if (narrativeSection !== null) sections.push(narrativeSection);
-
-  if (ctx.stories.length > 0) sections.push(buildStoriesSection(ctx.stories));
-
-  const verification = buildVerificationSection(ctx);
-  if (verification !== null) sections.push(verification);
-
-  const roundsSection = buildRoundsSection(ctx.rounds);
-  if (roundsSection !== null) sections.push(roundsSection);
-
-  const outOfScopeSection = buildOutOfScopeSection(ctx.outOfScope);
-  if (outOfScopeSection !== null) sections.push(outOfScopeSection);
-
-  const footer = buildFooter(ctx.run);
-  if (footer !== null) sections.push(footer);
-
-  // Appended last and verbatim: `gh` / `glab` suppress the repo's own template
-  // whenever `--body` / `--description` is passed, so it has to be re-embedded.
-  if (ctx.template !== undefined && ctx.template.trim().length > 0) sections.push(ctx.template.trim());
-
-  return sections.join("\n\n");
+  return mergeTemplate(ctx.template, buildBodySections(ctx), {
+    mode: ctx.templateMode,
+    sectionMap: ctx.templateSectionMap,
+  });
 }

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -1,3 +1,5 @@
+import type { TemplateMode } from "./pr-template-merge";
+
 /** One acceptance-test group as reported by `nax features resolve --json`. */
 export interface AcceptanceGroup {
   packageDir: string;
@@ -102,7 +104,7 @@ export interface FinishInput {
  */
 export interface FinishPrBodySettings {
   /** `merge` (default) · `strict` (keep unfillable headings, empty) · `ignore`. */
-  template?: "merge" | "strict" | "ignore";
+  template?: TemplateMode;
   /** Normalised template heading → body-section key, layered over the defaults. */
   sectionMap?: Record<string, string>;
 }

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -92,6 +92,19 @@ export interface FinishInput {
    */
   escalateTelegram: boolean;
   timeouts?: FinishTimeouts;
+  /** PR/MR body composition, forwarded from `finish.autoFlow.prBody`. */
+  prBody?: FinishPrBodySettings;
+}
+
+/**
+ * How the repo's own PR/MR template is honoured when composing the body.
+ * Absent (and absent fields) mean the defaults in `pr-template-merge.ts`.
+ */
+export interface FinishPrBodySettings {
+  /** `merge` (default) · `strict` (keep unfillable headings, empty) · `ignore`. */
+  template?: "merge" | "strict" | "ignore";
+  /** Normalised template heading → body-section key, layered over the defaults. */
+  sectionMap?: Record<string, string>;
 }
 export interface FinishResult {
   feature: string;

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -455,6 +455,34 @@ export const NaxConfigSchema = z
              * mechanical fallback (spec §Summary) or no such section at all.
              */
             narrative: z.boolean().default(true),
+            /**
+             * How the repo's own PR/MR template is honoured.
+             *
+             * `merge` (default) treats the template as *shape*: headings the
+             * body can fill keep their wording, headings it cannot are
+             * dropped, and content with no matching heading is appended under
+             * nax's own. `strict` keeps the unfillable headings, empty, for
+             * repos whose CI asserts a set of headings exists. `ignore` skips
+             * the template entirely.
+             *
+             * Never appends the template verbatim — that shipped an unfilled
+             * form below a filled one (#1504).
+             */
+            prBody: z
+              .object({
+                template: z.enum(["merge", "strict", "ignore"]).default("merge"),
+                /**
+                 * Template heading → body-section key, layered over the
+                 * defaults in `flows/nax-finish/pr-template-merge.ts`. Keys are
+                 * matched case- and punctuation-insensitively. An empty value
+                 * suppresses a default alias.
+                 *
+                 * Known section keys: `narrative`, `stories`, `verification`,
+                 * `rounds`, `outOfScope`.
+                 */
+                sectionMap: z.record(z.string(), z.string()).default({}),
+              })
+              .default({ template: "merge", sectionMap: {} }),
             reviewers: z
               .object({
                 spec: z.string().nullable().default(null),
@@ -493,6 +521,7 @@ export const NaxConfigSchema = z
             defaultAgent: null,
             model: null,
             narrative: true,
+            prBody: { template: "merge", sectionMap: {} },
             reviewers: { spec: null, quality: null, narrative: null },
             escalate: { telegram: true },
             notify: { mode: "escalation" },
@@ -506,6 +535,7 @@ export const NaxConfigSchema = z
           defaultAgent: null,
           model: null,
           narrative: true,
+          prBody: { template: "merge", sectionMap: {} },
           reviewers: { spec: null, quality: null, narrative: null },
           escalate: { telegram: true },
           notify: { mode: "escalation" },

--- a/src/plugins/builtin/auto-pr/pr-body.ts
+++ b/src/plugins/builtin/auto-pr/pr-body.ts
@@ -8,6 +8,12 @@
  */
 
 import type { UserStory } from "@/prd/types";
+// Imported from `flows/`, not re-implemented, so the draft body and the
+// nax-finish body compose a template identically. `flows/` is the more
+// constrained runtime (acpx's Node process — no `Bun`, no `@/*`), so code that
+// lives there runs here too; the reverse is not true, which is why the other
+// shared helpers in this directory were ported the other way.
+import { type BodySection, type MergeOptions, mergeTemplate } from "@flows/nax-finish/pr-template-merge";
 
 const SECONDS_PER_MINUTE = 60;
 const MS_PER_SECOND = 1000;
@@ -58,7 +64,6 @@ function buildSummaryLines(ctx: PrBodyContext): string[] {
   const failed = `${storySummary.failed} failed`;
   const skipped = `${storySummary.skipped} skipped`;
   return [
-    "## Run summary",
     `- Feature: ${ctx.feature}`,
     `- Stories: ${passed} / ${failed} / ${skipped}`,
     `- Duration: ${formatDuration(ctx.totalDurationMs)}`,
@@ -92,36 +97,38 @@ function buildStoryTable(stories: UserStory[]): string[] {
   return lines;
 }
 
+const REVIEW_PENDING_BANNER = "> Auto-opened by nax — review pending. Run nax-finish before merge.";
+
 /**
  * Build the PR/MR body.
  *
- * Layout (template present):
+ * Layout (template present, and it has a heading this can fill):
  * ```
  * > Auto-opened by nax — review pending. Run nax-finish before merge.
  * (blank line)
- * ## Run summary
- * - …
+ * ## <the template's own heading>
+ * (blank line)
+ * - Feature: …
  * | Story | Title | ACs |
  * | …     | …     | …   |
- * (blank line)
- * ---
- * <template verbatim>
  * ```
  *
- * When `template` is `null`, the `---` separator and template block are omitted.
+ * The template used to be appended verbatim after a `---` separator, which
+ * shipped an unfilled form below a filled one (nax#1504). It is now merged —
+ * same `mergeTemplate` the finish body uses, so promoting this draft to a
+ * finished PR does not change the body's shape for no reason.
+ *
+ * The banner is prepended outside the merge: it must lead the body, and
+ * `mergeTemplate` places headingless sections last.
  */
-export function buildBody(ctx: PrBodyContext, template: string | null): string {
-  const blocks: string[] = [];
-
-  blocks.push("> Auto-opened by nax — review pending. Run nax-finish before merge.");
-  blocks.push("");
-  blocks.push(...buildSummaryLines(ctx));
-  blocks.push(...buildStoryTable(ctx.stories));
-
-  if (template !== null) {
-    blocks.push("---");
-    blocks.push(template);
-  }
-
-  return blocks.join("\n");
+export function buildBody(ctx: PrBodyContext, template: string | null, opts: MergeOptions = {}): string {
+  const sections: BodySection[] = [
+    {
+      key: "stories",
+      heading: "Run summary",
+      body: [...buildSummaryLines(ctx), ...buildStoryTable(ctx.stories)].join("\n").trim(),
+    },
+  ];
+  const merged = mergeTemplate(template, sections, opts);
+  return merged.length > 0 ? `${REVIEW_PENDING_BANNER}\n\n${merged}` : REVIEW_PENDING_BANNER;
 }

--- a/src/plugins/builtin/nax-finish/config.ts
+++ b/src/plugins/builtin/nax-finish/config.ts
@@ -21,6 +21,8 @@ export interface FinishAutoFlowSettings {
   /** acpx `--model`; null passes no flag at all. Opt-in — see the schema. */
   model: string | null;
   narrative: boolean;
+  /** PR/MR body composition — see `finish.autoFlow.prBody` in the schema. */
+  prBody: { template: "merge" | "strict" | "ignore"; sectionMap: Record<string, string> };
   reviewers: { spec: string | null; quality: string | null; narrative: string | null };
   escalate: { telegram: boolean };
   notify: { mode: "escalation" | "always" | "off" };
@@ -37,6 +39,7 @@ const DEFAULT_FINISH_AUTO_FLOW_CONFIG: Omit<FinishAutoFlowSettings, "defaultAgen
   flowPath: "flows/nax-finish/nax-finish.flow.ts",
   model: null,
   narrative: true,
+  prBody: { template: "merge", sectionMap: {} },
   reviewers: { spec: null, quality: null, narrative: null },
   escalate: { telegram: true },
   notify: { mode: "escalation" },
@@ -82,6 +85,10 @@ export function getFinishAutoFlowConfig(ctx: { config?: unknown }): FinishAutoFl
     // `!== false` so an older config with no `narrative` key still narrates,
     // matching the schema default rather than silently opting out.
     narrative: autoFlow.narrative !== false,
+    prBody: {
+      template: autoFlow.prBody?.template ?? defaults.prBody.template,
+      sectionMap: autoFlow.prBody?.sectionMap ?? defaults.prBody.sectionMap,
+    },
     reviewers: {
       spec: autoFlow.reviewers?.spec ?? null,
       quality: autoFlow.reviewers?.quality ?? null,

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -308,6 +308,7 @@ async function executeFinishFlow(options: ExecuteFinishOptions): Promise<FinishT
     runId: ctx.runId,
     escalateTelegram,
     timeouts: { acceptanceMs: cfg.timeouts.acceptanceMs, gateMs: cfg.timeouts.gateMs },
+    prBody: { template: cfg.prBody.template, sectionMap: cfg.prBody.sectionMap },
   };
   const cmd = buildFlowArgv(flowPath, JSON.stringify(input), {
     defaultAgent: cfg.defaultAgent,

--- a/test/fixtures/pr-templates.ts
+++ b/test/fixtures/pr-templates.ts
@@ -1,0 +1,158 @@
+/**
+ * Real-world PR/MR template corpus for `mergeTemplate`.
+ *
+ * The merge has to work against templates nax has never seen, so the unit
+ * tests assert per-template behaviour *and* sweep the whole corpus for the
+ * invariants that hold regardless of shape (no placeholder comments, no
+ * dangling issue refs, no empty headings outside strict mode).
+ *
+ * Kept verbatim — including the trailing-whitespace and blank-line quirks real
+ * templates carry — because normalising them here would test a cleaned input
+ * the production path never sees.
+ */
+
+export interface TemplateFixture {
+  /** Stable id, used as the `test.each` label. */
+  name: string;
+  /** Where this shape comes from, so a future reader knows what it represents. */
+  origin: string;
+  text: string;
+}
+
+/** This repository's own template — the one that produced the #1504 defect. */
+const NAX: TemplateFixture = {
+  name: "nax",
+  origin: ".github/pull_request_template.md in this repo",
+  text: `## What
+
+<!-- Brief description of what this PR does -->
+
+## Why
+
+<!-- What problem does this solve? Link to issue if applicable -->
+
+Closes #
+
+## How
+
+<!-- Key implementation details, if non-obvious -->
+
+## Testing
+
+- [ ] Tests added/updated
+- [ ] \`bun test\` passes
+- [ ] \`bun run typecheck\` passes
+- [ ] \`bun run lint\` passes
+
+## Notes
+
+<!-- Anything reviewers should know? Breaking changes? -->
+`,
+};
+
+/** GitHub's widely-copied community template. */
+const GITHUB_COMMUNITY: TemplateFixture = {
+  name: "github-community",
+  origin: "github/docs community PR template",
+  text: `## Description
+
+Please include a summary of the change.
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran.
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+`,
+};
+
+/** GitLab's default merge-request description, which leads with prose. */
+const GITLAB_DEFAULT: TemplateFixture = {
+  name: "gitlab-default",
+  origin: ".gitlab/merge_request_templates/Default.md",
+  text: `<!-- Set the MR title to describe the change. -->
+
+## What does this MR do and why?
+
+_Describe in detail what your merge request does and why._
+
+## Screenshots or screen recordings
+
+_Screenshots are required for UI changes._
+
+## How to set up and validate locally
+
+_Numbered steps to set up and validate the change._
+`,
+};
+
+/** Frontmatter carries labels/assignees and must survive untouched. */
+const WITH_FRONTMATTER: TemplateFixture = {
+  name: "with-frontmatter",
+  origin: "template that presets labels via YAML frontmatter",
+  text: `---
+name: Standard change
+labels: ["needs-review", "team/platform"]
+assignees: octocat
+---
+
+## Summary
+
+<!-- one paragraph -->
+
+## Test plan
+
+<!-- how did you verify this? -->
+`,
+};
+
+/** No H2 anywhere — the merge must not try to place sections into it. */
+const PROSE_ONLY: TemplateFixture = {
+  name: "prose-only",
+  origin: "minimal repos that use a single prompt line",
+  text: `Thanks for contributing! Please describe your change and link any related
+issue below. Remember to run the test suite before requesting review.
+`,
+};
+
+/** Headings deeper than H2 only — same unparseable-shape path as prose-only. */
+const H3_ONLY: TemplateFixture = {
+  name: "h3-only",
+  origin: "templates that nest everything under a single H1",
+  text: `# Pull request
+
+### What changed
+
+<!-- describe -->
+
+### Testing
+
+<!-- describe -->
+`,
+};
+
+export const TEMPLATE_FIXTURES: TemplateFixture[] = [
+  NAX,
+  GITHUB_COMMUNITY,
+  GITLAB_DEFAULT,
+  WITH_FRONTMATTER,
+  PROSE_ONLY,
+  H3_ONLY,
+];
+
+/** The two fixtures with no H2, which fall back to the nax-only body. */
+export const UNPARSEABLE_FIXTURE_NAMES = ["prose-only", "h3-only"];
+
+export const TEMPLATE_BY_NAME: Record<string, string> = Object.fromEntries(
+  TEMPLATE_FIXTURES.map((f) => [f.name, f.text]),
+);

--- a/test/unit/flows/nax-finish/pr-body.test.ts
+++ b/test/unit/flows/nax-finish/pr-body.test.ts
@@ -236,16 +236,58 @@ describe("buildFinishBody — Run summary footer (US-002 AC15)", () => {
   });
 });
 
-describe("buildFinishBody — repository template (#1478)", () => {
-  test("appends the template verbatim after every deterministic section", () => {
+describe("buildFinishBody — repository template (#1478, merged per #1504)", () => {
+  // Superseded the original #1478 contract ("append the template verbatim
+  // last"), which shipped an unfilled form below a filled one — see
+  // `pr-template-merge.ts`. The template is now shape, not trailing content.
+  test("drops a template section nax cannot fill rather than shipping its blank checklist", () => {
     const body = buildFinishBody(
       baseCtx({
         stories: [story({ id: "US-001", title: "Header", acCount: 2 })],
         template: "## Checklist\n- [ ] docs updated",
       }),
     );
-    expect(body.endsWith("## Checklist\n- [ ] docs updated")).toBe(true);
-    expect(body.indexOf("## Stories")).toBeLessThan(body.indexOf("## Checklist"));
+    expect(body).not.toContain("## Checklist");
+    expect(body).not.toContain("- [ ] docs updated");
+    expect(body).toContain("| US-001 | Header | 2 |");
+  });
+
+  test("adopts a template heading it can fill, and puts nax's content under it", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story({ id: "US-001", title: "Header", acCount: 2 })],
+        narrative: "Replaced the widget cache.",
+        template: "## Summary\n\n<!-- describe -->\n\n## How\n\n<!-- details -->",
+      }),
+    );
+    expect(body).toContain("## Summary\n\nReplaced the widget cache.");
+    expect(body).toContain("## How\n\n| Story | Title | ACs |");
+    expect(body).not.toContain("## What changed");
+    expect(body).not.toContain("<!--");
+  });
+
+  test("keeps every unfillable heading, empty, under the strict mode a heading-checking CI needs", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story()],
+        template: "## Checklist\n- [ ] docs updated",
+        templateMode: "strict",
+      }),
+    );
+    expect(body).toContain("## Checklist");
+    expect(body).not.toContain("- [ ] docs updated");
+  });
+
+  test("honours a sectionMap override for a heading the default table does not know", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story({ id: "US-001", title: "Header", acCount: 2 })],
+        template: "## Werk\n\n<!-- x -->",
+        templateSectionMap: { werk: "stories" },
+      }),
+    );
+    expect(body).toContain("## Werk\n\n| Story | Title | ACs |");
+    expect(body).not.toContain("## Stories");
   });
 
   test("omits the template entirely when none resolved", () => {

--- a/test/unit/flows/nax-finish/pr-template-merge.test.ts
+++ b/test/unit/flows/nax-finish/pr-template-merge.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_SECTION_ALIASES, type BodySection, mergeTemplate } from "@flows/nax-finish/pr-template-merge";
+import { TEMPLATE_BY_NAME, TEMPLATE_FIXTURES, UNPARSEABLE_FIXTURE_NAMES } from "@test/fixtures/pr-templates";
+
+/**
+ * The nax-authored sections, in the canonical order `buildFinishBody` emits
+ * them. `footer` carries no heading, which is how a headingless trailing line
+ * is expressed — it must never be matched to a template heading.
+ */
+function sections(overrides: Partial<Record<string, string>> = {}): BodySection[] {
+  const all: BodySection[] = [
+    { key: "narrative", heading: "What changed", body: "Adds a description field." },
+    { key: "stories", heading: "Stories", body: "| Story | Title | ACs |\n|---|---|---|\n| US-001 | Carry it | 9 |" },
+    { key: "verification", heading: "Verification", body: "- Acceptance: passed\n- Gates: build, test" },
+    { key: "rounds", heading: "Review rounds", body: "### quality attempt 1\n- _no findings_" },
+    { key: "outOfScope", heading: "Out of scope", body: "- Making it required." },
+    { key: "footer", heading: "", body: "2/2 stories · 18m 24s" },
+  ];
+  return all
+    .map((s) => (overrides[s.key] !== undefined ? { ...s, body: overrides[s.key] as string } : s))
+    .filter((s) => s.body.length > 0);
+}
+
+/** Every H2 heading in a rendered body, in order. */
+function headings(body: string): string[] {
+  return body
+    .split("\n")
+    .filter((l) => /^##\s/.test(l))
+    .map((l) => l.replace(/^##\s+/, ""));
+}
+
+/** The text under a given H2, up to the next H2. */
+function bodyUnder(body: string, heading: string): string {
+  const lines = body.split("\n");
+  const start = lines.findIndex((l) => l.trim() === `## ${heading}`);
+  if (start === -1) return "";
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^##\s/.test(l));
+  return (end === -1 ? rest : rest.slice(0, end)).join("\n").trim();
+}
+
+describe("mergeTemplate — no template to merge", () => {
+  test("renders nax sections in canonical order when the template is absent", () => {
+    const out = mergeTemplate(undefined, sections());
+    expect(headings(out)).toEqual(["What changed", "Stories", "Verification", "Review rounds", "Out of scope"]);
+    expect(out.trimEnd().endsWith("2/2 stories · 18m 24s")).toBe(true);
+  });
+
+  test("treats a whitespace-only template as absent", () => {
+    expect(mergeTemplate("   \n\n  ", sections())).toBe(mergeTemplate(undefined, sections()));
+  });
+
+  test('mode "ignore" drops a perfectly parseable template', () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { mode: "ignore" });
+    expect(out).toBe(mergeTemplate(undefined, sections()));
+  });
+
+  test.each(UNPARSEABLE_FIXTURE_NAMES)("falls back to the nax body for the unparseable %s template", (name) => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME[name], sections());
+    expect(out).toBe(mergeTemplate(undefined, sections()));
+  });
+});
+
+describe("mergeTemplate — this repo's template (the #1504 defect)", () => {
+  const merged = mergeTemplate(TEMPLATE_BY_NAME.nax, sections());
+
+  test("adopts the template's headings and order for the sections it can fill", () => {
+    expect(headings(merged).slice(0, 3)).toEqual(["What", "How", "Testing"]);
+  });
+
+  test("fills each adopted heading with the matching nax content", () => {
+    expect(bodyUnder(merged, "What")).toBe("Adds a description field.");
+    expect(bodyUnder(merged, "How")).toContain("| US-001 | Carry it | 9 |");
+    expect(bodyUnder(merged, "Testing")).toBe("- Acceptance: passed\n- Gates: build, test");
+  });
+
+  test("drops template sections nax has nothing to say under", () => {
+    expect(headings(merged)).not.toContain("Why");
+    expect(headings(merged)).not.toContain("Notes");
+  });
+
+  test("appends nax sections the template has no home for, under nax's own headings", () => {
+    expect(headings(merged).slice(3)).toEqual(["Review rounds", "Out of scope"]);
+  });
+
+  test("emits no unchecked checkbox contradicting the verified gate list", () => {
+    expect(merged).not.toContain("- [ ]");
+    expect(bodyUnder(merged, "Testing")).toContain("Acceptance: passed");
+  });
+
+  test("emits no dangling issue reference", () => {
+    expect(merged).not.toMatch(/(closes|fixes|resolves)\s*#\s*$/im);
+  });
+});
+
+describe("mergeTemplate — corpus invariants", () => {
+  const parseable = TEMPLATE_FIXTURES.filter((f) => !UNPARSEABLE_FIXTURE_NAMES.includes(f.name));
+
+  test.each(TEMPLATE_FIXTURES.map((f) => f.name))("%s: never ships an HTML placeholder comment", (name) => {
+    expect(mergeTemplate(TEMPLATE_BY_NAME[name], sections())).not.toContain("<!--");
+  });
+
+  test.each(TEMPLATE_FIXTURES.map((f) => f.name))("%s: never ships an unchecked checkbox", (name) => {
+    expect(mergeTemplate(TEMPLATE_BY_NAME[name], sections())).not.toContain("- [ ]");
+  });
+
+  test.each(parseable.map((f) => f.name))("%s: never emits a heading with nothing under it", (name) => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME[name], sections());
+    for (const heading of headings(out)) expect(bodyUnder(out, heading)).not.toBe("");
+  });
+
+  test.each(TEMPLATE_FIXTURES.map((f) => f.name))("%s: carries every nax section through exactly once", (name) => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME[name], sections());
+    for (const s of sections()) {
+      const occurrences = out.split(s.body).length - 1;
+      expect(occurrences).toBe(1);
+    }
+  });
+});
+
+describe("mergeTemplate — heading matching", () => {
+  test("matches case-insensitively and ignores punctuation", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["github-community"], sections());
+    expect(bodyUnder(out, "How Has This Been Tested?")).toBe("- Acceptance: passed\n- Gates: build, test");
+    expect(bodyUnder(out, "Description")).toBe("Adds a description field.");
+  });
+
+  test("drops the unmatched sections of a third-party template", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["github-community"], sections());
+    expect(headings(out)).not.toContain("Type of change");
+    expect(headings(out)).not.toContain("Checklist:");
+  });
+
+  test("a sectionMap entry overrides the default alias table", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { sectionMap: { notes: "outOfScope" } });
+    expect(bodyUnder(out, "Notes")).toBe("- Making it required.");
+    expect(headings(out)).not.toContain("Out of scope");
+  });
+
+  test("a sectionMap entry can suppress a default alias by pointing it at no section", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { sectionMap: { what: "" } });
+    expect(headings(out)).not.toContain("What");
+    expect(headings(out)).toContain("What changed");
+  });
+
+  test("the first of two headings sharing a key consumes it; the second is dropped", () => {
+    const template = "## Summary\n\nx\n\n## Description\n\ny\n";
+    const out = mergeTemplate(template, sections());
+    expect(bodyUnder(out, "Summary")).toBe("Adds a description field.");
+    expect(headings(out)).not.toContain("Description");
+  });
+
+  test("the headingless footer is never matched to a template heading", () => {
+    const out = mergeTemplate("## Notes\n\n<!-- x -->\n", sections(), { sectionMap: { notes: "footer" } });
+    expect(headings(out)).not.toContain("Notes");
+    expect(out.trimEnd().endsWith("2/2 stories · 18m 24s")).toBe(true);
+  });
+
+  test("the default alias table maps the headings the corpus actually uses", () => {
+    expect(DEFAULT_SECTION_ALIASES.what).toBe("narrative");
+    expect(DEFAULT_SECTION_ALIASES.testing).toBe("verification");
+    expect(DEFAULT_SECTION_ALIASES.why).toBeUndefined();
+  });
+});
+
+describe("mergeTemplate — preamble and frontmatter", () => {
+  test("preserves YAML frontmatter verbatim at the top", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["with-frontmatter"], sections());
+    expect(out.startsWith('---\nname: Standard change\nlabels: ["needs-review", "team/platform"]')).toBe(true);
+    expect(out).toContain("assignees: octocat\n---");
+  });
+
+  test("frontmatter precedes the first heading", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["with-frontmatter"], sections());
+    expect(out.indexOf("---")).toBeLessThan(out.indexOf("## Summary"));
+  });
+
+  test("keeps preamble prose that survives comment stripping", () => {
+    const out = mergeTemplate("Please read CONTRIBUTING.md.\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out.startsWith("Please read CONTRIBUTING.md.")).toBe(true);
+  });
+
+  test("drops a preamble that was only a placeholder comment", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["gitlab-default"], sections());
+    expect(out.startsWith("<!--")).toBe(false);
+    expect(out).not.toContain("Set the MR title");
+  });
+
+  test("drops a dangling issue reference left in the preamble", () => {
+    const out = mergeTemplate("Closes #\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).not.toContain("Closes #");
+  });
+
+  test("keeps a real issue reference in the preamble", () => {
+    const out = mergeTemplate("Closes #1504\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).toContain("Closes #1504");
+  });
+});
+
+describe('mergeTemplate — "strict" mode', () => {
+  const strict = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { mode: "strict" });
+
+  test("keeps every template heading so a heading-checking bot still passes", () => {
+    expect(headings(strict).slice(0, 5)).toEqual(["What", "Why", "How", "Testing", "Notes"]);
+  });
+
+  test("leaves unfillable sections empty rather than shipping their placeholders", () => {
+    expect(bodyUnder(strict, "Why")).toBe("");
+    expect(bodyUnder(strict, "Notes")).toBe("");
+    expect(strict).not.toContain("<!--");
+    expect(strict).not.toContain("- [ ]");
+  });
+
+  test("still fills the sections it can match", () => {
+    expect(bodyUnder(strict, "What")).toBe("Adds a description field.");
+    expect(bodyUnder(strict, "Testing")).toBe("- Acceptance: passed\n- Gates: build, test");
+  });
+
+  test("still appends the nax sections the template has no home for", () => {
+    expect(headings(strict).slice(5)).toEqual(["Review rounds", "Out of scope"]);
+  });
+});
+
+describe("mergeTemplate — degenerate inputs", () => {
+  test("renders the template's shape when nax produced no sections at all", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, []);
+    expect(out).toBe("");
+  });
+
+  test("does not leave a run of blank lines where a section was dropped", () => {
+    expect(mergeTemplate(TEMPLATE_BY_NAME.nax, sections())).not.toMatch(/\n{3,}/);
+  });
+
+  test("does not emit trailing whitespace on any line", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["github-community"], sections());
+    for (const line of out.split("\n")) expect(line).toBe(line.trimEnd());
+  });
+
+  test("a sectionMap does not leak into the default alias table on the next call", () => {
+    const baseline = mergeTemplate(TEMPLATE_BY_NAME.nax, sections());
+    mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { sectionMap: { notes: "outOfScope", what: "" } });
+    expect(mergeTemplate(TEMPLATE_BY_NAME.nax, sections())).toBe(baseline);
+  });
+});

--- a/test/unit/flows/nax-finish/pr-template-merge.test.ts
+++ b/test/unit/flows/nax-finish/pr-template-merge.test.ts
@@ -156,6 +156,16 @@ describe("mergeTemplate — heading matching", () => {
     expect(out.trimEnd().endsWith("2/2 stories · 18m 24s")).toBe(true);
   });
 
+  test("a sectionMap key is matched the same way a template heading is — raw, as a human writes it in config", () => {
+    // The config schema promises keys match "case- and punctuation-
+    // insensitively". A user pins GitLab's default heading by pasting it, not
+    // by pre-normalising it to `what does this mr do and why`.
+    const out = mergeTemplate(TEMPLATE_BY_NAME["gitlab-default"], sections(), {
+      sectionMap: { "Screenshots or screen recordings": "rounds" },
+    });
+    expect(bodyUnder(out, "Screenshots or screen recordings")).toContain("quality attempt 1");
+  });
+
   test("the default alias table maps the headings the corpus actually uses", () => {
     expect(DEFAULT_SECTION_ALIASES.what).toBe("narrative");
     expect(DEFAULT_SECTION_ALIASES.testing).toBe("verification");
@@ -218,6 +228,34 @@ describe('mergeTemplate — "strict" mode', () => {
 
   test("still appends the nax sections the template has no home for", () => {
     expect(headings(strict).slice(5)).toEqual(["Review rounds", "Out of scope"]);
+  });
+});
+
+describe("mergeTemplate — hostile template shapes", () => {
+  test("a CRLF template does not leak carriage returns into the body", () => {
+    const out = mergeTemplate("## What\r\n\r\n<!-- x -->\r\n\r\n## Testing\r\n\r\n- [ ] tests\r\n", sections());
+    expect(out).not.toContain("\r");
+    expect(bodyUnder(out, "What")).toBe("Adds a description field.");
+  });
+
+  test("strips an unchecked checkbox left in the preamble, above the first heading", () => {
+    // A real shape: repos that open with a contributor checklist and only then
+    // start their sections. Preamble text is the one template region that
+    // survives into the body, so the no-unfilled-field rule has to hold there.
+    const out = mergeTemplate("- [ ] I read CONTRIBUTING.md\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).not.toContain("- [ ]");
+  });
+
+  test("keeps preamble prose that sits alongside a stripped checkbox", () => {
+    const out = mergeTemplate("Please confirm:\n\n- [ ] I read CONTRIBUTING.md\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).toContain("Please confirm:");
+    expect(out).not.toContain("- [ ]");
+  });
+
+  test("does not mistake a leading horizontal rule for YAML frontmatter", () => {
+    const out = mergeTemplate("---\n\nRead the guide.\n\n---\n\n## What\n\n<!-- x -->\n", sections());
+    expect(bodyUnder(out, "What")).toBe("Adds a description field.");
+    expect(out).toContain("Read the guide.");
   });
 });
 

--- a/test/unit/plugins/builtin/auto-pr-pr-body.test.ts
+++ b/test/unit/plugins/builtin/auto-pr-pr-body.test.ts
@@ -81,14 +81,34 @@ describe("buildBody (null template)", () => {
 });
 
 describe("buildBody (with template)", () => {
-  test("AC5 — ends with the template text verbatim preceded by '---' separator", () => {
+  // Supersedes the original AC5 ("ends with the template verbatim, preceded by
+  // a `---` separator"). Appending an unfilled template below filled content is
+  // the nax#1504 defect; the template is now merged, by the same
+  // `mergeTemplate` the nax-finish body uses.
+  test("AC5 — drops a template section it cannot fill instead of appending it blank", () => {
     const ctx = makeContext();
-    const template = "## Checklist\n- [ ] x";
+    const body = buildBody(ctx, "## Checklist\n- [ ] x");
 
-    const body = buildBody(ctx, template);
+    expect(body).not.toContain("## Checklist");
+    expect(body).not.toContain("- [ ] x");
+    expect(body).toContain("| US-001 | Config foundation | 4 |");
+  });
 
-    expect(body).toContain("---\n## Checklist\n- [ ] x");
-    expect(body.endsWith(template)).toBe(true);
+  test("AC5 — fills a template heading it can match, using the template's own wording", () => {
+    const ctx = makeContext();
+    const body = buildBody(ctx, "## How\n\n<!-- key details -->");
+
+    expect(body).toContain("## How");
+    expect(body).not.toContain("## Run summary");
+    expect(body).not.toContain("<!--");
+    expect(body).toContain("| US-001 | Config foundation | 4 |");
+  });
+
+  test("keeps the review-pending banner leading the body when a template merges in", () => {
+    const ctx = makeContext();
+    const body = buildBody(ctx, "## How\n\n<!-- x -->");
+
+    expect(body.startsWith("> Auto-opened by nax")).toBe(true);
   });
 
   test("table rows render story id, title, and AC count when template present", () => {

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -583,6 +583,29 @@ describe("nax-finish post-run action", () => {
     expect(r.message).toContain("not found");
   });
 
+  test("execute forwards prBody settings to the flow, defaulting to merge", async () => {
+    const inputFor = async (config: unknown) => {
+      let cmd: string[] = [];
+      _naxFinishDeps.run = async (c) => {
+        cmd = c;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      };
+      _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
+      await action.execute(baseCtx({ config } as never));
+      return JSON.parse(cmd[cmd.indexOf("--input-json") + 1]);
+    };
+
+    // A config carrying no `prBody` key must still merge — not fall back to the
+    // pre-#1504 verbatim append.
+    const defaulted = await inputFor({ finish: { autoFlow: { enabled: true } } });
+    expect(defaulted.prBody).toEqual({ template: "merge", sectionMap: {} });
+
+    const configured = await inputFor({
+      finish: { autoFlow: { enabled: true, prBody: { template: "strict", sectionMap: { werk: "stories" } } } },
+    });
+    expect(configured.prBody).toEqual({ template: "strict", sectionMap: { werk: "stories" } });
+  });
+
   test("execute omits reviewer profile env vars when reviewers are null", async () => {
     let capturedEnv: Record<string, string> | undefined;
     _naxFinishDeps.run = async (_cmd, opts) => {


### PR DESCRIPTION
## What

Adds `mergeTemplate` (`flows/nax-finish/pr-template-merge.ts`) and wires it into both PR/MR body builders — `flows/nax-finish/steps/pr-body.ts` (nax-finish) and `src/plugins/builtin/auto-pr/pr-body.ts` (auto-PR drafts). A repository's PR template is now used for its **shape** rather than appended as trailing content:

- a template heading the body can fill → keep the heading, replace its body
- a template heading it cannot fill → drop it (`merge`) or keep it empty (`strict`)
- nax content with no matching heading → append under nax's own heading

New config: `finish.autoFlow.prBody.template` (`merge` | `strict` | `ignore`, default `merge`) and `finish.autoFlow.prBody.sectionMap` for repos that want their own headings pinned explicitly.

## Why

`gh pr create --body` / `glab mr create --description` suppress the repo's template, so nax re-embedded it verbatim at the end of the generated body. That shipped a **blank form below a filled one**. PR #1504 is the live example: placeholder HTML comments, a dangling `Closes #`, a duplicate `## What` under nax's own `## What changed`, and four unchecked boxes (`- [ ] bun test passes`) sitting directly below a Verification section that already reported the gates green. The body contradicted itself.

A PR template is an input form, not decoration. The governing invariant is now **never emit a field that was not filled** — the same rule #1477 already imposed on nax's own sections, extended to template-derived text.

## How

Placement is decided by a heading-alias table, never by a model, so the facts in a body (gate results, story counts, diffstat, review rounds) stay a pure string join and remain greppable in PR history. Headings match case- and punctuation-insensitively, covering the shapes real templates use (`Summary` / `Description` / `Overview`, `How Has This Been Tested?`, GitLab's `What does this MR do and why?`).

A useful consequence fell out of the design: because a matched section's body is *replaced* and an unmatched one is *discarded*, no template checkbox ever survives — so there is no checkbox-versus-gate reconciliation code anywhere.

Degradation is graceful throughout. A template whose headings the table doesn't know loses nothing (its sections drop, nax's own headings are used); templates with no `##` at all fall back to the nax-only body rather than appending something unparsed; YAML frontmatter is preserved verbatim because it can set labels and assignees.

`mergeTemplate` lives under `flows/` and is imported from `src/` via `@flows/*` rather than being re-implemented. `flows/` is loaded by `acpx` in its own Node process, where nax's `src/` and `@/*` alias do not exist — so `flows/` cannot import `src/`, and shared code has to live on the `flows/` side. Importing it keeps one implementation; the alternative was duplicating an algorithm that will drift.

The last commit fixes three defects found reviewing the first two — each reproduced by a failing test first. Notably, `sectionMap` overrides never matched anything realistic (raw keys compared against normalised headings), and the original tests missed it because their fixtures were written pre-normalised.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

`mergeTemplate` is covered by a six-template corpus — this repo's own, GitHub community, GitLab default, YAML frontmatter, prose-only, H3-only — swept for the invariants that must hold against templates nax has never seen: no HTML placeholder comment, no unchecked checkbox, no heading with nothing under it, every nax section carried through exactly once. Plus hostile shapes: CRLF line endings, a preamble checklist, a leading horizontal rule.

Two tests that pinned the old contract are **superseded and rewritten, not deleted** — #1478's "appends the template verbatim after every deterministic section" and auto-pr AC5's "ends with the template text verbatim preceded by `---`". Both encoded the behaviour that produced the defect; each is replaced with merged-shape assertions plus a comment naming what it supersedes.

Full suite: 12169 + 1097 + 24 pass, 0 fail. `bun run build` confirms the `@flows` import resolves in the bundle.

## Notes

**This PR body was generated by hand in the shape the new merge produces** — the repo's own five headings, filled, with no placeholder comments, no dangling `Closes #`, and boxes checked only because the gates actually ran.

Behaviour changes worth a reviewer's attention:

- Auto-PR drafts no longer emit a `---` separator before the template, and their `## Run summary` heading is replaced by the template's own when one matches. This is deliberate: a draft and the PR promoted from it now compose a template identically, so promoting no longer reshapes the body.
- In this repo's template, `## Why` and `## Notes` are dropped from generated bodies — nax has nothing truthful to put under them. `strict` mode exists for repos whose CI asserts a set of headings is present; it is the one deliberate exception to the no-empty-heading rule.
- Auto-PR's run summary maps to the `stories` key, so it lands under `## How` here. Slightly loose semantically — flagging it rather than hiding it.
- A typo'd `sectionMap` key fails safe but silently: the template heading drops and nax's own heading is used, with no warning.

Not addressed here: the unrelated nax-finish issues found while diagnosing #1504 (non-hermetic `NAX_FINISH_*` env reads in `plugin.test.ts`, and review phases that pass leaving no trace in the finish audit or PR body).
