### PR TITLE
fix: key the story-scoped fix budget on the escalation rung, not the tier

### DIFF
--- a/docs/specs/SPEC-story-scoped-fix-budget.md
+++ b/docs/specs/SPEC-story-scoped-fix-budget.md
@@ -45,14 +45,16 @@ All introduced by US-001 in `src/findings/story-fix-history.ts` and re-exported 
 
 | Symbol | Kind | Purpose |
 |:---|:---|:---|
-| `StoryFixState` | interface | `{ iterations, declines }` for one `(story, tier)` |
+| `StoryFixState` | interface | `{ iterations, declines }` for one `(story, tier, agent)` rung |
 | `StoryFixHistory` | type | `Map<string, StoryFixState>` |
 | `createStoryFixHistory()` | function | Construct an empty store |
-| `storyFixKey(storyId, tier?)` | function | Derive the map key; `tier` defaults to `"default"` |
+| `storyFixKey(storyId, tier?, agent?)` | function | Derive the map key; `tier` and `agent` each default to `"default"` |
 | `getStoryFixState(store, key)` | function | Read a state, creating an empty one on miss |
 | `appendStoryFixIterations(store, key, iterations)` | function | Append this cycle's iterations to the state |
 
 `FixCycle.priorIterations` (US-002) and `execution.rectification.storyScopedFixBudget` (US-001) are the other two additions.
+
+> **Amendment (#1530).** The key was originally `(storyId, tier)`. The escalation ladder matches rungs by the `(tier, agent)` tuple and repeated tier names across agents are a supported shape, so a tier-only key could not distinguish a cross-agent rung — the escalated agent inherited the previous rung's exhausted budget and got zero fix iterations. The `agent` segment (read from `ctx.agentName`) closes that. AC-1.4 and AC-1.5 below still hold as written.
 
 ### Integration
 

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -291,7 +291,10 @@ export async function runRectification(
   const storyFixBudgetEnabled =
     !nbfPath && ctx.runtime.configLoader.current().execution?.rectification?.storyScopedFixBudget === true;
   const store = ctx.runtime.storyFixHistory;
-  const fixKey = storyFixBudgetEnabled ? storyFixKey(ctx.storyId, ctx.phaseTelemetry?.tier) : undefined;
+  // Keyed on the full escalation rung (tier AND agent), not the tier alone: a
+  // cross-agent ladder can escalate to a rung that reuses a tier name, and a
+  // tier-only key hands that rung the previous agent's exhausted budget (#1530).
+  const fixKey = storyFixBudgetEnabled ? storyFixKey(ctx.storyId, ctx.phaseTelemetry?.tier, ctx.agentName) : undefined;
   const fixState = fixKey !== undefined && store ? getStoryFixState(store, fixKey) : undefined;
   // Captured before the cycle runs so the exit-reason remap below (US-003 AC6)
   // reflects the budget state the cycle actually started with, independent of

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -166,6 +166,8 @@ export async function runFixCycle<F extends Finding>(
 
   const storyId = ctx.storyId;
   const packageDir = ctx.packageDir;
+  /** Correlation triple every `findings.cycle` log line carries; `storyId` stays first. */
+  const logCtx = { storyId, packageDir, cycleName };
   let totalCostUsd = 0;
 
   // Per-finding retirement ledger (#1369, #1384) — see `createDeclineLedger` for why
@@ -218,9 +220,7 @@ export async function runFixCycle<F extends Finding>(
       const orphanSources = [...new Set(cycle.findings.map((f) => f.source))];
       const retiredStrategies = declines.retiredNames(cycle.strategies, cycle.findings);
       logger?.warn("findings.cycle", "cycle exited — no matching strategy (orphaned findings)", {
-        storyId,
-        packageDir,
-        cycleName,
+        ...logCtx,
         reason: "no-strategy",
         findingsCount: cycle.findings.length,
         orphanSources,
@@ -242,9 +242,7 @@ export async function runFixCycle<F extends Finding>(
     if (uncappedActive.length === 0) {
       const exhaustedStrategy = active.find((s) => countStrategyAttempts(history, s.name) >= s.maxAttempts);
       logger?.info("findings.cycle", "cycle exited — all active strategies exhausted", {
-        storyId,
-        packageDir,
-        cycleName,
+        ...logCtx,
         reason: "max-attempts-per-strategy",
         exhaustedStrategy: exhaustedStrategy?.name,
       });
@@ -261,9 +259,7 @@ export async function runFixCycle<F extends Finding>(
     const totalAttempts = countTotalAttempts(history);
     if (totalAttempts >= cycle.config.maxAttemptsTotal) {
       logger?.info("findings.cycle", "cycle exited — total attempt cap reached", {
-        storyId,
-        packageDir,
-        cycleName,
+        ...logCtx,
         reason: "max-attempts-total",
         totalAttempts,
         maxAttemptsTotal: cycle.config.maxAttemptsTotal,
@@ -280,13 +276,19 @@ export async function runFixCycle<F extends Finding>(
     for (const strategy of uncappedActive) {
       const bailReason = strategy.bailWhen?.(history) ?? null;
       if (bailReason !== null) {
+        // `bailDetail` is computed over `history`, which folds in iterations
+        // carried from earlier cycles for this rung. Without the two counters
+        // below, a bail that fires on purely inherited history reads as a
+        // nonsense log — a detail quoting counts no iteration of THIS cycle
+        // produced (#1530). Report where the numbers came from.
+        const inheritedIterations = cycle.priorIterations?.length ?? 0;
         logger?.info("findings.cycle", "cycle exited — bail predicate fired", {
-          storyId,
-          packageDir,
-          cycleName,
+          ...logCtx,
           reason: "bail-when",
           strategyName: strategy.name,
           bailDetail: bailReason,
+          cycleIterations: cycle.iterations.length,
+          ...(inheritedIterations > 0 ? { inheritedIterations } : {}),
         });
         return finish({
           iterations: cycle.iterations,
@@ -379,9 +381,7 @@ export async function runFixCycle<F extends Finding>(
         // return before doing so, reporting costUsd: 0 for real spend (#1369).
         totalCostUsd += fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
         logger?.info("findings.cycle", "cycle exited — agent gave up", {
-          storyId,
-          packageDir,
-          cycleName,
+          ...logCtx,
           reason: "agent-gave-up",
           strategyName: firstUnresolved.strategyName,
           unresolvedDetail: firstUnresolved.unresolved,
@@ -396,9 +396,7 @@ export async function runFixCycle<F extends Finding>(
       }
 
       logger?.info("findings.cycle", "strategy gave up — retired, continuing with co-run siblings", {
-        storyId,
-        packageDir,
-        cycleName,
+        ...logCtx,
         strategyName: firstUnresolved.strategyName,
         unresolvedDetail: firstUnresolved.unresolved,
         ranWithoutGivingUp: fixesApplied.filter((fa) => !fa.unresolved).map((fa) => fa.strategyName),
@@ -442,9 +440,7 @@ export async function runFixCycle<F extends Finding>(
           logger,
         );
         logger?.warn("findings.cycle", "lite validate failed on terminal exhausted branch", {
-          storyId,
-          packageDir,
-          cycleName,
+          ...logCtx,
           error: errorMessage(err),
         });
         return finish({
@@ -475,9 +471,7 @@ export async function runFixCycle<F extends Finding>(
 
       if (liteFindingsAfter.length === 0 && !liteShortCircuited) {
         logger?.info("findings.cycle", "cycle exited — resolved after terminal lite validate", {
-          storyId,
-          packageDir,
-          cycleName,
+          ...logCtx,
           reason: "resolved",
         });
         return finish({
@@ -506,9 +500,7 @@ export async function runFixCycle<F extends Finding>(
           continue;
         }
         logger?.info("findings.cycle", "cycle exited — validate short-circuited", {
-          storyId,
-          packageDir,
-          cycleName,
+          ...logCtx,
           reason: "validate-short-circuit",
           liteFindingsAfterCount: liteFindingsAfter.length,
         });
@@ -521,9 +513,7 @@ export async function runFixCycle<F extends Finding>(
       }
 
       logger?.info("findings.cycle", "cycle exited — strategy attempt cap reached (lite validate)", {
-        storyId,
-        packageDir,
-        cycleName,
+        ...logCtx,
         reason: "max-attempts-per-strategy",
         exhaustedStrategy: group[0]?.name,
         liteFindingsAfterCount: liteFindingsAfter.length,
@@ -562,9 +552,7 @@ export async function runFixCycle<F extends Finding>(
           });
         }
         logger?.warn("findings.cycle", "validator retry", {
-          storyId,
-          packageDir,
-          cycleName,
+          ...logCtx,
           attempt: validatorAttempt + 1,
           error: errorMessage(err),
         });

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -491,9 +491,7 @@ export async function runFixCycle<F extends Finding>(
         if (companions.length > 0) {
           // Cost already accumulated at the top of this branch.
           logger?.info("findings.cycle", "exclusive strategy exhausted — continuing to companion strategies", {
-            storyId,
-            packageDir,
-            cycleName,
+            ...logCtx,
             exhaustedStrategies: group.map((s) => s.name),
             remainingStrategies: companions.map((s) => s.name),
           });

--- a/src/findings/story-fix-history.ts
+++ b/src/findings/story-fix-history.ts
@@ -1,17 +1,25 @@
 /**
  * Run-scoped story fix history store (US-004).
  *
- * One entry per (storyId, tier) pair, key format `${storyId}::${tier}`. The `tier`
- * segment is `ctx.phaseTelemetry?.tier` so a tier escalation yields a fresh budget
- * — the new model gets a real attempt rather than inheriting the prior model's
- * exhausted budget.
+ * One entry per (storyId, tier, agent) triple, key format
+ * `${storyId}::${tier}::${agent}` — an escalation rung, not just a tier. The
+ * `tier` segment is `ctx.phaseTelemetry?.tier` and the `agent` segment is
+ * `ctx.agentName`, so any escalation yields a fresh budget: the new rung gets a
+ * real attempt rather than inheriting the prior rung's exhausted counters.
+ *
+ * The agent segment is load-bearing, not decorative. `autoMode.escalation.tierOrder`
+ * matches rungs by the (tier, agent) tuple and repeated tier names across agents are
+ * a supported ladder shape (see `execution/escalation/escalation.ts`), so a rung pair
+ * like `fast/agentA -> fast/agentB` is a genuine escalation that a tier-only key
+ * cannot distinguish. Keying on the tier alone handed the escalated agent the
+ * previous agent's exhausted budget, and its cycle bailed at zero iterations (#1530).
  */
 
 import type { Iteration } from "./cycle-types";
 import type { Finding } from "./types";
 
 export interface StoryFixState {
-  /** Iterations from every prior cycle for this (story, tier), in completion order. */
+  /** Iterations from every prior cycle for this (story, tier, agent) rung, in completion order. */
   readonly iterations: readonly Iteration<Finding>[];
   /** Backing store for the decline ledger: strategy name -> declined findingKey set. */
   readonly declines: Map<string, Set<string>>;
@@ -23,8 +31,8 @@ export function createStoryFixHistory(): StoryFixHistory {
   return new Map<string, StoryFixState>();
 }
 
-export function storyFixKey(storyId: string, tier?: string): string {
-  return `${storyId}::${tier ?? "default"}`;
+export function storyFixKey(storyId: string, tier?: string, agent?: string): string {
+  return `${storyId}::${tier ?? "default"}::${agent ?? "default"}`;
 }
 
 export function getStoryFixState(store: StoryFixHistory, key: string): StoryFixState {

--- a/test/unit/execution/rectification-budget-invariants.test.ts
+++ b/test/unit/execution/rectification-budget-invariants.test.ts
@@ -80,6 +80,9 @@ const nrFixOp: RunOperation<{ story: string }, { applied: boolean }, typeof DEFA
   parse: () => ({ applied: true }),
 };
 
+/** Default agent for these contexts; the store key includes it (#1530). */
+const RBI_AGENT = "claude";
+
 function nrStrategy(maxAttempts: number): FixStrategy<Finding, { story: string }, { applied: boolean }> {
   return {
     name: "nr-fix-strategy",
@@ -118,7 +121,7 @@ function nrCtx(
     runtime,
     packageView: runtime.packages.repo(),
     packageDir: "/tmp",
-    agentName: "claude",
+    agentName: RBI_AGENT,
     storyId,
     ...(tier !== undefined
       ? {
@@ -237,7 +240,7 @@ describe("US-005b AC1: nbf runRectification does not record state in storyFixHis
   test("AC1 boundary: a blocking runRectification (no initialFindings) DOES record state for the same story", async () => {
     const runtime = track(makeBudgetRuntime(true));
     const storyId = "US-005b-1-blocking";
-    const key = storyFixKey(storyId, "fast");
+    const key = storyFixKey(storyId, "fast", RBI_AGENT);
 
     await nrRun(runtime, { storyId, tier: "fast" });
 
@@ -493,7 +496,7 @@ describe("US-005b AC4: phase output iterationCount reports this cycle's count, n
     });
 
     // Store accumulated across both cycles.
-    const key = storyFixKey(storyId, "fast");
+    const key = storyFixKey(storyId, "fast", RBI_AGENT);
     expect(getStoryFixState(runtime.storyFixHistory, key).iterations).toHaveLength(3);
 
     // Per-cycle output remained at this cycle's count (1), not the
@@ -654,7 +657,7 @@ describe("US-005b AC7: phaseTelemetry absent → no tier key → budget keyed on
 
     // Default key — proves the write happened under the canonical 'default'
     // segment when no tier is supplied.
-    const key = storyFixKey(storyId); // tier=undefined → "default"
+    const key = storyFixKey(storyId, undefined, RBI_AGENT); // tier=undefined → "default"
     const state = getStoryFixState(runtime.storyFixHistory, key);
     expect(state.iterations.length).toBeGreaterThanOrEqual(1);
   });
@@ -680,6 +683,6 @@ describe("US-005b AC8: ctx.storyId absent → no state recorded in storyFixHisto
     await nrRun(runtime, { storyId, tier: "fast", maxAttempts: 3 });
 
     expect(runtime.storyFixHistory.size).toBe(1);
-    expect(runtime.storyFixHistory.has(storyFixKey(storyId, "fast"))).toBe(true);
+    expect(runtime.storyFixHistory.has(storyFixKey(storyId, "fast", RBI_AGENT))).toBe(true);
   });
 });

--- a/test/unit/execution/story-scoped-fix-budget.test.ts
+++ b/test/unit/execution/story-scoped-fix-budget.test.ts
@@ -20,7 +20,7 @@
  *         (a tier escalation must yield a fresh budget).
  *   AC5 — storyScopedFixBudget enabled + first call runs 2 iterations then a
  *         second call runs 1 iteration for the same story/tier key →
- *         getStoryFixState(store, storyFixKey(storyId, tier)).iterations has
+ *         getStoryFixState(store, storyFixKey(storyId, tier, agent)).iterations has
  *         length 2 after the first, length 3 after the second.
  *   AC6 — storyScopedFixBudget enabled + ExecutionPlan.run executes a story
  *         whose main rectification consumes 2 of a 3-attempt per-strategy
@@ -54,6 +54,9 @@ import type { CallContext, DeterministicOperation, RunOperation } from "@/operat
 const testSel = pickSelector("test-story-budget-sel", "execution");
 
 const RB_FIXOP_NAME = "rb-fixop";
+
+/** Default agent for the test contexts; the store key includes it (#1530). */
+const RB_AGENT = "claude";
 
 const RB_FINDING: Finding = {
   source: "test-runner",
@@ -125,12 +128,12 @@ function createRuntimeWithConfig(config: ReturnType<typeof makeNaxConfig>): NaxR
   return makeTestRuntime({ config, agentManager: makeMockAgentManager() });
 }
 
-function rbCtx(runtime: NaxRuntime, storyId: string, tier?: string): CallContext {
+function rbCtx(runtime: NaxRuntime, storyId: string, tier?: string, agentName = RB_AGENT): CallContext {
   return {
     runtime,
     packageView: runtime.packages.repo(),
     packageDir: "/tmp",
-    agentName: "claude",
+    agentName,
     storyId,
     ...(tier !== undefined
       ? {
@@ -149,12 +152,20 @@ async function rbRun(
   opts: {
     storyId: string;
     tier?: string;
+    agentName?: string;
     maxAttempts?: number;
     resolveAfterCalls?: number;
     overrides?: Record<string, unknown>;
   },
 ): Promise<{ dispatchCount: number; phaseOutputs: Record<string, unknown>; result: unknown }> {
-  const { storyId, tier, maxAttempts = 3, resolveAfterCalls = Number.POSITIVE_INFINITY, overrides } = opts;
+  const {
+    storyId,
+    tier,
+    agentName,
+    maxAttempts = 3,
+    resolveAfterCalls = Number.POSITIVE_INFINITY,
+    overrides,
+  } = opts;
   let dispatchCount = 0;
   let gateCalls = 0;
   const origCallOp = _storyOrchestratorDeps.callOp;
@@ -174,7 +185,7 @@ async function rbRun(
   }) as typeof _storyOrchestratorDeps.callOp;
 
   try {
-    const ctx = rbCtx(runtime, storyId, tier);
+    const ctx = rbCtx(runtime, storyId, tier, agentName);
     const phaseOutputs = rbSeedPhaseOutputs();
     const result = await runRectification(ctx, rbState(maxAttempts), {}, phaseOutputs, {
       skipGateTriage: true,
@@ -279,6 +290,41 @@ describe("US-003 AC4: enabled + same storyId but different tier → fresh budget
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #1530 — a cross-agent escalation rung that reuses a tier name.
+// The ladder matches rungs by (tier, agent), so `fast/agent-a -> fast/agent-b`
+// is a real escalation. Keying the budget on the tier alone handed the escalated
+// agent the previous agent's exhausted counters, so it got zero fix iterations.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("#1530: enabled + same tier but different agent → fresh budget", () => {
+  test("a same-tier cross-agent escalation yields a fresh budget; the same rung stays exhausted", async () => {
+    const runtime = track(makeBudgetRuntime(true));
+
+    const first = await rbRun(runtime, { storyId: "S8", tier: "fast", agentName: "agent-a", maxAttempts: 3 });
+    expect(first.dispatchCount).toBe(3);
+
+    // Same rung — the budget IS shared, so nothing dispatches.
+    const sameRung = await rbRun(runtime, { storyId: "S8", tier: "fast", agentName: "agent-a", maxAttempts: 3 });
+    expect(sameRung.dispatchCount).toBe(0);
+
+    // Next rung up the ladder: same tier name, different agent. The escalated
+    // agent must get its own full cap rather than inheriting an exhausted one.
+    const nextRung = await rbRun(runtime, { storyId: "S8", tier: "fast", agentName: "agent-b", maxAttempts: 3 });
+    expect(nextRung.dispatchCount).toBe(3);
+  });
+
+  test("iterations accumulate per rung, not per tier", async () => {
+    const runtime = track(makeBudgetRuntime(true));
+
+    await rbRun(runtime, { storyId: "S9", tier: "fast", agentName: "agent-a", maxAttempts: 3, resolveAfterCalls: 2 });
+    await rbRun(runtime, { storyId: "S9", tier: "fast", agentName: "agent-b", maxAttempts: 3, resolveAfterCalls: 1 });
+
+    expect(getStoryFixState(runtime.storyFixHistory, storyFixKey("S9", "fast", "agent-a")).iterations).toHaveLength(2);
+    expect(getStoryFixState(runtime.storyFixHistory, storyFixKey("S9", "fast", "agent-b")).iterations).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // AC5 — getStoryFixState(store, storyFixKey(storyId, tier)).iterations
 // accumulates across cycles: first run 2 iterations → length 2; second run 1
 // iteration → length 3.
@@ -290,7 +336,7 @@ describe("US-003 AC5: enabled + store accumulates iterations across cycles", () 
     // First call: stop the gate after 2 fix dispatches so the cycle records
     // exactly two iterations without hitting the per-strategy cap.
     await rbRun(runtime, { storyId: "S6", maxAttempts: 3, resolveAfterCalls: 2 });
-    const key = storyFixKey("S6");
+    const key = storyFixKey("S6", undefined, RB_AGENT);
     expect(getStoryFixState(runtime.storyFixHistory, key).iterations).toHaveLength(2);
 
     // Second call: stop the gate after 1 fix dispatch — exactly one new
@@ -553,7 +599,7 @@ async function runPlanResumeScenario(
       | undefined;
     return {
       dispatchCount,
-      storeIterations: getStoryFixState(runtime.storyFixHistory, storyFixKey(storyId)).iterations.length,
+      storeIterations: getStoryFixState(runtime.storyFixHistory, storyFixKey(storyId, undefined, RB_AGENT)).iterations.length,
       rectificationExitReason: rectOutput?.exitReason,
     };
   } finally {

--- a/test/unit/findings/cycle-prior-iterations.test.ts
+++ b/test/unit/findings/cycle-prior-iterations.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { CallOpFn } from "@/findings/cycle";
 import { createDeclineLedger, runFixCycle } from "@/findings";
+import { makeLogger } from "@test/helpers";
 import type { Finding, FixStrategy, Iteration } from "@/findings";
 import {
   lintA,
@@ -317,6 +318,47 @@ describe("US-002 AC4/AC5 — bailWhen predicates read carried history", () => {
 
     expect(result.exitReason).toBe("bail-when");
     expect(result.bailDetail).toBe("no progress for 3 consecutive iterations");
+  });
+
+  test("[#1530] a bail fired on carried history reports how many iterations were inherited", async () => {
+    // Threshold 2 with two stalled priors: the predicate fires before this
+    // cycle records a single iteration, so `bailDetail` quotes counts that
+    // belong entirely to earlier cycles. The log must say so.
+    const strategy = bailsAfterConsecutiveNoProgress("lint-fix", 2);
+    const cycle = makeCycle([lintA], [strategy], async () => [lintA]);
+    cycle.priorIterations = [
+      stalledPriorIteration([lintA], "lint-fix", 1),
+      stalledPriorIteration([lintA], "lint-fix", 2),
+    ];
+    const logger = makeLogger();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+      logger: logger as unknown as Parameters<typeof runFixCycle>[3]["logger"],
+    });
+
+    expect(result.exitReason).toBe("bail-when");
+    expect(result.iterations).toHaveLength(0);
+
+    const bailLog = logger.calls.find((c) => c.message === "cycle exited — bail predicate fired");
+    expect(bailLog).toBeDefined();
+    expect(bailLog?.data).toMatchObject({ cycleIterations: 0, inheritedIterations: 2 });
+  });
+
+  test("[#1530] a bail with no carried history omits the inherited counter", async () => {
+    const strategy = bailsAfterConsecutiveNoProgress("lint-fix", 1);
+    const cycle = makeCycle([lintA], [strategy], async () => [lintA]);
+    const logger = makeLogger();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", {
+      callOp: makeCallOpMock() as unknown as CallOpFn,
+      logger: logger as unknown as Parameters<typeof runFixCycle>[3]["logger"],
+    });
+
+    expect(result.exitReason).toBe("bail-when");
+    const bailLog = logger.calls.find((c) => c.message === "cycle exited — bail predicate fired");
+    expect(bailLog?.data).toMatchObject({ cycleIterations: 1 });
+    expect(bailLog?.data).not.toHaveProperty("inheritedIterations");
   });
 
   test("AC5: two stalled prior iterations + first live iteration resolves → does NOT bail", async () => {

--- a/test/unit/findings/story-fix-history.test.ts
+++ b/test/unit/findings/story-fix-history.test.ts
@@ -42,13 +42,37 @@ describe("storyFixKey (US-004)", () => {
     const fast = storyFixKey("US-004", "fast");
     const powerful = storyFixKey("US-004", "powerful");
     expect(fast).not.toBe(powerful);
-    expect(fast).toBe("US-004::fast");
-    expect(powerful).toBe("US-004::powerful");
+    expect(fast).toBe("US-004::fast::default");
+    expect(powerful).toBe("US-004::powerful::default");
   });
 
   test("[US-004 AC 5] undefined tier is canonicalised to 'default'", () => {
     expect(storyFixKey("US-004")).toBe(storyFixKey("US-004", "default"));
-    expect(storyFixKey("US-004")).toBe("US-004::default");
+    expect(storyFixKey("US-004")).toBe("US-004::default::default");
+  });
+
+  // The escalation ladder is a (tier, agent) tuple and repeated tier names across
+  // agents are a supported shape, so the tier alone does not identify a rung.
+  test("[#1530] the same tier under different agents produces different keys", () => {
+    const agentA = storyFixKey("US-004", "fast", "agent-a");
+    const agentB = storyFixKey("US-004", "fast", "agent-b");
+    expect(agentA).not.toBe(agentB);
+    expect(agentA).toBe("US-004::fast::agent-a");
+    expect(agentB).toBe("US-004::fast::agent-b");
+  });
+
+  test("[#1530] undefined agent is canonicalised to 'default'", () => {
+    expect(storyFixKey("US-004", "fast")).toBe(storyFixKey("US-004", "fast", "default"));
+  });
+
+  test("[#1530] agent and tier are independently significant", () => {
+    const keys = new Set([
+      storyFixKey("US-004", "fast", "agent-a"),
+      storyFixKey("US-004", "fast", "agent-b"),
+      storyFixKey("US-004", "balanced", "agent-a"),
+      storyFixKey("US-004", "balanced", "agent-b"),
+    ]);
+    expect(keys.size).toBe(4);
   });
 });
 


### PR DESCRIPTION
Fixes #1530. Follow-up to #1522, which fixed the routing half of the same defect.

## What was still broken

#1522 made an escalation record authoritative in `routing.ts`, so a sideways or downward escalated tier survives a router re-classification and the budget key differs. The key itself was untouched:

```ts
// before
export function storyFixKey(storyId: string, tier?: string): string {
  return `${storyId}::${tier ?? "default"}`;
}
```

But the escalation ladder matches rungs by the **(tier, agent) tuple**, and `src/execution/escalation/escalation.ts:19` documents repeated tier names across agents as a supported shape. Any rung pair sharing a tier name still collided — a ladder whose first two rungs are `fast/agentA` then `fast/agentB` collides on the very first escalation.

The consequence is not a cosmetic mis-key. `cycle.priorIterations` is seeded from the store and folded into the bail history (`cycle.ts`), so the escalated agent inherited the previous agent's exhausted strategy counters *and* its bail state. `withIncreasingFailuresBail` fired before a single iteration ran, and the escalated attempt reported `iterationCount: 0` after paying for a full implementer + gates + review pass. `storyScopedFixBudget` defaults to `true`, so this is the default path.

## Change

**Key on the full rung.** `storyFixKey(storyId, tier, agent)` → `${storyId}::${tier}::${agent}`, with the agent segment read from `ctx.agentName` in `rectification.ts`. No type plumbing needed — `CallContext.agentName` is already required and already carries the story's resolved agent.

**Attribute the bail log.** `bailDetail` is computed over `history`, which folds in carried iterations, so a bail on purely inherited history printed counts that no iteration of the logging cycle produced — which is what made the original report read as a nonsense log rather than a carryover. The bail line now carries `cycleIterations`, plus `inheritedIterations` when non-zero.

**One incidental refactor, forced by the file-size gate.** `cycle.ts` sat at exactly its 600-line cap, so the two added log fields breached it. The `storyId` / `packageDir` / `cycleName` triple repeated across all eleven `findings.cycle` log payloads is now bound once as `logCtx` and spread. `storyId` remains the first key, so `check:logger-storyid` still passes. Net effect on the file is −12 lines.

## Tests

New:

- same-tier-different-agent keys diverge; tier and agent are independently significant (4 distinct keys across 2×2)
- undefined agent canonicalises to `default`
- a cross-agent rung gets its own full per-strategy cap while the same rung stays exhausted — the regression test for the actual bug
- iterations accumulate per rung, not per tier
- the bail log reports both counters, and omits `inheritedIterations` when nothing was carried

Updated: existing store reads that addressed keys as `(storyId, tier)` now pass the agent. These were read-side only — no dispatch-count assertion changed, which is the evidence that story-scoping behaviour is otherwise untouched.

## Verification

- `bun run test` — all phases pass (unit 20.4s, integration 10.2s, ui 0.3s, exit 0)
- `bun run typecheck` — clean
- `bun run lint` — clean, including `check:file-sizes` (11 grandfathered, baseline 11) and `check:logger-storyid` (0 violations)
- Pre-commit ran all 17 static gates

Verified RED-first: before the source change, the two behavioural tests failed with `dispatchCount` 0 (expected 3) and inherited iteration counts landing on the wrong key.
