### PR TITLE
feat(agents): register pi as a selectable ACP agent, with A/B profiles

### DIFF
--- a/.nax/config.json
+++ b/.nax/config.json
@@ -15,6 +15,11 @@
       "fast": "minimax/MiniMax-M2.7",
       "balanced": "minimax/MiniMax-M2.7",
       "powerful": "minimax/MiniMax-M2.7"
+    },
+    "pi": {
+      "fast": "huggingface/MiniMaxAI/MiniMax-M2.7",
+      "balanced": "huggingface/MiniMaxAI/MiniMax-M2.7",
+      "powerful": "huggingface/MiniMaxAI/MiniMax-M2.7"
     }
   },
   "autoMode": {

--- a/.nax/profiles/opencode-ab.json
+++ b/.nax/profiles/opencode-ab.json
@@ -1,0 +1,8 @@
+{
+  "agent": {
+    "default": "opencode",
+    "fallback": {
+      "enabled": false
+    }
+  }
+}

--- a/.nax/profiles/pi.json
+++ b/.nax/profiles/pi.json
@@ -1,0 +1,8 @@
+{
+  "agent": {
+    "default": "pi",
+    "fallback": {
+      "enabled": false
+    }
+  }
+}

--- a/scripts/baselines/file-sizes-baseline.json
+++ b/scripts/baselines/file-sizes-baseline.json
@@ -1,7 +1,6 @@
 {
-  "updatedAt": "2026-08-09T05:16:56.067Z",
+  "updatedAt": "2026-08-10T06:14:46.745Z",
   "byFile": {
-    "src/agents/acp/adapter.ts": 629,
     "src/agents/acp/spawn-client.ts": 734,
     "src/agents/manager.ts": 790,
     "src/context/engine/providers/code-neighbor.ts": 613,

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -30,7 +30,6 @@ import type {
 } from "../types";
 import { CompleteError, SessionTurnError } from "../types";
 import { defaultAcpTokenUsageMapper } from "./token-mapper";
-import type { AgentRegistryEntry } from "./types";
 import type { SessionTokenUsage } from "./wire-types";
 
 import {
@@ -45,6 +44,7 @@ import {
   throwIfAborted,
 } from "./adapter-lifecycle";
 import { buildTurnResult, extractContextToolCall, extractOutput, extractQuestion } from "./adapter-output";
+import { resolveRegistryEntry } from "./agent-entries";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Backward-compat re-exports (consumers import from this file via barrel)
@@ -73,46 +73,7 @@ const INTERACTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 min for human to respond
 // Agent registry
 // ─────────────────────────────────────────────────────────────────────────────
 
-const AGENT_REGISTRY: Record<string, AgentRegistryEntry> = {
-  claude: {
-    binary: "claude",
-    displayName: "Claude Code (ACP)",
-    supportedTiers: ["fast", "balanced", "powerful"],
-    maxContextTokens: 200_000,
-  },
-  codex: {
-    binary: "codex",
-    displayName: "OpenAI Codex (ACP)",
-    supportedTiers: ["fast", "balanced"],
-    maxContextTokens: 128_000,
-  },
-  gemini: {
-    binary: "gemini",
-    displayName: "Gemini CLI (ACP)",
-    supportedTiers: ["fast", "balanced", "powerful"],
-    maxContextTokens: 1_000_000,
-  },
-  opencode: {
-    binary: "opencode",
-    displayName: "opencode (ACP)",
-    supportedTiers: ["fast", "balanced", "powerful"],
-    maxContextTokens: 128_000,
-  },
-};
-
-const DEFAULT_ENTRY: AgentRegistryEntry = {
-  binary: "claude",
-  displayName: "ACP Agent",
-  supportedTiers: ["balanced"],
-  maxContextTokens: 128_000,
-};
-
-function resolveRegistryEntry(agentName: string): AgentRegistryEntry {
-  return AGENT_REGISTRY[agentName] ?? DEFAULT_ENTRY;
-}
-
-/** Names that have a real ACP adapter entry (subset of KNOWN_AGENT_NAMES). */
-export const ACP_ADAPTER_NAMES: ReadonlySet<string> = new Set(Object.keys(AGENT_REGISTRY));
+export { ACP_ADAPTER_NAMES } from "./agent-entries";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // AcpAgentAdapter

--- a/src/agents/acp/agent-entries.ts
+++ b/src/agents/acp/agent-entries.ts
@@ -1,0 +1,61 @@
+/**
+ * Per-agent ACP adapter entries.
+ *
+ * One row per agent name that nax can drive over ACP: the binary whose presence
+ * on PATH means "installed", the display name, and the capability envelope the
+ * adapter advertises. Kept separate from the adapter itself so adding an agent
+ * is a data change, not a change to session-lifecycle code.
+ */
+
+import type { AgentRegistryEntry } from "./types";
+
+const AGENT_REGISTRY: Record<string, AgentRegistryEntry> = {
+  claude: {
+    binary: "claude",
+    displayName: "Claude Code (ACP)",
+    supportedTiers: ["fast", "balanced", "powerful"],
+    maxContextTokens: 200_000,
+  },
+  codex: {
+    binary: "codex",
+    displayName: "OpenAI Codex (ACP)",
+    supportedTiers: ["fast", "balanced"],
+    maxContextTokens: 128_000,
+  },
+  gemini: {
+    binary: "gemini",
+    displayName: "Gemini CLI (ACP)",
+    supportedTiers: ["fast", "balanced", "powerful"],
+    maxContextTokens: 1_000_000,
+  },
+  opencode: {
+    binary: "opencode",
+    displayName: "opencode (ACP)",
+    supportedTiers: ["fast", "balanced", "powerful"],
+    maxContextTokens: 128_000,
+  },
+  // Reached through the third-party pi-acp bridge, which acpx spawns via npx.
+  // pi advertises model selection as an ACP config option, so all three tiers
+  // are selectable; the conservative context ceiling matches pi's own default
+  // for models whose metadata it cannot resolve.
+  pi: {
+    binary: "pi",
+    displayName: "Pi Coding Agent (ACP)",
+    supportedTiers: ["fast", "balanced", "powerful"],
+    maxContextTokens: 128_000,
+  },
+};
+
+const DEFAULT_ENTRY: AgentRegistryEntry = {
+  binary: "claude",
+  displayName: "ACP Agent",
+  supportedTiers: ["balanced"],
+  maxContextTokens: 128_000,
+};
+
+export function resolveRegistryEntry(agentName: string): AgentRegistryEntry {
+  return AGENT_REGISTRY[agentName] ?? DEFAULT_ENTRY;
+}
+
+/** Names that have a real ACP adapter entry (subset of KNOWN_AGENT_NAMES). */
+export const ACP_ADAPTER_NAMES: ReadonlySet<string> = new Set(Object.keys(AGENT_REGISTRY));

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -10,7 +10,7 @@ import { AcpAgentAdapter } from "./acp/adapter";
 import type { AgentAdapter } from "./types";
 
 /** Known agent names (used for name validation and health checks) */
-export const KNOWN_AGENT_NAMES = ["claude", "codex", "opencode", "gemini", "aider"];
+export const KNOWN_AGENT_NAMES = ["claude", "codex", "opencode", "gemini", "aider", "pi"];
 
 /**
  * Test-only adapter overrides. Keys are agent names; values are adapter instances

--- a/test/unit/agents/acp/agent-entries.test.ts
+++ b/test/unit/agents/acp/agent-entries.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { AcpAgentAdapter, ACP_ADAPTER_NAMES } from "@/agents/acp";
+import { KNOWN_AGENT_NAMES } from "@/agents";
+
+describe("ACP agent entries", () => {
+  test("every adapter entry is also a known agent name", () => {
+    for (const name of ACP_ADAPTER_NAMES) {
+      expect(KNOWN_AGENT_NAMES).toContain(name);
+    }
+  });
+
+  test("pi is registered as a selectable ACP agent", () => {
+    expect(KNOWN_AGENT_NAMES).toContain("pi");
+    expect(ACP_ADAPTER_NAMES.has("pi")).toBe(true);
+  });
+
+  test("pi resolves to its own entry rather than the default fallback", () => {
+    const pi = new AcpAgentAdapter("pi");
+    const unknown = new AcpAgentAdapter("not-a-real-agent");
+
+    expect(pi.binary).toBe("pi");
+    expect(pi.displayName).toBe("Pi Coding Agent (ACP)");
+    expect(pi.displayName).not.toBe(unknown.displayName);
+  });
+
+  test("pi advertises all three model tiers so tier routing can select a model", () => {
+    expect([...new AcpAgentAdapter("pi").capabilities.supportedTiers].sort()).toEqual([
+      "balanced",
+      "fast",
+      "powerful",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Registers **pi** as a fourth ACP agent alongside claude / codex / opencode, and adds two config overlay profiles so it can be A/B'd against opencode on the same feature. **The repo default is unchanged** — `agent.default` is still `claude` with fallback on.

## Why a config profile alone was not enough

`createAgentRegistry().getAgent(name)` returns `undefined` for any name outside `KNOWN_AGENT_NAMES`, so a profile naming `pi` would have resolved to no adapter at run time. pi also needed a real entry in the ACP agent table, otherwise it silently inherits `DEFAULT_ENTRY` — which reports `binary: "claude"` and a single `balanced` tier.

## Why `adapter.ts` was split

`adapter.ts` was a grandfathered oversized file at 629 lines, and the new agent row pushed it to 639, which `check:file-sizes` rejects. Rather than shrink the row, the per-agent registry table moved to `src/agents/acp/agent-entries.ts`. That drops `adapter.ts` to **590 lines — under the 600 limit outright**, so the grandfathered baseline falls from 11 files to 10. Adding an agent is now a data change rather than an edit to session-lifecycle code.

## The profiles

| Profile | Effect |
|:---|:---|
| `.nax/profiles/pi.json` | `agent.default: "pi"`, fallback off |
| `.nax/profiles/opencode-ab.json` | `agent.default: "opencode"`, fallback off |

`models.pi` pins all three tiers to the same MiniMax model, mirroring how `models.opencode` is already pinned, so a comparison isolates the harness rather than the model.

`opencode-ab` exists because the pre-existing `.nax/profiles/opencode.json` falls back `opencode -> claude`. Running the baseline arm through it would let claude silently finish stories the agent under test failed, which destroys the comparison. Both arms therefore run fallback-off, so a failure is attributed to the agent that caused it.

```bash
nax run -f <feature> --profile opencode-ab   # baseline
nax run -f <feature> --profile pi            # candidate
```

## Notes on pi as an agent

pi is reached through the third-party `pi-acp` bridge, which acpx spawns via `npx`. Verified against a live ACP handshake and a real edit task:

- Model selection **works** — pi advertises `model_control: "config_option"` and honours `acpx --model`. This contradicts pi-acp's own README, which says model selection over ACP is unsupported.
- Gaps vs opencode: no MCP (`http`/`sse` both false), no `fs/*` or `terminal/*` delegation, no `session/request_permission` (so `--approve-all` and `execution.permissionProfile` do not constrain it), `sessionCapabilities` is `list` only, `embeddedContext` false.

Because of the missing permission channel, pi is deliberately **not** wired as a fallback target for any other agent — it is opt-in via profile only.

## Known limitation

pi reports its models under the `huggingface/MiniMaxAI/*` namespace, which `src/agents/cost/` does not price. Cost attribution for pi runs may read zero; compare tokens rather than dollars until a run proves otherwise.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (all 17 gate scripts)
- [x] `bun run test` — full unit + integration + ui, all green
- [x] New `test/unit/agents/acp/agent-entries.test.ts` — 4 tests pinning that pi is known, resolves to its own entry rather than `DEFAULT_ENTRY`, and advertises all three tiers
- [x] Config load verified for all three paths: default -> `claude`/fallback-on, `--profile pi` -> `pi`/fallback-off, `--profile opencode-ab` -> `opencode`/fallback-off
- [ ] The A/B itself — to be run on a real feature
