### PR TITLE
fix(worktree): classify merge failures by git state instead of stderr text

### DIFF
--- a/src/execution/merge-conflict-rectify.ts
+++ b/src/execution/merge-conflict-rectify.ts
@@ -84,8 +84,8 @@ export async function rectifyConflictedStory(options: RectifyConflictedStoryOpti
   logger?.info("parallel", "Rectifying story on updated base", { storyId, attempt: "rectification" });
 
   try {
-    const { WorktreeManager } = await import("../worktree/manager");
-    const { MergeEngine } = await import("../worktree/merge");
+    const { WorktreeManager } = await import("../worktree");
+    const { MergeEngine } = await import("../worktree");
     const { runPipeline } = await import("../pipeline/runner");
     const { defaultPipeline } = await import("../pipeline/stages");
     const { routeTask } = await import("../routing");

--- a/src/execution/parallel-batch.ts
+++ b/src/execution/parallel-batch.ts
@@ -97,12 +97,12 @@ export const _parallelBatchDeps = {
   },
 
   createWorktreeManager: async () => {
-    const { WorktreeManager } = await import("../worktree/manager");
+    const { WorktreeManager } = await import("../worktree");
     return new WorktreeManager();
   },
 
-  createMergeEngine: async (worktreeManager: import("../worktree/manager").WorktreeManager) => {
-    const { MergeEngine } = await import("../worktree/merge");
+  createMergeEngine: async (worktreeManager: import("../worktree").WorktreeManager) => {
+    const { MergeEngine } = await import("../worktree");
     return new MergeEngine(worktreeManager);
   },
 
@@ -264,6 +264,16 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
         workerResult.merged.push(story);
         logger?.info("parallel-batch", "Story merged successfully", {
           storyId: mergeResult.storyId,
+        });
+      } else if (mergeResult.failureKind === "error") {
+        // Non-conflict merge failure. Nothing for rectification to resolve, so treat
+        // it as a plain story failure rather than buying an agent session for it.
+        // Only an explicit "error" lands here — an unlabelled failure keeps the
+        // historical conflict path so no caller silently loses rectification.
+        workerResult.failed.push({ story, error: mergeResult.error ?? "merge failed" });
+        logger?.error("parallel-batch", "Merge failed for a non-conflict reason", {
+          storyId: mergeResult.storyId,
+          error: mergeResult.error,
         });
       } else {
         // Merge conflict — move to mergeConflicts for rectification below

--- a/src/execution/parallel-coordinator.ts
+++ b/src/execution/parallel-coordinator.ts
@@ -18,8 +18,7 @@ import type { PRD, UserStory } from "../prd";
 import { markStoryFailed, markStoryPassed, savePRD } from "../prd";
 import type { PostRunStatusWriter } from "../prd";
 import { errorMessage } from "../utils/errors";
-import { WorktreeManager } from "../worktree/manager";
-import { MergeEngine, type StoryDependencies } from "../worktree/merge";
+import { MergeEngine, type StoryDependencies, WorktreeManager } from "../worktree";
 import { executeParallelBatch } from "./parallel-worker";
 import { groupStoriesByDependencies } from "./story-selector";
 
@@ -243,6 +242,15 @@ export async function executeParallel(
           logger?.info("parallel", "Story merged successfully", {
             storyId: mergeResult.storyId,
             retryCount: mergeResult.retryCount,
+          });
+        } else if (mergeResult.failureKind === "error") {
+          // Non-conflict git failure — there is no conflict to rectify, so record the
+          // real cause instead of queueing an agent session that cannot help. Only an
+          // explicit "error" lands here; an unlabelled failure keeps the conflict path.
+          markStoryFailed(currentPrd, mergeResult.storyId, undefined, undefined, statusWriter);
+          logger?.error("parallel", "Merge failed for a non-conflict reason", {
+            storyId: mergeResult.storyId,
+            error: mergeResult.error,
           });
         } else {
           // Merge conflict — mark story as failed

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -22,8 +22,7 @@ import type { routeTask } from "../routing";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { spawn } from "../utils/bun-deps";
 import { captureDiffSummary, captureOutputFiles } from "../utils/git";
-import { WorktreeManager } from "../worktree/manager";
-import { MergeEngine } from "../worktree/merge";
+import { MergeEngine, WorktreeManager } from "../worktree";
 import { handleTierEscalation } from "./escalation";
 import { appendProgress } from "./progress";
 
@@ -160,6 +159,19 @@ export async function handlePipelineSuccess(
   if (ctx.config.execution.storyIsolation === "worktree") {
     const story = ctx.story;
     const mergeResult = await _resultHandlerDeps.mergeEngine.merge(ctx.workdir, story.id);
+    // Only an explicit "error" diverts away from rectification. A failure with no
+    // failureKind keeps the historical behaviour (assume conflict) so a result from
+    // outside this module cannot silently lose its rectification pass.
+    if (!mergeResult.success && mergeResult.failureKind === "error") {
+      // A non-conflict git failure (dirty tree, missing branch, repository stuck
+      // mid-merge). There is nothing for conflict rectification to resolve, so fail
+      // the story with the real cause instead of spending a session on it.
+      logger?.error("worktree", "Merge failed for a non-conflict reason — marking story as failed", {
+        storyId: story.id,
+        error: mergeResult.error,
+      });
+      return { storiesCompletedDelta: 0, costDelta, prd, prdDirty: false };
+    }
     if (!mergeResult.success) {
       // Merge conflict after the story passed all checks — attempt rectification.
       const { rectifyConflictedStory } = await import("./merge-conflict-rectify");

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -1,3 +1,5 @@
 export { WorktreeManager } from "./manager";
+export { _mergeDeps, MergeEngine } from "./merge";
+export type { MergeFailureKind, MergeResult, StoryDependencies } from "./merge";
 export { prepareWorktreeDependencies, WorktreeDependencyPreparationError } from "./dependencies";
 export type { PrepareWorktreeDependenciesOptions, WorktreeDependencyContext, WorktreeInfo } from "./types";

--- a/src/worktree/merge.ts
+++ b/src/worktree/merge.ts
@@ -8,11 +8,29 @@ export const _mergeDeps = {
   spawn,
 };
 
+/**
+ * Why a merge did not succeed.
+ *
+ * `conflict` — git left the repository mid-merge with unmerged paths. This is the
+ * only kind that is rectifiable: there is a real textual conflict for an agent to
+ * resolve.
+ *
+ * `error` — anything else: a dirty working tree, a missing branch, a repository
+ * already stuck mid-merge, a spawn failure. There is no conflict to resolve, so
+ * routing one of these into conflict rectification only spends an agent session
+ * on a problem it cannot fix.
+ */
+export type MergeFailureKind = "conflict" | "error";
+
 export interface MergeResult {
   success: boolean;
   storyId: string;
   conflictFiles?: string[];
   retryCount?: number;
+  /** Set whenever `success` is false. */
+  failureKind?: MergeFailureKind;
+  /** Human-readable cause, carried on `failureKind: "error"` results. */
+  error?: string;
 }
 
 export interface StoryDependencies {
@@ -23,16 +41,51 @@ export class MergeEngine {
   constructor(private worktreeManager: WorktreeManager) {}
 
   /**
-   * Merges branch nax/<storyId> into current branch with --no-ff
-   * Returns { success: true } on clean merge
-   * Returns { success: false, conflictFiles: [...] } on conflict
-   * Cleans up worktree after successful merge
+   * True when the repository has an in-progress merge — i.e. `MERGE_HEAD` resolves.
+   *
+   * This is the authoritative signal for "did a conflict happen?". Reading it from
+   * git rather than string-matching stderr is what keeps one story's leftover state
+   * from being reported as the next story's conflict: `git merge` into a repository
+   * that is already mid-merge fails with "fatal: Exiting because of an unresolved
+   * conflict", whose text contains "conflict" but says nothing about THIS merge.
+   */
+  private async isMidMerge(projectRoot: string): Promise<boolean> {
+    const proc = _mergeDeps.spawn(["git", "rev-parse", "-q", "--verify", "MERGE_HEAD"], {
+      cwd: projectRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return (await proc.exited) === 0;
+  }
+
+  /**
+   * Merges branch nax/<storyId> into the current branch with --no-ff.
+   *
+   * TOTAL over git-level failures — it never throws for them. Callers (`mergeAll`,
+   * `pipeline-result-handler`) treat merging as one step in a longer sequence, so a
+   * throw here aborted the whole batch and discarded the results of stories that had
+   * already merged successfully. Every outcome is a value instead:
+   *
+   *   { success: true }                          clean merge, worktree cleaned up
+   *   { success: false, failureKind: "conflict" } real conflict, aborted, rectifiable
+   *   { success: false, failureKind: "error" }    everything else, NOT rectifiable
    */
   async merge(projectRoot: string, storyId: string): Promise<Omit<MergeResult, "storyId">> {
     const branchName = `nax/${storyId}`;
 
     try {
-      // Perform merge with --no-ff
+      // Guard: never merge into a repository that is already mid-merge. Doing so
+      // fails in a way that reads like this story's own conflict, and would send an
+      // innocent story to rectification carrying the previous story's file list.
+      if (await this.isMidMerge(projectRoot)) {
+        const error = `Repository has an unresolved merge in progress; refusing to merge ${branchName}`;
+        getSafeLogger()?.error("worktree", "Refusing to merge into a mid-merge repository", {
+          storyId,
+          projectRoot,
+        });
+        return { success: false, failureKind: "error", error };
+      }
+
       const mergeProc = _mergeDeps.spawn(
         ["git", "merge", "--no-ff", branchName, "-m", `Merge branch '${branchName}'`],
         {
@@ -63,29 +116,54 @@ export class MergeEngine {
         return { success: true };
       }
 
-      // Merge failed - check for conflicts
-      const output = `${stdout}\n${stderr}`;
-      if (output.includes("CONFLICT") || output.includes("conflict") || output.includes("Automatic merge failed")) {
-        // Extract conflict files
-        const conflictFiles = await this.getConflictFiles(projectRoot);
-
-        // Abort the merge
-        await this.abortMerge(projectRoot);
-
-        return {
-          success: false,
-          conflictFiles,
-        };
-      }
-
-      // Other error
-      throw new Error(`Merge failed: ${stderr || stdout || "unknown error"}`);
+      return await this.classifyMergeFailure(projectRoot, storyId, `${stdout}\n${stderr}`);
     } catch (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-      throw new Error(`Failed to merge branch ${branchName}: ${String(error)}`);
+      // Spawn-level failure (git missing, cwd gone). Still a value, not a throw.
+      getSafeLogger()?.error("worktree", "Merge failed before git could report", {
+        storyId,
+        error: errorMessage(error),
+      });
+      return { success: false, failureKind: "error", error: errorMessage(error) };
     }
+  }
+
+  /**
+   * Decide what a non-zero `git merge` exit actually was, by interrogating the
+   * repository rather than pattern-matching stderr.
+   */
+  private async classifyMergeFailure(
+    projectRoot: string,
+    storyId: string,
+    output: string,
+  ): Promise<Omit<MergeResult, "storyId">> {
+    const logger = getSafeLogger();
+    const conflictFiles = await this.getConflictFiles(projectRoot);
+    const midMerge = await this.isMidMerge(projectRoot);
+
+    // No merge in progress and nothing unmerged => git refused before touching the
+    // index (dirty tree, missing branch, unrelated histories). Not a conflict.
+    if (!midMerge && conflictFiles.length === 0) {
+      const error = output.trim() || "unknown error";
+      logger?.error("worktree", "Merge failed for a non-conflict reason", {
+        storyId,
+        error,
+      });
+      return { success: false, failureKind: "error", error };
+    }
+
+    // A real conflict. Abort so the next story starts from a clean index — and if
+    // the abort does not take, say so rather than reporting a tidy conflict: the
+    // repository is now unusable for every merge that follows.
+    if (!(await this.abortMerge(projectRoot))) {
+      const error = `Merge conflict in ${storyId} could not be aborted; repository left mid-merge`;
+      logger?.error("worktree", "git merge --abort failed — repository left mid-merge", {
+        storyId,
+        conflictFiles,
+      });
+      return { success: false, failureKind: "error", conflictFiles, error };
+    }
+
+    return { success: false, failureKind: "conflict", conflictFiles };
   }
 
   /**
@@ -109,6 +187,8 @@ export class MergeEngine {
           success: false,
           storyId,
           conflictFiles: [],
+          failureKind: "error",
+          error: `Skipped: depends on a story that failed to merge (${deps.filter((d) => failedStories.has(d)).join(", ")})`,
         });
         failedStories.add(storyId);
         continue;
@@ -117,8 +197,10 @@ export class MergeEngine {
       // Try to merge
       let result = await this.merge(projectRoot, storyId);
 
-      // If conflict, retry once after rebasing
-      if (!result.success && result.conflictFiles) {
+      // Only a real conflict is worth a rebase-and-retry. A non-conflict error
+      // (dirty tree, missing branch, repository stuck mid-merge) is not fixed by
+      // rebasing, and retrying it just fails the same way twice.
+      if (result.failureKind === "conflict") {
         try {
           // Rebase worktree on updated base
           await this.rebaseWorktree(projectRoot, storyId);
@@ -133,6 +215,8 @@ export class MergeEngine {
               storyId,
               conflictFiles: result.conflictFiles,
               retryCount: 1,
+              failureKind: result.failureKind ?? "error",
+              error: result.error,
             });
             failedStories.add(storyId);
             continue;
@@ -151,6 +235,8 @@ export class MergeEngine {
             storyId,
             conflictFiles: result.conflictFiles,
             retryCount: 1,
+            failureKind: "error",
+            error: errorMessage(error),
           });
           failedStories.add(storyId);
         }
@@ -162,11 +248,15 @@ export class MergeEngine {
           retryCount: 0,
         });
       } else {
-        // Failed without conflicts (shouldn't happen normally)
+        // Non-conflict failure. Record it and carry on with the remaining stories —
+        // this used to be unreachable because merge() threw instead of returning,
+        // which took the whole batch (and every already-merged result) down with it.
         results.push({
           success: false,
           storyId,
           retryCount: 0,
+          failureKind: result.failureKind ?? "error",
+          error: result.error,
         });
         failedStories.add(storyId);
       }
@@ -296,9 +386,15 @@ export class MergeEngine {
   }
 
   /**
-   * Aborts an in-progress merge
+   * Aborts an in-progress merge. Returns whether the repository was actually
+   * returned to a clean state.
+   *
+   * The exit code is load-bearing: a failed abort leaves MERGE_HEAD set, and every
+   * subsequent `git merge` in the batch then fails with text containing "conflict",
+   * which used to be attributed to whichever story merged next. Callers must be able
+   * to tell "conflict, cleaned up" from "conflict, repository still broken".
    */
-  private async abortMerge(projectRoot: string): Promise<void> {
+  private async abortMerge(projectRoot: string): Promise<boolean> {
     try {
       const proc = _mergeDeps.spawn(["git", "merge", "--abort"], {
         cwd: projectRoot,
@@ -306,13 +402,20 @@ export class MergeEngine {
         stderr: "pipe",
       });
 
-      await proc.exited;
+      const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+      if (exitCode !== 0) {
+        getSafeLogger()?.error("worktree", "Failed to abort merge", {
+          exitCode,
+          stderr: stderr.trim(),
+        });
+        return false;
+      }
+      return true;
     } catch (error) {
-      // Log warning but don't throw - merge might already be aborted
-      const logger = getSafeLogger();
-      logger?.warn("worktree", "Failed to abort merge", {
+      getSafeLogger()?.error("worktree", "Failed to abort merge", {
         error: errorMessage(error),
       });
+      return false;
     }
   }
 }

--- a/test/unit/execution/merge.test.ts
+++ b/test/unit/execution/merge.test.ts
@@ -5,8 +5,8 @@
  * Covers: MergeEngine topological sort and merge logic
  */
 
-import { describe, expect, it } from "bun:test";
-import { MergeEngine } from "../../../src/worktree/merge";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { _mergeDeps, MergeEngine } from "../../../src/worktree/merge";
 import type { StoryDependencies } from "../../../src/worktree/merge";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -265,5 +265,188 @@ describe("MergeEngine.mergeAll", () => {
 
     // Restore original method
     engine.merge = originalMerge;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Git-state classification — these drive the REAL merge() through the injected
+// spawn seam. The suite above stubs engine.merge wholesale, which is why the
+// throw-instead-of-return defect survived: the function under test was replaced.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One faked git invocation. */
+interface FakeProc {
+  exit: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+/** Build a `_mergeDeps.spawn` stand-in that answers per git command. */
+function fakeSpawn(handler: (cmd: readonly string[]) => FakeProc): typeof _mergeDeps.spawn {
+  return ((cmd: string[]) => {
+    const res = handler(cmd);
+    return {
+      exited: Promise.resolve(res.exit),
+      stdout: new Response(res.stdout ?? "").body,
+      stderr: new Response(res.stderr ?? "").body,
+    };
+  }) as unknown as typeof _mergeDeps.spawn;
+}
+
+const isMergeCmd = (cmd: readonly string[]) => cmd[1] === "merge" && cmd[2] === "--no-ff";
+const isAbortCmd = (cmd: readonly string[]) => cmd[1] === "merge" && cmd[2] === "--abort";
+const isMergeHeadProbe = (cmd: readonly string[]) => cmd[1] === "rev-parse" && cmd.includes("MERGE_HEAD");
+const isUnmergedProbe = (cmd: readonly string[]) => cmd[1] === "diff" && cmd.includes("--diff-filter=U");
+
+/** Real `git merge` output for a dirty working tree — note: contains no "conflict". */
+const DIRTY_TREE_STDERR =
+  "error: Your local changes to the following files would be overwritten by merge:\n\tf.txt\nAborting\n";
+
+describe("MergeEngine — non-conflict git failures", () => {
+  let origSpawn: typeof _mergeDeps.spawn;
+
+  beforeEach(() => {
+    origSpawn = _mergeDeps.spawn;
+  });
+
+  afterEach(() => {
+    _mergeDeps.spawn = origSpawn;
+  });
+
+  it("mergeAll stays total when a story fails for a non-conflict reason", async () => {
+    // US-002 fails with the real dirty-tree message: exit 2, no "conflict" text,
+    // repo left clean (no MERGE_HEAD, no unmerged files). Previously this threw
+    // out of mergeAll, discarding US-001's recorded success and never trying US-003.
+    _mergeDeps.spawn = fakeSpawn((cmd) => {
+      if (isMergeCmd(cmd) && cmd[3] === "nax/US-002") return { exit: 2, stderr: DIRTY_TREE_STDERR };
+      if (isMergeCmd(cmd)) return { exit: 0 };
+      if (isMergeHeadProbe(cmd)) return { exit: 1 }; // never mid-merge
+      if (isUnmergedProbe(cmd)) return { exit: 0, stdout: "" }; // no unmerged files
+      return { exit: 0 };
+    });
+
+    const engine = new MergeEngine(mockWorktreeManager);
+    const results = await engine.mergeAll("/repo", ["US-001", "US-002", "US-003"], {});
+
+    expect(results.length).toBe(3);
+    expect(results[0]).toMatchObject({ storyId: "US-001", success: true });
+    expect(results[1]).toMatchObject({ storyId: "US-002", success: false, failureKind: "error" });
+    expect(results[2]).toMatchObject({ storyId: "US-003", success: true });
+    // An "error" is not a conflict — routing it to conflict rectification would
+    // spend an agent session resolving a conflict that does not exist.
+    expect(results[1].conflictFiles ?? []).toEqual([]);
+  });
+
+  it("classifies by repo state, not by the word 'conflict' in stderr", async () => {
+    // Real output when the repo is left mid-merge by an earlier story:
+    //   "fatal: Exiting because of an unresolved conflict."
+    // It contains "conflict", but THIS story caused nothing — the repo is clean
+    // by the time we probe it, so it must be an error, not this story's conflict.
+    _mergeDeps.spawn = fakeSpawn((cmd) => {
+      if (isMergeCmd(cmd)) {
+        return { exit: 128, stderr: "error: Merging is not possible.\nfatal: Exiting because of an unresolved conflict.\n" };
+      }
+      if (isMergeHeadProbe(cmd)) return { exit: 1 };
+      if (isUnmergedProbe(cmd)) return { exit: 0, stdout: "" };
+      return { exit: 0 };
+    });
+
+    const engine = new MergeEngine(mockWorktreeManager);
+    const result = await engine.merge("/repo", "US-001");
+
+    expect(result.success).toBe(false);
+    expect(result.failureKind).toBe("error");
+  });
+
+  it("refuses to merge into a repository that is already mid-merge", async () => {
+    let mergeAttempted = false;
+    _mergeDeps.spawn = fakeSpawn((cmd) => {
+      if (isMergeCmd(cmd)) {
+        mergeAttempted = true;
+        return { exit: 0 };
+      }
+      if (isMergeHeadProbe(cmd)) return { exit: 0 }; // MERGE_HEAD resolves => mid-merge
+      return { exit: 0 };
+    });
+
+    const engine = new MergeEngine(mockWorktreeManager);
+    const result = await engine.merge("/repo", "US-001");
+
+    expect(result.success).toBe(false);
+    expect(result.failureKind).toBe("error");
+    // The guard must fire BEFORE git merge runs — merging into a dirty index is
+    // what produced the misattributed conflict in the first place.
+    expect(mergeAttempted).toBe(false);
+  });
+
+  /**
+   * A conflicting repository, faked with real state transitions: the failing merge
+   * SETS MERGE_HEAD and a successful abort clears it. A fake that answers the
+   * MERGE_HEAD probe with a constant would be answering the pre-merge guard too, so
+   * the guard would short-circuit and the test would pass without the conflict path
+   * ever running.
+   */
+  function conflictingRepo(opts: { abortExit: number; unmerged: string }) {
+    let midMerge = false;
+    return fakeSpawn((cmd) => {
+      if (isMergeCmd(cmd)) {
+        midMerge = true;
+        return { exit: 1, stderr: "CONFLICT (content): Merge conflict in f.txt\n" };
+      }
+      if (isAbortCmd(cmd)) {
+        if (opts.abortExit === 0) midMerge = false;
+        return { exit: opts.abortExit, stderr: opts.abortExit === 0 ? "" : "fatal: could not abort\n" };
+      }
+      if (isMergeHeadProbe(cmd)) return { exit: midMerge ? 0 : 1 };
+      if (isUnmergedProbe(cmd)) return { exit: 0, stdout: opts.unmerged };
+      return { exit: 0 };
+    });
+  }
+
+  it("does not report a clean conflict when git merge --abort fails", async () => {
+    // A genuine conflict, but the abort fails, so the repo stays mid-merge and
+    // every later merge in the batch is invalid. Reporting a plain conflict here
+    // would hand the story to rectification against an unusable repo.
+    _mergeDeps.spawn = conflictingRepo({ abortExit: 128, unmerged: "f.txt\n" });
+
+    const engine = new MergeEngine(mockWorktreeManager);
+    const result = await engine.merge("/repo", "US-001");
+
+    expect(result.success).toBe(false);
+    expect(result.failureKind).toBe("error");
+  });
+
+  it("still reports a real conflict as a conflict, with its files", async () => {
+    _mergeDeps.spawn = conflictingRepo({ abortExit: 0, unmerged: "f.txt\nsrc/g.ts\n" });
+
+    const engine = new MergeEngine(mockWorktreeManager);
+    const result = await engine.merge("/repo", "US-001");
+
+    expect(result.success).toBe(false);
+    expect(result.failureKind).toBe("conflict");
+    expect(result.conflictFiles).toEqual(["f.txt", "src/g.ts"]);
+  });
+
+  it("mergeAll reports every story when the repo is stuck mid-merge", async () => {
+    // The mid-merge guard makes each subsequent story fail fast rather than
+    // being misreported as its own conflict.
+    _mergeDeps.spawn = fakeSpawn((cmd) => {
+      if (isMergeHeadProbe(cmd)) return { exit: 0 };
+      return { exit: 0 };
+    });
+
+    const engine = new MergeEngine(mockWorktreeManager);
+    const results = await engine.mergeAll("/repo", ["US-001", "US-002"], {});
+
+    expect(results.length).toBe(2);
+    expect(results.every((r) => !r.success && r.failureKind === "error")).toBe(true);
+  });
+});
+
+describe("worktree barrel", () => {
+  it("exports the merge surface so consumers need not reach into the leaf module", async () => {
+    const barrel = await import("@/worktree");
+    expect(barrel.MergeEngine).toBeDefined();
+    expect(barrel._mergeDeps).toBeDefined();
   });
 });


### PR DESCRIPTION
Second of two PRs from a whole-repo latent-bug review. The first covered the queue command path (#1531); this one covers worktree merge integration.

Both bugs here are the same root cause: **`merge()` decided what git had done by pattern-matching stderr**, and threw when no pattern matched.

## 1. A non-conflict merge failure aborted the entire run

```ts
// Other error
throw new Error(`Merge failed: ${stderr || stdout || "unknown error"}`);
```

`mergeAll()` called `merge()` unguarded, and the escape did not stop there — the catch in `unified-executor` only re-throws. So a single git failure that did not match a conflict pattern unwound the whole run: stories that had already merged were left merged on disk but recorded as neither `merged` nor `mergeConflicts`, and the remaining stories were never attempted.

The `mergeAll` doc comment promised the opposite ("marks story as failed, continues with remaining stories"), and there was even a branch written for it — but it was **unreachable**, because `merge()` threw rather than returning a failure.

Verified reachable against real git. Two of the three failure modes probed reach the `throw`:

| Trigger | Exit | stderr contains "conflict"? | Old routing |
|:--|:--|:--|:--|
| Dirty working tree over a merged file | 2 | no — `error: Your local changes … would be overwritten` | **throw** |
| Branch missing | 1 | no — `merge: nax/US-999 - not something we can merge` | **throw** |
| Repository already mid-merge | 128 | yes — `fatal: Exiting because of an unresolved conflict` | conflict path — see below |

The first row is not exotic: the base repo is where worktree branches land, and other stages run against it.

This is also not parallel-only. `pipeline-result-handler` calls `merge()` per story whenever `execution.storyIsolation === "worktree"`, which is an independent config flag — so a sequential run with worktree isolation hit the same throw.

**Fix:** failures are values. `merge()` is now total over git-level failures and returns `failureKind: "conflict" | "error"`. The previously-unreachable branch in `mergeAll` is now live, so the batch records the failure and continues.

## 2. A failed `git merge --abort` was attributed to the next story

`abortMerge` never checked its exit code, so a failed abort left the repository mid-merge. The next story's merge then failed with `fatal: Exiting because of an unresolved conflict` — which **contains the substring "conflict"**, so the old classifier called it that story's conflict, and `getConflictFiles` handed it the *previous* story's unmerged paths (`git diff --diff-filter=U` reads live index state, not per-story state). An innocent story was then sent to conflict rectification carrying someone else's file list.

**Fix:** three parts.

- `merge()` classifies by interrogating the repository — `MERGE_HEAD` and unmerged paths — not by matching stderr text.
- `abortMerge` returns whether the repository was actually cleaned. A failed abort is reported as an `error`, not a tidy conflict, because every subsequent merge in the batch is now invalid.
- A guard refuses to merge into a repository that is already mid-merge, so later stories fail fast instead of inheriting the blame.

## 3. `MergeEngine` was not exported from the worktree barrel

`src/worktree/index.ts` exported only `WorktreeManager` and the dependency helpers, so four `src/` files imported the leaf `../worktree/merge` directly — against the barrel rule in `project-conventions.md` — and the sanctioned `_deps` mocking pattern could not reach the merge seam without the same violation.

**Fix:** export `MergeEngine`, `StoryDependencies`, `MergeResult`, `MergeFailureKind` and `_mergeDeps` from the barrel, and switch the four importers onto it.

## Consumer routing

`pipeline-result-handler`, `parallel-batch` and `parallel-coordinator` previously treated *any* merge failure as a conflict and queued rectification. A non-conflict error has nothing to resolve, so that spent an agent session on a problem it could not fix.

They now divert only on an explicit `failureKind: "error"`. A failure result **without** `failureKind` keeps the historical conflict path — deliberately, so that a result originating outside this module cannot silently lose its rectification pass. An earlier revision inverted this and disabled rectification for unlabelled failures; the existing `parallel-batch` test caught it.

## Test plan

Seven new tests in `test/unit/execution/merge.test.ts`, all confirmed **red against the unfixed source and green after** — verified by stashing `src/` while keeping the tests.

They drive the real `merge()` through the `_mergeDeps.spawn` seam. That matters: the pre-existing `mergeAll` tests stub `engine.merge` wholesale, replacing the function under test, which is precisely why the throw survived.

- `mergeAll` stays total when a story fails for a non-conflict reason — the other two stories still merge and are still reported
- classification follows repo state, not the word "conflict" in stderr
- merging into an already-mid-merge repository is refused *before* `git merge` runs
- a failed `git merge --abort` is not reported as a clean conflict
- a real conflict is still a conflict, with its files
- `mergeAll` reports every story when the repo is stuck mid-merge
- the barrel exposes the merge surface

The two conflict-path tests use a stateful git fake whose failing merge *sets* `MERGE_HEAD` and whose successful abort clears it. A constant-answer fake also answers the pre-merge guard, which short-circuits the test into passing for the wrong reason.

Gates on the final rebased commit:

| Gate | Result |
|:--|:--|
| `bun run typecheck` | exit 0 |
| `bun run lint` | exit 0, baselines unchanged |
| `bun run test` | exit 0 — unit 12424 pass, integration 1102 pass, ui 24 pass, 0 fail |

## Note for reviewers

A plain `nax run` does **not** exercise this code. The merge path needs either `execution.storyIsolation: "worktree"` or `parallelCount > 1` with two or more stories; otherwise no `MergeEngine` is constructed.
