### PR TITLE
chore: upgrade to TypeScript 7.0.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@biomejs/biome": "^1.9.4",
         "@types/bun": "^1.3.8",
         "react-devtools-core": "^7.0.1",
-        "typescript": "^5.7.3",
+        "typescript": "^7.0.2",
       },
     },
   },
@@ -107,6 +107,46 @@
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "acpx": ["acpx@0.12.1", "", { "dependencies": { "@agentclientprotocol/sdk": "^1.2.1", "commander": "^15.0.0", "skillflag": "^0.2.0", "tsx": "^4.23.0", "zod": "^4.4.3" }, "bin": { "acpx": "dist/cli.js" } }, "sha512-MoV932yPJUcjkX2L9u5TeFncvrxVD+jNTd3ES/tslaiT78S/7CwtgintmX9bonPbSgOB9vinvN+1OCHTQq4HJg=="],
 
@@ -234,7 +274,7 @@
 
     "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@biomejs/biome": "^1.9.4",
     "@types/bun": "^1.3.8",
     "react-devtools-core": "^7.0.1",
-    "typescript": "^5.7.3"
+    "typescript": "^7.0.2"
   },
   "license": "MIT",
   "author": "William Khoo",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": ".",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"],


### PR DESCRIPTION
## What

Upgrades TypeScript from 5.7.3 (resolving to 5.9.3) to 7.0.2 — the native Go port of the compiler — and removes the `baseUrl` option that TS 7 has deleted.

Two commits, deliberately split:

- `chore(tsconfig): drop removed baseUrl option` — verified green under the **old** 5.9.3, so it stands alone and can be reverted independently of the bump.
- `chore(deps): upgrade typescript to 7.0.2`

## Why

`bun run typecheck` drops from **3.71s to 0.51s (7.3x)**. The pre-commit hook runs `typecheck`, so this is felt on every commit, and it is one of six jobs in the CI matrix.

`baseUrl` is a hard blocker rather than a preference — TS 7 errors with `TS5102: Option 'baseUrl' has been removed`. Removal is a no-op for module resolution here because the `paths` entries are already tsconfig-relative (`"@/*": ["./src/*"]`), which is why all 716 alias imports keep resolving and 5.9.3 stays green without it.

## How

The entire diff is three files: one deleted `tsconfig.json` line, the devDep bump, and `bun.lock` picking up the 20 platform-native binary packages that 7.0.2 ships as dependencies.

The risk here is unusually low, and specifically so for this repo:

- **`tsc` is typecheck-only.** `bun build` produces the bundle, so there is no emit-parity exposure at all.
- **Biome is the linter, not typescript-eslint** — the single biggest TS 7 blocker industry-wide, and this repo is not exposed to it.
- **No programmatic `typescript` API consumers.** Zero `from "typescript"` imports; no ts-morph, ts-node, tsx, or ttypescript. TS 7.0's reduced JS API surface cannot bite.
- **Tests are unaffected by design** — Bun transpiles directly and never loads the `typescript` package.
- **No peer constraints.** None of `@types/bun`, `@types/react`, `zod`, `ink`, `commander`, or `acpx` declare a `typescript` peer range.
- **No legacy syntax.** No decorators, `const enum`, `namespace`, or triple-slash refs, and zero `@ts-ignore`/`@ts-expect-error` in `src/`.

## Testing

- [x] Tests added/updated — n/a, no behavioural change
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

Ran the complete CI matrix from `ci.yml:33` locally, plus the build and full suite:

| Gate | Result |
|:--|:--|
| `typecheck` | 0 errors |
| `lint` (Biome + 8 custom checks) | all at baseline |
| `check:dispatch-context` | pass |
| `check:process-cwd` | pass |
| `check:no-adapter-wrap` | pass |
| `check:test-mocks` | pass |
| `build` | nax.js 4.88 MB, unchanged |
| `bun run test` | **0 fail** (1137 integration, 24 ui, unit) |

Correctness parity was checked before committing: across `tsconfig.json`, `tsconfig.contracts.json`, and `tsconfig.dispatch-context.json`, 7.0.2 and 5.9.3 report identical results.

## Notes

No breaking changes to consumers. `dist/` is built by `bun build` and is byte-identical in size; the package publishes no `.d.ts`.

Two pre-existing issues surfaced while validating this, both **out of scope** and unchanged by the upgrade:

1. **`tsconfig.test.json` is dead config.** Nothing invokes it — `git log -S` finds zero commits referencing it from any script, hook, or workflow. It was created in #791 (ADR-020 Wave 2) intending a test-tree typecheck gate, but the gate that actually shipped was the narrow `tsconfig.dispatch-context.json`. Consequently `test/**` and `scripts/**` have never been typechecked, and that config reports **2140 errors** of genuine fixture drift (`RunOptions.statusFile`, stale `PipelineContext` shapes, `nbfRectify.sourceDiffCap`). 7.0.2 reports the identical 2140 with exact per-file parity, so this upgrade neither causes nor hides them.
2. **Stale comment** at `test/unit/runtime/dispatch-context.test.ts:7` claims those type-level tests are validated by `tsconfig.test.json`; they are actually validated by `tsconfig.dispatch-context.json` via `scripts/check-dispatch-context.sh`.

Worth a follow-up issue to burn down the 2140 and wire the config into `typecheck` and CI.
