### PR TITLE
fix(queue): stop the queue command path silently dropping user commands

### DIFF
--- a/src/execution/queue-handler.ts
+++ b/src/execution/queue-handler.ts
@@ -5,6 +5,7 @@
  * Uses rename-before-read pattern to prevent race conditions.
  */
 
+import { rename, unlink } from "node:fs/promises";
 import path from "node:path";
 import { getLogger } from "../logger";
 import { parseQueueFile } from "../queue";
@@ -57,11 +58,17 @@ export async function readQueueFile(workdir: string): Promise<QueueCommand[]> {
       return [];
     }
 
-    // Atomically rename to .processing (prevents concurrent reads)
+    // Atomically rename to .processing (prevents concurrent reads).
+    // Uses node:fs/promises rename (not a `mv` subprocess) — unlike a spawned
+    // `mv`, whose exit code we'd have to inspect manually, `rename()` rejects
+    // on failure so a genuine failure (permission denied, cross-device, the
+    // file already moved by another process) is always caught here.
     try {
-      await Bun.spawn(["mv", queuePath, processingPath], { stdout: "pipe" }).exited;
+      await rename(queuePath, processingPath);
     } catch (error) {
-      // File was already moved by another process, or doesn't exist anymore
+      logger?.warn("queue", "Failed to rename queue file for processing", {
+        error: (error as Error).message,
+      });
       return [];
     }
 
@@ -99,7 +106,7 @@ export async function clearQueueFile(workdir: string): Promise<void> {
     const file = Bun.file(processingPath);
     const exists = await file.exists();
     if (exists) {
-      await Bun.spawn(["rm", processingPath], { stdout: "pipe" }).exited;
+      await unlink(processingPath);
     }
   } catch (error) {
     logger?.warn("queue", "Failed to clear queue file", {

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -55,7 +55,7 @@ export const completionStage: PipelineStage = {
     // Calculate PRD path — prefer ctx.prdPath (already resolved by runner), fall back to
     // featureDir reconstruction, with a last-resort for contexts where neither is set (e.g. tests).
     const prdPath =
-      ctx.prdPath ?? (ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/nax/features/unknown/prd.json`);
+      ctx.prdPath ?? (ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/.nax/features/unknown/prd.json`);
 
     // Collect story metrics
     const storyStartTime = ctx.storyStartTime || new Date().toISOString();

--- a/src/pipeline/stages/queue-check.ts
+++ b/src/pipeline/stages/queue-check.ts
@@ -22,6 +22,41 @@ import {
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 /**
+ * Resolve the PRD path for this pipeline context. Prefers the feature directory
+ * when known; falls back to the canonical `.nax/features/unknown/prd.json` path
+ * (matching the layout documented in `.gitignore` / `.naxignore` /
+ * `src/cli/accept.ts` / `src/cli/features-resolve.ts`) so a missing featureDir
+ * never writes an untracked, un-ignored file into the repo root.
+ */
+function resolvePrdPath(ctx: PipelineContext): string {
+  return ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/.nax/features/unknown/prd.json`;
+}
+
+/**
+ * PAUSE and ABORT stop processing mid-loop and clear the whole queue file — any
+ * commands still unprocessed after the current index are lost with no record.
+ * That control flow is intentional (a paused/aborted run should not keep applying
+ * queued mutations), but the loss must be auditable. Logs one warn naming how many
+ * commands were dropped and their types, before the queue file is cleared.
+ */
+function logDroppedCommands(
+  logger: ReturnType<typeof getLogger>,
+  ctx: PipelineContext,
+  queueCommands: readonly { type: string }[],
+  currentIndex: number,
+): void {
+  const dropped = queueCommands.slice(currentIndex + 1);
+  if (dropped.length === 0) {
+    return;
+  }
+  logger.warn("queue", "Dropped unprocessed queue commands", {
+    storyId: ctx.story?.id ?? "unknown",
+    droppedCount: dropped.length,
+    droppedTypes: dropped.map((c) => c.type),
+  });
+}
+
+/**
  * Queue Check Stage
  *
  * Checks for queue commands (PAUSE/ABORT/SKIP) before executing a story.
@@ -51,9 +86,10 @@ export const queueCheckStage: PipelineStage = {
       return { action: "continue" };
     }
 
-    for (const cmd of queueCommands) {
+    for (const [index, cmd] of queueCommands.entries()) {
       if (cmd.type === "PAUSE") {
         logger.warn("queue", "Paused by user", { storyId: ctx.story?.id ?? "unknown", command: "PAUSE" });
+        logDroppedCommands(logger, ctx, queueCommands, index);
         await clearQueueFile(ctx.workdir);
         return { action: "pause", reason: "User requested pause via .queue.txt" };
       }
@@ -69,8 +105,8 @@ export const queueCheckStage: PipelineStage = {
         }
 
         // Save PRD path from featureDir
-        const prdPath = ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/nax/features/unknown/prd.json`;
-        await savePRD(ctx.prd, prdPath);
+        await savePRD(ctx.prd, resolvePrdPath(ctx));
+        logDroppedCommands(logger, ctx, queueCommands, index);
         await clearQueueFile(ctx.workdir);
 
         return { action: "pause", reason: "User requested abort" };
@@ -80,8 +116,7 @@ export const queueCheckStage: PipelineStage = {
         logger.warn("queue", "Retrying story by user request", { storyId: cmd.storyId });
         resetStoryToPending(ctx.prd, cmd.storyId);
 
-        const prdPath = ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/nax/features/unknown/prd.json`;
-        await savePRD(ctx.prd, prdPath);
+        await savePRD(ctx.prd, resolvePrdPath(ctx));
         continue;
       }
 
@@ -92,8 +127,7 @@ export const queueCheckStage: PipelineStage = {
         });
         setStoryPriority(ctx.prd, cmd.storyId, cmd.value);
 
-        const prdPath = ctx.featureDir ? `${ctx.featureDir}/prd.json` : `${ctx.workdir}/nax/features/unknown/prd.json`;
-        await savePRD(ctx.prd, prdPath);
+        await savePRD(ctx.prd, resolvePrdPath(ctx));
         continue;
       }
 
@@ -118,10 +152,7 @@ export const queueCheckStage: PipelineStage = {
             storyFile: cmd.storyFile,
           });
 
-          const prdPath = ctx.featureDir
-            ? `${ctx.featureDir}/prd.json`
-            : `${ctx.workdir}/nax/features/unknown/prd.json`;
-          await savePRD(ctx.prd, prdPath);
+          await savePRD(ctx.prd, resolvePrdPath(ctx));
         } catch (err) {
           logger.error("queue", "Failed to inject story — skipping INJECT command", {
             storyId: ctx.story?.id ?? "unknown",
@@ -133,24 +164,22 @@ export const queueCheckStage: PipelineStage = {
       }
 
       if (cmd.type === "SKIP") {
-        // Check if this SKIP applies to any story in the current batch
+        logger.warn("queue", "Skipping story by user request", {
+          storyId: cmd.storyId,
+        });
+
+        // Mark as skipped in PRD unconditionally — matches RETRY / PRIORITY / INJECT,
+        // which all mutate ctx.prd regardless of batch membership. Without this, a
+        // SKIP naming a story outside the current batch (e.g. sequential mode, where
+        // ctx.stories has length 1) is silently discarded by clearQueueFile below.
+        // markStorySkipped no-ops for an unknown storyId, same as resetStoryToPending.
+        markStorySkipped(ctx.prd, cmd.storyId);
+        await savePRD(ctx.prd, resolvePrdPath(ctx));
+
+        // Batch membership is an ADDITIONAL, separate action: if the story is part of
+        // the batch currently being executed, also remove it from the batch.
         const isTargeted = ctx.stories.some((s) => s.id === cmd.storyId);
-
         if (isTargeted) {
-          logger.warn("queue", "Skipping story by user request", {
-            storyId: cmd.storyId,
-          });
-
-          // Mark as skipped in PRD
-          markStorySkipped(ctx.prd, cmd.storyId);
-
-          // Save PRD
-          const prdPath = ctx.featureDir
-            ? `${ctx.featureDir}/prd.json`
-            : `${ctx.workdir}/nax/features/unknown/prd.json`;
-          await savePRD(ctx.prd, prdPath);
-
-          // Remove from batch
           ctx.stories = ctx.stories.filter((s) => s.id !== cmd.storyId);
 
           // If batch is now empty, skip this iteration

--- a/src/pipeline/stages/queue-check.ts
+++ b/src/pipeline/stages/queue-check.ts
@@ -182,8 +182,12 @@ export const queueCheckStage: PipelineStage = {
         if (isTargeted) {
           ctx.stories = ctx.stories.filter((s) => s.id !== cmd.storyId);
 
-          // If batch is now empty, skip this iteration
+          // If batch is now empty, skip this iteration. This is the third
+          // early-return path that clears the whole queue file, so it drops any
+          // still-unprocessed commands exactly like PAUSE / ABORT do — audit it
+          // the same way.
           if (ctx.stories.length === 0) {
+            logDroppedCommands(logger, ctx, queueCommands, index);
             await clearQueueFile(ctx.workdir);
             return { action: "skip", reason: "All stories in batch were skipped" };
           }

--- a/test/unit/execution/queue-handler.test.ts
+++ b/test/unit/execution/queue-handler.test.ts
@@ -1,0 +1,134 @@
+/**
+ * queue-handler — rename-before-read queue file processing
+ *
+ * Bun-native rename/unlink replace the previous `mv`/`rm` subprocess calls
+ * (see forbidden-patterns-source.md). Also pins that a rename failure is
+ * observable (logged) and non-fatal — readQueueFile returns [] rather than
+ * throwing, and does not leave the run stuck retrying the same failure forever
+ * without a trace.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { clearQueueFile, readQueueFile } from "@/execution";
+import { getLogger, initLogger, resetLogger } from "@/logger";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+async function readWarnLines(logFile: string): Promise<Array<{ stage: string; message: string; data?: Record<string, unknown> }>> {
+  await getLogger().flush();
+  const file = Bun.file(logFile);
+  if (!(await file.exists())) return [];
+  const lines = (await file.text()).trim().split("\n").filter(Boolean);
+  return lines.map((l) => JSON.parse(l)).filter((e) => e.level === "warn");
+}
+
+describe("readQueueFile", () => {
+  let workdir: string;
+  let logFile: string;
+
+  beforeEach(() => {
+    workdir = makeTempDir("nax-queue-handler-");
+    logFile = join(workdir, "audit.jsonl");
+    initLogger({ level: "silent", filePath: logFile });
+  });
+
+  afterEach(() => {
+    resetLogger();
+    cleanupTempDir(workdir);
+  });
+
+  test("missing .queue.txt returns [] with no warn", async () => {
+    const commands = await readQueueFile(workdir);
+
+    expect(commands).toEqual([]);
+    const warns = await readWarnLines(logFile);
+    expect(warns).toHaveLength(0);
+  });
+
+  test("parses commands from an existing .queue.txt", async () => {
+    await Bun.write(join(workdir, ".queue.txt"), "SKIP US-001\nPAUSE\n");
+
+    const commands = await readQueueFile(workdir);
+
+    expect(commands).toEqual([{ type: "SKIP", storyId: "US-001" }, { type: "PAUSE" }]);
+  });
+
+  test("a rename failure logs a specific rename-failure warn, not the generic read-failure fallback", async () => {
+    await Bun.write(join(workdir, ".queue.txt"), "PAUSE\n");
+    // Deny write permission on workdir so the rename cannot create/replace a
+    // directory entry — a real, reproducible EACCES/EPERM failure with no
+    // monkeypatching of globals required.
+    const { chmodSync } = await import("node:fs");
+    chmodSync(workdir, 0o555);
+
+    try {
+      const commands = await readQueueFile(workdir);
+      expect(commands).toEqual([]);
+    } finally {
+      chmodSync(workdir, 0o755);
+    }
+
+    const warns = await readWarnLines(logFile);
+    expect(warns.length).toBeGreaterThan(0);
+    expect(warns[0].stage).toBe("queue");
+    // Pins that the failure is attributed to the rename step specifically —
+    // the old `mv` subprocess's `.exited` resolves (does not reject) on
+    // failure, so its catch block never ran and the generic "Failed to read
+    // queue file" fallback (via a subsequent ENOENT on the never-created
+    // processing file) fired instead, with no mention of "rename".
+    expect(warns[0].message.toLowerCase()).toContain("rename");
+  });
+});
+
+describe("clearQueueFile", () => {
+  let workdir: string;
+  let logFile: string;
+
+  beforeEach(() => {
+    workdir = makeTempDir("nax-queue-handler-clear-");
+    logFile = join(workdir, "audit.jsonl");
+    initLogger({ level: "silent", filePath: logFile });
+  });
+
+  afterEach(() => {
+    resetLogger();
+    cleanupTempDir(workdir);
+  });
+
+  test("missing .queue.txt.processing is a silent no-op", async () => {
+    await clearQueueFile(workdir);
+
+    const warns = await readWarnLines(logFile);
+    expect(warns).toHaveLength(0);
+  });
+
+  test("deletes an existing .queue.txt.processing file", async () => {
+    const processingPath = join(workdir, ".queue.txt.processing");
+    await Bun.write(processingPath, "PAUSE\n");
+
+    await clearQueueFile(workdir);
+
+    expect(await Bun.file(processingPath).exists()).toBe(false);
+  });
+
+  test("an unlink failure is logged rather than thrown", async () => {
+    const processingPath = join(workdir, ".queue.txt.processing");
+    await Bun.write(processingPath, "PAUSE\n");
+    // Deny write permission on workdir: Bun.file(...).exists() (a stat, needs
+    // only read+execute on the parent) still reports true, but unlink (needs
+    // write on the parent directory) fails with a real EACCES — no
+    // monkeypatching of globals required.
+    const { chmodSync } = await import("node:fs");
+    chmodSync(workdir, 0o555);
+
+    try {
+      await clearQueueFile(workdir);
+    } finally {
+      chmodSync(workdir, 0o755);
+    }
+
+    const warns = await readWarnLines(logFile);
+    expect(warns.length).toBeGreaterThan(0);
+    expect(warns[0].stage).toBe("queue");
+  });
+});

--- a/test/unit/pipeline/stages/queue-check.test.ts
+++ b/test/unit/pipeline/stages/queue-check.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { initLogger, resetLogger } from "@/logger";
+import { getLogger, initLogger, resetLogger } from "@/logger";
 import { queueCheckStage } from "@/pipeline";
 import type { PipelineContext } from "@/pipeline";
 import { cleanupTempDir, makePRD, makeStory, makeTempDir } from "@test/helpers";
@@ -91,6 +91,33 @@ describe("queueCheckStage — RETRY / PRIORITY", () => {
     expect(ctx.stories.map((s) => s.id)).toEqual(["US-001"]);
   });
 
+  test("SKIP for a story outside the current batch still marks it skipped (out-of-batch SKIP is not discarded)", async () => {
+    const s1 = makeStory({ id: "US-001", status: "running" });
+    const s2 = makeStory({ id: "US-007", status: "pending" });
+    const prd = makePRD({ userStories: [s1, s2] });
+    // Sequential mode: ctx.stories only contains the story currently running (US-001).
+    const ctx = makeCtx(workdir, { prd, stories: [s1], story: s1 });
+
+    await Bun.write(join(workdir, ".queue.txt"), "SKIP US-007\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(ctx.prd.userStories[1].status).toBe("skipped");
+    // Not in the current batch, so the batch itself is unaffected.
+    expect(result.action).toBe("continue");
+    expect(ctx.stories.map((s) => s.id)).toEqual(["US-001"]);
+  });
+
+  test("SKIP for an unknown story ID is a no-op and continues", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, ".queue.txt"), "SKIP US-999\n");
+
+    const result = await queueCheckStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.prd.userStories[0].status).toBe("pending");
+  });
+
   test("PAUSE still stops execution (existing behavior)", async () => {
     const ctx = makeCtx(workdir);
     await Bun.write(join(workdir, ".queue.txt"), "PAUSE\n");
@@ -104,6 +131,21 @@ describe("queueCheckStage — RETRY / PRIORITY", () => {
     const ctx = makeCtx(workdir);
     const result = await queueCheckStage.execute(ctx);
     expect(result.action).toBe("continue");
+  });
+
+  test("with no featureDir, the PRD fallback path is under .nax/features/unknown (not nax/features/unknown)", async () => {
+    const failedStory = makeStory({ id: "US-001", status: "failed" });
+    const prd = makePRD({ userStories: [failedStory] });
+    const ctx = makeCtx(workdir, { prd, stories: [failedStory], story: failedStory, featureDir: undefined });
+
+    await Bun.write(join(workdir, ".queue.txt"), "RETRY US-001\n");
+
+    await queueCheckStage.execute(ctx);
+
+    const dotPrdFile = Bun.file(join(workdir, ".nax", "features", "unknown", "prd.json"));
+    const noDotPrdFile = Bun.file(join(workdir, "nax", "features", "unknown", "prd.json"));
+    expect(await dotPrdFile.exists()).toBe(true);
+    expect(await noDotPrdFile.exists()).toBe(false);
   });
 });
 
@@ -259,5 +301,49 @@ describe("queueCheckStage — INJECT", () => {
     } finally {
       cleanupTempDir(outsideDir);
     }
+  });
+});
+
+describe("queueCheckStage — PAUSE/ABORT dropped-command audit", () => {
+  let workdir: string;
+  let logFile: string;
+
+  beforeEach(() => {
+    workdir = makeTempDir("nax-queue-check-dropped-");
+    logFile = join(workdir, "audit.jsonl");
+    initLogger({ level: "silent", filePath: logFile });
+  });
+
+  afterEach(async () => {
+    resetLogger();
+    cleanupTempDir(workdir);
+  });
+
+  test("PAUSE followed by an unprocessed RETRY logs a warn recording the dropped command", async () => {
+    const story = makeStory({ id: "US-001", status: "pending" });
+    const prd = makePRD({ userStories: [story] });
+    const ctx = {
+      workdir,
+      featureDir: workdir,
+      prd,
+      stories: [story],
+      story,
+    } as unknown as PipelineContext;
+
+    await Bun.write(join(workdir, ".queue.txt"), "PAUSE\nRETRY US-002\n");
+
+    const result = await queueCheckStage.execute(ctx);
+    expect(result.action).toBe("pause");
+
+    await getLogger().flush();
+    const lines = (await Bun.file(logFile).text()).trim().split("\n").filter(Boolean);
+    const entries = lines.map((l) => JSON.parse(l));
+    const dropped = entries.find((e) => e.stage === "queue" && e.message.includes("Dropped"));
+
+    expect(dropped).toBeDefined();
+    expect(dropped.data.storyId).toBe(story.id);
+    expect(dropped.data.droppedCount).toBe(1);
+    // storyId must be the first key in the data object (project-conventions.md).
+    expect(Object.keys(dropped.data)[0]).toBe("storyId");
   });
 });

--- a/test/unit/pipeline/stages/queue-check.test.ts
+++ b/test/unit/pipeline/stages/queue-check.test.ts
@@ -346,4 +346,38 @@ describe("queueCheckStage — PAUSE/ABORT dropped-command audit", () => {
     // storyId must be the first key in the data object (project-conventions.md).
     expect(Object.keys(dropped.data)[0]).toBe("storyId");
   });
+
+  test("a SKIP that empties the batch also records the commands it drops", async () => {
+    // Third early-return path that clears the whole queue file: SKIP removes the
+    // last story from the batch, so the stage returns "skip" before reaching the
+    // trailing RETRY. Same loss as PAUSE/ABORT, so it must be audited the same way.
+    const story = makeStory({ id: "US-001", status: "pending" });
+    const other = makeStory({ id: "US-002", status: "failed" });
+    const prd = makePRD({ userStories: [story, other] });
+    const ctx = {
+      workdir,
+      featureDir: workdir,
+      prd,
+      stories: [story],
+      story,
+    } as unknown as PipelineContext;
+
+    await Bun.write(join(workdir, ".queue.txt"), "SKIP US-001\nRETRY US-002\n");
+
+    const result = await queueCheckStage.execute(ctx);
+    expect(result.action).toBe("skip");
+    // The dropped RETRY really did not run — US-002 is still failed.
+    expect(ctx.prd.userStories[1].status).toBe("failed");
+
+    await getLogger().flush();
+    const lines = (await Bun.file(logFile).text()).trim().split("\n").filter(Boolean);
+    const entries = lines.map((l) => JSON.parse(l));
+    const dropped = entries.find((e) => e.stage === "queue" && e.message.includes("Dropped"));
+
+    expect(dropped).toBeDefined();
+    expect(dropped.data.storyId).toBe(story.id);
+    expect(dropped.data.droppedCount).toBe(1);
+    expect(dropped.data.droppedTypes).toEqual(["RETRY"]);
+    expect(Object.keys(dropped.data)[0]).toBe("storyId");
+  });
 });


### PR DESCRIPTION
Fixes four latent bugs in the queue command path (`.queue.txt`), found during a whole-repo review. They share a shape: **a user command is accepted, silently dropped, and then destroyed by `clearQueueFile`** — no mutation, no log, no error.

The queue path's existing tests only covered the happy in-batch case, which is why all four survived.

## 1. Out-of-batch `SKIP` was silently discarded

`SKIP` was gated on batch membership with no `else` branch:

```ts
const isTargeted = ctx.stories.some((s) => s.id === cmd.storyId);
if (isTargeted) { /* markStorySkipped + savePRD + filter batch */ }
```

In sequential mode `ctx.stories` has length 1, so `SKIP US-007` issued while `US-001` is running mutated nothing and was then destroyed by the `clearQueueFile` at the end of the loop.

This was inconsistent with every sibling command — `RETRY`, `PRIORITY` and `INJECT` all mutate `ctx.prd` unconditionally. The documented contract in `src/queue/manager.ts` is "SKIP US-XXX: Skip a specific story", with no batch qualifier. `markStorySkipped` has only two call sites, both in this stage, so nothing else could pick the command up later.

**Fix:** `markStorySkipped` + `savePRD` now run unconditionally, matching the siblings. Batch filtering and the "batch empty → `action: skip`" behaviour remain as an *additional* step gated on membership, so existing in-batch semantics are unchanged.

## 2. PRD fallback path was missing its leading dot

```ts
: `${ctx.workdir}/nax/features/unknown/prd.json`   // no dot
```

The canonical directory is `.nax/features/`. This literal appeared at five sites in `queue-check.ts` and one in `completion.ts`.

This is not a dead path: `merge-conflict-rectify.ts` builds a pipeline context with `featureDir: undefined` and `workdir: worktreePath`, then runs `defaultPipeline` — whose first stage is `queueCheckStage`. And because the path has no dot it matches **none** of the ignore lists (`.gitignore` entries are all `.nax`-prefixed, `.naxignore` is `.nax/`, and `NAX_GITIGNORE_ENTRIES` — written into `.git/info/exclude` for every worktree — is likewise all `.nax`-prefixed). The stray file therefore lands inside the story worktree untracked-but-not-ignored, where the `git add -A` in `autoCommitIfDirty` sweeps it into the story branch. Meanwhile the state it was meant to persist is lost, since no loader reads that location.

**Fix:** corrected to `.nax/features/unknown/prd.json`, with the five duplicated ternaries collapsed into a single `resolvePrdPath(ctx)` helper so there is one literal.

## 3. `mv` failure in `readQueueFile` was unreachable by its own catch

```ts
try {
  await Bun.spawn(["mv", queuePath, processingPath], { stdout: "pipe" }).exited;
} catch (error) {
  // File was already moved by another process, or doesn't exist anymore
  return [];
}
```

`.exited` resolves with the exit code on failure and rejects only when the executable is missing from `$PATH` (verified under Bun 1.3.13). The catch could therefore only ever fire for "`mv` not on PATH" — never for the case its comment describes. Consequences: a failed rename left `.queue.txt` in place, so the same failure recurred on every story for the rest of the run.

**Fix:** replaced the `mv` / `rm` subprocesses with `rename()` / `unlink()` from `node:fs/promises` — the idiom already used elsewhere in the codebase for this pattern (`status-file.ts`, `session/scratch-purge.ts`, `commands/migrate.ts`) — which reject on failure, with an explicit warn on the rename path.

## 4. Early returns silently discarded the rest of the command file

Three paths clear the whole queue file and return mid-loop: `PAUSE`, `ABORT`, and the `SKIP` that empties the batch. A file containing `PAUSE\nRETRY US-002` lost the `RETRY` entirely with no record.

**Fix:** the control flow is intentional and unchanged — a paused or aborted run should not keep applying queued mutations. What was missing is auditability, so each of the three paths now emits one `warn` recording how many commands were dropped and their types before clearing.

## Test plan

Six new tests across `test/unit/pipeline/stages/queue-check.test.ts` and a new `test/unit/execution/queue-handler.test.ts`.

Each was confirmed **red on the unfixed source and green after** — verified by reverting `src/` while keeping the tests, so none of them is a test that would have passed anyway:

- out-of-batch `SKIP` marks the story skipped (received `pending` before the fix)
- unknown-id `SKIP` is a no-op, mirroring `resetStoryToPending`
- with no `featureDir`, the PRD lands under `.nax/features/unknown/` and **not** under `nax/features/unknown/`
- a rename failure logs a rename-specific warn rather than the generic read-failure fallback
- an unlink failure is logged rather than thrown
- `PAUSE` followed by an unprocessed `RETRY` logs the drop; likewise a `SKIP` that empties the batch, asserting the dropped `RETRY` genuinely did not run

The rename/unlink failures are driven by real filesystem permissions rather than mocked globals, so no new injection seam was added.

Gates, all run on the final commit:

| Gate | Result |
|:--|:--|
| `bun run typecheck` | exit 0 |
| `bun run lint` | exit 0, all baselines unchanged |
| `bun run test` | exit 0 — unit 12410 pass, integration 1102 pass, ui 24 pass, 0 fail |

## Deliberately out of scope

Two pre-existing behaviours mentioned as context for finding 3 are unchanged, since altering them is a real behavioural shift rather than a bug fix: a stale `.queue.txt.processing` surviving a crash, and the lack of retry/backoff when a rename fails.
