### PR TITLE
fix(finish): close five silent-green paths in the nax-finish flow

### DIFF
--- a/flows/nax-finish/flow-ctx.ts
+++ b/flows/nax-finish/flow-ctx.ts
@@ -39,6 +39,8 @@ export interface LoadCtxOutput {
   /** Test-file regex sources from `nax features resolve`; empty = cannot classify. */
   testFileRegex?: string[];
   route?: string;
+  /** Set only when `route` is `escalate` — see `preflight`. */
+  reason?: string;
 }
 
 export function fixAttemptCount(ctx: StepsCtx, fixNodeId: string): number {
@@ -111,15 +113,32 @@ export function findingsOf(ctx: OutputsCtx, phase: FinishPhase): Finding[] {
  * would have discarded the earlier `shaBefore` and silently under-scoped the
  * review.
  *
+ * Only commit steps that actually **committed** anchor the window. A fix node
+ * that edited nothing still records a `commit_*` step, and its `shaBefore` is
+ * the current HEAD — so scoping to it asks the reviewer for `HEAD..HEAD`, an
+ * empty diff, while the prompt tells it the prior findings "have since been
+ * fixed and committed". It returns clean, `route_*` sends the flow onward, and
+ * the findings ship unfixed. That leaves the loop through the green door, so
+ * `MAX_FIX_ATTEMPTS` never catches it. A no-op round therefore either yields
+ * the window to a later real commit, or falls back to a full review.
+ *
+ * Rounds journalled before `committed` existed carry no such field; `!== false`
+ * keeps replaying them on the previous behaviour rather than widening every
+ * resumed review to the whole branch.
+ *
  * Returns null — a full review — when there is no prior review of this phase
- * (round 1), no commit since it (nothing new to look at), or the commit step
- * recorded no `shaBefore`.
+ * (round 1), no commit landed since it (nothing new to look at), or the commit
+ * step recorded no `shaBefore`.
  */
 export function incrementalSince(ctx: OutputsCtx & StepsCtx, phase: "spec" | "quality"): string | null {
   const steps = ctx.state.steps ?? [];
   const lastReview = steps.map((s) => s.nodeId).lastIndexOf(`review_${phase}`);
   if (lastReview < 0) return null;
-  const firstCommit = steps.slice(lastReview + 1).find((s) => s.nodeId.startsWith("commit_"));
+  const firstCommit = steps
+    .slice(lastReview + 1)
+    .find(
+      (s) => s.nodeId.startsWith("commit_") && (s.output as { committed?: boolean } | undefined)?.committed !== false,
+    );
   if (!firstCommit) return null;
   return (firstCommit.output as { shaBefore?: string | null } | undefined)?.shaBefore ?? null;
 }

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -36,6 +36,12 @@
  *   faced mechanical checks. A test-only fix skips the re-review by explicit
  *   cost tradeoff; see `gateCommitRoute` for why that is a known hole. The skip
  *   records `review-skipped`, so it is visible in the audit.
+ * - `load_ctx` and `open_pr` both route to `escalate` rather than throwing on
+ *   their own failures. acpx has no error edge, so a throw ends the run with no
+ *   result file for the plugin to read or notify from — the one outcome that
+ *   must always be reported is "a human is needed" (#1399). `open_pr` matters
+ *   most: it is reached only after every gate is green, so a failed push or
+ *   forge call there discards a completed, verified run.
  * - Every `commit_*` node appends its round to the finish-audit trail as it
  *   happens, rather than a terminal node reconstructing them from
  *   `ctx.state.steps`. Appending live is what makes the trail survive a flow
@@ -49,6 +55,7 @@ import { narrativePrompt, parseNarrativeNode } from "./narrative";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
 import {
   _contextDeps,
+  acceptanceGateNode,
   amendPrBodyNode,
   appendRound,
   buildCommitRound,
@@ -59,21 +66,19 @@ import {
   detectForge,
   filesInCommit,
   loadFinishPrContext,
-  loadQualityCommands,
   openOrPromotePr,
   partitionTestFiles,
   postEscalation,
   preflight,
+  qualityGatesNode,
   resolveFeature,
   routeReviewAndRecord,
-  runAcceptanceGate,
-  runQualityGates,
   writeResult,
 } from "./steps";
 import type { Forge } from "./steps/forge";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle } from "./steps/pr-body";
 import type { FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
-import { MAX_FIX_ATTEMPTS, parseFixVerdict, parseReviewVerdict, repromptCount } from "./verdict";
+import { parseFixVerdict, parseReviewVerdict, repromptCount } from "./verdict";
 
 /**
  * Disabled only on an explicit "0". An unset variable means enabled, so a flow
@@ -92,59 +97,6 @@ export const _openPrDeps = {
   buildFinishTitle,
   buildFinishBody,
 };
-
-/**
- * Re-run the acceptance gate, routing on the shared fix-cap rules.
- *
- * "Nothing ran" is not a pass — the same rule `quality_gates` applies to an
- * unconfigured repo. `nax features resolve` reports `groups: []` for BOTH
- * `no-prd` and `disabled`, and reports `exists: false` for a group whose test
- * was expected at its canonical path but never generated. Treating all of those
- * as green let the flow open a ready PR having verified nothing about the
- * feature's own contract (#1398). Only `disabled` — the repo's explicit opt-out
- * — skips cleanly.
- */
-async function acceptanceGateNode(ctx: {
-  input: unknown;
-  outputs: unknown;
-  state: { steps: { nodeId: string }[] };
-}): Promise<{ route: string; reason?: string; output: string }> {
-  const i = inputOf(ctx);
-  const { groups = [], acceptanceStatus } = loadCtxOf(ctx);
-  if (acceptanceStatus === "disabled") {
-    return { route: "proceed", output: "[acceptance] disabled in .nax/config.json — skipping" };
-  }
-  if (acceptanceStatus === "no-prd") {
-    return {
-      route: "escalate",
-      reason: `Acceptance targets could not be computed (status: no-prd) — nothing was verified for "${i.feature}".`,
-      output: "[acceptance] no prd.json resolved — acceptance targets unknown",
-    };
-  }
-
-  const r = await runAcceptanceGate(i.workdir, groups, { timeoutMs: i.timeouts?.acceptanceMs });
-  if (r.passed) {
-    // A real failure below routes to the fix loop, which is more actionable;
-    // the coverage hole is only reported once the runnable groups are green.
-    if (r.missing.length > 0) {
-      return {
-        route: "escalate",
-        reason: `Acceptance test never generated for: ${r.missing.join(", ")} — that package's contract is unverified.`,
-        output: r.output,
-      };
-    }
-    return { route: "proceed", output: r.output };
-  }
-  const attempts = fixAttemptCount(ctx, "fix_acceptance");
-  if (attempts >= MAX_FIX_ATTEMPTS) {
-    return {
-      route: "escalate",
-      reason: `Acceptance tests still failing after ${attempts} fix attempts.`,
-      output: r.output,
-    };
-  }
-  return { route: "fix", output: r.output };
-}
 
 /**
  * Route for `commit_gate`, whose successor depends on what the fix touched.
@@ -260,6 +212,7 @@ export default defineFlow({
           testFileRegex: resolution.testFileRegex,
           commitsAhead: pf.commitsAhead,
           route: pf.route,
+          ...(pf.reason ? { reason: pf.reason } : {}),
         };
       },
     },
@@ -333,75 +286,7 @@ export default defineFlow({
     commit_gate: commitFixNode("gate"),
     quality_gates: {
       nodeType: "action",
-      async run(ctx) {
-        const i = inputOf(ctx);
-
-        // Acceptance is gate zero here, not just at the `acceptance` node.
-        // Both fix loops that run after it — quality review and this gate —
-        // edit code, and the repo-root `test` command does not cover the
-        // feature's acceptance tests: they live under `<pkg>/.nax/features/<f>/`
-        // and usually need their own runner config. Re-running them here is what
-        // makes "nothing reaches open_pr without the feature's own contract
-        // passing against the tree as it will ship" true on every path (#1398).
-        //
-        // Unconditional, though the common green path re-runs a gate that
-        // already passed: acceptance is the cheapest gate in the pipeline, and a
-        // conditional skip derived from step history would be a check that can
-        // be *wrong* — a silent false green, the failure mode this exists to
-        // prevent.
-        //
-        // `missing` is deliberately ignored: groups are resolved once at
-        // load_ctx, so a coverage hole was already escalated by the acceptance
-        // node and cannot appear here.
-        const acc = await runAcceptanceGate(i.workdir, loadCtxOf(ctx).groups ?? [], {
-          timeoutMs: i.timeouts?.acceptanceMs,
-        });
-        if (!acc.passed) {
-          // Short-circuit: the repo gates are re-run next round anyway, and
-          // skipping them keeps this out of the "nothing configured" branch
-          // below, which would otherwise misreport configured-but-skipped
-          // commands as absent.
-          const accAttempts = fixAttemptCount(ctx, "fix_gate");
-          const failing = ["acceptance"];
-          if (accAttempts >= MAX_FIX_ATTEMPTS) {
-            return {
-              route: "escalate",
-              reason: `A later fix broke the feature's own contract: acceptance still failing after ${accAttempts} fix attempts.`,
-              ran: [],
-              failing,
-              output: acc.output,
-            };
-          }
-          return { route: "fix", ran: [], failing, output: acc.output };
-        }
-
-        const cmds = await loadQualityCommands(i.workdir);
-        const r = await runQualityGates(i.workdir, cmds, { timeoutMs: i.timeouts?.gateMs });
-        if (r.passed) return { route: "green", ran: r.ran, failing: r.failing, output: r.output };
-        // Nothing configured is not a pass — escalate immediately rather than
-        // open a "ready" PR having verified nothing. An LLM fix node cannot
-        // invent the repo's build/test commands.
-        if (r.ran.length === 0) {
-          return {
-            route: "escalate",
-            reason: "No quality.commands configured in .nax/config.json — nax-finish verified nothing.",
-            ran: r.ran,
-            failing: r.failing,
-            output: r.output,
-          };
-        }
-        const attempts = fixAttemptCount(ctx, "fix_gate");
-        if (attempts >= MAX_FIX_ATTEMPTS) {
-          return {
-            route: "escalate",
-            reason: `Quality gates still failing after ${attempts} fix attempts (${r.failing.join(", ")}).`,
-            ran: r.ran,
-            failing: r.failing,
-            output: r.output,
-          };
-        }
-        return { route: "fix", ran: r.ran, failing: r.failing, output: r.output };
-      },
+      run: qualityGatesNode,
     },
     open_pr: {
       nodeType: "action",
@@ -414,7 +299,24 @@ export default defineFlow({
         }
         // Every fix node edited the working tree; without this the PR would be
         // opened from a remote branch missing all of them.
-        const sync = await commitAndPush(i.workdir, i.branch, `fix(${i.feature}): nax-finish automated fixes`);
+        //
+        // Routed, not thrown. acpx has no error edge, so a throw here kills the
+        // flow — and this is the last node on the happy path, reached only once
+        // every gate is green and every fix has landed. It died before
+        // `writeResult`, so the plugin found no result file and notified
+        // nobody: the #1399 failure mode the `escalate` node was hardened
+        // against and this one was not. A protected branch, an expired token or
+        // a non-fast-forward push is exactly the kind of dead end `escalate`
+        // exists to report.
+        let sync: { committed: boolean };
+        try {
+          sync = await commitAndPush(i.workdir, i.branch, `fix(${i.feature}): nax-finish automated fixes`);
+        } catch (error) {
+          return {
+            route: "escalate",
+            reason: `nax-finish could not push "${i.branch}", so no PR was opened: ${String(error)}`,
+          };
+        }
 
         const fallbackTitle = `nax-finish: ${i.feature}`;
         const fallbackBody = `Automated finish of \`${i.feature}\`.`;
@@ -441,7 +343,18 @@ export default defineFlow({
           body = fallbackBody;
         }
 
-        const r = await openOrPromotePr(i.workdir, i.branch, title, body, forge);
+        // Same reasoning as the push above: a forge that refuses to create or
+        // promote (rate limit, revoked token, unrecognised remote) must reach a
+        // human through `escalate`, not take the flow down silently.
+        let r: { status: "opened" | "promoted" | "already-ready"; url?: string };
+        try {
+          r = await openOrPromotePr(i.workdir, i.branch, title, body, forge);
+        } catch (error) {
+          return {
+            route: "escalate",
+            reason: `nax-finish could not open or promote the PR for "${i.branch}": ${String(error)}`,
+          };
+        }
         await writeResult(i, { feature: i.feature, status: r.status, url: r.url });
         // The PR now exists with the mechanical narrative already in place.
         // Anything the narrative node does from here is an improvement on a
@@ -478,12 +391,14 @@ export default defineFlow({
             : routed.route_quality?.route === "escalate"
               ? routed.route_quality
               : undefined;
-        const loopExhausted =
-          outs.acceptance?.route === "escalate"
-            ? outs.acceptance
-            : outs.quality_gates?.route === "escalate"
-              ? outs.quality_gates
-              : undefined;
+        // Ordered by how far down the graph the node sits, so the *last* thing
+        // that gave up names the reason. `load_ctx` and `open_pr` are here
+        // because both can now route here rather than throw — a base ref that
+        // does not resolve, and a push or forge call that failed after every
+        // gate was green.
+        const loopExhausted = [outs.open_pr, outs.quality_gates, outs.acceptance, outs.load_ctx].find(
+          (o) => o?.route === "escalate",
+        );
         const reason =
           verdict?.escalationReason ?? loopExhausted?.reason ?? "nax-finish could not reach a green, shippable state";
 
@@ -531,7 +446,15 @@ export default defineFlow({
     },
   },
   edges: [
-    { from: "load_ctx", switch: { on: "$.route", cases: { proceed: "acceptance", "nothing-to-finish": "open_pr" } } },
+    {
+      from: "load_ctx",
+      switch: {
+        on: "$.route",
+        // `escalate`: the branch could not be measured against its base at all,
+        // so neither "proceed" nor "nothing-to-finish" would be a true claim.
+        cases: { proceed: "acceptance", "nothing-to-finish": "open_pr", escalate: "escalate" },
+      },
+    },
     {
       from: "acceptance",
       switch: { on: "$.route", cases: { proceed: "review_spec", fix: "fix_acceptance", escalate: "escalate" } },
@@ -591,7 +514,10 @@ export default defineFlow({
     },
     // The narrative runs only once the PR exists. acpx has no error edge, so an
     // acp node before `open_pr` would be able to fail the flow and cost the PR.
-    { from: "open_pr", switch: { on: "$.route", cases: { narrate: "narrative", done: "finish_done" } } },
+    {
+      from: "open_pr",
+      switch: { on: "$.route", cases: { narrate: "narrative", done: "finish_done", escalate: "escalate" } },
+    },
     { from: "narrative", to: "amend_body" },
   ],
 });

--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -334,9 +334,12 @@ const RETRY_NOTICE = [
  * available — it is told to open whatever the fix touches — it just is not asked
  * to re-derive a verdict on unchanged code.
  *
- * `since` is only ever supplied when exactly one commit separates the two
- * reviews (see `incrementalSince`), so `since..HEAD` provably contains every
- * change made since the previous verdict.
+ * `since` is the parent of the *first* commit that landed after the previous
+ * verdict, not of the latest one (see `incrementalSince`) — the acceptance loop
+ * can commit between a spec fix and its re-review, and the window has to span
+ * both. So `since..HEAD` provably contains every change made since that
+ * verdict, however many commits that took, and it is never supplied at all when
+ * no commit landed.
  */
 export function buildReviewPrompt(
   phase: "spec" | "quality",

--- a/flows/nax-finish/steps/context.ts
+++ b/flows/nax-finish/steps/context.ts
@@ -92,11 +92,42 @@ export function partitionTestFiles(paths: string[], regexSources: string[]): { t
   return { test, nonTest };
 }
 
-export async function preflight(
-  workdir: string,
-  base: string,
-): Promise<{ commitsAhead: number; route: "proceed" | "nothing-to-finish" }> {
+export interface PreflightOutcome {
+  commitsAhead: number;
+  route: "proceed" | "nothing-to-finish" | "escalate";
+  /** Set only on `escalate` — why the count could not be trusted. */
+  reason?: string;
+}
+
+/**
+ * How far ahead of the base branch this branch is.
+ *
+ * A failed count must never be reported as zero. `base` reaches here from
+ * `detectBaseBranch`, whose last-resort `origin/master` is returned without
+ * being verified — so a repo whose base ref is not fetched locally makes
+ * `rev-list` exit non-zero with empty stdout. `Number.parseInt("") || 0` turned
+ * that into `0`, indistinguishable from "this branch has no new commits", and
+ * the flow reported `nothing-to-finish` having reviewed, verified and pushed
+ * nothing. Both the non-zero exit and unreadable output escalate instead: a
+ * human can fetch the base, and no fix node can.
+ */
+export async function preflight(workdir: string, base: string): Promise<PreflightOutcome> {
   const res = await _contextDeps.run(["git", "rev-list", "--count", `${base}..HEAD`], { cwd: workdir });
-  const commitsAhead = Number.parseInt(res.stdout.trim(), 10) || 0;
+  if (res.exitCode !== 0) {
+    const detail = res.stderr.trim() || res.stdout.trim() || `exit ${res.exitCode}`;
+    return {
+      commitsAhead: 0,
+      route: "escalate",
+      reason: `Could not count commits against "${base}" — git rev-list failed: ${detail}. The base branch may not exist locally; nax-finish will not treat that as "nothing to finish".`,
+    };
+  }
+  const commitsAhead = Number.parseInt(res.stdout.trim(), 10);
+  if (!Number.isFinite(commitsAhead)) {
+    return {
+      commitsAhead: 0,
+      route: "escalate",
+      reason: `git rev-list --count ${base}..HEAD exited 0 but printed no readable count: "${res.stdout.trim()}".`,
+    };
+  }
   return { commitsAhead, route: commitsAhead > 0 ? "proceed" : "nothing-to-finish" };
 }

--- a/flows/nax-finish/steps/gates.ts
+++ b/flows/nax-finish/steps/gates.ts
@@ -1,0 +1,183 @@
+/**
+ * The two gate nodes — `acceptance` and `quality_gates`.
+ *
+ * Split out of `nax-finish.flow.ts`, which sits against the 600-line source
+ * cap. They belong together: both answer the same question ("did anything
+ * actually verify this tree?"), both enforce the same rule that **nothing ran
+ * is not a pass**, and both route on the shared `MAX_FIX_ATTEMPTS` cap.
+ *
+ * Keeping them out of the flow file also makes them callable in tests without
+ * reaching through `flow.nodes.*`.
+ */
+import { fixAttemptCount, inputOf, loadCtxOf } from "../flow-ctx";
+import { MAX_FIX_ATTEMPTS } from "../verdict";
+import { runAcceptanceGate } from "./acceptance";
+import { type QualityCommands, loadQualityCommands, runQualityGates } from "./quality";
+
+/** The slice of an acpx `FlowNodeContext` these nodes read. */
+export interface GateNodeCtx {
+  input: unknown;
+  outputs: unknown;
+  state: { steps: { nodeId: string }[] };
+}
+
+export interface AcceptanceNodeOutput {
+  route: string;
+  reason?: string;
+  output: string;
+}
+
+export interface QualityGatesNodeOutput {
+  route: string;
+  reason?: string;
+  ran: string[];
+  failing: string[];
+  output: string;
+}
+
+/** The repo's explicit opt-out, as reported by `nax features resolve`. */
+function acceptanceDisabled(ctx: GateNodeCtx): boolean {
+  return loadCtxOf(ctx).acceptanceStatus === "disabled";
+}
+
+/**
+ * Re-run the acceptance gate, routing on the shared fix-cap rules.
+ *
+ * "Nothing ran" is not a pass — the same rule `quality_gates` applies to an
+ * unconfigured repo. `nax features resolve` reports `groups: []` for `no-prd`,
+ * for `disabled`, **and** for an `ok` resolution whose PRD grouped to no
+ * package at all; it reports `exists: false` for a group whose test was
+ * expected at its canonical path but never generated. Treating any of those as
+ * green let the flow open a ready PR having verified nothing about the
+ * feature's own contract (#1398). Only `disabled` — the repo's explicit opt-out
+ * — skips cleanly.
+ */
+export async function acceptanceGateNode(ctx: GateNodeCtx): Promise<AcceptanceNodeOutput> {
+  const i = inputOf(ctx);
+  const { groups = [], acceptanceStatus } = loadCtxOf(ctx);
+  if (acceptanceStatus === "disabled") {
+    return { route: "proceed", output: "[acceptance] disabled in .nax/config.json — skipping" };
+  }
+  if (acceptanceStatus === "no-prd") {
+    return {
+      route: "escalate",
+      reason: `Acceptance targets could not be computed (status: no-prd) — nothing was verified for "${i.feature}".`,
+      output: "[acceptance] no prd.json resolved — acceptance targets unknown",
+    };
+  }
+
+  const r = await runAcceptanceGate(i.workdir, groups, { timeoutMs: i.timeouts?.acceptanceMs });
+  if (r.passed) {
+    // A real failure below routes to the fix loop, which is more actionable;
+    // the coverage hole is only reported once the runnable groups are green.
+    if (r.missing.length > 0) {
+      return {
+        route: "escalate",
+        reason: `Acceptance test never generated for: ${r.missing.join(", ")} — that package's contract is unverified.`,
+        output: r.output,
+      };
+    }
+    // Passed, nothing missing, and nothing ran: the resolver produced no group
+    // to run at all. `status: "ok"` does NOT imply a target exists — it means
+    // the PRD loaded — so this is the one remaining way an empty gate reports
+    // green. Escalating matches what `runQualityGates` does for a repo with no
+    // configured commands: an LLM fix node cannot invent the missing target.
+    if (r.ran === 0) {
+      return {
+        route: "escalate",
+        reason: `No acceptance test target resolved for "${i.feature}" (status: ${acceptanceStatus ?? "unknown"}) — nothing verified its contract.`,
+        output: r.output,
+      };
+    }
+    return { route: "proceed", output: r.output };
+  }
+  const attempts = fixAttemptCount(ctx, "fix_acceptance");
+  if (attempts >= MAX_FIX_ATTEMPTS) {
+    return {
+      route: "escalate",
+      reason: `Acceptance tests still failing after ${attempts} fix attempts.`,
+      output: r.output,
+    };
+  }
+  return { route: "fix", output: r.output };
+}
+
+/**
+ * Acceptance is gate zero here, not just at the `acceptance` node.
+ *
+ * Both fix loops that run after it — quality review and this gate — edit code,
+ * and the repo-root `test` command does not cover the feature's acceptance
+ * tests: they live under `<pkg>/.nax/features/<f>/` and usually need their own
+ * runner config. Re-running them here is what makes "nothing reaches open_pr
+ * without the feature's own contract passing against the tree as it will ship"
+ * true on every path (#1398).
+ *
+ * Unconditional apart from the repo's own opt-out, though the common green path
+ * re-runs a gate that already passed: acceptance is the cheapest gate in the
+ * pipeline, and a conditional skip derived from step history would be a check
+ * that can be *wrong* — a silent false green, the failure mode this exists to
+ * prevent. The `disabled` skip is not such a derivation: it is the same
+ * resolver field the `acceptance` node already honours, and the two nodes
+ * disagreeing about who owns the opt-out is its own bug.
+ *
+ * `missing` is deliberately ignored: groups are resolved once at load_ctx, so a
+ * coverage hole was already escalated by the acceptance node and cannot appear
+ * here.
+ */
+async function reverifyAcceptance(ctx: GateNodeCtx): Promise<QualityGatesNodeOutput | null> {
+  if (acceptanceDisabled(ctx)) return null;
+  const i = inputOf(ctx);
+  const acc = await runAcceptanceGate(i.workdir, loadCtxOf(ctx).groups ?? [], {
+    timeoutMs: i.timeouts?.acceptanceMs,
+  });
+  if (acc.passed) return null;
+  // Short-circuit: the repo gates are re-run next round anyway, and skipping
+  // them keeps this out of the "nothing configured" branch below, which would
+  // otherwise misreport configured-but-skipped commands as absent.
+  const attempts = fixAttemptCount(ctx, "fix_gate");
+  const failing = ["acceptance"];
+  if (attempts >= MAX_FIX_ATTEMPTS) {
+    return {
+      route: "escalate",
+      reason: `A later fix broke the feature's own contract: acceptance still failing after ${attempts} fix attempts.`,
+      ran: [],
+      failing,
+      output: acc.output,
+    };
+  }
+  return { route: "fix", ran: [], failing, output: acc.output };
+}
+
+export async function qualityGatesNode(ctx: GateNodeCtx): Promise<QualityGatesNodeOutput> {
+  const i = inputOf(ctx);
+
+  const accFailure = await reverifyAcceptance(ctx);
+  if (accFailure) return accFailure;
+
+  const cmds: QualityCommands = await loadQualityCommands(i.workdir);
+  const r = await runQualityGates(i.workdir, cmds, { timeoutMs: i.timeouts?.gateMs });
+  if (r.passed) return { route: "green", ran: r.ran, failing: r.failing, output: r.output };
+  // Nothing configured is not a pass — escalate immediately rather than open a
+  // "ready" PR having verified nothing. An LLM fix node cannot invent the
+  // repo's build/test commands.
+  if (r.ran.length === 0) {
+    return {
+      route: "escalate",
+      reason: "No quality.commands configured in .nax/config.json — nax-finish verified nothing.",
+      ran: r.ran,
+      failing: r.failing,
+      output: r.output,
+    };
+  }
+  const attempts = fixAttemptCount(ctx, "fix_gate");
+  if (attempts >= MAX_FIX_ATTEMPTS) {
+    return {
+      route: "escalate",
+      reason: `Quality gates still failing after ${attempts} fix attempts (${r.failing.join(", ")}).`,
+      ran: r.ran,
+      failing: r.failing,
+      output: r.output,
+    };
+  }
+  return { route: "fix", ran: r.ran, failing: r.failing, output: r.output };
+}

--- a/flows/nax-finish/steps/index.ts
+++ b/flows/nax-finish/steps/index.ts
@@ -1,6 +1,7 @@
 export * from "./context";
 export * from "./acceptance";
 export * from "./quality";
+export * from "./gates";
 export * from "./escalate";
 export * from "./forge";
 export * from "./git";

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -353,6 +353,40 @@ describe("review nodes — incremental scoping window", () => {
     expect(p).toContain("git diff origin/main...HEAD");
   });
 
+  // A fix node that edited nothing still records a `commit_*` step, and that
+  // step's `shaBefore` is the *current* HEAD — so scoping to it asks for
+  // `HEAD..HEAD`, an empty diff. The reviewer is simultaneously told the prior
+  // findings "have since been fixed and committed", so it returns clean and
+  // route_* sends the flow onward with the findings unfixed. That exits the
+  // loop through the green door rather than the fix cap, which is why
+  // MAX_FIX_ATTEMPTS never catches it.
+  test("a fix that committed nothing falls back to a full review", () => {
+    const p = promptOf("review_quality", {
+      outputs: { ...LOAD, review_quality: { findings: [{ severity: "HIGH", title: "t", problem: "p", fix: "f" }] } },
+      steps: makeFlowSteps([
+        "review_quality",
+        "fix_quality",
+        ["commit_quality", { committed: false, shaBefore: "head-sha", shaAfter: "head-sha" }],
+      ]),
+    });
+    expect(p).toContain("git diff origin/main...HEAD");
+    expect(p).not.toContain("head-sha..HEAD");
+  });
+
+  // The window must still open at the tree the last verdict passed on, so a
+  // no-op round followed by a real one scopes from the REAL commit's parent.
+  test("a no-op round before a real commit scopes from the commit that landed", () => {
+    const p = promptOf("review_quality", {
+      outputs: { ...LOAD, review_quality: { findings: [] } },
+      steps: makeFlowSteps([
+        "review_quality",
+        ["commit_gate", { committed: false, shaBefore: "head-sha", shaAfter: "head-sha" }],
+        ["commit_gate", { committed: true, shaBefore: "head-sha", shaAfter: "new-sha" }],
+      ]),
+    });
+    expect(p).toContain("git diff head-sha..HEAD");
+  });
+
   test("only commits AFTER the last review count — an earlier one does not scope it", () => {
     const p = promptOf("review_quality", {
       outputs: { ...LOAD, review_quality: { findings: [] } },

--- a/test/unit/flows/nax-finish/flow-graph-open-pr-recovery.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph-open-pr-recovery.test.ts
@@ -1,0 +1,86 @@
+/**
+ * `open_pr` when the network half fails.
+ *
+ * acpx has no error edge, so a node that throws kills the flow — and `open_pr`
+ * is the last node on the happy path, reached only after every gate is green
+ * and every fix has landed. A throw there left no result file at all, so the
+ * plugin reported "flow produced no result file" and notified nobody: #1399's
+ * failure mode, which `escalate` was hardened against and this node was not.
+ *
+ * Both failures must route to `escalate` (which writes a result, pushes what it
+ * can, and delivers) rather than propagate.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import flow from "@flows/nax-finish/nax-finish.flow";
+import { _gitDeps } from "@flows/nax-finish/steps/git";
+import { _prDeps } from "@flows/nax-finish/steps/pr";
+import { _resultDeps } from "@flows/nax-finish/steps/result";
+import { makeFlowCtx } from "@test/helpers";
+import type { FlowNodeContext } from "acpx/flows";
+
+const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
+const ctxOf = (outputs: Record<string, unknown>): FlowNodeContext => makeFlowCtx({ input: INPUT, outputs });
+const openPr = flow.nodes.open_pr as unknown as {
+  run: (ctx: FlowNodeContext) => Promise<{ route: string; reason?: string; status?: string }>;
+};
+
+const originalPrRun = _prDeps.run;
+const originalGitRun = _gitDeps.run;
+const originalWriteText = _resultDeps.writeText;
+afterEach(() => {
+  _prDeps.run = originalPrRun;
+  _gitDeps.run = originalGitRun;
+  _resultDeps.writeText = originalWriteText;
+});
+
+/** A forge that answers every probe happily, so only the push can fail. */
+const happyForge = async (cmd: string[]) =>
+  cmd.join(" ").includes("remote get-url")
+    ? { exitCode: 0, stdout: "git@github.com:o/r", stderr: "" }
+    : { exitCode: 0, stdout: JSON.stringify({ isDraft: false, url: "https://gh/pr/1" }), stderr: "" };
+
+describe("open_pr — failure routing", () => {
+  test("a rejected push escalates instead of killing the flow with no result", async () => {
+    _gitDeps.run = async (cmd) => {
+      if (cmd.includes("--porcelain")) return { exitCode: 0, stdout: "", stderr: "" };
+      if (cmd.includes("push"))
+        return { exitCode: 1, stdout: "", stderr: "! [remote rejected] feat/x -> feat/x (protected branch hook)" };
+      return { exitCode: 0, stdout: "sha", stderr: "" };
+    };
+    _prDeps.run = happyForge;
+    _resultDeps.writeText = async () => {};
+
+    const out = await openPr.run(ctxOf({ load_ctx: { route: "proceed", base: "origin/main" } }));
+
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("push");
+    expect(out.reason).toContain("feat/x");
+  });
+
+  test("a forge that refuses to open the PR escalates rather than throwing", async () => {
+    _gitDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+    _prDeps.run = async (cmd) => {
+      if (cmd.join(" ").includes("remote get-url")) return { exitCode: 0, stdout: "git@github.com:o/r", stderr: "" };
+      if (cmd.includes("view")) return { exitCode: 1, stdout: "", stderr: "no pull requests found" };
+      return { exitCode: 1, stdout: "", stderr: "GraphQL: was submitted too quickly (rate limit)" };
+    };
+    _resultDeps.writeText = async () => {};
+
+    const out = await openPr.run(ctxOf({ load_ctx: { route: "proceed", base: "origin/main" } }));
+
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("feat/x");
+  });
+
+  test("the escalate route has an edge to the escalate node — otherwise the switch dead-ends", () => {
+    const edge = flow.edges.find((e) => e.from === "open_pr" && "switch" in e);
+    if (!edge || !("switch" in edge)) throw new Error("no switch edge from open_pr");
+    expect(edge.switch.cases.escalate).toBe("escalate");
+  });
+
+  test("load_ctx can escalate too, so an unresolvable base is not read as nothing-to-finish", () => {
+    const edge = flow.edges.find((e) => e.from === "load_ctx" && "switch" in e);
+    if (!edge || !("switch" in edge)) throw new Error("no switch edge from load_ctx");
+    expect(edge.switch.cases.escalate).toBe("escalate");
+  });
+});

--- a/test/unit/flows/nax-finish/flow-graph-open-pr-recovery.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph-open-pr-recovery.test.ts
@@ -84,3 +84,44 @@ describe("open_pr — failure routing", () => {
     expect(edge.switch.cases.escalate).toBe("escalate");
   });
 });
+
+/**
+ * Whole-graph invariants, asserted once rather than per edge.
+ *
+ * A switch case naming a node that does not exist dead-ends only when that
+ * route is taken — and the routes added here are the failure paths, which no
+ * happy-path test ever walks. `finish_done` exists solely because acpx requires
+ * a real node for every case, so this is the rule the graph is already built
+ * around; nothing checked it.
+ */
+describe("flow graph integrity", () => {
+  const targetsOf = (edge: (typeof flow.edges)[number]): string[] =>
+    "to" in edge ? [edge.to] : Object.values(edge.switch.cases);
+
+  test("every edge target names a declared node", () => {
+    const declared = new Set(Object.keys(flow.nodes));
+    const dangling = flow.edges.flatMap((e) =>
+      targetsOf(e)
+        .filter((t) => !declared.has(t))
+        .map((t) => `${e.from} -> ${t}`),
+    );
+    expect(dangling).toEqual([]);
+  });
+
+  test("every declared node is reachable from the start node", () => {
+    const reachable = new Set([flow.startAt]);
+    for (let grew = true; grew; ) {
+      grew = false;
+      for (const edge of flow.edges) {
+        if (!reachable.has(edge.from)) continue;
+        for (const target of targetsOf(edge)) {
+          if (!reachable.has(target)) {
+            reachable.add(target);
+            grew = true;
+          }
+        }
+      }
+    }
+    expect(Object.keys(flow.nodes).filter((n) => !reachable.has(n))).toEqual([]);
+  });
+});

--- a/test/unit/flows/nax-finish/steps/context.test.ts
+++ b/test/unit/flows/nax-finish/steps/context.test.ts
@@ -90,6 +90,31 @@ describe("context steps", () => {
     _contextDeps.run = async () => ok("3\n");
     expect(await preflight("/w", "origin/main")).toEqual({ commitsAhead: 3, route: "proceed" });
   });
+
+  // `detectBaseBranch`'s last-resort `origin/master` is returned unverified, so
+  // a repo whose base ref is not fetched locally fails this count. Parsing the
+  // empty stdout gave `NaN || 0` — indistinguishable from a branch with no new
+  // commits — and the flow reported `nothing-to-finish` having reviewed,
+  // verified and pushed nothing.
+  test("preflight escalates when the base ref cannot be resolved, rather than reading it as 0 commits", async () => {
+    _contextDeps.run = async () => ({
+      exitCode: 128,
+      stdout: "",
+      stderr: "fatal: ambiguous argument 'origin/master..HEAD': unknown revision",
+    });
+    const r = await preflight("/w", "origin/master");
+    expect(r.route).toBe("escalate");
+    expect(r.commitsAhead).toBe(0);
+    expect(r.reason).toContain("origin/master");
+    expect(r.reason).toContain("unknown revision");
+  });
+
+  test("preflight escalates on unreadable output from a zero exit", async () => {
+    _contextDeps.run = async () => ok("not-a-number\n");
+    const r = await preflight("/w", "origin/main");
+    expect(r.route).toBe("escalate");
+    expect(r.reason).toContain("not-a-number");
+  });
 });
 
 describe("partitionTestFiles", () => {

--- a/test/unit/flows/nax-finish/steps/gates.test.ts
+++ b/test/unit/flows/nax-finish/steps/gates.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The two gate nodes, driven directly.
+ *
+ * `flow-graph.test.ts` exercises them through `flow.nodes.*` for the wiring;
+ * these cover the "nothing ran" holes, where a gate reports green having
+ * verified nothing — the failure mode the whole node exists to prevent.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { _acceptanceDeps } from "@flows/nax-finish/steps/acceptance";
+import { acceptanceGateNode, qualityGatesNode } from "@flows/nax-finish/steps/gates";
+import { _qualityDeps } from "@flows/nax-finish/steps/quality";
+import { makeFlowCtx } from "@test/helpers";
+import type { FlowNodeContext } from "acpx/flows";
+
+const INPUT = { feature: "x", workdir: "/repo", branch: "feat/x", prdPath: "p", escalateTelegram: false };
+const ctxOf = (outputs: Record<string, unknown>): FlowNodeContext => makeFlowCtx({ input: INPUT, outputs });
+
+const GROUP = {
+  packageDir: "",
+  testPath: ".nax/features/x/a.test.ts",
+  exists: true,
+  command: "bun test {{FILE}}",
+  language: "typescript",
+};
+
+const originalAcceptanceRun = _acceptanceDeps.runShell;
+const originalQualityRun = _qualityDeps.runShell;
+const originalReadText = _qualityDeps.readText;
+afterEach(() => {
+  _acceptanceDeps.runShell = originalAcceptanceRun;
+  _qualityDeps.runShell = originalQualityRun;
+  _qualityDeps.readText = originalReadText;
+});
+
+describe("acceptanceGateNode", () => {
+  // `resolveFeatureAcceptance` returns `{ status: "ok", groups: [] }` whenever
+  // the PRD loads but groups to nothing — so "ok" does NOT imply a target
+  // exists. `runAcceptanceGate` reports `passed: true, ran: 0` for that, which
+  // routed `proceed` and opened a ready PR with the feature's contract
+  // unverified: #1398's failure mode on the one path its guard did not cover.
+  test("escalates when the status is ok but no group was runnable — nothing verified the contract", async () => {
+    let ran = 0;
+    _acceptanceDeps.runShell = async () => {
+      ran += 1;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const out = await acceptanceGateNode(ctxOf({ load_ctx: { groups: [], acceptanceStatus: "ok" } }));
+    expect(out.route).toBe("escalate");
+    expect(out.reason).toContain("No acceptance test target resolved");
+    expect(out.reason).toContain("nothing verified its contract");
+    expect(ran).toBe(0);
+  });
+
+  test("a runnable green group still proceeds", async () => {
+    _acceptanceDeps.runShell = async () => ({ exitCode: 0, stdout: "ok", stderr: "" });
+    const out = await acceptanceGateNode(ctxOf({ load_ctx: { groups: [GROUP], acceptanceStatus: "ok" } }));
+    expect(out.route).toBe("proceed");
+  });
+});
+
+describe("qualityGatesNode", () => {
+  const commands = JSON.stringify({ quality: { commands: { test: "bun test" } } });
+
+  // The `acceptance` node honours the repo's opt-out; this node re-ran the gate
+  // regardless. Today `disabled` also carries `groups: []` so it is inert, but
+  // the two nodes disagreeing about who owns the opt-out is what would put the
+  // flow into a fix loop for tests the repo explicitly turned off.
+  test("honours acceptance.enabled=false instead of re-running the disabled gate", async () => {
+    let acceptanceRuns = 0;
+    _acceptanceDeps.runShell = async () => {
+      acceptanceRuns += 1;
+      return { exitCode: 1, stdout: "", stderr: "would fail" };
+    };
+    _qualityDeps.readText = async () => commands;
+    _qualityDeps.runShell = async () => ({ exitCode: 0, stdout: "green", stderr: "" });
+
+    const out = await qualityGatesNode(ctxOf({ load_ctx: { groups: [GROUP], acceptanceStatus: "disabled" } }));
+    expect(acceptanceRuns).toBe(0);
+    expect(out.route).toBe("green");
+    expect(out.ran).toEqual(["test"]);
+  });
+
+  test("still re-runs the acceptance gate when acceptance is enabled", async () => {
+    let acceptanceRuns = 0;
+    _acceptanceDeps.runShell = async () => {
+      acceptanceRuns += 1;
+      return { exitCode: 1, stdout: "", stderr: "broken by a later fix" };
+    };
+    _qualityDeps.readText = async () => commands;
+
+    const out = await qualityGatesNode(ctxOf({ load_ctx: { groups: [GROUP], acceptanceStatus: "ok" } }));
+    expect(acceptanceRuns).toBe(1);
+    expect(out.route).toBe("fix");
+    expect(out.failing).toEqual(["acceptance"]);
+  });
+});


### PR DESCRIPTION
## Summary

A review of `flows/nax-finish/` for latent bugs turned up five paths where the flow ends a run claiming success on work nothing verified, or loses a completed run outright. **None of them is caught by `MAX_FIX_ATTEMPTS`** — every one leaves its loop through the green door rather than the cap, which is why they are invisible in the audit trail.

## The five bugs

### 1. A fix that committed nothing scoped its re-review to an empty diff

`commitFixes` returns `shaBefore === shaAfter === HEAD` when the fix node edited nothing, and `incrementalSince` anchored the re-review window on it regardless. The reviewer was then handed `git diff HEAD..HEAD` **and** told, by `buildReviewPrompt`, that the prior findings "have since been fixed and committed". It returned clean, `route_*` sent the flow onward, and the findings shipped unfixed.

```
review_quality (3 findings) -> fix_quality (edits nothing) -> commit_quality (committed:false)
  -> review_quality  "The fix is `git diff <HEAD>..HEAD`"   <- empty
  -> clean -> quality_gates -> open_pr
```

`commit_gate` was already guarded by its `unchanged` route; `commit_spec` and `commit_quality` have unconditional edges, so `commitFixNode` computed the same signal and the graph discarded it. `incrementalSince` now skips commit steps carrying `committed: false`, yielding the window to a later real commit or falling back to a full review. Rounds journalled before that field existed (`!== false`) keep their previous behaviour on resume.

### 2. `preflight` read a git failure as "no commits ahead"

```ts
const commitsAhead = Number.parseInt(res.stdout.trim(), 10) || 0;   // exit code never checked
```

`detectBaseBranch` returns its last-resort `origin/master` **unverified**, so a repo whose base ref is not fetched locally makes `rev-list --count` exit non-zero with empty stdout — and `NaN || 0` made that indistinguishable from a branch with nothing new. The flow reported `nothing-to-finish` having reviewed, verified and pushed nothing, and the plugin reported it as a success. Both a non-zero exit and unreadable output now route `escalate`, via a new `load_ctx -> escalate` edge.

The unverified `origin/master` fallback itself is left alone — `steps/context.test.ts` pins it as intended behaviour, and this change turns it into a readable escalation rather than a silent no-op.

### 3. `open_pr` threw on push and forge failures

acpx has no error edge, so a throw ends the run — and `open_pr` is the last node on the happy path, reached only once every gate is green and every fix has landed. It died before `writeResult`, so the plugin hit `missingResultOutcome`: a warning log, `success: false`, and no notification unless `notify.mode === "always"`. A protected branch, an expired token, a non-fast-forward push or a rate-limited `gh pr create` discarded a fully verified run.

This is the failure mode #1399 hardened `escalate` against — that node writes its result *before* touching the network for exactly this reason. Both calls now route to `escalate` instead of propagating.

### 4. The acceptance gate reported green when no group was runnable

`resolveFeatureAcceptance` returns `{ status: "ok", groups: [] }` whenever the PRD loads but groups to no package — so `"ok"` does **not** imply a target exists. `runAcceptanceGate` reports `passed: true, ran: 0` for that (appending "no acceptance test files present — nothing to run" to the output and passing anyway), and the node routed `proceed`. That is #1398's failure mode surviving on the one path the node's own comment asserted could not exist. `ran === 0` now escalates, matching what `runQualityGates` already does for a repo with no configured commands.

### 5. `quality_gates` ignored `acceptance.enabled: false`

The `acceptance` node honours the repo's opt-out and skips; `quality_gates` re-ran the gate unconditionally. Inert today (a `disabled` resolution also carries no groups), but the two nodes disagreeing about who owns the opt-out is what would put the flow into a fix loop for tests the repo explicitly turned off.

## Structural change

`nax-finish.flow.ts` was three lines under the 600-line hard cap, so both gate nodes moved to a new `flows/nax-finish/steps/gates.ts`. They belong together: same "nothing ran is not a pass" rule, same fix cap, and they are now callable in tests without reaching through `flow.nodes.*`. The flow file is down to 517 lines.

Also corrects `buildReviewPrompt`'s claim that `since` implies exactly one commit — it deliberately spans every commit since the last verdict, which is what makes the window complete when the acceptance loop commits between a spec fix and its re-review.

## Behaviour change worth calling out

Fix 4 turns a currently-"successful" outcome into an escalation for any repo whose PRD groups to zero acceptance targets. That is the intent of #1398 — such a run verified nothing — but it is the one change here that alters a passing path rather than a failing one.

## Test plan

- [x] `bun run test` — 12438 unit / 1102 integration / 24 UI, 0 fail
- [x] `bun run typecheck`, `bun run lint`, all 17 pre-commit gates
- [x] Every fix has a regression test, written first and confirmed red (8 failures + 1 module-not-found) before implementing
- [x] New `test/unit/flows/nax-finish/steps/gates.test.ts` — the two "nothing ran" holes
- [x] New `test/unit/flows/nax-finish/flow-graph-open-pr-recovery.test.ts` — push/forge failure routing, plus whole-graph invariants (every edge target is a declared node; every node is reachable from `startAt`). The new routes are failure paths no happy-path test walks, which is exactly where a typo'd switch case would have survived.
- [x] `.nax/features/finish-pr-body/.nax-acceptance.test.ts` — 50/50 still green
- [ ] Not exercised end-to-end under a real `acpx flow run`; the unit tests import the flow module and drive its nodes and edges directly.
