### PR TITLE
fix: a failed worktree merge is not a passed story

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 15, not 10: this job absorbed the `typecheck` + `check:all` matrix (#1534),
+    # which used to run in parallel under its own 5-minute budget. The work grew
+    # while the budget did not, and a timeout here reads like a test failure.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 

--- a/flows/nax-finish/flow-ctx.ts
+++ b/flows/nax-finish/flow-ctx.ts
@@ -17,6 +17,7 @@
  *   *outcome*, so the currently-executing node is never in this list — which is
  *   what lets `incrementalSince` find the *previous* review rather than itself.
  */
+import type { AcceptanceStatus } from "./steps/context";
 import type { AcceptanceGroup, Finding, FinishInput, FinishPhase, ReviewVerdict } from "./types";
 
 /** Minimal shapes so each reader takes only the part of the context it reads. */
@@ -34,8 +35,8 @@ export interface LoadCtxOutput {
   base?: string;
   specPath?: string;
   groups?: AcceptanceGroup[];
-  /** `nax features resolve`'s acceptance status: "ok" | "disabled" | "no-prd". */
-  acceptanceStatus?: string;
+  /** `nax features resolve`'s acceptance status, narrowed at `resolveFeature`. */
+  acceptanceStatus?: AcceptanceStatus;
   /** Test-file regex sources from `nax features resolve`; empty = cannot classify. */
   testFileRegex?: string[];
   route?: string;

--- a/flows/nax-finish/steps/context.ts
+++ b/flows/nax-finish/steps/context.ts
@@ -12,10 +12,35 @@ export async function detectBaseBranch(workdir: string): Promise<string> {
   return main.exitCode === 0 ? "origin/main" : "origin/master";
 }
 
+/**
+ * The acceptance resolutions this flow knows how to route on, as emitted by
+ * `resolveFeatureAcceptance` (`src/cli/features-acceptance.ts`).
+ *
+ * A closed set, not `string`: `steps/gates.ts` branches on all three by literal
+ * — `disabled` decides whether the acceptance gate runs at all — and a typo in
+ * any of those comparisons against a `string` compiles cleanly and silently
+ * stops a gate from firing.
+ */
+export type AcceptanceStatus = "ok" | "no-prd" | "disabled";
+
+const ACCEPTANCE_STATUSES: readonly AcceptanceStatus[] = ["ok", "no-prd", "disabled"];
+
+/**
+ * Narrow the resolver's status, degrading anything unrecognised to `no-prd`.
+ *
+ * A status this flow cannot interpret is not a licence to proceed: it is
+ * neither the explicit opt-out nor a resolution to trust. `no-prd` routes to
+ * `escalate`, which is the honest answer and matches the existing default for
+ * a status that is missing entirely.
+ */
+export function toAcceptanceStatus(raw: unknown): AcceptanceStatus {
+  return ACCEPTANCE_STATUSES.find((s) => s === raw) ?? "no-prd";
+}
+
 export interface FeatureResolution {
   specPath: string;
   specKind: "markdown" | "prd";
-  acceptanceStatus: string;
+  acceptanceStatus: AcceptanceStatus;
   groups: AcceptanceGroup[];
   /**
    * Test-file classification regexes, as sources, from `nax features resolve`
@@ -57,7 +82,7 @@ export async function resolveFeature(feature: string, workdir: string): Promise<
   return {
     specPath: parsed.specSource.path,
     specKind: parsed.specSource.kind,
-    acceptanceStatus: parsed.acceptance?.status ?? "no-prd",
+    acceptanceStatus: toAcceptanceStatus(parsed.acceptance?.status),
     groups: parsed.acceptance?.groups ?? [],
     testFileRegex: parsed.testPatterns?.regex ?? [],
   };

--- a/src/execution/merge-conflict-rectify.ts
+++ b/src/execution/merge-conflict-rectify.ts
@@ -15,6 +15,7 @@ import type { PluginRegistry } from "../plugins/registry";
 import type { PRD } from "../prd";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { errorMessage } from "../utils/errors";
+import type { MergeResult } from "../worktree";
 
 /**
  * Close a stale ACP session by name — best-effort, swallows all errors.
@@ -54,6 +55,32 @@ export type RectificationResult =
       pipelineFailure?: boolean;
       conflictFiles?: string[];
     };
+
+/**
+ * Build the failure result for a post-rectification merge that did not land.
+ *
+ * `finalConflict` used to be hardcoded `true` here, which was the last place
+ * still guessing: after #1533 the merge engine reports *why* it failed, and a
+ * dirty tree or a missing branch is not a conflict the agent failed to resolve.
+ * Telling the operator otherwise sends them looking for a conflict that was
+ * never there.
+ *
+ * Only an explicit `"error"` clears the flag. An absent result, or one from a
+ * merge engine predating `failureKind`, keeps the historical conflict reading.
+ */
+export function rectifyMergeFailure(
+  storyId: string,
+  cost: number,
+  mergeResult: MergeResult | undefined,
+): RectificationResult {
+  return {
+    success: false,
+    storyId,
+    cost,
+    finalConflict: mergeResult?.failureKind !== "error",
+    conflictFiles: mergeResult?.conflictFiles ?? [],
+  };
+}
 
 /** Options passed to rectifyConflictedStory */
 export interface RectifyConflictedStoryOptions extends ConflictedStoryInfo, DispatchContext {
@@ -158,9 +185,12 @@ export async function rectifyConflictedStory(options: RectifyConflictedStoryOpti
     const mergeResult = mergeResults[0];
 
     if (!mergeResult || !mergeResult.success) {
-      const conflictFiles = mergeResult?.conflictFiles ?? [];
-      logger?.info("parallel", "Rectification failed - preserving worktree", { storyId });
-      return { success: false, storyId, cost, finalConflict: true, conflictFiles };
+      logger?.info("parallel", "Rectification failed - preserving worktree", {
+        storyId,
+        failureKind: mergeResult?.failureKind,
+        error: mergeResult?.error,
+      });
+      return rectifyMergeFailure(storyId, cost, mergeResult);
     }
 
     logger?.info("parallel", "Rectification succeeded - story merged", {

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -57,6 +57,46 @@ async function removeWorktreeDirectory(projectRoot: string, storyId: string): Pr
   }
 }
 
+/**
+ * Record a story whose pipeline passed but whose branch never landed on the base.
+ *
+ * By the time this runs, `completionStage` has already marked the story passed,
+ * written that to disk (`stages/completion.ts`) and emitted `story:completed`.
+ * Correcting only the in-memory PRD is therefore not enough on two counts:
+ *
+ * - The executor answers `prdDirty: true` by **reloading from disk**
+ *   (`unified-executor.ts:484-486`), which would restore `passed` and discard
+ *   the correction. The `savePRD` here is what makes it stick.
+ * - `isComplete(prd)` / `countStories(prd)` read story status, so leaving it
+ *   `passed` lets the whole run report complete for code that is not on the branch.
+ *
+ * Mirrors the `case "fail"` arm of `handlePipelineFailure`, minus the tier
+ * escalation: every gate already passed, so there is nothing to retry at a
+ * higher tier — the branch simply could not land.
+ */
+async function failStoryAfterMerge(ctx: PipelineHandlerContext, prd: PRD, reason: string): Promise<void> {
+  markStoryFailed(prd, ctx.story.id, undefined, undefined, ctx.statusWriter);
+  await savePRD(prd, ctx.prdPath);
+
+  if (ctx.featureDir) {
+    await appendProgress(ctx.featureDir, ctx.story.id, "failed", `${ctx.story.title} — ${reason}`);
+  }
+
+  // `story:completed` is already on the bus for this story. Without this
+  // correction every reporter, hook and the TUI keeps showing a success the
+  // PRD no longer claims.
+  pipelineEventBus.emit({
+    type: "story:failed",
+    storyId: ctx.story.id,
+    story: { id: ctx.story.id, title: ctx.story.title, status: ctx.story.status, attempts: ctx.story.attempts },
+    reason,
+    countsTowardEscalation: false,
+    feature: ctx.feature,
+    attempts: ctx.story.attempts,
+    cost: ctx.runtime.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
+  });
+}
+
 /** Filter noise from output files (test files, lock files, nax runtime files) */
 function filterOutputFiles(files: string[]): string[] {
   const NOISE = [
@@ -166,11 +206,17 @@ export async function handlePipelineSuccess(
       // A non-conflict git failure (dirty tree, missing branch, repository stuck
       // mid-merge). There is nothing for conflict rectification to resolve, so fail
       // the story with the real cause instead of spending a session on it.
+      const reason = `Merge failed for a non-conflict reason: ${mergeResult.error ?? "unknown error"}`;
       logger?.error("worktree", "Merge failed for a non-conflict reason — marking story as failed", {
         storyId: story.id,
         error: mergeResult.error,
       });
-      return { storiesCompletedDelta: 0, costDelta, prd, prdDirty: false };
+      await failStoryAfterMerge(ctx, prd, reason);
+      // Nothing will revisit this worktree — no rectification pass is coming —
+      // so reclaim the directory. The branch stays for diagnostics, exactly as
+      // the `case "fail"` arm does.
+      await removeWorktreeDirectory(ctx.workdir, story.id);
+      return { storiesCompletedDelta: 0, costDelta, prd, prdDirty: true };
     }
     if (!mergeResult.success) {
       // Merge conflict after the story passed all checks — attempt rectification.
@@ -194,8 +240,16 @@ export async function handlePipelineSuccess(
           storyId: story.id,
           conflictFiles: mergeResult.conflictFiles,
         });
-        // Return as failure: story passed review but can't land on main
-        return { storiesCompletedDelta: 0, costDelta, prd, prdDirty: false };
+        // Return as failure: story passed review but can't land on main.
+        // The worktree is deliberately NOT reclaimed here — rectification
+        // preserves it so the unresolved conflict can be inspected by hand.
+        const files = (mergeResult.conflictFiles ?? []).join(", ");
+        await failStoryAfterMerge(
+          ctx,
+          prd,
+          `Merge conflict could not be rectified${files ? ` (${files})` : ""} — the branch did not land`,
+        );
+        return { storiesCompletedDelta: 0, costDelta, prd, prdDirty: true };
       }
     }
     logger?.info("worktree", "Merged story to main", { storyId: story.id });

--- a/src/pipeline/stages/queue-check.ts
+++ b/src/pipeline/stages/queue-check.ts
@@ -164,17 +164,22 @@ export const queueCheckStage: PipelineStage = {
       }
 
       if (cmd.type === "SKIP") {
-        logger.warn("queue", "Skipping story by user request", {
-          storyId: cmd.storyId,
-        });
-
-        // Mark as skipped in PRD unconditionally — matches RETRY / PRIORITY / INJECT,
-        // which all mutate ctx.prd regardless of batch membership. Without this, a
+        // Mark as skipped in PRD regardless of batch membership — matches RETRY /
+        // PRIORITY / INJECT, which all mutate ctx.prd the same way. Without this, a
         // SKIP naming a story outside the current batch (e.g. sequential mode, where
         // ctx.stories has length 1) is silently discarded by clearQueueFile below.
-        // markStorySkipped no-ops for an unknown storyId, same as resetStoryToPending.
-        markStorySkipped(ctx.prd, cmd.storyId);
-        await savePRD(ctx.prd, resolvePrdPath(ctx));
+        //
+        // Report what actually happened. A SKIP naming a story the PRD does not
+        // contain (a typo, a stale id) changes nothing, so announcing a skip and
+        // writing the PRD behind it would be two lies and a wasted write.
+        if (markStorySkipped(ctx.prd, cmd.storyId)) {
+          logger.warn("queue", "Skipping story by user request", { storyId: cmd.storyId });
+          await savePRD(ctx.prd, resolvePrdPath(ctx));
+        } else {
+          logger.warn("queue", "SKIP names a story that is not in the PRD — ignoring", {
+            storyId: cmd.storyId,
+          });
+        }
 
         // Batch membership is an ADDITIONAL, separate action: if the story is part of
         // the batch currently being executed, also remove it from the batch.

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -329,11 +329,19 @@ export function resetFailedStoriesToPending(prd: PRD, opts: ResetFailedOptions =
 }
 
 /** Mark a story as skipped */
-export function markStorySkipped(prd: PRD, storyId: string): void {
+/**
+ * Mark a story skipped. Returns whether a story with that id was found.
+ *
+ * The return value is what lets callers tell "skipped it" from "there was
+ * nothing to skip" — a SKIP naming a story the PRD does not contain used to be
+ * announced in the log as though it had happened, and persisted an unchanged
+ * PRD behind it.
+ */
+export function markStorySkipped(prd: PRD, storyId: string): boolean {
   const story = prd.userStories.find((s) => s.id === storyId);
-  if (story) {
-    story.status = "skipped";
-  }
+  if (!story) return false;
+  story.status = "skipped";
+  return true;
 }
 
 /**

--- a/test/unit/execution/merge-conflict-rectify.test.ts
+++ b/test/unit/execution/merge-conflict-rectify.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { RectifyConflictedStoryOptions } from "../../../src/execution/merge-conflict-rectify";
-import { rectifyConflictedStory } from "../../../src/execution/merge-conflict-rectify";
+import { rectifyConflictedStory, rectifyMergeFailure } from "../../../src/execution/merge-conflict-rectify";
 import { makeMockAgentManager, makeNaxConfig, makePRD, makeSessionManager, makeStory } from "../../helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -131,5 +131,51 @@ describe("rect AC-7: rectifyConflictedStory catches errors and returns failure �
     const failureCheck: FailureVariant = { success: false, storyId: "x", cost: 0, finalConflict: false };
     expect(successCheck.success).toBe(true);
     expect(failureCheck.success).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The post-rectification merge reports WHY it did not land
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("rectifyMergeFailure: carries the merge classification instead of assuming a conflict", () => {
+  test("a real conflict is reported as a final conflict, with its files", () => {
+    const r = rectifyMergeFailure("US-001", 1.5, {
+      success: false,
+      storyId: "US-001",
+      failureKind: "conflict",
+      conflictFiles: ["src/a.ts", "src/b.ts"],
+    });
+
+    expect(r).toMatchObject({
+      success: false,
+      storyId: "US-001",
+      cost: 1.5,
+      finalConflict: true,
+      conflictFiles: ["src/a.ts", "src/b.ts"],
+    });
+  });
+
+  test("a non-conflict git failure is NOT reported as a final conflict", () => {
+    // Telling the operator the agent could not resolve a conflict, when git
+    // actually refused over a dirty tree or a missing branch, sends them
+    // looking for a conflict that was never there.
+    const r = rectifyMergeFailure("US-001", 0, {
+      success: false,
+      storyId: "US-001",
+      failureKind: "error",
+      error: "working tree is dirty",
+    });
+
+    expect(r).toMatchObject({ finalConflict: false, conflictFiles: [] });
+  });
+
+  test("an absent result keeps the historical conflict reading", () => {
+    // mergeAll returned nothing for this story. Unknown is not "error", so the
+    // conservative reading — the one every caller had before failureKind
+    // existed — is preserved.
+    const r = rectifyMergeFailure("US-001", 0, undefined);
+
+    expect(r).toMatchObject({ finalConflict: true, conflictFiles: [] });
   });
 });

--- a/test/unit/execution/pipeline-result-handler.test.ts
+++ b/test/unit/execution/pipeline-result-handler.test.ts
@@ -2,9 +2,12 @@
  * Unit tests for pipeline-result-handler.ts (ENH-005 — outputFiles capture)
  */
 
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+import { loadPRD, savePRD } from "@/prd";
 import { makeMockRuntime } from "../../helpers/runtime";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
 import { _tierEscalationDeps } from "../../../src/execution/escalation/tier-escalation";
 import type { PRD, UserStory } from "../../../src/prd/types";
 import { _gitDeps } from "../../../src/utils/git";
@@ -448,5 +451,116 @@ describe("handlePipelineFailure — story:skipped event", () => {
     await handlePipelineFailure(ctx, failResult);
 
     expect(capturedSkipped).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A story whose branch never landed must not be recorded as passed
+// ---------------------------------------------------------------------------
+
+/**
+ * These assert the **on-disk** prd.json, not `ctx.prd`.
+ *
+ * That is the whole point. `completionStage` runs before this handler and has
+ * already written `status: "passed"` to disk, and the executor answers
+ * `prdDirty: true` by *reloading* from disk (`unified-executor.ts:484-486`) —
+ * it never saves on the handler's behalf. So a handler that mutates `ctx.prd`
+ * and sets `prdDirty` without calling `savePRD` has its correction silently
+ * discarded on the next reload. An in-memory assertion passes against exactly
+ * that bug; only reading the file back catches it.
+ */
+describe("handlePipelineSuccess — a failed worktree merge is not a passed story", () => {
+  let tempDir: string;
+  let prdPath: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-merge-fail-");
+    prdPath = join(tempDir, "prd.json");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  /** Mirrors the state completionStage leaves behind: passed, in memory and on disk. */
+  async function seedPassedStory(): Promise<{ story: UserStory; ctx: PipelineHandlerContext }> {
+    const story = makeStory("US-001");
+    const ctx = makeCtx(story, {
+      config: WORKTREE_CONFIG,
+      prdPath,
+      workdir: tempDir,
+      storyGitRef: undefined,
+    });
+    await savePRD(ctx.prd, prdPath);
+    expect((await loadPRD(prdPath)).userStories[0]?.status).toBe("passed");
+    return { story, ctx };
+  }
+
+  function stubSpawn(): string[][] {
+    const calls: string[][] = [];
+    _resultHandlerDeps.spawn = mock((args: unknown) => {
+      calls.push(args as string[]);
+      return {
+        stdout: new ReadableStream({ start(c) { c.close(); } }),
+        stderr: new ReadableStream({ start(c) { c.close(); } }),
+        exited: Promise.resolve(0),
+        kill: mock(() => {}),
+      };
+    }) as unknown as typeof _resultHandlerDeps.spawn;
+    return calls;
+  }
+
+  test("a non-conflict merge failure marks the story failed on disk", async () => {
+    const { ctx } = await seedPassedStory();
+    stubSpawn();
+    _resultHandlerDeps.mergeEngine = {
+      merge: mock(async () => ({ success: false as const, failureKind: "error" as const, error: "dirty tree" })),
+    } as unknown as typeof _resultHandlerDeps.mergeEngine;
+
+    const result = await handlePipelineSuccess(ctx, makeMinimalResult());
+
+    expect((await loadPRD(prdPath)).userStories[0]?.status).toBe("failed");
+    expect(result.storiesCompletedDelta).toBe(0);
+    expect(result.prdDirty).toBe(true);
+  });
+
+  test("the reported failure survives the executor's reload-from-disk", async () => {
+    const { ctx } = await seedPassedStory();
+    stubSpawn();
+    _resultHandlerDeps.mergeEngine = {
+      merge: mock(async () => ({ success: false as const, failureKind: "error" as const, error: "missing branch" })),
+    } as unknown as typeof _resultHandlerDeps.mergeEngine;
+
+    const result = await handlePipelineSuccess(ctx, makeMinimalResult());
+
+    // Exactly what unified-executor does when prdDirty is true. A handler that
+    // only mutated ctx.prd would come back "passed" here.
+    const reloaded = result.prdDirty ? await loadPRD(ctx.prdPath) : result.prd;
+    expect(reloaded.userStories[0]?.status).toBe("failed");
+  });
+
+  test("a non-conflict merge failure reclaims the worktree directory", async () => {
+    const { ctx } = await seedPassedStory();
+    const calls = stubSpawn();
+    _resultHandlerDeps.mergeEngine = {
+      merge: mock(async () => ({ success: false as const, failureKind: "error" as const, error: "dirty tree" })),
+    } as unknown as typeof _resultHandlerDeps.mergeEngine;
+
+    await handlePipelineSuccess(ctx, makeMinimalResult());
+
+    expect(calls.some((a) => a.includes("worktree") && a.includes("remove"))).toBe(true);
+  });
+
+  test("a clean merge still reports the story as passed", async () => {
+    const { ctx } = await seedPassedStory();
+    stubSpawn();
+    _resultHandlerDeps.mergeEngine = {
+      merge: mock(async () => ({ success: true as const })),
+    } as unknown as typeof _resultHandlerDeps.mergeEngine;
+
+    const result = await handlePipelineSuccess(ctx, makeMinimalResult());
+
+    expect((await loadPRD(prdPath)).userStories[0]?.status).toBe("passed");
+    expect(result.storiesCompletedDelta).toBe(1);
   });
 });

--- a/test/unit/flows/nax-finish/steps/context.test.ts
+++ b/test/unit/flows/nax-finish/steps/context.test.ts
@@ -71,6 +71,36 @@ describe("context steps", () => {
     expect(r.groups).toEqual([]);
   });
 
+  test("resolveFeature degrades an unrecognised acceptance status to no-prd", async () => {
+    // A status this flow does not know cannot be reasoned about: it is neither
+    // the explicit opt-out nor a resolution we can trust. `no-prd` is the one
+    // value that routes to `escalate`, which is the honest answer — the same
+    // posture as the missing-status default just above.
+    _contextDeps.run = async () =>
+      ok(
+        JSON.stringify({
+          specSource: { kind: "markdown", path: ".nax/features/x/spec.md" },
+          acceptance: { status: "partially-resolved", groups: [] },
+        }),
+      );
+    const r = await resolveFeature("x", "/w");
+    expect(r.acceptanceStatus).toBe("no-prd");
+  });
+
+  test("resolveFeature passes through every status the flow actually branches on", async () => {
+    for (const status of ["ok", "no-prd", "disabled"] as const) {
+      _contextDeps.run = async () =>
+        ok(
+          JSON.stringify({
+            specSource: { kind: "markdown", path: ".nax/features/x/spec.md" },
+            acceptance: { status, groups: [] },
+          }),
+        );
+      const r = await resolveFeature("x", "/w");
+      expect(r.acceptanceStatus).toBe(status);
+    }
+  });
+
   test("resolveFeature throws when specSource is missing", async () => {
     _contextDeps.run = async () => ok(JSON.stringify({ status: "no-prd", featureName: "x" }));
     await expect(resolveFeature("x", "/w")).rejects.toThrow('no specSource for "x"');

--- a/test/unit/pipeline/stages/queue-check.test.ts
+++ b/test/unit/pipeline/stages/queue-check.test.ts
@@ -118,6 +118,28 @@ describe("queueCheckStage — RETRY / PRIORITY", () => {
     expect(ctx.prd.userStories[0].status).toBe("pending");
   });
 
+  test("SKIP for an unknown story ID does not write the PRD", async () => {
+    // markStorySkipped cannot skip a story that is not there, so persisting is
+    // a write that records nothing. The real cost is the log line above it,
+    // which used to announce a skip that never happened.
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, ".queue.txt"), "SKIP US-999\n");
+
+    await queueCheckStage.execute(ctx);
+
+    expect(await Bun.file(join(workdir, "prd.json")).exists()).toBe(false);
+  });
+
+  test("SKIP for a known story still writes the PRD", async () => {
+    const ctx = makeCtx(workdir);
+    await Bun.write(join(workdir, ".queue.txt"), "SKIP US-001\n");
+
+    await queueCheckStage.execute(ctx);
+
+    expect(await Bun.file(join(workdir, "prd.json")).exists()).toBe(true);
+    expect(ctx.prd.userStories[0].status).toBe("skipped");
+  });
+
   test("PAUSE still stops execution (existing behavior)", async () => {
     const ctx = makeCtx(workdir);
     await Bun.write(join(workdir, ".queue.txt"), "PAUSE\n");


### PR DESCRIPTION
Findings from a pre-release review of the unreleased `v0.77.3..main` delta. The first is a
regression introduced by #1533 and blocks a clean release; the rest are smaller reporting and
typing gaps found alongside it.

## P0 — a failed worktree merge reported the story, and the run, as successful

`completionStage` runs before `handlePipelineSuccess` and, on the sequential path
(`skipPrdPersistence` is set only for parallel batches), it marks the story passed, writes that to
`prd.json` and emits `story:completed`. Both merge-failure branches below then returned without
correcting any of it — so `isComplete(prd)` still saw a green run, and a resume skipped the story
as done, for code that never landed on the branch.

#1533 is what made the non-conflict case reachable. `merge()` used to throw for every non-conflict
git failure, which ended the run loudly. Making it total was right, but the new value-returning
branch inherited the missing bookkeeping from the conflict branch beside it. The two parallel call
sites added in the same commit (`parallel-coordinator`, `parallel-batch`) both record the failure;
this one did not.

`failStoryAfterMerge` mirrors the `case "fail"` arm of `handlePipelineFailure` minus the tier
escalation — every gate already passed, so there is nothing to retry higher.

**The `savePRD` in it is load-bearing.** `prdDirty` means "I already wrote to disk, reload from
it", and the executor answers it with `loadPRD` (`unified-executor.ts:484-486`). Setting the flag
without saving would reload the `passed` copy and discard the correction — so a test asserting only
`ctx.prd` would pass against the bug. The new tests read `prd.json` back, and one replays the
executor's reload explicitly. Deleting the `savePRD` fails 2 of them.

The non-conflict branch also reclaims the worktree directory, matching `case "fail"`. The conflict
branch deliberately does not — rectification preserves that worktree so the unresolved conflict
stays inspectable.

## The rest

- **`merge-conflict-rectify`** was the third `mergeAll` consumer and the only one #1533 did not
  update: it hardcoded `finalConflict: true` and read neither `failureKind` nor `error`, so a merge
  that failed over a dirty tree or a missing branch was reported as a conflict the agent could not
  resolve. Extracted `rectifyMergeFailure` so the classification is testable on its own.
- **SKIP** logged "Skipping story by user request" before knowing whether the story existed, then
  persisted an unchanged PRD behind it. `markStorySkipped` now returns whether it found anything.
- **`acceptanceStatus`** was typed `string` while `steps/gates.ts` branches on three literals, one
  of which (`disabled`) decides whether the acceptance gate runs at all. A typo in any of those
  comparisons compiled cleanly and would have silently stopped a gate firing.
- **CI**: #1534 folded the `checks` matrix into the `test` job but left `timeout-minutes: 10`. The
  work grew while the budget did not; raised to 15.

## Behavioural change worth knowing about

The acceptance-status narrowing is not a bare cast: an **unrecognised** status degrades to `no-prd`,
which routes to `escalate`. Previously it flowed through and could reach `proceed`. The skew this
could bite — an older flow against a newer CLI emitting a status it has never heard of — now stops
for a human rather than proceeding on a guess, matching the default already applied to a status
that is missing entirely.

## Deliberately left open

`markStorySkipped` still overwrites a terminal status, so a SKIP naming an already-`passed` story
flips it to `skipped`. That is a question about what SKIP should *mean* rather than a reporting bug,
and the ABORT path at `queue-check.ts:103` relies on the current behaviour.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check:all` — 17/17 gates
- [x] unit — 12449 pass / 0 fail (+11, matching the 11 tests added)
- [x] integration — 1102 pass / 0 fail
- [x] ui — 24 pass / 0 fail
- [x] e2e — 27 pass / 0 fail
- [x] coverage floor — lines 84.67%, functions 86.72% (floor 80%)
- [x] mutation check — removing the `savePRD` fails 2 of the new tests
- [ ] a real sequential run with `execution.storyIsolation: "worktree"` against a repo where the
      merge genuinely fails (not covered by the suite — the merge engine is stubbed)