### PR TITLE
fix: prevent unsafe regression and test rectification

### DIFF
--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -94,6 +94,7 @@ export function resolveMaxAttemptsOutcome(failureCategory?: FailureCategory): "p
     case "verifier-rejected":
     case "greenfield-no-tests":
     case "no-tests-authored":
+    case "test-incorrect":
       return "pause";
     case "runtime-crash":
       return "pause";

--- a/src/execution/lifecycle/run-regression.ts
+++ b/src/execution/lifecycle/run-regression.ts
@@ -4,8 +4,8 @@
  * Runs full test suite once after all stories complete, then attempts
  * targeted rectification per responsible story. Handles edge cases:
  * - Partial completion: only check stories marked passed
- * - Overlapping file changes: try last modified story first
- * - Unmapped tests: warn and mark all passed stories for re-verification
+ * - Regression attribution: use per-story gate transitions
+ * - Unmapped tests: fail safely without rectifying an unrelated story
  */
 
 import type { NaxConfig } from "@/config";
@@ -19,7 +19,6 @@ import { countStories } from "@/prd";
 import type { NaxRuntime } from "@/runtime";
 import { parseTestOutput } from "@/test-runners";
 import type { TestSummary } from "@/test-runners";
-import { hasCommitsForStory } from "@/utils/git";
 import {
   type FlakeQuarantineReport,
   NULL_QUARANTINE_MEMO,
@@ -97,8 +96,8 @@ export interface DeferredRegressionOptions {
   runtime: NaxRuntime;
   /**
    * Per-story metrics from the main run, carrying per-story gate snapshots
-   * (`failingTestFiles`). When present, regression blame is attributed via
-   * gate transition (accurate) before falling back to the git heuristic.
+   * (`failingTestFiles`). Regression blame is attributed only when a gate
+   * transition identifies a passed story.
    */
   storyMetrics?: readonly StorySnapshot[];
   /**
@@ -144,44 +143,16 @@ export interface DeferredRegressionResult {
 }
 
 /**
- * Map a test file to the story responsible for it via git log.
- *
- * Searches recent commits for story IDs in the format US-NNN.
- * Returns the first matching story ID, or undefined if not found.
- */
-async function findResponsibleStory(
-  testFile: string,
-  workdir: string,
-  passedStories: UserStory[],
-): Promise<UserStory | undefined> {
-  const logger = getSafeLogger();
-
-  // Try each passed story in reverse order (most recent first)
-  for (let i = passedStories.length - 1; i >= 0; i--) {
-    const story = passedStories[i];
-    const hasCommits = await hasCommitsForStory(workdir, story.id, 50);
-    if (hasCommits) {
-      logger?.info("regression", `Mapped test to story ${story.id}`, { testFile });
-      return story;
-    }
-  }
-
-  return undefined;
-}
-
-/**
  * Attribute a failing test file to the story that introduced the regression,
  * using per-story gate snapshots.
  *
  * A snapshot records the tests failing AFTER each story's full-suite gate. The
  * earliest story (chronologically, by `completedAt`) whose snapshot contains
  * the failing test is treated as where it transitioned pass -> fail — i.e. the
- * story responsible for the regression. Unlike the git-recency heuristic in
- * {@link findResponsibleStory} (which blames whichever story most recently
- * committed, regardless of who broke the test), this follows the failing test.
+ * story responsible for the regression. This follows the failing test rather
+ * than guessing from unrelated story commits.
  *
- * Assumptions / limitations (caller falls back to the git heuristic when this
- * returns `undefined`, so a miss degrades to prior behaviour, never worse):
+ * Assumptions / limitations:
  * - **Sequential only.** Callers must withhold snapshots for parallel runs:
  *   `completedAt` order is not causal there and worktrees isolate gate state.
  * - **Green baseline.** "Earliest containing" approximates a true pass -> fail
@@ -393,38 +364,28 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
 
   if (testFilesInFailures.size === 0) {
     logger?.warn("regression", "No test files found in failures (unmapped)");
-    // Mark all passed stories for re-verification
-    for (const story of passedStories) {
-      affectedStories.add(story.id);
-      affectedStoriesObjs.set(story.id, story);
-    }
   } else {
     const testFilesArray = Array.from(testFilesInFailures);
     const snapshots = options.storyMetrics ?? [];
     const passedById = new Map(passedStories.map((s) => [s.id, s]));
 
     for (const testFile of testFilesArray) {
-      // Prefer transition attribution (causal: blames the story where the test
-      // went pass -> fail). Fall back to the git-recency heuristic when no gate
-      // snapshot maps the test to a *passed* story (e.g. single-session +
-      // deferred has no per-story gate, so no snapshots exist).
-      let responsibleStory: UserStory | undefined;
+      // Attribute only with causal evidence: the story where this file first
+      // transitioned to failing. A miss is left unresolved rather than guessed.
       const transitionId = findResponsibleStoryByTransition(testFile, snapshots);
-      if (transitionId && passedById.has(transitionId)) {
-        responsibleStory = passedById.get(transitionId);
+      const responsibleStory = transitionId ? passedById.get(transitionId) : undefined;
+      if (responsibleStory) {
         logger?.info("regression", "Mapped test to story via gate transition", {
           storyId: transitionId,
           testFile,
         });
-      }
-      if (!responsibleStory) {
-        responsibleStory = await findResponsibleStory(testFile, workdir, passedStories);
-      }
-      if (responsibleStory) {
         affectedStories.add(responsibleStory.id);
         affectedStoriesObjs.set(responsibleStory.id, responsibleStory);
       } else {
-        logger?.warn("regression", "Could not map test file to story", { testFile });
+        logger?.warn("regression", "Could not safely map test file to a passed story", {
+          testFile,
+          ...(transitionId ? { transitionStoryId: transitionId } : {}),
+        });
       }
     }
   }

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -190,7 +190,11 @@ export class ExecutionPlan {
     // canonical sequence and runs any phase whose output is missing or non-passing.
     // Halts on first failure (same RED→GREEN contract as the main loop). Skipped
     // entirely when rectification was exhausted — the story is already terminal.
-    if (this.state.rectification && (!rectResult.rectificationExhausted || rectResult.liteScopeIncomplete)) {
+    if (
+      this.state.rectification &&
+      !rectResult.terminalReviewRequired &&
+      (!rectResult.rectificationExhausted || rectResult.liteScopeIncomplete)
+    ) {
       // The first rectification ran with a strategy-specific revalidation set
       // (STRATEGY_TO_REVALIDATION_PHASES) that may have excluded phases this
       // resume block runs for the first time (e.g. full-suite-rectify excludes

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -270,6 +270,13 @@ export async function runRectification(
   if (initialFindings.length === 0) {
     return {};
   }
+  if (initialFindings.some((finding) => finding.category === "incorrect-test-assertion")) {
+    getSafeLogger()?.warn("story-orchestrator", "Incorrect test diagnosis requires human review", {
+      storyId: ctx.storyId,
+      findingCount: initialFindings.length,
+    });
+    return { terminalReviewRequired: true, unfixedFindings: initialFindings };
+  }
   if (!ctx.storyId) {
     // runFixCycle requires storyId for parallel-log correlation.
     return {};

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -261,6 +261,8 @@ export interface RectificationOverrides {
 export interface RectificationResult {
   rectificationExhausted?: boolean;
   unfixedFindings?: readonly Finding[];
+  /** Verifier diagnosed an incorrect test; automatic fixes must stop for human review. */
+  terminalReviewRequired?: boolean;
   /** Validate short-circuited with empty findings — resume must still run scope-backfill phases. */
   liteScopeIncomplete?: boolean;
   /** Populated when exitReason is "agent-gave-up" — the implementer's UNRESOLVED: reason text. */

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -42,6 +42,8 @@ export type FailureCategory =
   | "session-failure"
   /** Tests were written and implemented but still fail after all sessions */
   | "tests-failing"
+  /** Verifier found concrete test assertions that conflict with otherwise-met acceptance criteria */
+  | "test-incorrect"
   /** Full-suite gate failed and rectification retries exhausted before verifier */
   | "full-suite-gate-exhausted"
   /** Verifier explicitly rejected the implementation */

--- a/src/operations/verify.ts
+++ b/src/operations/verify.ts
@@ -80,6 +80,23 @@ function buildVerifierFindings(verdict: VerifierVerdict, categorization: Verdict
         },
       ];
     }
+    case "test-incorrect": {
+      const assertions = verdict.testFailureDiagnosis?.assertions ?? [];
+      const files = assertions.map((assertion) => assertion.file);
+      return [
+        {
+          source: "tdd-verifier",
+          severity: "error",
+          category: "incorrect-test-assertion",
+          fixTarget: "test",
+          message: `Verifier identified incorrect test assertion(s) in ${files.join(", ")}; human review required`,
+          meta: {
+            assertions,
+            reasoning: verdict.reasoning,
+          },
+        },
+      ];
+    }
     default:
       return [];
   }

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -118,6 +118,10 @@ export function routeTddFailure(
       // explicitly to keep the exhaustiveness check honest. An infra prep failure
       // is not auto-recoverable by a stronger tier, so pause for human review.
       return pauseFallback;
+    case "test-incorrect":
+      // Tests are executable specifications. A verifier diagnosis must pause
+      // for a human ruling rather than authorizing automatic source/test edits.
+      return pauseFallback;
     default:
       // Exhaustive check: if a new FailureCategory is added, this errors at compile time.
       failureCategory satisfies never;

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -325,7 +325,8 @@ export class TddPromptBuilder {
       "Re-emit the verdict as the FINAL content of your reply.\n" +
       "Output ONLY the JSON object — no markdown fences, no explanation, no prose.\n" +
       "The reply must start with { and end with } on its own line.\n" +
-      "Required top-level fields: version, approved, tests, testModifications, acceptanceCriteria, quality, fixes, reasoning."
+      "Required top-level fields: version, approved, tests, testModifications, acceptanceCriteria, quality, fixes, reasoning.\n" +
+      'Optional testFailureDiagnosis: null, or {"cause":"test-incorrect","assertions":[{"file":"...","testName":"...","reasoning":"..."}]}.'
     );
   }
 
@@ -345,7 +346,7 @@ export class TddPromptBuilder {
       "- Set reasoning to a single sentence.\n" +
       "Output ONLY the JSON object — no markdown fences, no prose.\n" +
       "Schema (minimal):\n" +
-      `{"version":1,"approved":boolean,"tests":{"allPassing":boolean,"passCount":number,"failCount":number},"testModifications":{"detected":boolean,"files":[],"legitimate":boolean,"reasoning":"..."},"acceptanceCriteria":{"allMet":boolean,"criteria":[]},"quality":{"rating":"good"|"acceptable"|"poor","issues":[]},"fixes":[],"reasoning":"..."}`
+      `{"version":1,"approved":boolean,"tests":{"allPassing":boolean,"passCount":number,"failCount":number},"testModifications":{"detected":boolean,"files":[],"legitimate":boolean,"reasoning":"..."},"testFailureDiagnosis":null,"acceptanceCriteria":{"allMet":boolean,"criteria":[]},"quality":{"rating":"good"|"acceptable"|"poor","issues":[]},"fixes":[],"reasoning":"..."}`
     );
   }
 

--- a/src/prompts/sections/verdict.ts
+++ b/src/prompts/sections/verdict.ts
@@ -28,15 +28,23 @@ Set \`approved: false\` when ANY of these conditions are true:
 - The implementer loosened test assertions to mask bugs
 - The implementer made illegitimate test changes
 
+When tests fail but the implementation satisfies every acceptance criterion and
+a specific test assertion contradicts the specification, set
+\`testFailureDiagnosis.cause\` to \`"test-incorrect"\` and identify each
+assertion with its file, test name, and reasoning. Do not use this diagnosis if
+the implementer modified tests or any acceptance criterion is unmet.
+
 **JSON schema** (fill in all fields with real values):
 
 \`\`\`json
-{"version":1,"approved":true,"tests":{"allPassing":true,"passCount":42,"failCount":0},"testModifications":{"detected":false,"files":[],"legitimate":true,"reasoning":"..."},"acceptanceCriteria":{"allMet":true,"criteria":[{"criterion":"...","met":true}]},"quality":{"rating":"good","issues":[]},"fixes":[],"reasoning":"..."}
+{"version":1,"approved":true,"tests":{"allPassing":true,"passCount":42,"failCount":0},"testModifications":{"detected":false,"files":[],"legitimate":true,"reasoning":"..."},"testFailureDiagnosis":null,"acceptanceCriteria":{"allMet":true,"criteria":[{"criterion":"...","met":true}]},"quality":{"rating":"good","issues":[]},"fixes":[],"reasoning":"..."}
 \`\`\`
 
 **Field notes:**
 - \`quality.rating\` must be one of: \`"good"\`, \`"acceptable"\`, \`"poor"\`
 - \`testModifications.files\` — list any test files the implementer changed
+- \`testFailureDiagnosis\` — normally \`null\`; for a concrete incorrect-test
+  diagnosis use \`{"cause":"test-incorrect","assertions":[{"file":"...","testName":"...","reasoning":"..."}]}\`
 - \`acceptanceCriteria\` and \`quality\` are advisory in this TDD verifier verdict; do not use them to reject semantic correctness
 - \`fixes\` — keep this empty; the verifier must not apply code or test fixes
 - \`reasoning\` — brief summary of your overall assessment

--- a/src/tdd/verdict-reader.ts
+++ b/src/tdd/verdict-reader.ts
@@ -5,10 +5,26 @@
 import { unlink } from "node:fs/promises";
 import path from "node:path";
 import { getLogger } from "../logger";
-import type { VerifierVerdict } from "./verdict";
+import type { TestFailureDiagnosis, VerifierVerdict } from "./verdict";
 
 /** File name written by the verifier agent */
 export const VERDICT_FILE = ".nax-verifier-verdict.json";
+
+function isValidTestFailureDiagnosis(value: unknown): value is TestFailureDiagnosis {
+  if (!value || typeof value !== "object") return false;
+  const diagnosis = value as Record<string, unknown>;
+  if (!["implementation", "test-incorrect", "unknown"].includes(diagnosis.cause as string)) return false;
+  if (!Array.isArray(diagnosis.assertions)) return false;
+  return diagnosis.assertions.every((assertion) => {
+    if (!assertion || typeof assertion !== "object") return false;
+    const item = assertion as Record<string, unknown>;
+    return (
+      typeof item.file === "string" &&
+      typeof item.reasoning === "string" &&
+      (item.testName === undefined || typeof item.testName === "string")
+    );
+  });
+}
 
 /**
  * Validate that a parsed object has the required fields for a VerifierVerdict.
@@ -36,6 +52,14 @@ export function isValidVerdict(obj: unknown): obj is VerifierVerdict {
   if (!Array.isArray(mods.files)) return false;
   if (typeof mods.legitimate !== "boolean") return false;
   if (typeof mods.reasoning !== "string") return false;
+
+  if (
+    v.testFailureDiagnosis !== undefined &&
+    v.testFailureDiagnosis !== null &&
+    !isValidTestFailureDiagnosis(v.testFailureDiagnosis)
+  ) {
+    return false;
+  }
 
   // acceptanceCriteria sub-object
   if (!v.acceptanceCriteria || typeof v.acceptanceCriteria !== "object") return false;
@@ -156,6 +180,9 @@ export function coerceVerdict(obj: Record<string, unknown>): VerifierVerdict | n
         legitimate: true,
         reasoning: "Not assessed in free-form verdict",
       },
+      ...(isValidTestFailureDiagnosis(obj.testFailureDiagnosis)
+        ? { testFailureDiagnosis: obj.testFailureDiagnosis }
+        : {}),
       acceptanceCriteria: { allMet, criteria },
       quality: { rating, issues: [] },
       fixes: Array.isArray(obj.fixes) ? (obj.fixes as string[]) : [],

--- a/src/tdd/verdict.ts
+++ b/src/tdd/verdict.ts
@@ -13,6 +13,17 @@ import type { FailureCategory } from "./types";
 // Re-export for backward compatibility
 export { VERDICT_FILE, isValidVerdict, readVerdict, cleanupVerdict, coerceVerdict } from "./verdict-reader";
 
+export interface TestFailureDiagnosis {
+  /** The verifier's judgment about why story-scoped tests remain red. */
+  cause: "implementation" | "test-incorrect" | "unknown";
+  /** Concrete assertions supporting a test-incorrect judgment. */
+  assertions: Array<{
+    file: string;
+    testName?: string;
+    reasoning: string;
+  }>;
+}
+
 /** Structured verdict written by the verifier (session 3) */
 export interface VerifierVerdict {
   /** Schema version */
@@ -42,6 +53,9 @@ export interface VerifierVerdict {
     /** Reasoning for legitimacy judgment */
     reasoning: string;
   };
+
+  /** Optional structured diagnosis for remaining test failures. */
+  testFailureDiagnosis?: TestFailureDiagnosis | null;
 
   /** Acceptance criteria check */
   acceptanceCriteria: {
@@ -85,9 +99,11 @@ export interface VerdictCategorization {
  * @returns Categorized outcome with optional failureCategory and reviewReason
  *
  * Logic:
- * - verdict.approved = true → success
  * - Not approved, illegitimate test mods → verifier-rejected
+ * - Red tests with an admissible incorrect-test diagnosis → test-incorrect
  * - Not approved, tests failing → tests-failing
+ * - Approved with red tests → tests-failing (approval cannot override test state)
+ * - verdict.approved = true with green tests → success
  * - Not approved for semantic AC/quality concerns only → success (advisory; semantic review owns these)
  * - Not approved, other → success (advisory; verifier only blocks TDD integrity failures)
  * - null verdict, testsPass=true → success
@@ -105,10 +121,6 @@ export function categorizeVerdict(verdict: VerifierVerdict | null, testsPass: bo
     };
   }
 
-  if (verdict.approved) {
-    return { success: true };
-  }
-
   if (verdict.testModifications.detected && !verdict.testModifications.legitimate) {
     const files = verdict.testModifications.files.join(", ") || "unknown files";
     return {
@@ -119,6 +131,14 @@ export function categorizeVerdict(verdict: VerifierVerdict | null, testsPass: bo
   }
 
   if (!verdict.tests.allPassing) {
+    if (hasAdmissibleIncorrectTestDiagnosis(verdict)) {
+      const files = verdict.testFailureDiagnosis?.assertions.map((assertion) => assertion.file).join(", ");
+      return {
+        success: false,
+        failureCategory: "test-incorrect",
+        reviewReason: `Verifier identified incorrect test assertion(s) in ${files}; human review required before changing tests or source.`,
+      };
+    }
     return {
       success: false,
       failureCategory: "tests-failing",
@@ -127,4 +147,16 @@ export function categorizeVerdict(verdict: VerifierVerdict | null, testsPass: bo
   }
 
   return { success: true };
+}
+
+function hasAdmissibleIncorrectTestDiagnosis(verdict: VerifierVerdict): boolean {
+  const diagnosis = verdict.testFailureDiagnosis;
+  return (
+    verdict.approved === false &&
+    verdict.testModifications.detected === false &&
+    verdict.acceptanceCriteria.allMet === true &&
+    diagnosis?.cause === "test-incorrect" &&
+    diagnosis.assertions.length > 0 &&
+    diagnosis.assertions.every((assertion) => assertion.file.trim() !== "" && assertion.reasoning.trim() !== "")
+  );
 }

--- a/test/integration/execution/runner-escalation.test.ts
+++ b/test/integration/execution/runner-escalation.test.ts
@@ -393,6 +393,7 @@ describe("resolveMaxAttemptsOutcome", () => {
     ["isolation-violation", "pause"],
     ["verifier-rejected", "pause"],
     ["greenfield-no-tests", "pause"],
+    ["test-incorrect", "pause"],
     ["session-failure", "fail"],
     ["tests-failing", "fail"],
     ["full-suite-gate-exhausted", "fail"],

--- a/test/integration/pipeline/pipeline.test.ts
+++ b/test/integration/pipeline/pipeline.test.ts
@@ -397,6 +397,14 @@ describe("routeTddFailure", () => {
     });
   });
 
+  describe("test-incorrect", () => {
+    test("pauses with the verifier review reason", () => {
+      const result = routeTddFailure("test-incorrect", false, makeCtx(), "Assertion conflicts with AC7");
+      expect(result.action).toBe("pause");
+      if (result.action === "pause") expect(result.reason).toBe("Assertion conflicts with AC7");
+    });
+  });
+
   describe("no failureCategory (backward compat)", () => {
     test("undefined category → pause with reviewReason, default message, and in lite mode", () => {
       const r1 = routeTddFailure(undefined, false, makeCtx(), "human review needed");
@@ -415,6 +423,7 @@ describe("routeTddFailure", () => {
     const nonIsolationCategories: Array<FailureCategory | undefined> = [
       "session-failure",
       "tests-failing",
+      "test-incorrect",
       "full-suite-gate-exhausted",
       "verifier-rejected",
       undefined,

--- a/test/unit/execution/execution-stage.test.ts
+++ b/test/unit/execution/execution-stage.test.ts
@@ -133,6 +133,15 @@ describe("routeTddFailure", () => {
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
+  it("pauses on test-incorrect with the verifier's review reason", () => {
+    const ctx: MockContext = {};
+    const result = routeTddFailure("test-incorrect", false, ctx, "Incorrect assertion; human review required");
+
+    expect(result.action).toBe("pause");
+    if (result.action === "pause") expect(result.reason).toBe("Incorrect assertion; human review required");
+    expect(ctx.retryAsLite).toBeUndefined();
+  });
+
   it("uses custom reviewReason when pausing", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure(undefined, false, ctx, "Custom reason for pause");

--- a/test/unit/execution/lifecycle-execution.test.ts
+++ b/test/unit/execution/lifecycle-execution.test.ts
@@ -328,7 +328,7 @@ describe("runDeferredRegression - behavioral tests (with mocked deps)", () => {
     expect(result.rectificationAttempts).toBe(0);
   });
 
-  test("unmapped failures (no file field) → all passed stories in affectedStories", async () => {
+  test("unmapped failures (no file field) do not blame passed stories", async () => {
     let verCallCount = 0;
     _regressionDeps.runVerification = mock(async (): Promise<VerificationResult> => {
       verCallCount++;
@@ -372,7 +372,8 @@ describe("runDeferredRegression - behavioral tests (with mocked deps)", () => {
       runtime: makeRuntime(),
     });
 
-    expect(result.affectedStories).toContain("US-001");
-    expect(result.affectedStories).toContain("US-002");
+    expect(result.success).toBe(false);
+    expect(result.affectedStories).toEqual([]);
+    expect(_regressionDeps.runFixCycle).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/execution/lifecycle/run-regression-attribution.test.ts
+++ b/test/unit/execution/lifecycle/run-regression-attribution.test.ts
@@ -1,12 +1,11 @@
 /**
  * Unit tests for deferred-regression blame attribution.
  *
- * Covers the transition-based attribution that replaces the git-recency
- * heuristic: a failing test is attributed to the EARLIEST story whose
+ * Covers transition-based attribution: a failing test is attributed to the
+ * EARLIEST story whose
  * per-story full-suite-gate snapshot shows it failing (i.e. the story where
- * the test transitioned pass -> fail). Falls back to the git heuristic when no
- * snapshot data is available (e.g. single-session + deferred, which has no
- * per-story gate).
+ * the test transitioned pass -> fail). Failures without causal attribution are
+ * left unresolved rather than assigned to an unrelated passed story.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -82,9 +81,9 @@ const deferredConfig = makeNaxConfig({
   },
 });
 
-function makePrd(storyIds: string[]): PRD {
+function makePrd(storyIds: string[], failedStoryIds: ReadonlySet<string> = new Set()): PRD {
   return {
-    userStories: storyIds.map((id) => ({ id, status: "passed", title: id })),
+    userStories: storyIds.map((id) => ({ id, status: failedStoryIds.has(id) ? "failed" : "passed", title: id })),
   } as unknown as PRD;
 }
 
@@ -165,28 +164,15 @@ describe("runDeferredRegression — transition attribution", () => {
     expect(rectified).toEqual(["US-002"]);
   });
 
-  test("falls back to the git heuristic when no snapshot maps the failing test", async () => {
-    // No snapshot contains foo.test.ts → transition returns undefined → git
-    // fallback maps the test to the most-recently-committed passed story.
-    _regressionDeps.runVerification = mock(async () =>
-      _regressionDeps.runVerification.mock.calls.length === 1
-        ? {
-            success: false,
-            status: "TEST_FAILURE",
-            countsTowardEscalation: true,
-            output: "fail",
-            passCount: 0,
-            failCount: 1,
-          }
-        : {
-            success: true,
-            status: "SUCCESS",
-            countsTowardEscalation: false,
-            output: "pass",
-            passCount: 10,
-            failCount: 0,
-          },
-    );
+  test("leaves a failing test unattributed when no snapshot maps it", async () => {
+    _regressionDeps.runVerification = mock(async () => ({
+      success: false,
+      status: "TEST_FAILURE",
+      countsTowardEscalation: true,
+      output: "fail",
+      passCount: 0,
+      failCount: 1,
+    }));
     _regressionDeps.parseTestOutput = mock(() => ({
       passed: 0,
       failed: 1,
@@ -197,39 +183,23 @@ describe("runDeferredRegression — transition attribution", () => {
       rectified.push(cycleCtx.storyId);
       return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
     });
-    // Make every git query report "has commits" so the heuristic returns the
-    // most-recent passed story (US-002).
-    const origSpawn = _gitDeps.spawn;
-    _gitDeps.spawn = mock(() => ({
-      exited: Promise.resolve(0),
-      stdout: "abc1234 commit",
-      stderr: "",
-      kill: () => {},
-    })) as unknown as typeof _gitDeps.spawn;
+    const result = await runDeferredRegression({
+      config: deferredConfig,
+      prd: makePrd(["US-001", "US-002"]),
+      workdir: "/tmp/test-workdir",
+      runtime: makeMockRuntime(),
+      storyMetrics: [
+        snap("US-001", "2026-01-01T00:00:00.000Z", []),
+        snap("US-002", "2026-01-01T00:01:00.000Z", ["bar.test.ts"]),
+      ],
+    } as unknown as DeferredRegressionOptions);
 
-    try {
-      const result = await runDeferredRegression({
-        config: deferredConfig,
-        prd: makePrd(["US-001", "US-002"]),
-        workdir: "/tmp/test-workdir",
-        runtime: makeMockRuntime(),
-        storyMetrics: [
-          snap("US-001", "2026-01-01T00:00:00.000Z", []),
-          snap("US-002", "2026-01-01T00:01:00.000Z", ["bar.test.ts"]),
-        ],
-      } as unknown as DeferredRegressionOptions);
-
-      expect(result.affectedStories).toEqual(["US-002"]);
-      expect(rectified).toEqual(["US-002"]);
-    } finally {
-      _gitDeps.spawn = origSpawn;
-    }
+    expect(result.success).toBe(false);
+    expect(result.affectedStories).toEqual([]);
+    expect(rectified).toEqual([]);
   });
 
-  test("does not blame a transition hit that is not a passed story (guard)", async () => {
-    // Snapshot points at US-099, which is not among the passed stories. The
-    // guard must reject it and fall back to git (which maps nothing in /tmp),
-    // so US-099 is never added to affected stories.
+  test("does not blame a passed story for a failed story's test", async () => {
     _regressionDeps.runVerification = mock(async () => ({
       success: false,
       status: "TEST_FAILURE",
@@ -250,15 +220,29 @@ describe("runDeferredRegression — transition attribution", () => {
       costUsd: 0,
     }));
 
-    const result = await runDeferredRegression({
-      config: deferredConfig,
-      prd: makePrd(["US-001", "US-002"]),
-      workdir: "/tmp/test-workdir",
-      runtime: makeMockRuntime(),
-      storyMetrics: [snap("US-099", "2026-01-01T00:01:00.000Z", ["foo.test.ts"])],
-    } as unknown as DeferredRegressionOptions);
+    const originalSpawn = _gitDeps.spawn;
+    _gitDeps.spawn = mock(() => ({
+      exited: Promise.resolve(0),
+      stdout: "abc1234 chore(US-004): unrelated passing story",
+      stderr: "",
+      kill: () => {},
+    })) as unknown as typeof _gitDeps.spawn;
 
-    expect(result.affectedStories).not.toContain("US-099");
-    expect(result.affectedStories).toEqual([]);
+    try {
+      const result = await runDeferredRegression({
+        config: deferredConfig,
+        prd: makePrd(["US-003", "US-004"], new Set(["US-003"])),
+        workdir: "/tmp/test-workdir",
+        runtime: makeMockRuntime(),
+        storyMetrics: [snap("US-003", "2026-01-01T00:01:00.000Z", ["foo.test.ts"])],
+      } as unknown as DeferredRegressionOptions);
+
+      expect(result.success).toBe(false);
+      expect(result.affectedStories).not.toContain("US-004");
+      expect(result.affectedStories).toEqual([]);
+      expect(_regressionDeps.runFixCycle).not.toHaveBeenCalled();
+    } finally {
+      _gitDeps.spawn = originalSpawn;
+    }
   });
 });

--- a/test/unit/execution/lifecycle/run-regression.test.ts
+++ b/test/unit/execution/lifecycle/run-regression.test.ts
@@ -109,12 +109,26 @@ function makePrd(storyIds: string[]): PRD {
   } as unknown as PRD;
 }
 
+function failuresFor(storyIds: string[]) {
+  return storyIds.map((storyId) => ({
+    file: `${storyId}.test.ts`,
+    testName: `${storyId} regression`,
+    error: "boom",
+    stackTrace: [],
+  }));
+}
+
 function makeOptions(storyIds: string[], runtimeOverride?: NaxRuntime): DeferredRegressionOptions {
   return {
     config: makeConfig(),
     prd: makePrd(storyIds),
     workdir: "/tmp/test-workdir",
     runtime: runtimeOverride ?? makeMockRuntime(),
+    storyMetrics: storyIds.map((storyId, index) => ({
+      storyId,
+      completedAt: new Date(index * 1_000).toISOString(),
+      failingTestFiles: [`${storyId}.test.ts`],
+    })),
   } as unknown as DeferredRegressionOptions;
 }
 
@@ -181,7 +195,7 @@ describe("runDeferredRegression — early exit after first story", () => {
     _regressionDeps.parseTestOutput = mock(() => ({
       passed: 0,
       failed: 92,
-      failures: [], // unmapped → all stories affected
+      failures: failuresFor(["US-001", "US-002", "US-003"]),
     }));
     const rectifiedStories: string[] = [];
     _regressionDeps.runFixCycle = mock(async (_cycle, cycleCtx) => {
@@ -202,7 +216,7 @@ describe("runDeferredRegression — early exit after first story", () => {
     expect(result.storyCosts).toEqual({ "US-001": 0.5 });
   });
 
-  test("count-only failures are treated as unmapped and still trigger deferred rectification", async () => {
+  test("count-only failures remain unresolved instead of rectifying every passed story", async () => {
     const verifyCalls: string[] = [];
 
     _regressionDeps.runVerification = mock(async () => {
@@ -232,11 +246,11 @@ describe("runDeferredRegression — early exit after first story", () => {
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
 
-    expect(result.success).toBe(true);
-    expect(result.affectedStories).toEqual(["US-001", "US-002"]);
-    expect(rectifiedStories).toEqual(["US-001"]);
-    expect(result.rectificationAttempts).toBe(1);
-    expect(verifyCalls).toHaveLength(2);
+    expect(result.success).toBe(false);
+    expect(result.affectedStories).toEqual([]);
+    expect(rectifiedStories).toEqual([]);
+    expect(result.rectificationAttempts).toBe(0);
+    expect(verifyCalls).toHaveLength(1);
   });
 });
 
@@ -262,7 +276,13 @@ describe("runDeferredRegression — synthetic finding when no structured failure
       return makePassResult(230);
     });
 
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 230, failed: 0, failures: [] }));
+    let parseCallCount = 0;
+    _regressionDeps.parseTestOutput = mock(() => {
+      parseCallCount++;
+      return parseCallCount === 1
+        ? { passed: 230, failed: 1, failures: failuresFor(["US-001"]) }
+        : { passed: 230, failed: 0, failures: [] };
+    });
 
     let capturedFindingCount = -1;
     _regressionDeps.runFixCycle = mock(async (cycle, cycleCtx) => {
@@ -301,7 +321,7 @@ describe("runDeferredRegression — early exit after second story", () => {
     _regressionDeps.parseTestOutput = mock(() => ({
       passed: 0,
       failed: 92,
-      failures: [],
+      failures: failuresFor(["US-001", "US-002", "US-003"]),
     }));
     const rectifiedStories: string[] = [];
     _regressionDeps.runFixCycle = mock(async (_cycle, cycleCtx) => {
@@ -336,7 +356,7 @@ describe("runDeferredRegression — no story fixes anything", () => {
     _regressionDeps.parseTestOutput = mock(() => ({
       passed: 0,
       failed: 92,
-      failures: [],
+      failures: failuresFor(["US-001", "US-002"]),
     }));
     _regressionDeps.runFixCycle = mock(async () => makeFixCycleResult(false)); // never fixed
 
@@ -369,7 +389,7 @@ describe("runDeferredRegression — test output context forwarding", () => {
 
     _regressionDeps.parseTestOutput = mock((output) => {
       capturedParseArgs.push(output);
-      return { passed: 0, failed: 92, failures: [] };
+      return { passed: 0, failed: 92, failures: failuresFor(["US-001", "US-002"]) };
     }) as unknown as typeof _regressionDeps.parseTestOutput;
     _regressionDeps.runFixCycle = mock(async () => makeFixCycleResult(true, 0.1));
 
@@ -438,7 +458,7 @@ describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
       if (i === 0) return makeVerifyResult(); // initial: fail
       return makePassResult(); // mid-loop after first story: pass
     });
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 5, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 5, failures: failuresFor(["US-001"]) }));
     _regressionDeps.runFixCycle = mock(async () => makeFixCycleResult(true, 1.2559));
 
     const result = await runDeferredRegression(makeOptions(["US-001"]));
@@ -451,7 +471,7 @@ describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
     // US-001 cycle fails (maxRectificationAttempts = 2, handled inside runFixCycle)
     // Then the final re-run passes
     _regressionDeps.runVerification = mock(async () => makeVerifyResult());
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: failuresFor(["US-001"]) }));
     _regressionDeps.runFixCycle = mock(async () => makeFixCycleResult(false, 1.5, 2));
 
     const result = await runDeferredRegression(makeOptions(["US-001"]));
@@ -470,7 +490,11 @@ describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
       if (i === 1) return makeVerifyResult(); // mid after US-001: still fail
       return makePassResult(); // mid after US-002: pass
     });
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({
+      passed: 0,
+      failed: 3,
+      failures: failuresFor(["US-001", "US-002"]),
+    }));
     let storyIdx = 0;
     _regressionDeps.runFixCycle = mock(async () => {
       storyIdx++;
@@ -492,7 +516,7 @@ describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
 describe("runDeferredRegression — storyDurations + storyOutcomes", () => {
   test("storyDurations is a non-negative number per story", async () => {
     _regressionDeps.runVerification = mock(async () => makeVerifyResult());
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: failuresFor(["US-001"]) }));
     _regressionDeps.runFixCycle = mock(async () => makeFixCycleResult(false, 0.2, 2));
 
     const result = await runDeferredRegression(makeOptions(["US-001"]));
@@ -509,7 +533,11 @@ describe("runDeferredRegression — storyDurations + storyOutcomes", () => {
       if (i === 1) return makeVerifyResult(); // mid after US-001: still fail
       return makeVerifyResult(); // final re-run: still fail
     });
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({
+      passed: 0,
+      failed: 3,
+      failures: failuresFor(["US-001", "US-002"]),
+    }));
     let storyIdx = 0;
     _regressionDeps.runFixCycle = mock(async () => {
       storyIdx++;
@@ -526,7 +554,7 @@ describe("runDeferredRegression — storyDurations + storyOutcomes", () => {
 
   test("storyOutcomes latches true once any cycle succeeds", async () => {
     _regressionDeps.runVerification = mock(async () => makeVerifyResult());
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: failuresFor(["US-001"]) }));
     _regressionDeps.runFixCycle = mock(async () => makeFixCycleResult(true, 0.3));
 
     const result = await runDeferredRegression(makeOptions(["US-001"]));
@@ -568,7 +596,7 @@ describe("runDeferredRegression — runtime threading (AC5/AC6)", () => {
       if (i === 0) return makeVerifyResult(); // initial: fail
       return makePassResult(); // mid-loop: pass → early exit
     });
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: failuresFor(["US-001"]) }));
 
     let capturedAgentManager: unknown;
     _regressionDeps.runFixCycle = mock(async (_cycle, cycleCtx) => {
@@ -593,7 +621,7 @@ describe("runDeferredRegression — runtime threading (AC5/AC6)", () => {
       if (i === 0) return makeVerifyResult();
       return makePassResult();
     });
-    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: failuresFor(["US-001"]) }));
 
     let capturedRuntime: unknown;
     _regressionDeps.runFixCycle = mock(async (_cycle, cycleCtx) => {

--- a/test/unit/execution/rectification-budget-invariants.test.ts
+++ b/test/unit/execution/rectification-budget-invariants.test.ts
@@ -250,6 +250,28 @@ describe("US-005b AC1: nbf runRectification does not record state in storyFixHis
   });
 });
 
+describe("incorrect-test terminal review", () => {
+  test("does not enter the automatic fix cycle", async () => {
+    const runtime = track(makeBudgetRuntime(true));
+    const incorrectTest: Finding = {
+      source: "tdd-verifier",
+      severity: "error",
+      category: "incorrect-test-assertion",
+      message: "Assertion conflicts with AC7",
+      fixTarget: "test",
+    };
+
+    const { dispatchCount, phaseOutputs, result } = await nrRun(runtime, {
+      storyId: "US-1524",
+      overrides: { initialFindings: [incorrectTest] },
+    });
+
+    expect(dispatchCount).toBe(0);
+    expect(phaseOutputs.rectification).toBeUndefined();
+    expect(result).toMatchObject({ terminalReviewRequired: true, unfixedFindings: [incorrectTest] });
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // AC2 — a non-blocking-fix invocation does not consume the blocking budget.
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/operations/verify-op-normalized-findings.test.ts
+++ b/test/unit/operations/verify-op-normalized-findings.test.ts
@@ -59,6 +59,29 @@ function makeVerifierRejectedVerdict(files: string[] = ["test/unit/foo.test.ts"]
   });
 }
 
+function makeIncorrectTestVerdict() {
+  return JSON.stringify({
+    version: 1,
+    approved: false,
+    tests: { allPassing: false, passCount: 4, failCount: 1 },
+    testModifications: { detected: false, files: [], legitimate: true, reasoning: "no mods" },
+    testFailureDiagnosis: {
+      cause: "test-incorrect",
+      assertions: [
+        {
+          file: "test/unit/foo.test.ts",
+          testName: "injects the failure note",
+          reasoning: "The assertion conflicts with AC7.",
+        },
+      ],
+    },
+    acceptanceCriteria: { allMet: true, criteria: [] },
+    quality: { rating: "good", issues: [] },
+    fixes: [],
+    reasoning: "Implementation is conformant; the assertion is incorrect.",
+  });
+}
+
 /** Advisory-only rejection: tests pass, AC not met but quality advisory — categorizeVerdict returns success=true */
 function makeAdvisoryOnlyVerdict() {
   return JSON.stringify({
@@ -230,5 +253,22 @@ describe("AC3: normalizedFindings when verifier-rejected", () => {
     expect(result.normalizedFindings.length).toBe(1);
     expect(result.normalizedFindings.length).toBeGreaterThan(0);
     expect((result.normalizedFindings[0] as Record<string, unknown>).category).toBe("illegitimate-test-edits");
+  });
+});
+
+describe("test-incorrect normalized finding", () => {
+  test("preserves the assertion diagnosis as a test-targeted finding", async () => {
+    const { verifierOp } = await import("@/operations");
+    const ctx = await makeCtx();
+    const parse = verifierOp.parse as ParseFn;
+
+    const result = parse(makeIncorrectTestVerdict(), makeInput(), ctx);
+    const finding = result.normalizedFindings[0] as Record<string, unknown>;
+
+    expect(result.failureCategory).toBe("test-incorrect");
+    expect(result.normalizedFindings).toHaveLength(1);
+    expect(finding.category).toBe("incorrect-test-assertion");
+    expect(finding.fixTarget).toBe("test");
+    expect(finding.message).toContain("test/unit/foo.test.ts");
   });
 });

--- a/test/unit/prd/prd-failure-category.test.ts
+++ b/test/unit/prd/prd-failure-category.test.ts
@@ -145,9 +145,10 @@ describe("FailureCategory export from src/execution", () => {
     const isolation: FailureCategory = "isolation-violation";
     const session: FailureCategory = "session-failure";
     const failing: FailureCategory = "tests-failing";
+    const incorrectTest: FailureCategory = "test-incorrect";
     const gateExhausted: FailureCategory = "full-suite-gate-exhausted";
     const rejected: FailureCategory = "verifier-rejected";
-    expect([isolation, session, failing, gateExhausted, rejected]).toHaveLength(5);
+    expect([isolation, session, failing, incorrectTest, gateExhausted, rejected]).toHaveLength(6);
   });
 });
 

--- a/test/unit/tdd/story-run-result-shape.test.ts
+++ b/test/unit/tdd/story-run-result-shape.test.ts
@@ -45,6 +45,7 @@ describe("StoryRunResult shape fields (Slice D rename verification)", () => {
       "isolation-violation",
       "session-failure",
       "tests-failing",
+      "test-incorrect",
       "full-suite-gate-exhausted",
       "verifier-rejected",
       "greenfield-no-tests",

--- a/test/unit/verification/tdd-verdict.test.ts
+++ b/test/unit/verification/tdd-verdict.test.ts
@@ -288,14 +288,14 @@ describe("categorizeVerdict", () => {
     expect(result.failureCategory).toBeUndefined();
   });
 
-  test("approved=true with failing tests still → success (verifier approved)", () => {
-    // Verifier takes precedence — if it says approved, we trust it
+  test("approved=true cannot override failing tests", () => {
     const verdict = makeVerdict({
       approved: true,
       tests: { allPassing: false, passCount: 5, failCount: 2 },
     });
     const result = categorizeVerdict(verdict, false);
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.failureCategory).toBe("tests-failing");
   });
 
   // --- illegitimate test modifications ---
@@ -347,6 +347,73 @@ describe("categorizeVerdict", () => {
     expect(result.success).toBe(false);
     expect(result.failureCategory).toBe("tests-failing");
     expect(result.reviewReason).toContain("3 failure(s)");
+  });
+
+  test("structured incorrect-test diagnosis pauses source rectification", () => {
+    const verdict = makeVerdict({
+      approved: false,
+      tests: { allPassing: false, passCount: 8, failCount: 1 },
+      testFailureDiagnosis: {
+        cause: "test-incorrect",
+        assertions: [
+          {
+            file: "test/unit/foo.test.ts",
+            testName: "injects the required failure note",
+            reasoning: "The assertion omits the note required by AC7.",
+          },
+        ],
+      },
+    });
+
+    const result = categorizeVerdict(verdict, false);
+
+    expect(result.success).toBe(false);
+    expect(result.failureCategory).toBe("test-incorrect");
+    expect(result.reviewReason).toContain("test/unit/foo.test.ts");
+    expect(result.reviewReason).toContain("human review");
+  });
+
+  test("incorrect-test diagnosis requires concrete assertions", () => {
+    const verdict = makeVerdict({
+      approved: false,
+      tests: { allPassing: false, passCount: 8, failCount: 1 },
+      testFailureDiagnosis: { cause: "test-incorrect", assertions: [] },
+    });
+
+    expect(categorizeVerdict(verdict, false).failureCategory).toBe("tests-failing");
+  });
+
+  test("incorrect-test diagnosis is inadmissible when the implementer modified tests", () => {
+    const verdict = makeVerdict({
+      approved: false,
+      tests: { allPassing: false, passCount: 8, failCount: 1 },
+      testModifications: {
+        detected: true,
+        files: ["test/unit/foo.test.ts"],
+        legitimate: true,
+        reasoning: "Implementer changed the assertion.",
+      },
+      testFailureDiagnosis: {
+        cause: "test-incorrect",
+        assertions: [{ file: "test/unit/foo.test.ts", reasoning: "Assertion is wrong." }],
+      },
+    });
+
+    expect(categorizeVerdict(verdict, false).failureCategory).toBe("tests-failing");
+  });
+
+  test("incorrect-test diagnosis is inadmissible when acceptance criteria are unmet", () => {
+    const verdict = makeVerdict({
+      approved: false,
+      tests: { allPassing: false, passCount: 8, failCount: 1 },
+      acceptanceCriteria: { allMet: false, criteria: [{ criterion: "AC7", met: false }] },
+      testFailureDiagnosis: {
+        cause: "test-incorrect",
+        assertions: [{ file: "test/unit/foo.test.ts", reasoning: "Assertion is wrong." }],
+      },
+    });
+
+    expect(categorizeVerdict(verdict, false).failureCategory).toBe("tests-failing");
   });
 
   // --- advisory acceptance criteria / quality ---


### PR DESCRIPTION
## Summary

Fixes #1523 and Fixes #1524 by making both automated recovery paths fail safely when causality is uncertain.

- Deferred regression recovery now requires transition-based attribution to a passed story and no longer falls back to recent Git commits.
- Verifier verdicts can explicitly diagnose incorrect test assertions with concrete file/reasoning evidence.
- Incorrect-test diagnoses stop automatic rectification and route to terminal human review instead of allowing agents to rewrite tests.
- Red tests cannot be overridden by an otherwise approved verifier verdict.

## Human-review outcome

For #1524, terminal human review means the run pauses with the verifier's concrete incorrect-test diagnosis and preserves the failing tests. No fix cycle edits the tests automatically; a human must decide whether the test is wrong, the implementation is wrong, or the acceptance criteria need clarification.

## Review

Quality-only post-implementation review completed against `origin/main`: **no findings**.

The review traced verdict parsing/categorization, normalized findings, rectification control flow, terminal routing, and regression attribution. It also ran 101 focused tests and typecheck successfully.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test` — 12,398 unit pass; 1,102 integration pass; 24 UI pass
- `git diff --check`
