### PR TITLE
fix(nax-finish): record every review phase so a clean review leaves a trace

### DIFF
--- a/flows/nax-finish/commit-message.ts
+++ b/flows/nax-finish/commit-message.ts
@@ -23,8 +23,67 @@ const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW"] as const;
 /** How much gate output to quote in the body before it stops being a commit message. */
 const MAX_GATE_OUTPUT_LINES = 20;
 
+/**
+ * Markers a test runner uses to introduce a failing case, worst-supported-first.
+ *
+ * A heuristic, deliberately: nax orchestrates polyglot repos, so this cannot be
+ * one runner's format. Each entry is the literal token that precedes the test's
+ * name — bun/jest `(fail)`, go `--- FAIL:`, pytest `FAILED`, and the tick-style
+ * reporters. Nothing downstream depends on a match; a miss just falls back to
+ * the output tail, which is what shipped before.
+ */
+const FAILURE_MARKERS = ["(fail)", "--- FAIL:", "FAILED ", "FAIL ", "✗ ", "× "];
+
+/** How many failing test names to name before the message stops being a commit message. */
+const MAX_NAMED_FAILURES = 10;
+
+/**
+ * Strip machine-local filesystem layout out of text bound for shipped history.
+ *
+ * Two passes, because the two cases differ: a path under the repo is meaningful
+ * once made relative, while a path outside it is noise no reader of the commit
+ * can act on. The home-directory pattern catches what remains — runner output
+ * routinely quotes absolute paths from outside the repo (caches, toolchains).
+ */
+function redactPaths(text: string, workdir?: string): string {
+  const withoutRepo = workdir ? text.split(`${workdir}/`).join("") : text;
+  return withoutRepo.replace(/(?:\/Users\/|\/home\/)[^/\s)]+\//g, "~/");
+}
+
+/**
+ * The names of the tests that actually failed, in output order.
+ *
+ * This is the whole point of the change: the body used to be the last 20 lines
+ * of runner stdout, and a suite whose *passing* tests write to stderr pushes the
+ * real failure out of that window — so the commit named a stack trace from a
+ * test that passed (#1506).
+ */
+function failingTestNames(output: string): string[] {
+  const names: string[] = [];
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    const marker = FAILURE_MARKERS.find((m) => trimmed.startsWith(m));
+    if (!marker) continue;
+    // Drop bun's trailing `[0.12ms]` timing — it is noise in a commit message
+    // and makes otherwise-identical messages differ between runs.
+    const name = trimmed
+      .slice(marker.length)
+      .replace(/\s*\[[\d.]+m?s\]$/, "")
+      .trim();
+    if (name) names.push(name);
+    if (names.length >= MAX_NAMED_FAILURES) break;
+  }
+  return names;
+}
+
 interface MessageCtx {
   outputs: Record<string, unknown>;
+}
+
+/** Options carrying what the message builder cannot read off `ctx.outputs`. */
+interface MessageOptions {
+  /** Absolute repo root, used to rewrite quoted paths as repo-relative. */
+  workdir?: string;
 }
 
 interface PhaseOutputs {
@@ -88,20 +147,30 @@ function subjectFor(phase: FinishPhase, ctx: MessageCtx): string {
   return findings.length > 0 ? reviewSubject(phase, findings) : `apply ${phase} review fixes`;
 }
 
-function bodyFor(phase: FinishPhase, ctx: MessageCtx): string[] {
+/**
+ * What to quote from a runner's output: the failing test names if they can be
+ * identified, otherwise the tail, as before.
+ *
+ * Never both. Naming the failures *and* pasting the tail reproduces the noise
+ * this replaces, and the tail is the weaker signal whenever the names exist.
+ */
+function runnerEvidence(output: string, opts: MessageOptions): string {
+  const clean = redactPaths(output, opts.workdir).trim();
+  const names = failingTestNames(clean);
+  if (names.length > 0) return ["Failed tests:", ...names.map((n) => `- ${n}`)].join("\n");
+  return clean.split("\n").slice(-MAX_GATE_OUTPUT_LINES).join("\n");
+}
+
+function bodyFor(phase: FinishPhase, ctx: MessageCtx, opts: MessageOptions): string[] {
   if (phase === "gate") {
     const gate = outputsFor(ctx, "quality_gates");
     const failing = gate.failing ?? [];
-    const tail = (gate.output ?? "").trim().split("\n").slice(-MAX_GATE_OUTPUT_LINES).join("\n");
-    return [...(failing.length > 0 ? [`Failing: ${failing.join(", ")}`] : []), ...(tail ? [tail] : [])];
+    const evidence = runnerEvidence(gate.output ?? "", opts);
+    return [...(failing.length > 0 ? [`Failing: ${failing.join(", ")}`] : []), ...(evidence ? [evidence] : [])];
   }
   if (phase === "acceptance") {
-    const tail = (outputsFor(ctx, "acceptance").output ?? "")
-      .trim()
-      .split("\n")
-      .slice(-MAX_GATE_OUTPUT_LINES)
-      .join("\n");
-    return tail ? [tail] : [];
+    const evidence = runnerEvidence(outputsFor(ctx, "acceptance").output ?? "", opts);
+    return evidence ? [evidence] : [];
   }
   const findings = findingsFor(ctx, phase);
   if (findings.length === 0) return [];
@@ -129,8 +198,13 @@ function phaseLabel(phase: FinishPhase): string {
  * described is still a commit that must happen — failing here would strand the
  * fix uncommitted and reintroduce the stale-diff bug (#1397).
  */
-export function buildFixCommitMessage(phase: FinishPhase, feature: string, ctx: MessageCtx): string {
+export function buildFixCommitMessage(
+  phase: FinishPhase,
+  feature: string,
+  ctx: MessageCtx,
+  opts: MessageOptions = {},
+): string {
   const subject = truncate(`fix(${feature}): ${subjectFor(phase, ctx)}`);
-  const body = bodyFor(phase, ctx);
+  const body = bodyFor(phase, ctx, opts);
   return [subject, ...body, `nax-finish: ${phaseLabel(phase)} fixes`].join("\n\n");
 }

--- a/flows/nax-finish/commit-message.ts
+++ b/flows/nax-finish/commit-message.ts
@@ -71,7 +71,12 @@ function failingTestNames(output: string): string[] {
       .replace(/\s*\[[\d.]+m?s\]$/, "")
       .trim();
     if (name) names.push(name);
-    if (names.length >= MAX_NAMED_FAILURES) break;
+  }
+  // Say so when the list is cut short. A bare list of ten reads as "ten tests
+  // failed", and a reader who acts on that count is acting on a truncation.
+  if (names.length > MAX_NAMED_FAILURES) {
+    const dropped = names.length - MAX_NAMED_FAILURES;
+    return [...names.slice(0, MAX_NAMED_FAILURES), `...and ${dropped} more failing test(s)`];
   }
   return names;
 }

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -34,7 +34,8 @@
  * - `commit_gate` re-enters `review_quality` when its fix touched non-test code
  *   — the gate loop was previously the one editing loop whose output only ever
  *   faced mechanical checks. A test-only fix skips the re-review by explicit
- *   cost tradeoff; see `gateCommitRoute` for why that is a known hole.
+ *   cost tradeoff; see `gateCommitRoute` for why that is a known hole. The skip
+ *   records `review-skipped`, so it is visible in the audit.
  * - Every `commit_*` node appends its round to the finish-audit trail as it
  *   happens, rather than a terminal node reconstructing them from
  *   `ctx.state.steps`. Appending live is what makes the trail survive a flow
@@ -50,6 +51,7 @@ import {
   _contextDeps,
   amendPrBodyNode,
   appendRound,
+  buildCommitRound,
   buildEscalationComment,
   commitAndPush,
   commitFixes,
@@ -154,7 +156,7 @@ async function acceptanceGateNode(ctx: {
  *   The defect that motivated the re-entry (rs-stock `b6fb66dd`) was itself
  *   test-only — 8 copy-pasted stubs across 3 test files — so this route would
  *   not have caught it. Widen it here if test-quality regressions start
- *   shipping.
+ *   shipping — the audit's `review-skipped` rounds are the evidence.
  * - `changed` — production code was touched, or the paths could not be
  *   classified at all. "Cannot classify" reviews rather than skips.
  */
@@ -206,31 +208,29 @@ function commitFixNode(phase: FinishPhase) {
         buildFixCommitMessage(phase, i.feature, messageCtx, { workdir: i.workdir }),
         { skipHooks: true },
       );
-      await appendRound(i, {
-        ts: new Date().toISOString(),
-        phase,
-        attempt: fixAttemptCount(ctx, `fix_${phase}`),
-        committed,
-        // `gate` and `acceptance` have no reviewer node, so their empty finding
-        // list means "nobody looked" — not "a reviewer approved this". Saying
-        // which is what stops the PR body inventing a review (#1507).
-        outcome: phase === "spec" || phase === "quality" ? "fixed" : "no-reviewer",
-        findings: findingsOf(ctx, phase),
-        ...(phase === "gate" ? { failing: gateOutputs(ctx).failing ?? [] } : {}),
-        // Carry `shaAfter` onto committed rounds only: a no-op round has no
-        // commit, so no SHA to record — keeping the field absent (rather than
-        // null/undefined) lets the result-file reader distinguish "no commit"
-        // from "record lost".
-        ...(committed && shaAfter ? { sha: shaAfter } : {}),
-      });
-      // Only `commit_gate` routes on this; the other phases have unconditional
-      // edges and ignore it.
+      // Routed BEFORE the round is recorded: `buildCommitRound` needs the
+      // successor to tell an owed-but-skipped re-review from a phase that never
+      // had a reviewer. Only `commit_gate` routes on this; the other phases have
+      // unconditional edges and ignore it.
       const route =
         phase === "gate"
           ? await gateCommitRoute(i, committed, shaAfter, loadCtxOf(ctx).testFileRegex ?? [])
           : committed
             ? "changed"
             : "unchanged";
+      await appendRound(
+        i,
+        buildCommitRound({
+          phase,
+          attempt: fixAttemptCount(ctx, `fix_${phase}`),
+          committed,
+          route,
+          findings: findingsOf(ctx, phase),
+          failing: phase === "gate" ? (gateOutputs(ctx).failing ?? []) : undefined,
+          shaAfter,
+          now: new Date().toISOString(),
+        }),
+      );
       return { committed, route, shaBefore, shaAfter };
     },
   };

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -63,6 +63,7 @@ import {
   postEscalation,
   preflight,
   resolveFeature,
+  routeReviewAndRecord,
   runAcceptanceGate,
   runQualityGates,
   writeResult,
@@ -70,7 +71,7 @@ import {
 import type { Forge } from "./steps/forge";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle } from "./steps/pr-body";
 import type { FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
-import { MAX_FIX_ATTEMPTS, parseFixVerdict, parseReviewVerdict, repromptCount, routeReview } from "./verdict";
+import { MAX_FIX_ATTEMPTS, parseFixVerdict, parseReviewVerdict, repromptCount } from "./verdict";
 
 /**
  * Disabled only on an explicit "0". An unset variable means enabled, so a flow
@@ -210,6 +211,10 @@ function commitFixNode(phase: FinishPhase) {
         phase,
         attempt: fixAttemptCount(ctx, `fix_${phase}`),
         committed,
+        // `gate` and `acceptance` have no reviewer node, so their empty finding
+        // list means "nobody looked" — not "a reviewer approved this". Saying
+        // which is what stops the PR body inventing a review (#1507).
+        outcome: phase === "spec" || phase === "quality" ? "fixed" : "no-reviewer",
         findings: findingsOf(ctx, phase),
         ...(phase === "gate" ? { failing: gateOutputs(ctx).failing ?? [] } : {}),
         // Carry `shaAfter` onto committed rounds only: a no-op round has no
@@ -286,7 +291,7 @@ export default defineFlow({
     },
     route_spec: {
       nodeType: "compute",
-      run: (ctx) => routeReview(ctx, "spec"),
+      run: (ctx) => routeReviewAndRecord(ctx, "spec"),
     },
     fix_spec: {
       nodeType: "acp",
@@ -312,7 +317,7 @@ export default defineFlow({
     },
     route_quality: {
       nodeType: "compute",
-      run: (ctx) => routeReview(ctx, "quality"),
+      run: (ctx) => routeReviewAndRecord(ctx, "quality"),
     },
     fix_quality: {
       nodeType: "acp",

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -203,7 +203,7 @@ function commitFixNode(phase: FinishPhase) {
       // PR opens, and a hook failure here would kill the flow mid-loop.
       const { committed, shaBefore, shaAfter } = await commitFixes(
         i.workdir,
-        buildFixCommitMessage(phase, i.feature, messageCtx),
+        buildFixCommitMessage(phase, i.feature, messageCtx, { workdir: i.workdir }),
         { skipHooks: true },
       );
       await appendRound(i, {

--- a/flows/nax-finish/steps/commit-round.ts
+++ b/flows/nax-finish/steps/commit-round.ts
@@ -1,0 +1,64 @@
+/**
+ * Assembling the audit round a `commit_<phase>` node records.
+ *
+ * Split out of `nax-finish.flow.ts` for room — that file sits against the
+ * 600-line source cap — but the split earns its keep independently: the round's
+ * shape is a data decision with four conditional fields, and it is now unit
+ * testable without driving a flow node through a git mock.
+ *
+ * Pairs with `./review-round`, which records the rounds that produce no commit.
+ */
+import type { Finding, FinishPhase, FinishRound, FinishRoundOutcome } from "../types";
+
+/** Phases that own a reviewer node; every other phase's round has nobody behind it. */
+const REVIEWED_PHASES: FinishPhase[] = ["spec", "quality"];
+
+/**
+ * What produced this round, given the successor the commit routed to.
+ *
+ * The `route` argument is why this is computed after the commit rather than
+ * alongside it: `tests-only` is only known once the committed paths have been
+ * classified, and it is the difference between "no reviewer exists for this
+ * phase" and "a reviewer exists, was owed a look, and was skipped".
+ */
+export function commitRoundOutcome(phase: FinishPhase, route: string): FinishRoundOutcome {
+  if (REVIEWED_PHASES.includes(phase)) return "fixed";
+  // Only `gate` can skip an owed re-review; `acceptance` has no reviewer to
+  // skip, so its `tests-only`-shaped routes (it has none today) stay honest.
+  if (phase === "gate" && route === "tests-only") return "review-skipped";
+  return "no-reviewer";
+}
+
+export interface CommitRoundInput {
+  phase: FinishPhase;
+  attempt: number;
+  committed: boolean;
+  /** The successor this commit routed to — see `commitRoundOutcome`. */
+  route: string;
+  findings: Finding[];
+  /** Gate commands that were red this round; omitted for non-gate phases. */
+  failing?: string[];
+  /** Post-commit HEAD, when there was a commit. */
+  shaAfter?: string | null;
+  now: string;
+}
+
+/**
+ * Build the round record for a commit checkpoint.
+ *
+ * `sha` and `failing` are omitted rather than set to null/undefined: a reader of
+ * the JSONL distinguishes "no commit" from "record lost" by the key's absence,
+ * and that only works if absence is never used to mean anything else.
+ */
+export function buildCommitRound(i: CommitRoundInput): FinishRound {
+  return {
+    ts: i.now,
+    phase: i.phase,
+    attempt: i.attempt,
+    committed: i.committed,
+    outcome: commitRoundOutcome(i.phase, i.route),
+    findings: i.findings,
+    ...(i.failing ? { failing: i.failing } : {}),
+    ...(i.committed && i.shaAfter ? { sha: i.shaAfter } : {}),
+  };
+}

--- a/flows/nax-finish/steps/index.ts
+++ b/flows/nax-finish/steps/index.ts
@@ -7,3 +7,4 @@ export * from "./git";
 export * from "./pr";
 export * from "./pr-narrative";
 export * from "./result";
+export * from "./review-round";

--- a/flows/nax-finish/steps/index.ts
+++ b/flows/nax-finish/steps/index.ts
@@ -6,5 +6,6 @@ export * from "./forge";
 export * from "./git";
 export * from "./pr";
 export * from "./pr-narrative";
+export * from "./commit-round";
 export * from "./result";
 export * from "./review-round";

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -340,10 +340,30 @@ function buildRoundHeading(round: FinishRound): string {
   return `${base} (${short})`;
 }
 
+/**
+ * What an empty finding list means, in the reader's terms.
+ *
+ * Four different things used to render identically as "_no findings_", which a
+ * human reads as "a reviewer looked at this and approved it" (#1507). Only
+ * `passed` means that. `no-reviewer` is the one that actively misleads: the
+ * gate phase has no reviewer node at all, so its empty list is the absence of a
+ * review, not the result of one.
+ *
+ * `fixed` and the legacy `undefined` both fall through to "_no findings_":
+ * rounds written before `outcome` existed carry no field to read, and claiming
+ * anything more specific about them would be inventing detail.
+ */
+const EMPTY_ROUND_NOTE: Record<string, string> = {
+  passed: "- _no findings_",
+  "no-reviewer": "- _no reviewer for this phase_",
+  unparseable: "- _reviewer output could not be parsed_",
+  escalated: "- _escalated for human review_",
+};
+
 function buildRoundBlock(round: FinishRound): string {
   const lines: string[] = [buildRoundHeading(round)];
   if (round.findings.length === 0) {
-    lines.push("- _no findings_");
+    lines.push(EMPTY_ROUND_NOTE[round.outcome ?? ""] ?? "- _no findings_");
   } else {
     for (const finding of round.findings) lines.push(renderFinding(finding));
   }

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -358,6 +358,7 @@ const EMPTY_ROUND_NOTE: Record<string, string> = {
   "no-reviewer": "- _no reviewer for this phase_",
   unparseable: "- _reviewer output could not be parsed_",
   escalated: "- _escalated for human review_",
+  "review-skipped": "- _re-review skipped: this fix touched test files only_",
 };
 
 function buildRoundBlock(round: FinishRound): string {

--- a/flows/nax-finish/steps/review-round.ts
+++ b/flows/nax-finish/steps/review-round.ts
@@ -1,0 +1,74 @@
+/**
+ * Recording the review rounds that produce no commit.
+ *
+ * `commit_<phase>` is the audit seam for rounds that *fix* something — it is the
+ * only point where a round's findings and its resulting commit are both known.
+ * But that made a commit the sole evidence a reviewer ever ran: a review that
+ * passed produced no `fix_*`, therefore no `commit_*`, therefore no round, and
+ * "this phase passed" became indistinguishable from "this phase never ran"
+ * (#1507). Worse, it made the owed re-review in #1506 unprovable after the fact.
+ *
+ * So the two seams split by what they know:
+ * - `commit_<phase>` records rounds that changed the tree (`outcome: "fixed"`).
+ * - here records rounds that did not (`passed` / `unparseable` / `escalated`).
+ *
+ * Wrapping `routeReview` rather than living inside it keeps that function pure
+ * and synchronous — it is the flow's routing SSOT and is exercised by a large
+ * table of unit tests that would all have to become async otherwise.
+ */
+import { inputOf } from "../flow-ctx";
+import type { OutputsCtx, StepsCtx } from "../flow-ctx";
+import type { Finding, FinishRoundOutcome } from "../types";
+import { routeReview } from "../verdict";
+import { appendRound } from "./result";
+
+/** Route → what to call the round. `fix` is absent by construction — see below. */
+const OUTCOME_BY_ROUTE: Record<string, FinishRoundOutcome> = {
+  clean: "passed",
+  reprompt: "unparseable",
+  escalate: "escalated",
+};
+
+/**
+ * The Nth time this phase's *review* node has run.
+ *
+ * Deliberately not `fixAttemptCount`: that counts `fix_<phase>` steps, which is
+ * the right number for a round that fixed something and the wrong one here — a
+ * review that passes on the first look runs zero fix nodes, and every clean
+ * round would be numbered 0. Self-inclusive, for the same reason `repromptCount`
+ * is: acpx records the `review_<phase>` step before `route_<phase>` executes.
+ */
+function reviewAttemptCount(ctx: StepsCtx, phase: "spec" | "quality"): number {
+  return (ctx.state.steps ?? []).filter((s) => s.nodeId === `review_${phase}`).length;
+}
+
+/**
+ * Route this phase's review verdict, and record the round when it produced no
+ * commit.
+ *
+ * `fix` is the one route that records nothing here: it leads to `fix_<phase>` →
+ * `commit_<phase>`, which appends the round with the commit attached. Recording
+ * at both seams would double-count every fixed round in the PR body.
+ *
+ * Best-effort, exactly like `appendRound` itself: the route is returned whether
+ * or not the write lands. Losing the record is bad; failing the run that has
+ * already done the work is worse.
+ */
+export async function routeReviewAndRecord(
+  ctx: { input: unknown } & OutputsCtx & StepsCtx,
+  phase: "spec" | "quality",
+): Promise<{ route: string; escalationReason?: string; findings: Finding[] }> {
+  const routed = routeReview(ctx, phase);
+  const outcome = OUTCOME_BY_ROUTE[routed.route];
+  if (outcome) {
+    await appendRound(inputOf(ctx), {
+      ts: new Date().toISOString(),
+      phase,
+      attempt: reviewAttemptCount(ctx, phase),
+      committed: false,
+      outcome,
+      findings: routed.findings,
+    });
+  }
+  return routed;
+}

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -78,7 +78,20 @@ export type FinishRoundOutcome =
    * `passed`: an empty finding list here means "nobody looked", and rendering it
    * as "no findings" manufactures evidence of a review that does not exist.
    */
-  | "no-reviewer";
+  | "no-reviewer"
+  /**
+   * A re-review was owed and deliberately skipped — today only a `gate` fix
+   * that touched test files exclusively (`gateCommitRoute` → `tests-only`).
+   *
+   * Distinct from `no-reviewer`, which the same node writes when the fix *is*
+   * routed on to `review_quality`. Without the distinction both wrote
+   * `no-reviewer`, so the audit could not tell a gate fix that was re-reviewed
+   * from one whose re-review was skipped by policy — the #1507 failure mode
+   * surviving on the one path where the omission is intentional, and the path
+   * where a reader most needs to know. Recording it is also what makes "how
+   * often does this fire?" answerable before anyone decides to close the hole.
+   */
+  | "review-skipped";
 
 export interface FinishRound {
   ts: string;

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -52,6 +52,34 @@ export type FinishPhase = "acceptance" | "spec" | "quality" | "gate";
  * finish that died mid-loop is exactly when the record of what it already
  * changed on the branch matters most.
  */
+/**
+ * What produced a round — the difference between "a reviewer read this and
+ * approved it" and "nothing read this".
+ *
+ * Rounds used to be appended only where a fix produced a commit, so a review
+ * that passed left no record at all and was indistinguishable from a review
+ * that never ran (#1507). Every phase that executes now records a round, and
+ * this field says which of the five things happened.
+ *
+ * Optional because rounds recorded by earlier versions have no `outcome`, and
+ * the PR body still has to render those without claiming more than it knows.
+ */
+export type FinishRoundOutcome =
+  /** A reviewer reported findings and this phase's fix node ran. */
+  | "fixed"
+  /** A reviewer ran and reported nothing. The only value that means "approved". */
+  | "passed"
+  /** The reviewer replied, but no verdict could be read out of it. */
+  | "unparseable"
+  /** Handed off to a human — an explicit escalate, a cap, or a node that emitted nothing. */
+  | "escalated"
+  /**
+   * This phase has no reviewer at all (`gate`, `acceptance`). Distinct from
+   * `passed`: an empty finding list here means "nobody looked", and rendering it
+   * as "no findings" manufactures evidence of a review that does not exist.
+   */
+  | "no-reviewer";
+
 export interface FinishRound {
   ts: string;
   phase: FinishPhase;
@@ -59,6 +87,8 @@ export interface FinishRound {
   attempt: number;
   /** True when the fix produced a commit; false when it changed nothing. */
   committed: boolean;
+  /** What produced this round; absent on rounds written before it existed. */
+  outcome?: FinishRoundOutcome;
   /** Reviewer findings this round set out to fix (spec/quality phases). */
   findings: Finding[];
   /** Gate commands that were red this round (gate phase). */

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -118,14 +118,31 @@ export function repromptCount(ctx: StepsCtx, phase: "spec" | "quality"): number 
  * findings, so checking `findings.length === 0` ahead of it would route an
  * unreadable review to `clean`, and the flow would open a PR having reviewed
  * nothing. That silent false green is worse than the crash this replaces.
+ *
+ * An **absent** verdict escalates for the same reason, and it is a distinct
+ * case from an unparseable one: `parseReviewVerdict` never returns undefined,
+ * so a missing entry means the node produced no output at all — it never ran,
+ * or it died before emitting. Neither is an approval. This must not fall
+ * through to `findings ?? []`, because `ctx.outputs` holds only each node's
+ * latest output: on a loop re-entry the previous round's clean verdict can
+ * still be sitting there, and routing on it re-approves a diff nobody read.
+ * There is no reprompt path here — a node that emitted nothing has no raw tail
+ * to quote back, so a human is the only remaining reader.
  */
 export function routeReview(
   ctx: OutputsCtx & StepsCtx,
   phase: "spec" | "quality",
 ): { route: string; escalationReason?: string; findings: Finding[] } {
   const verdict = (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`];
-  const findings = verdict?.findings ?? [];
-  if (verdict?.route === "reprompt") {
+  if (!verdict) {
+    return {
+      route: "escalate",
+      escalationReason: `${phase} reviewer produced no verdict — the node emitted no output, so nothing reviewed this diff.`,
+      findings: [],
+    };
+  }
+  const findings = verdict.findings ?? [];
+  if (verdict.route === "reprompt") {
     // `attempts` is self-inclusive (see repromptCount) — it already counts this
     // round's failure, so `<=` (not `<`) is what makes MAX_REPROMPT_ATTEMPTS=1
     // tolerate exactly one retry before escalating.
@@ -139,7 +156,7 @@ export function routeReview(
       findings,
     };
   }
-  if (verdict?.route === "escalate") {
+  if (verdict.route === "escalate") {
     return {
       route: "escalate",
       escalationReason: verdict.escalationReason ?? `${phase} review raised a finding needing human judgment`,

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -248,10 +248,18 @@ function buildFlowEnv(cfg: FinishAutoFlowSettings): Record<string, string> {
   // Strip these before spreading the rest of `process.env`: this very process
   // may itself have been launched by an outer nax-finish flow, and an
   // unconfigured reviewer must not let that ambient value leak into the child.
+  //
+  // NAX_FINISH_NARRATIVE belongs in the same list even though it is a switch
+  // rather than a profile, and leaving it out was a real leak: an outer flow
+  // with narration disabled exports `0`, every inner flow inherited it, and the
+  // inner run went silent while its config said otherwise. Every var this
+  // function is responsible for setting, it must also be responsible for
+  // clearing — a partial strip is the bug, not the variable count.
   const {
     NAX_FINISH_SPEC_PROFILE: _spec,
     NAX_FINISH_QUALITY_PROFILE: _quality,
     NAX_FINISH_NARRATIVE_PROFILE: _narrative,
+    NAX_FINISH_NARRATIVE: _narrativeSwitch,
     ...rest
   } = process.env;
   const env: Record<string, string> = { ...rest } as Record<string, string>;

--- a/test/unit/flows/nax-finish/commit-message.test.ts
+++ b/test/unit/flows/nax-finish/commit-message.test.ts
@@ -84,14 +84,19 @@ describe("buildFixCommitMessage — body", () => {
     expect(msg).toContain("nax-finish: quality review fixes");
   });
 
-  test("the gate body carries the gate output tail, not a finding list", () => {
+  // Was "carries the gate output tail": the body now names the failing test
+  // when the output identifies one, and falls back to the tail only when it
+  // cannot (covered below). What matters here is unchanged — the gate body
+  // reports runner evidence, never a reviewer finding list.
+  test("the gate body carries runner evidence, not a finding list", () => {
     const msg = buildFixCommitMessage(
       "gate",
       "f",
       ctxOf({ quality_gates: { failing: ["test"], output: "FAIL src/a.test.ts\n1 failed" } }),
     );
     expect(msg).toContain("Failing: test");
-    expect(msg).toContain("1 failed");
+    expect(msg).toContain("src/a.test.ts");
+    expect(msg).not.toContain("[HIGH]");
   });
 
   test("a subject-only message still ends with a single trailing newline-free line", () => {
@@ -103,5 +108,55 @@ describe("buildFixCommitMessage — body", () => {
     const msg = buildFixCommitMessage("spec", "f", ctxOf({ review_spec: { findings: [finding()] } }));
     expect(msg.split("\n")[1]).toBe("");
     expect(msg.split("\n")[2]).not.toBe("");
+  });
+});
+
+// The gate body used to be the raw last-20-lines of runner stdout. On the run
+// that motivated this (#1506) those 20 lines were three stack traces emitted as
+// *warnings* by tests that passed, so the message named the wrong failure
+// entirely — and pasted the author's absolute home path into shipped history.
+describe("buildFixCommitMessage — gate body names the failure", () => {
+  // Authentic shape: bun prints `(fail) <describe> > <test>` for real failures,
+  // while passing tests can still write stack traces to stderr.
+  const REAL_GATE_OUTPUT = [
+    "Warning: [finish-pr] Failed to write PR title/body",
+    "      at updatePrBody (/Users/someone/work/nax/flows/nax-finish/steps/pr.ts:111:19)",
+    "      at async <anonymous> (/Users/someone/work/nax/test/unit/flows/nax-finish/steps/pr.test.ts:476:21)",
+    "(fail) nax-finish post-run action > execute omits reviewer profile env vars [0.12ms]",
+    " 12121 pass",
+    " 1 fail",
+  ].join("\n");
+
+  const gateMsg = (output: string, workdir?: string) =>
+    buildFixCommitMessage("gate", "f", ctxOf({ quality_gates: { failing: ["test"], output } }), { workdir });
+
+  test("names the failing test rather than whichever lines happened to be last", () => {
+    const msg = gateMsg(REAL_GATE_OUTPUT);
+    expect(msg).toContain("execute omits reviewer profile env vars");
+  });
+
+  test("does not present a passing test's warning trace as the failure", () => {
+    const msg = gateMsg(REAL_GATE_OUTPUT);
+    expect(msg).not.toContain("Failed to write PR title/body");
+  });
+
+  test("strips absolute paths so shipped history carries no local filesystem layout", () => {
+    const msg = gateMsg(REAL_GATE_OUTPUT);
+    expect(msg).not.toContain("/Users/someone");
+  });
+
+  test("rewrites paths under the workdir to repo-relative", () => {
+    const msg = gateMsg("      at foo (/Users/someone/work/nax/src/a.ts:1:2)", "/Users/someone/work/nax");
+    expect(msg).toContain("src/a.ts:1:2");
+    expect(msg).not.toContain("/Users/someone");
+  });
+
+  test("falls back to the output tail when no failing test can be identified", () => {
+    const msg = gateMsg("something broke\nexit code 2");
+    expect(msg).toContain("exit code 2");
+  });
+
+  test("still records which gate commands were red", () => {
+    expect(gateMsg(REAL_GATE_OUTPUT)).toContain("Failing: test");
   });
 });

--- a/test/unit/flows/nax-finish/commit-message.test.ts
+++ b/test/unit/flows/nax-finish/commit-message.test.ts
@@ -159,4 +159,14 @@ describe("buildFixCommitMessage — gate body names the failure", () => {
   test("still records which gate commands were red", () => {
     expect(gateMsg(REAL_GATE_OUTPUT)).toContain("Failing: test");
   });
+
+  // A bare list of ten reads as "ten tests failed". A reader who acts on that
+  // count is acting on a truncation, so the cut has to announce itself.
+  test("says how many failing tests it left out rather than truncating silently", () => {
+    const many = Array.from({ length: 14 }, (_, i) => `(fail) suite > case ${i}`).join("\n");
+    const msg = gateMsg(many);
+    expect(msg).toContain("case 0");
+    expect(msg).toContain("...and 4 more failing test(s)");
+    expect(msg).not.toContain("case 13");
+  });
 });

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -9,8 +9,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import flow from "@flows/nax-finish/nax-finish.flow";
 import { _gitDeps } from "@flows/nax-finish/steps/git";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
-import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
 import { makeFlowCtx, makeFlowSteps } from "@test/helpers";
+import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
@@ -37,7 +37,7 @@ describe("commit_* nodes", () => {
     id: string,
     porcelain: string,
     outputs: Record<string, unknown> = {},
-    postCommitSha: string = "post-commit-sha",
+    postCommitSha = "post-commit-sha",
   ) => {
     const calls: string[][] = [];
     const rounds: unknown[] = [];
@@ -159,6 +159,28 @@ describe("commit_* nodes", () => {
     expect(rounds).toHaveLength(1);
     expect(rounds[0]).toMatchObject({ phase: "gate", committed: false });
     expect(rounds[0]).not.toHaveProperty("sha");
+  });
+
+  test("marks a review-phase round as fixed — a reviewer found something and this fixed it", async () => {
+    const { rounds } = await runCommitNode("commit_quality", " M a.ts\n", {
+      review_quality: { findings: [{ severity: "LOW", title: "T", problem: "P", fix: "F" }] },
+    });
+    expect(rounds[0]).toMatchObject({ outcome: "fixed" });
+  });
+
+  // The gate phase has no `review_gate` node at all. Recording its empty finding
+  // list without saying so let the PR body render "- _no findings_", which reads
+  // as "a reviewer looked and approved this" — manufactured evidence for a
+  // review that cannot have happened (#1507).
+  test("marks a gate round as having no reviewer, never as a clean review", async () => {
+    const { rounds } = await runCommitNode("commit_gate", "", { quality_gates: { failing: ["test"] } });
+    expect(rounds[0]).toMatchObject({ phase: "gate", outcome: "no-reviewer" });
+    expect(rounds[0].outcome).not.toBe("passed");
+  });
+
+  test("marks an acceptance round as having no reviewer", async () => {
+    const { rounds } = await runCommitNode("commit_acceptance", " M a.ts\n");
+    expect(rounds[0]).toMatchObject({ phase: "acceptance", outcome: "no-reviewer" });
   });
 });
 

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -219,12 +219,17 @@ describe("gate re-entry is scoped to non-test changes", () => {
 
   const TS_TEST_REGEX = ["\\.test\\.ts$", "(^|/)test/"];
 
+  const gateRounds: unknown[] = [];
+
   const runGateCommit = async (
     files: string[],
     regex: string[] = TS_TEST_REGEX,
     opts: { revParseFails?: boolean } = {},
   ) => {
-    _resultDeps.appendText = async () => {};
+    gateRounds.length = 0;
+    _resultDeps.appendText = async (_p, s) => {
+      gateRounds.push(JSON.parse(s));
+    };
     _gitDeps.run = async (cmd) => {
       if (cmd.includes("--porcelain")) return { exitCode: 0, stdout: " M a\n", stderr: "" };
       if (cmd.includes("rev-parse"))
@@ -257,6 +262,35 @@ describe("gate re-entry is scoped to non-test changes", () => {
 
   test("an empty file list (git show failed) reviews rather than skipping", async () => {
     expect((await runGateCommit([])).route).toBe("changed");
+  });
+
+  // The skip is a deliberate cost tradeoff, but until it says so in the audit
+  // it is indistinguishable from a gate fix that WAS re-reviewed — both wrote
+  // `no-reviewer`. That is the #1507 failure mode surviving on the one path
+  // where the omission is on purpose, which is exactly where a reader most
+  // needs to know. Recording it is also what makes "how often does this fire?"
+  // answerable before anyone decides whether to close the hole.
+  test("a skipped re-review says so in the audit trail", async () => {
+    await runGateCommit(["test/unit/a.test.ts"]);
+    expect(gateRounds[0]).toMatchObject({ phase: "gate", outcome: "review-skipped" });
+  });
+
+  test("a gate fix that IS re-reviewed is not marked skipped", async () => {
+    await runGateCommit(["src/scheduler.ts"]);
+    expect(gateRounds[0]).toMatchObject({ phase: "gate", outcome: "no-reviewer" });
+  });
+
+  test("a gate fix that committed nothing is not marked skipped — there was nothing to review", async () => {
+    _resultDeps.appendText = async (_p, s) => {
+      gateRounds.push(JSON.parse(s));
+    };
+    gateRounds.length = 0;
+    _gitDeps.run = async (cmd) => {
+      if (cmd.includes("--porcelain")) return { exitCode: 0, stdout: "", stderr: "" };
+      return { exitCode: 0, stdout: "sha1\n", stderr: "" };
+    };
+    await nodeRun<{ route: string }>("commit_gate").run(ctxOf({ outputs: { load_ctx: { testFileRegex: [] } } }));
+    expect(gateRounds[0]).toMatchObject({ outcome: "no-reviewer" });
   });
 
   // A committed fix whose HEAD will not resolve is real and unclassifiable. It

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { narrativeOf, prTitleOf } from "@flows/nax-finish/flow-ctx";
 import flow from "@flows/nax-finish/nax-finish.flow";
 import { _acceptanceDeps } from "@flows/nax-finish/steps/acceptance";
 import { _contextDeps } from "@flows/nax-finish/steps/context";
@@ -7,9 +8,8 @@ import { _gitDeps } from "@flows/nax-finish/steps/git";
 import { _prDeps } from "@flows/nax-finish/steps/pr";
 import { _qualityDeps } from "@flows/nax-finish/steps/quality";
 import { _resultDeps } from "@flows/nax-finish/steps/result";
-import { narrativeOf, prTitleOf } from "@flows/nax-finish/flow-ctx";
-import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
 import { makeFlowCtx, makeFlowSteps } from "@test/helpers";
+import type { FlowNodeContext, FlowStepRecord } from "acpx/flows";
 
 const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
 
@@ -326,45 +326,45 @@ describe("review parse + route_* nodes", () => {
 
   const finding = { severity: "HIGH" as const, title: "t", problem: "p", fix: "f" };
 
-  test("route_spec sends findings to the fix node while under the cap", () => {
-    const out = nodeRun<{ route: string }>("route_spec").run(
+  test("route_spec sends findings to the fix node while under the cap", async () => {
+    const out = (await nodeRun<{ route: string }>("route_spec").run(
       ctxOf({ outputs: { review_spec: { route: "proceed", findings: [finding] } } }),
-    ) as { route: string };
+    )) as { route: string };
     expect(out.route).toBe("fix");
   });
 
-  test("route_spec escalates once the fix cap is reached", () => {
-    const out = nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
+  test("route_spec escalates once the fix cap is reached", async () => {
+    const out = (await nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
       ctxOf({
         outputs: { review_spec: { route: "proceed", findings: [finding] } },
         steps: makeFlowSteps(["fix_spec", "fix_spec", "fix_spec"]),
       }),
-    ) as { route: string; escalationReason?: string };
+    )) as { route: string; escalationReason?: string };
     expect(out.route).toBe("escalate");
     expect(out.escalationReason).toContain("after 3 fix attempts");
   });
 
-  test("route_spec passes the reviewer's own escalate verdict straight through", () => {
-    const out = nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
+  test("route_spec passes the reviewer's own escalate verdict straight through", async () => {
+    const out = (await nodeRun<{ route: string; escalationReason?: string }>("route_spec").run(
       ctxOf({
         outputs: {
           review_spec: { route: "escalate", findings: [finding], escalationReason: "AC-3 contradicts the schema" },
         },
       }),
-    ) as { route: string; escalationReason?: string };
+    )) as { route: string; escalationReason?: string };
     expect(out.route).toBe("escalate");
     expect(out.escalationReason).toBe("AC-3 contradicts the schema");
   });
 
-  test("route_quality reads the quality verdict, not the spec one", () => {
-    const out = nodeRun<{ route: string }>("route_quality").run(
+  test("route_quality reads the quality verdict, not the spec one", async () => {
+    const out = (await nodeRun<{ route: string }>("route_quality").run(
       ctxOf({
         outputs: {
           review_spec: { route: "proceed", findings: [finding] },
           review_quality: { route: "clean", findings: [] },
         },
       }),
-    ) as { route: string };
+    )) as { route: string };
     expect(out.route).toBe("clean");
   });
 });

--- a/test/unit/flows/nax-finish/pr-body.test.ts
+++ b/test/unit/flows/nax-finish/pr-body.test.ts
@@ -7,9 +7,9 @@
  * auto-PR-opened PRs read the same.
  */
 import { afterEach, describe, expect, test } from "bun:test";
+import { resolveTitle } from "@flows/nax-finish/pr-title";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle, loadFinishPrContext } from "@flows/nax-finish/steps/pr-body";
 import type { FinishPrContext, FinishPrStory } from "@flows/nax-finish/steps/pr-body";
-import { resolveTitle } from "@flows/nax-finish/pr-title";
 import type { Finding, FinishRound } from "@flows/nax-finish/types";
 
 const story = (over: Partial<FinishPrStory> = {}): FinishPrStory => ({
@@ -27,9 +27,7 @@ const finding = (over: Partial<Finding> = {}): Finding => ({
   ...over,
 });
 
-const committedRound = (
-  over: Partial<FinishRound> & { sha?: string } = {},
-): FinishRound => ({
+const committedRound = (over: Partial<FinishRound> & { sha?: string } = {}): FinishRound => ({
   ts: "2026-01-01T00:00:00.000Z",
   phase: "spec",
   attempt: 1,
@@ -128,10 +126,7 @@ describe("buildFinishBody — Review rounds (US-002 AC8-AC12)", () => {
   test("renders one heading per round naming phase and attempt", () => {
     const body = buildFinishBody(
       baseCtx({
-        rounds: [
-          committedRound({ phase: "spec", attempt: 1 }),
-          committedRound({ phase: "quality", attempt: 2 }),
-        ],
+        rounds: [committedRound({ phase: "spec", attempt: 1 }), committedRound({ phase: "quality", attempt: 2 })],
       }),
     );
     expect(body).toContain("## Review rounds");
@@ -186,6 +181,52 @@ describe("buildFinishBody — Review rounds (US-002 AC8-AC12)", () => {
   test("renders no Review rounds heading when rounds is empty", () => {
     const body = buildFinishBody(baseCtx({ rounds: [] }));
     expect(body).not.toContain("## Review rounds");
+  });
+});
+
+// #1507: an empty finding list means four different things, and the body used
+// to render all of them as "_no findings_" — which a human reads as "a reviewer
+// looked and approved this". Only `passed` means that.
+describe("buildFinishBody — what an empty round actually means", () => {
+  const emptyRound = (over: Record<string, unknown>) => ({
+    ts: "2026-01-01T00:00:00.000Z",
+    phase: "quality",
+    attempt: 1,
+    committed: false,
+    findings: [],
+    ...over,
+  });
+
+  test("a passed review still reads as no findings", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ outcome: "passed" })] }));
+    expect(body).toContain("- _no findings_");
+  });
+
+  test("a gate round says no reviewer ran, NOT that a reviewer found nothing", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ phase: "gate", outcome: "no-reviewer" })] }));
+    expect(body).toContain("### gate attempt 1");
+    expect(body).toContain("no reviewer");
+    expect(body).not.toContain("- _no findings_");
+  });
+
+  test("an unparseable review is not rendered as a pass", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ outcome: "unparseable" })] }));
+    expect(body).toContain("could not be parsed");
+    expect(body).not.toContain("- _no findings_");
+  });
+
+  test("an escalated review is not rendered as a pass", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ outcome: "escalated" })] }));
+    expect(body).toContain("escalated");
+    expect(body).not.toContain("- _no findings_");
+  });
+
+  // Rounds written before `outcome` existed carry no such field. The body must
+  // keep rendering them exactly as it did, rather than claiming they had no
+  // reviewer — it does not know that.
+  test("a legacy round with no outcome renders as before", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({})] }));
+    expect(body).toContain("- _no findings_");
   });
 });
 
@@ -304,9 +345,7 @@ describe("buildFinishBody — repository template (#1478, merged per #1504)", ()
 
 describe("buildFinishBody — What changed section (#1477)", () => {
   test("renders the narrative first, above the Stories table", () => {
-    const body = buildFinishBody(
-      baseCtx({ stories: [story()], narrative: "Replaced the widget cache." }),
-    );
+    const body = buildFinishBody(baseCtx({ stories: [story()], narrative: "Replaced the widget cache." }));
     expect(body.indexOf("## What changed")).toBe(0);
     expect(body).toContain("Replaced the widget cache.");
     expect(body.indexOf("## What changed")).toBeLessThan(body.indexOf("## Stories"));
@@ -360,7 +399,9 @@ describe("loadFinishPrContext — diffstat scope", () => {
   });
 
   test("reports the excluded artifacts as a shortstat rather than dropping them", async () => {
-    const calls = captureRun((cmd) => (cmd.includes("--shortstat") ? " 5 files changed, 1248 insertions(+)\n" : " a.ts | 1 +\n"));
+    const calls = captureRun((cmd) =>
+      cmd.includes("--shortstat") ? " 5 files changed, 1248 insertions(+)\n" : " a.ts | 1 +\n",
+    );
     _prBodyDeps.readText = async () => null;
     const ctx = await loadFinishPrContext(INPUT, { base: "origin/main", gatesRan: [] });
 

--- a/test/unit/flows/nax-finish/pr-body.test.ts
+++ b/test/unit/flows/nax-finish/pr-body.test.ts
@@ -209,6 +209,15 @@ describe("buildFinishBody — what an empty round actually means", () => {
     expect(body).not.toContain("- _no findings_");
   });
 
+  // The reader has to be able to see the skip. A PR whose gate fix bypassed the
+  // re-review by policy looks, in every other respect, exactly like one that was
+  // re-reviewed and came back clean.
+  test("a skipped re-review is visible in the body, not disguised as a clean one", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ phase: "gate", outcome: "review-skipped" })] }));
+    expect(body).toContain("re-review skipped");
+    expect(body).not.toContain("- _no findings_");
+  });
+
   test("an unparseable review is not rendered as a pass", () => {
     const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ outcome: "unparseable" })] }));
     expect(body).toContain("could not be parsed");

--- a/test/unit/flows/nax-finish/steps/commit-round.test.ts
+++ b/test/unit/flows/nax-finish/steps/commit-round.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { buildCommitRound, commitRoundOutcome } from "@flows/nax-finish/steps/commit-round";
+
+const NOW = "2026-08-08T05:00:00.000Z";
+const base = {
+  phase: "gate" as const,
+  attempt: 1,
+  committed: true,
+  route: "changed",
+  findings: [],
+  now: NOW,
+};
+
+describe("commitRoundOutcome", () => {
+  test("a review phase's fix round is `fixed`", () => {
+    expect(commitRoundOutcome("spec", "changed")).toBe("fixed");
+    expect(commitRoundOutcome("quality", "changed")).toBe("fixed");
+  });
+
+  // The distinction this function exists for: both of these are gate rounds
+  // that committed, and only one of them is about to be re-reviewed.
+  test("a gate fix routed on to the re-review is `no-reviewer`", () => {
+    expect(commitRoundOutcome("gate", "changed")).toBe("no-reviewer");
+  });
+
+  test("a gate fix whose re-review was skipped by policy is `review-skipped`", () => {
+    expect(commitRoundOutcome("gate", "tests-only")).toBe("review-skipped");
+  });
+
+  test("a gate fix that committed nothing is not marked skipped — nothing was owed", () => {
+    expect(commitRoundOutcome("gate", "unchanged")).toBe("no-reviewer");
+  });
+
+  test("acceptance has no reviewer to skip", () => {
+    expect(commitRoundOutcome("acceptance", "tests-only")).toBe("no-reviewer");
+    expect(commitRoundOutcome("acceptance", "changed")).toBe("no-reviewer");
+  });
+});
+
+describe("buildCommitRound", () => {
+  test("carries the post-commit sha when there was a commit", () => {
+    expect(buildCommitRound({ ...base, shaAfter: "deadbeef" }).sha).toBe("deadbeef");
+  });
+
+  // Absence is load-bearing: it is how a reader of the JSONL tells "no commit"
+  // from "record lost", so it must never be spelled null or undefined.
+  test("omits sha entirely when nothing was committed", () => {
+    const round = buildCommitRound({ ...base, committed: false, shaAfter: "deadbeef" });
+    expect(round).not.toHaveProperty("sha");
+  });
+
+  test("omits sha when the commit happened but HEAD would not resolve", () => {
+    expect(buildCommitRound({ ...base, shaAfter: null })).not.toHaveProperty("sha");
+  });
+
+  test("omits failing for phases that have no gate commands", () => {
+    expect(buildCommitRound({ ...base, phase: "spec" })).not.toHaveProperty("failing");
+  });
+
+  test("records an empty failing list as present, distinguishing it from a non-gate phase", () => {
+    expect(buildCommitRound({ ...base, failing: [] }).failing).toEqual([]);
+  });
+
+  test("passes through the round's identity fields unchanged", () => {
+    const round = buildCommitRound({ ...base, phase: "quality", attempt: 3, route: "changed" });
+    expect(round).toMatchObject({ ts: NOW, phase: "quality", attempt: 3, committed: true });
+  });
+});

--- a/test/unit/flows/nax-finish/steps/review-round.test.ts
+++ b/test/unit/flows/nax-finish/steps/review-round.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { _resultDeps } from "@flows/nax-finish/steps/result";
+import { routeReviewAndRecord } from "@flows/nax-finish/steps/review-round";
+import type { FinishRound } from "@flows/nax-finish/types";
+import { makeFlowStep } from "@test/helpers";
+
+const originalAppendText = _resultDeps.appendText;
+afterEach(() => {
+  _resultDeps.appendText = originalAppendText;
+});
+
+const INPUT = {
+  auditDir: "/home/u/.nax/proj/finish-audit/feat-x",
+  workdir: "/repo",
+  feature: "feat-x",
+  runId: "run-1",
+};
+
+const FINDING = { severity: "HIGH", title: "t", problem: "p", fix: "f" };
+
+/** Capture every round `routeReviewAndRecord` appends, parsed back from JSONL. */
+function captureRounds(): FinishRound[] {
+  const written: FinishRound[] = [];
+  _resultDeps.appendText = async (_p, s) => {
+    for (const line of s.split("\n")) if (line.trim()) written.push(JSON.parse(line));
+  };
+  return written;
+}
+
+const ctxWith = (verdict: unknown, steps = [makeFlowStep("review_quality")]) => ({
+  input: INPUT,
+  outputs: { review_quality: verdict },
+  state: { steps },
+});
+
+describe("routeReviewAndRecord", () => {
+  test("records a round when the review passes with no findings", async () => {
+    const rounds = captureRounds();
+    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [] }), "quality");
+
+    expect(r.route).toBe("clean");
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0]).toMatchObject({
+      phase: "quality",
+      committed: false,
+      findings: [],
+      outcome: "passed",
+    });
+    expect(rounds[0].sha).toBeUndefined();
+  });
+
+  test("does NOT record when the review routes to fix — commit_<phase> records that round", async () => {
+    // The round is appended at `commit_<phase>`, where the findings AND the
+    // resulting commit are both known. Recording here too would double-count it.
+    const rounds = captureRounds();
+    const r = await routeReviewAndRecord(ctxWith({ route: "proceed", findings: [FINDING] }), "quality");
+
+    expect(r.route).toBe("fix");
+    expect(rounds).toEqual([]);
+  });
+
+  test("records an unparseable review as its own outcome, not as a pass", async () => {
+    const rounds = captureRounds();
+    await routeReviewAndRecord(ctxWith({ route: "reprompt", findings: [], raw: "prose" }), "quality");
+
+    expect(rounds[0]).toMatchObject({ outcome: "unparseable", committed: false });
+  });
+
+  test("records an escalated review as its own outcome", async () => {
+    const rounds = captureRounds();
+    await routeReviewAndRecord(ctxWith({ route: "escalate", findings: [], escalationReason: "judgment" }), "quality");
+
+    expect(rounds[0]).toMatchObject({ outcome: "escalated" });
+  });
+
+  test("records the absent-verdict escalation, so a reviewer that emitted nothing leaves a trace", async () => {
+    const rounds = captureRounds();
+    const r = await routeReviewAndRecord({ input: INPUT, outputs: {}, state: { steps: [] } }, "quality");
+
+    expect(r.route).toBe("escalate");
+    expect(rounds[0]).toMatchObject({ outcome: "escalated" });
+  });
+
+  test("numbers the attempt by review round, not by fix count", async () => {
+    const rounds = captureRounds();
+    const steps = [
+      makeFlowStep("review_quality"),
+      makeFlowStep("fix_quality"),
+      makeFlowStep("commit_quality"),
+      makeFlowStep("review_quality"),
+    ];
+    await routeReviewAndRecord(ctxWith({ route: "clean", findings: [] }, steps), "quality");
+
+    expect(rounds[0].attempt).toBe(2);
+  });
+
+  test("carries the findings a clean-after-escalate verdict reported", async () => {
+    const rounds = captureRounds();
+    await routeReviewAndRecord(ctxWith({ route: "escalate", findings: [FINDING] }), "quality");
+
+    expect(rounds[0].findings).toHaveLength(1);
+  });
+
+  test("an unwritable audit dir does not fail the route", async () => {
+    _resultDeps.appendText = async () => {
+      throw new Error("EACCES");
+    };
+    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [] }), "quality");
+    expect(r.route).toBe("clean");
+  });
+});

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -7,8 +7,8 @@ import {
   repromptCount,
   routeReview,
 } from "@flows/nax-finish/verdict";
-import type { FlowStepRecord } from "acpx/flows";
 import { makeFlowStep, makeFlowSteps, reviewRounds } from "@test/helpers";
+import type { FlowStepRecord } from "acpx/flows";
 
 // The real reply that killed flow run 2026-08-05T154112386Z-nax-finish-600cf3f3 on
 // rs-stock, with private identifiers replaced by generic equivalents — the shape
@@ -164,5 +164,25 @@ describe("routeReview", () => {
     const r = routeReview(routeCtx({ route: "proceed", findings: [FINDING] }, steps), "quality");
     expect(r.route).toBe("escalate");
     expect(r.escalationReason).toContain("fix attempts");
+  });
+
+  // A reviewer that produced NO output at all is not an approval. `ctx.outputs`
+  // keeps only each node's latest output, so an absent verdict is either "the
+  // node never ran" or "it died without emitting" — and in a loop the previous
+  // round's clean verdict may still be sitting there. Defaulting to `findings ??
+  // []` made all three read as "clean" and opened a PR having verified nothing.
+  test("an absent verdict is NEVER routed clean", () => {
+    const r = routeReview({ outputs: {}, state: { steps: [] } }, "quality");
+    expect(r.route).not.toBe("clean");
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toContain("no verdict");
+  });
+
+  test("an absent verdict escalates rather than reusing the previous round's clean verdict", () => {
+    // The stale-output case: round 1 passed clean, round 2's node emitted
+    // nothing. Routing on the leftover output would silently re-approve.
+    const steps = makeFlowSteps(["review_quality", "route_quality", "commit_gate"]);
+    const r = routeReview({ outputs: { review_spec: { route: "clean", findings: [] } }, state: { steps } }, "quality");
+    expect(r.route).toBe("escalate");
   });
 });

--- a/test/unit/plugins/builtin/nax-finish/plugin-env.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin-env.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The child environment nax-finish hands to `acpx flow run`.
+ *
+ * Split out of `plugin.test.ts` (800-line test cap) and, more importantly,
+ * because these tests are the only ones in the suite that must control ambient
+ * `process.env`. Keeping them together makes the hermetic setup one block
+ * rather than a trap for the next test added to the big file.
+ *
+ * The bug that motivated the split (#1506): `plugin.test.ts` asserted the
+ * reviewer-profile keys were `undefined` in the child env, but never set them in
+ * `process.env` first — so the assertion passed whether or not `buildFlowEnv`
+ * stripped anything. It also read ambient env, so when the repo's own suite ran
+ * *inside* a nax-finish flow it inherited the exported profiles and failed,
+ * which is what put a production change into the gate phase to begin with.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _naxFinishDeps, naxFinishPlugin } from "@/plugins";
+import type { PostRunContext } from "@/plugins/types";
+
+const action = naxFinishPlugin.extensions.postRunAction!;
+
+const origDeps = { ...(_naxFinishDeps as Record<string, unknown>) };
+
+/**
+ * Every var `buildFlowEnv` is responsible for. Cleared before each test and
+ * restored after, so these tests behave identically inside and outside a
+ * nax-finish flow — the hermeticity this file exists to guarantee.
+ */
+const MANAGED_KEYS = [
+  "NAX_FINISH_SPEC_PROFILE",
+  "NAX_FINISH_QUALITY_PROFILE",
+  "NAX_FINISH_NARRATIVE_PROFILE",
+  "NAX_FINISH_NARRATIVE",
+] as const;
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of MANAGED_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  Object.assign(_naxFinishDeps, origDeps);
+  for (const k of MANAGED_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+const baseCtx = (over: Partial<PostRunContext> = {}): PostRunContext =>
+  ({
+    runId: "r",
+    feature: "x",
+    workdir: "/repo",
+    prdPath: "/repo/.nax/features/x/prd.json",
+    branch: "feat/x",
+    totalDurationMs: 1,
+    totalCost: 0,
+    storySummary: { completed: 2, failed: 0, skipped: 0, paused: 0 },
+    stories: [],
+    config: { finish: { autoFlow: { enabled: true } } },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    ...over,
+  }) as unknown as PostRunContext;
+
+/** Run the action and hand back the env it passed to the child process. */
+async function capturedChildEnv(ctx: PostRunContext = baseCtx()): Promise<Record<string, string>> {
+  let env: Record<string, string> = {};
+  _naxFinishDeps.run = async (_cmd, opts) => {
+    env = opts.env ?? {};
+    return { exitCode: 0, stdout: "", stderr: "" };
+  };
+  _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
+  await action.execute(ctx);
+  return env;
+}
+
+describe("buildFlowEnv — reviewer profiles", () => {
+  // The real regression test for the strip. This process may itself have been
+  // launched by an outer nax-finish flow, which exports these vars; with no
+  // reviewer configured, that ambient value must NOT reach the child. Deleting
+  // the destructure in `buildFlowEnv` fails exactly this test and no other.
+  test("strips an inherited profile when no reviewer is configured", async () => {
+    process.env.NAX_FINISH_SPEC_PROFILE = "leaked-from-outer-flow";
+    process.env.NAX_FINISH_QUALITY_PROFILE = "leaked-from-outer-flow";
+    process.env.NAX_FINISH_NARRATIVE_PROFILE = "leaked-from-outer-flow";
+
+    const env = await capturedChildEnv();
+
+    expect(env.NAX_FINISH_SPEC_PROFILE).toBeUndefined();
+    expect(env.NAX_FINISH_QUALITY_PROFILE).toBeUndefined();
+    expect(env.NAX_FINISH_NARRATIVE_PROFILE).toBeUndefined();
+  });
+
+  test("a configured reviewer overrides the inherited value rather than appending to it", async () => {
+    process.env.NAX_FINISH_SPEC_PROFILE = "leaked-from-outer-flow";
+    const ctx = baseCtx({
+      config: { finish: { autoFlow: { enabled: true, reviewers: { spec: "my-spec-profile" } } } },
+    } as Partial<PostRunContext>);
+
+    const env = await capturedChildEnv(ctx);
+
+    expect(env.NAX_FINISH_SPEC_PROFILE).toBe("my-spec-profile");
+  });
+
+  test("omits the profile keys entirely when no reviewer is configured and none is inherited", async () => {
+    const env = await capturedChildEnv();
+    expect(env.NAX_FINISH_SPEC_PROFILE).toBeUndefined();
+    expect(env.NAX_FINISH_QUALITY_PROFILE).toBeUndefined();
+  });
+
+  test("leaves unrelated environment variables untouched", async () => {
+    const env = await capturedChildEnv();
+    expect(env.PATH).toBe(process.env.PATH as string);
+  });
+});
+
+describe("buildFlowEnv — narrative switch", () => {
+  // The original strip covered the three *_PROFILE vars and stopped there,
+  // leaving NAX_FINISH_NARRATIVE with the identical leak: an outer flow that
+  // disabled narration exported `0`, and every inner flow inherited it and went
+  // silent. Same failure mode, one variable further along.
+  test("strips an inherited NAX_FINISH_NARRATIVE when narration is enabled", async () => {
+    process.env.NAX_FINISH_NARRATIVE = "0";
+
+    const env = await capturedChildEnv();
+
+    expect(env.NAX_FINISH_NARRATIVE).toBeUndefined();
+  });
+
+  test("still signals the disabled case explicitly", async () => {
+    const ctx = baseCtx({
+      config: { finish: { autoFlow: { enabled: true, narrative: false } } },
+    } as Partial<PostRunContext>);
+
+    const env = await capturedChildEnv(ctx);
+
+    expect(env.NAX_FINISH_NARRATIVE).toBe("0");
+  });
+});

--- a/test/unit/plugins/builtin/nax-finish/plugin.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin.test.ts
@@ -507,9 +507,7 @@ describe("nax-finish post-run action", () => {
     };
     _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
 
-    await action.execute(
-      baseCtx({ config: { finish: { autoFlow: { enabled: true, narrative: false } } } }),
-    );
+    await action.execute(baseCtx({ config: { finish: { autoFlow: { enabled: true, narrative: false } } } }));
 
     expect(capturedEnv?.NAX_FINISH_NARRATIVE).toBe("0");
   });
@@ -604,20 +602,6 @@ describe("nax-finish post-run action", () => {
       finish: { autoFlow: { enabled: true, prBody: { template: "strict", sectionMap: { werk: "stories" } } } },
     });
     expect(configured.prBody).toEqual({ template: "strict", sectionMap: { werk: "stories" } });
-  });
-
-  test("execute omits reviewer profile env vars when reviewers are null", async () => {
-    let capturedEnv: Record<string, string> | undefined;
-    _naxFinishDeps.run = async (_cmd, opts) => {
-      capturedEnv = opts.env;
-      return { exitCode: 0, stdout: "", stderr: "" };
-    };
-    _naxFinishDeps.readResult = async () => ({ feature: "x", status: "opened" });
-
-    await action.execute(baseCtx());
-
-    expect(capturedEnv?.NAX_FINISH_SPEC_PROFILE).toBeUndefined();
-    expect(capturedEnv?.NAX_FINISH_QUALITY_PROFILE).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #1507. Addresses the test-hermeticity and commit-message parts of #1506.

## Why

`nax-finish` appended a round to the audit trail **only where a fix produced a commit**. A review that ran and found nothing produced no `fix_*`, therefore no `commit_*`, therefore no round — so "this phase passed" and "this phase never ran" were indistinguishable afterwards. That is #1507, and it is why the owed re-review in #1506 could not be answered from artifacts at all: there is no second source of truth, because nax-finish's reviewers are `acp` nodes and never touch nax's own `prompt-audit`/`review-audit` path.

## What changed

**1. Every executing review phase records a round** (`f351c3c8`)

The two seams now split by what they know:

| seam | records |
|:--|:--|
| `commit_<phase>` | rounds that changed the tree (`outcome: "fixed"`) |
| `routeReviewAndRecord` (new) | rounds that did not — `passed` / `unparseable` / `escalated` |

`routeReviewAndRecord` wraps `routeReview` rather than living inside it, so that function stays pure and synchronous — it is the routing SSOT with a large table of unit tests that would otherwise all become async.

`FinishRound.outcome` is **optional**, so rounds written by earlier versions still render without the body claiming more than it knows.

**2. A phase with no reviewer says so** (`f351c3c8`)

There is no `review_gate` node. `commit_gate` nevertheless recorded `findings: []`, and the PR body rendered that as:

```
### gate attempt 1 (86237bf)
- _no findings_
```

which reads as "a reviewer looked at this commit and approved it". It cannot mean that. `gate` and `acceptance` rounds are now `no-reviewer`, and the body renders all five cases distinctly. This is the inverse of #1507's complaint and arguably worse — it manufactured positive evidence rather than omitting it.

**3. `routeReview` no longer treats an absent verdict as clean** (`f351c3c8`)

`verdict.ts` defaulted to `verdict?.findings ?? []` and returned `clean` for an empty list, so a missing entry routed identically to an approval. Since `ctx.outputs` keeps only each node's latest output, a loop re-entry could route on the *previous* round's clean verdict and re-approve a diff nobody read.

To be precise about scope: this closes a **fail-open path, not an observed failure**. `parseReviewVerdict("")` returns a `reprompt` verdict rather than `undefined`, so an empty reply cannot reach this branch — it guards the case where no output is recorded at all. It is cheap and it fails toward a human.

**4. The reviewer-env strip is hermetic and actually tested** (`aaa7f6d6`)

`plugin.test.ts` asserted the profile keys were `undefined` in the child env but never set them in `process.env` first — so it passed whether or not `buildFlowEnv` stripped anything. It also read ambient env, so the repo's own suite failed when run *inside* a nax-finish flow, which is what created gate work for the flow to then "fix" in production code.

- Env tests moved to `plugin-env.test.ts` with clear/restore around every managed var.
- The new test sets the vars before executing. **Verified by deleting the destructure: exactly that test goes red**, which the one it replaces did not.
- **`NAX_FINISH_NARRATIVE` is now stripped too.** The original fix covered the three `*_PROFILE` vars and stopped, leaving the switch with the identical leak — an outer flow with narration disabled exports `0` and every inner flow inherits it. Reproduced before fixing: `NAX_FINISH_NARRATIVE=0 bun test …` failed. Every var this function sets, it must also clear.

**5. Gate commit messages name the failing test** (`657e3042`, `+ truncation notice`)

The body was the last 20 lines of runner stdout. When a suite's *passing* tests write to stderr, those lines push the real failure out of the window. On the motivating commit the result was three stack traces from tests that passed, no failing test named, and an absolute home path in shipped history.

Against that exact input, before and after:

```
 Failing: test                                          Failing: test

 Warning: [finish-pr] Failed to write PR title/body     Failed tests:
   at updatePrBody (/Users/<name>/…/steps/pr.ts:111)    - nax-finish post-run action > execute omits
   at async openOrPromotePr (/Users/<name>/…:81)          reviewer profile env vars when reviewers are null
   at async <anonymous> (/Users/<name>/…:503)
  12121 pass
  1 fail
```

Marker set is a documented heuristic across runners (bun/jest, go, pytest, tick reporters); a miss falls back to the tail exactly as before. Paths under the workdir become repo-relative, and any remaining home prefix reduces to `~/`. `buildFixCommitMessage` takes an optional options object, so existing callers are unaffected.

**6. A skipped re-review says so** (`75bf013f`)

`commit_gate` wrote `outcome: "no-reviewer"` whether or not the fix went on to `review_quality` — so a gate fix whose re-review was *deliberately skipped* was byte-identical in the audit to one that **was** re-reviewed. That is this PR's own failure mode surviving on the one path where the omission is on purpose.

- New `review-skipped` outcome, written when `gateCommitRoute` returns `tests-only`. `unchanged` stays `no-reviewer` — nothing committed means no review was owed.
- The route is now computed *before* the round is recorded, since the successor is what distinguishes the two cases.
- Round assembly moved to `steps/commit-round.ts`: needed for room against the 600-line cap, and it earns the split independently — four conditional fields, now unit-testable without driving a flow node through a git mock.

## Deliberately not included

**Closing the `tests-only` hole.** `commit_gate` still routes a test-only fix straight to `quality_gates`, skipping the re-review — the hole the code comment already labels "**This is a real hole**". I confirmed it is reachable here: `testPatterns` is *derived* by `nax features resolve` (24 regexes, `resolution: "root-config"`), not empty as the absent config key suggests.

That change would alter what the flow *does*, not just what it records — measured reviewer calls run 60-101s, and `MAX_FIX_ATTEMPTS = 3` puts the worst case at ~3 extra reviews per finish. It belongs in its own PR with its own revert boundary. This PR makes the skip **countable** so that decision can be made on evidence rather than intuition.

## Test plan

- [x] `bun run test` — 12232 unit + 1097 integration + 24 UI, 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint` — all 9 checks including the file-size ratchet (`nax-finish.flow.ts` 597/600 after reclaiming headroom, `plugin.test.ts` 786/800)
- [x] Each commit typechecks and passes the nax-finish suites independently (bisectable)
- [x] Strip regression verified by reverting the production change — the new test fails, the old one did not
- [x] Suite passes identically with and without `NAX_FINISH_*` leaked into the environment

One existing test asserted the old tail-quoting contract this change replaces; it was updated to the new contract, with the fallback path covered separately.
