### PR TITLE
docs(test): correct the validation command in dispatch-context header

### DIFF
--- a/test/unit/runtime/dispatch-context.test.ts
+++ b/test/unit/runtime/dispatch-context.test.ts
@@ -4,7 +4,9 @@
  * Each test creates a value of the subtype and assigns it to the base type.
  * If the subtype does not extend DispatchContext, TypeScript compilation fails.
  *
- * These tests are validated by `bun x tsc --project tsconfig.test.json --noEmit`.
+ * These tests are validated by `bun run check:dispatch-context`, which runs
+ * `bun x tsc --project tsconfig.dispatch-context.json --noEmit` (that config
+ * includes this file only) and is gated in CI.
  */
 
 import { describe, expect, test } from "bun:test";


### PR DESCRIPTION
## What

Corrects the file header of `test/unit/runtime/dispatch-context.test.ts`, which named the wrong config as the thing validating its type-level tests.

```diff
- * These tests are validated by `bun x tsc --project tsconfig.test.json --noEmit`.
+ * These tests are validated by `bun run check:dispatch-context`, which runs
+ * `bun x tsc --project tsconfig.dispatch-context.json --noEmit` (that config
+ * includes this file only) and is gated in CI.
```

Comment-only, 3 insertions and 1 deletion. No code change.

## Why

The old claim was actively misleading in the worst way — it named a config that **runs nowhere**. `tsconfig.test.json` is wired to no script, hook, or workflow (see #1514), so a reader following that header would believe these type-level assertions are enforced by a command nobody executes.

They are in fact enforced, just by a different config: `scripts/check-dispatch-context.sh` runs `tsconfig.dispatch-context.json`, whose `include` is exactly this one file, and `check:dispatch-context` is in the CI matrix at `ci.yml:33`.

This is step 1 of the #1514 plan and the only part that is independent of the larger decision — worth landing whether that issue ends in "gate `test/`" or "delete the config".

## Testing

- [x] Tests added/updated — n/a, comment only
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

Every claim the new comment makes was verified rather than assumed:

| Claim | Check |
|:--|:--|
| `bun run check:dispatch-context` validates this file | runs green |
| that config includes this file only | `tsconfig.dispatch-context.json:3` → `["test/unit/runtime/dispatch-context.test.ts"]` |
| it is gated in CI | `ci.yml:33` matrix includes `check:dispatch-context` |
| the tests still run | 8 pass, 0 fail |

## Notes

Two pre-existing conditions were observed while verifying, both **left untouched** as out of scope — and both are further symptoms of the #1514 root cause rather than new problems:

1. **Editor/LSP reports phantom type errors in this file** (`PipelineContext is missing agentManager, sessionManager, runtime, abortSignal`). These are a config-scope artifact, not a real defect: `tsconfig.json` excludes `test/`, so an editor finds no project for the file and falls back to inferred defaults — pulling in `lib.dom` without `skipLibCheck` or `bun-types`. Reproduced deliberately: checking the file outside its project yields 599 errors, including lib-level `WebAssembly` conflicts. Through the correct config it is clean, under **both** TS 5.9.3 and 7.0.2. Worth noting that the unwired config also degrades the editor experience, not just CI.

2. **Biome flags unsorted imports** in this file. `bun run lint` only covers `src/`, `bin/`, and `flows/`, so `test/` is unlinted as well as untypechecked. Pre-existing and ungated; fixing it here would add unrelated diff noise to a comment fix.

Relates to #1514.
