### PR TITLE
chore: wire the NaxConfig cast gate into CI and pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,4 +22,7 @@ bun run check:no-adapter-wrap
 echo "[pre-commit] Running dispatch context check..."
 bun run check:dispatch-context
 
+echo "[pre-commit] Running NaxConfig cast check..."
+bun run check:naxconfig-cast
+
 echo "[pre-commit] OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        check: [typecheck, lint, check:test-mocks, check:process-cwd, check:no-adapter-wrap, check:dispatch-context]
+        check: [typecheck, lint, check:test-mocks, check:process-cwd, check:no-adapter-wrap, check:dispatch-context, check:naxconfig-cast]
     steps:
       - uses: actions/checkout@v5
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "check:process-cwd": "bash scripts/check-process-cwd.sh",
     "check:no-adapter-wrap": "bash scripts/check-no-adapter-wrap.sh",
     "check:dispatch-context": "bash scripts/check-dispatch-context.sh",
+    "check:naxconfig-cast": "bash scripts/check-no-silent-naxconfig-cast.sh",
     "prepublishOnly": "bun run build",
     "test:full": "FULL=1 NAX_PRECHECK=1 bun test test/ --timeout=60000"
   },

--- a/scripts/check-no-silent-naxconfig-cast.sh
+++ b/scripts/check-no-silent-naxconfig-cast.sh
@@ -3,9 +3,28 @@
 # production source. Test fixtures are excluded — those are intentional
 # partial-config builders.
 #
-# Allowed sites (schema-derived, runtime-validated):
-#   src/config/defaults.ts
-#   src/config/loader.ts
+# Allowed sites — each cast is reached only with a runtime shape the code has
+# already guaranteed, so the assertion cannot silently paper over a partial:
+#
+#   src/config/defaults.ts          schema-derived (NaxConfigSchema.parse)
+#   src/config/loader.ts            follows the layered safeParse
+#   src/operations/setup-generate.ts
+#       :123 casts `result.data` straight out of `NaxConfigSchema.safeParse`,
+#            which throws on failure — same guarantee as loader.ts.
+#       :63  rebuilds an already-typed `NaxConfig` param, only narrowing
+#            `quality.commands`; the cast is forced by a local widening above it.
+#   src/cli/routing-calibrate.ts
+#       :165 merges DEFAULT_CONFIG with the result of `loadConfig`, which
+#            safeParses and throws — two validated configs in, so the cast only
+#            re-narrows `deepMergeConfig`'s `Record<string, unknown>` return.
+#   src/plugins/builtin/nax-finish/config.ts
+#       :51  deliberately accepts an unvalidated object (older configs, partial
+#            test fixtures). `pickSelector.select` is a total property copy and
+#            every field read downstream is optional and default-merged, so a
+#            partial yields defaults rather than an undefined-access.
+#
+# NOTE: entries are matched per FILE, so a new cast added to an allow-listed
+# file is also exempt. Tighten to a per-line ratchet if that becomes a problem.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -17,6 +36,9 @@ matches=$(grep -RnE 'as (unknown as )?NaxConfig\b' src/ \
   --exclude-dir=node_modules \
   | grep -vE '^src/config/defaults\.ts:' \
   | grep -vE '^src/config/loader\.ts:' \
+  | grep -vE '^src/operations/setup-generate\.ts:' \
+  | grep -vE '^src/cli/routing-calibrate\.ts:' \
+  | grep -vE '^src/plugins/builtin/nax-finish/config\.ts:' \
   || true)
 
 if [ -n "$matches" ]; then


### PR DESCRIPTION
`scripts/check-no-silent-naxconfig-cast.sh` existed and worked, but was invoked by nothing — not `lint`, not CI, not the pre-commit hook. So it had been failing unnoticed on four sites in `src/`.

## The four casts are not defects

I traced each to whether the runtime shape is actually guaranteed. None is a live silent-fail:

| Site | Why the shape is guaranteed |
|:--|:--|
| `setup-generate.ts:123` | Casts `result.data` straight out of a `NaxConfigSchema.safeParse` that throws on failure — the same guarantee that already exempts `loader.ts`. |
| `setup-generate.ts:63` | Rebuilds an already-typed `NaxConfig` param, narrowing only `quality.commands`. The cast is forced by a local widening 14 lines above it. |
| `routing-calibrate.ts:165` | Merges `DEFAULT_CONFIG` with `loadConfig`'s output, which safeParses and throws. Two validated configs in, so the cast only re-narrows `deepMergeConfig`'s `Record<string, unknown>` return. |
| `nax-finish/config.ts:51` | Deliberately accepts an unvalidated object (older configs, partial test fixtures). `pickSelector.select` is a total property copy and every field read downstream is optional and default-merged, so a partial yields defaults rather than an undefined access. |

All four are allow-listed with that reasoning recorded at the allow-list itself, so the next reader does not have to re-derive it.

## Wiring

Wired the same way its sibling shell gates (`check:process-cwd`, `check:no-adapter-wrap`, `check:dispatch-context`) already are: a `package.json` script, an entry in the CI check matrix, and a step in the pre-commit hook. Not added to `bun run lint`, matching those siblings.

## Verification

The gate still does its job — this is the check that matters, since an allow-list can quietly neuter one:

- A fresh `as unknown as NaxConfig` in a non-allow-listed file makes it **exit 1** and names the file.
- With that file removed it **exits 0**.

`typecheck` · `lint` · 12293 unit · 1099 integration · 24 ui all green. The pre-commit hook ran the new step on this very commit.

## Known limit

Allow-list entries match per **file**, so a new cast added inside an allow-listed file is also exempt. That is the script's existing design and it is now written down at the allow-list. If it becomes a problem, the fix is a per-line ratchet against a baseline, the way `check-nax-error` and `check-file-sizes` already work.
