### PR TITLE
fix(status-file): count regression-failed as failed in countProgress

### DIFF
--- a/src/execution/status-file.ts
+++ b/src/execution/status-file.ts
@@ -162,11 +162,15 @@ export interface NaxStatusFile {
 /**
  * Derive progress counts from PRD story statuses.
  *
- * Counts each story by its current status. `pending` is computed as
- * everything not in the four explicit terminal/waiting states. `failed`
- * also counts `regression-failed` — mirrors countStories() in src/prd/index.ts,
- * which the deferred regression gate relies on for the same classification
- * (see run-completion.ts, RL-004).
+ * `failed` counts both `failed` and `regression-failed` — mirrors
+ * countStories() in src/prd/index.ts, which the deferred regression gate
+ * relies on for the same classification (see run-completion.ts, RL-004).
+ *
+ * `pending` is everything else: `pending`, `in-progress`, `skipped`, and
+ * `decomposed` all fall into this bucket today. That collapses statuses
+ * countStories() tracks separately (`skipped`, `decomposed`) — status.json's
+ * `progress` shape has no dedicated field for them. Not addressed here;
+ * tracked as a follow-up alongside this fix.
  */
 export function countProgress(prd: PRD): NaxStatusFile["progress"] {
   const stories = prd.userStories;

--- a/src/execution/status-file.ts
+++ b/src/execution/status-file.ts
@@ -163,12 +163,15 @@ export interface NaxStatusFile {
  * Derive progress counts from PRD story statuses.
  *
  * Counts each story by its current status. `pending` is computed as
- * everything not in the four explicit terminal/waiting states.
+ * everything not in the four explicit terminal/waiting states. `failed`
+ * also counts `regression-failed` — mirrors countStories() in src/prd/index.ts,
+ * which the deferred regression gate relies on for the same classification
+ * (see run-completion.ts, RL-004).
  */
 export function countProgress(prd: PRD): NaxStatusFile["progress"] {
   const stories = prd.userStories;
   const passed = stories.filter((s) => s.status === "passed").length;
-  const failed = stories.filter((s) => s.status === "failed").length;
+  const failed = stories.filter((s) => s.status === "failed" || s.status === "regression-failed").length;
   const paused = stories.filter((s) => s.status === "paused").length;
   const blocked = stories.filter((s) => s.status === "blocked").length;
   const total = stories.length;

--- a/test/integration/execution/status-file.test.ts
+++ b/test/integration/execution/status-file.test.ts
@@ -151,6 +151,24 @@ describe("countProgress", () => {
     expect(progress.failed).toBe(1);
     expect(progress.pending).toBe(0);
   });
+
+  test("failed and regression-failed both contribute to the failed bucket", () => {
+    const stories = [
+      makeStory("US-001", "passed"),
+      makeStory("US-002", "failed"),
+      makeStory("US-003", "regression-failed"),
+      makeStory("US-004", "pending"),
+    ];
+    const progress = countProgress(makePrd(stories));
+
+    expect(progress.total).toBe(4);
+    expect(progress.passed).toBe(1);
+    expect(progress.failed).toBe(2);
+    expect(progress.pending).toBe(1);
+    expect(progress.pending).toBe(
+      progress.total - progress.passed - progress.failed - progress.paused - progress.blocked,
+    );
+  });
 });
 
 // ============================================================================

--- a/test/integration/execution/status-file.test.ts
+++ b/test/integration/execution/status-file.test.ts
@@ -133,6 +133,24 @@ describe("countProgress", () => {
     expect(skipped.passed).toBe(0);
     expect(countProgress(makePrd([makeStory("US-001", "in-progress")])).pending).toBe(1);
   });
+
+  test("regression-failed counts as failed, not pending", () => {
+    // A story that passed acceptance but was later flipped to regression-failed
+    // in-memory by the deferred regression gate (run-completion.ts) must be
+    // classified the same way countStories() in src/prd/index.ts classifies it.
+    const stories = [
+      makeStory("US-001", "passed"),
+      makeStory("US-002", "passed"),
+      makeStory("US-003", "passed"),
+      makeStory("US-004", "regression-failed"),
+    ];
+    const progress = countProgress(makePrd(stories));
+
+    expect(progress.total).toBe(4);
+    expect(progress.passed).toBe(3);
+    expect(progress.failed).toBe(1);
+    expect(progress.pending).toBe(0);
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- `countProgress()` (builds status.json's `progress` block) only checked `status === "failed"`, unlike the sibling `countStories()` in `src/prd/index.ts`, which also counts `"regression-failed"`.
- When the deferred regression gate flips a story to `regression-failed` in-memory (`run-completion.ts`, RL-004) — deliberately without persisting it to `prd.json`, per issue #250/PR #254 — `countProgress()` dropped that story into the residual `pending` bucket instead of `failed`.
- Net effect: a completed run could produce a self-contradictory `status.json` — `run.status: "failed"` and `postRun.regression.status: "failed"` with the story listed in `affectedStories`, but `progress: { failed: 0, pending: 1 }`.
- Fix: `failed` now also counts `regression-failed`, matching `countStories()`.

Found while diagnosing why a headless run's `nax` CLI summary (3 passed / 1 failed) disagreed with `prd.json` (4 passed) — that particular gap is intentional/documented, but digging into it surfaced this real bug in `status.json`'s own internal consistency.

## Review notes
Ran a code-review pass on this diff (verdict: approve, no critical/high issues). Applied the two in-scope suggestions:
- added a test covering `failed` + `regression-failed` together (kills a mutant that swaps which literal maps to the bucket)
- tightened the docstring to spell out that `skipped`/`decomposed` still collapse into `pending` today (same defect class, out of scope for this PR — flagged as a follow-up)

Verified and **did not** apply one suggested "write-ordering" fix in `run-completion.ts` — traced it and confirmed there's no actual disk write between the two mutations it worried about (`setPostRunPhase` is in-memory only, no `await` in between), so it wasn't a real bug.

**Note:** this PR was originally opened from a branch accidentally forked off `fix/acceptance-target-protection` instead of `main`, which pulled in ~3.9k unrelated lines and a broken test from that in-progress feature branch, causing CI to fail. Rebased onto `origin/main` via cherry-pick and force-pushed — the diff is now scoped to the two files below.

## Test plan
- [x] `bun test test/integration/execution/status-file.test.ts` — 20/20 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Pre-commit hooks (typecheck, lint, process.cwd, adapter-wrap, dispatch-context) — all passed
- [x] CI on the rebased branch — all 7 checks pass