### PR TITLE
fix(finish): always re-review a committed gate fix (#1510)

### DIFF
--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -31,11 +31,11 @@
  *   the `acceptance` node last passed, and the repo-root `test` command does
  *   not cover per-feature acceptance tests — so without this a fix could break
  *   the contract the first gate proved and still ship.
- * - `commit_gate` re-enters `review_quality` when its fix touched non-test code
- *   — the gate loop was previously the one editing loop whose output only ever
- *   faced mechanical checks. A test-only fix skips the re-review by explicit
- *   cost tradeoff; see `gateCommitRoute` for why that is a known hole. The skip
- *   records `review-skipped`, so it is visible in the audit.
+ * - `commit_gate` re-enters `review_quality` whenever its fix committed — the
+ *   gate loop was otherwise the one editing loop whose output faced only
+ *   mechanical checks, which a fix that degrades the tests it repairs will
+ *   satisfy. A test-only fix used to skip the re-review as a cost tradeoff;
+ *   #1510 closed that hole. See `gateCommitRoute`.
  * - `load_ctx` and `open_pr` both route to `escalate` rather than throwing on
  *   their own failures. acpx has no error edge, so a throw ends the run with no
  *   result file for the plugin to read or notify from — the one outcome that
@@ -103,14 +103,23 @@ export const _openPrDeps = {
  *
  * - `unchanged` — nothing committed; no new diff, so nothing to review.
  * - `tests-only` — every touched path matched the repo's test-file patterns.
- *   Skipped by explicit choice: the re-review is the flow's most expensive node
- *   and a gate fix is usually a mechanical test repair. **This is a real hole.**
- *   The defect that motivated the re-entry (rs-stock `b6fb66dd`) was itself
- *   test-only — 8 copy-pasted stubs across 3 test files — so this route would
- *   not have caught it. Widen it here if test-quality regressions start
- *   shipping — the audit's `review-skipped` rounds are the evidence.
  * - `changed` — production code was touched, or the paths could not be
  *   classified at all. "Cannot classify" reviews rather than skips.
+ *
+ * `tests-only` and `changed` both re-enter `review_quality` (#1510). They used
+ * to diverge: `tests-only` skipped the re-review as a cost tradeoff, on the
+ * reasoning that a gate fix is usually a mechanical test repair. That was a
+ * real hole — the defect that motivated the re-entry was itself test-only, 8
+ * copy-pasted stubs across 3 test files, so the skip would not have caught the
+ * very thing it was built for. A gate fix can turn a red suite green by
+ * degrading the tests it repairs, and `quality_gates` is satisfied by exactly
+ * that; nothing else read that diff. The audit settled the cost side: across
+ * every finish recorded, exactly one `gate` round has ever fired, so the skip
+ * was saving a review that almost never runs.
+ *
+ * The classification is kept even though both routes now review. It is what a
+ * cheaper test-quality-scoped reviewer would key off if gate rounds ever become
+ * frequent enough for the full re-review to hurt.
  */
 async function gateCommitRoute(
   i: FinishInput,
@@ -509,7 +518,7 @@ export default defineFlow({
       from: "commit_gate",
       switch: {
         on: "$.route",
-        cases: { changed: "review_quality", "tests-only": "quality_gates", unchanged: "quality_gates" },
+        cases: { changed: "review_quality", "tests-only": "review_quality", unchanged: "quality_gates" },
       },
     },
     // The narrative runs only once the PR exists. acpx has no error edge, so an

--- a/flows/nax-finish/steps/commit-round.ts
+++ b/flows/nax-finish/steps/commit-round.ts
@@ -57,6 +57,7 @@ export function buildCommitRound(i: CommitRoundInput): FinishRound {
     committed: i.committed,
     outcome: commitRoundOutcome(i.phase, i.route),
     findings: i.findings,
+    route: i.route,
     ...(i.failing ? { failing: i.failing } : {}),
     ...(i.committed && i.shaAfter ? { sha: i.shaAfter } : {}),
   };

--- a/flows/nax-finish/steps/commit-round.ts
+++ b/flows/nax-finish/steps/commit-round.ts
@@ -16,16 +16,15 @@ const REVIEWED_PHASES: FinishPhase[] = ["spec", "quality"];
 /**
  * What produced this round, given the successor the commit routed to.
  *
- * The `route` argument is why this is computed after the commit rather than
- * alongside it: `tests-only` is only known once the committed paths have been
- * classified, and it is the difference between "no reviewer exists for this
- * phase" and "a reviewer exists, was owed a look, and was skipped".
+ * `route` no longer changes the answer, and that is the point: since #1510
+ * every committed gate fix re-enters `review_quality`, so no route can skip an
+ * owed re-review. The parameter stays because the round is still keyed on the
+ * successor conceptually, and a future route that *does* bypass a reviewer
+ * would need to be reflected here rather than silently inheriting
+ * `no-reviewer`.
  */
-export function commitRoundOutcome(phase: FinishPhase, route: string): FinishRoundOutcome {
+export function commitRoundOutcome(phase: FinishPhase, _route: string): FinishRoundOutcome {
   if (REVIEWED_PHASES.includes(phase)) return "fixed";
-  // Only `gate` can skip an owed re-review; `acceptance` has no reviewer to
-  // skip, so its `tests-only`-shaped routes (it has none today) stay honest.
-  if (phase === "gate" && route === "tests-only") return "review-skipped";
   return "no-reviewer";
 }
 

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -108,6 +108,19 @@ export interface FinishRound {
   /** Gate commands that were red this round (gate phase). */
   failing?: string[];
   /**
+   * The successor this round's commit routed to — `changed` / `tests-only` /
+   * `unchanged` for `gate`, `changed` / `unchanged` elsewhere.
+   *
+   * Recorded because `outcome` stopped carrying it. Until #1510 a tests-only
+   * gate fix was the only round writing `review-skipped`, so the outcome
+   * doubled as the classification; now every committed gate fix is reviewed
+   * and writes `no-reviewer`, which would leave "what did this fix touch?"
+   * unanswerable from the trail. That question is the input to deciding
+   * whether the re-review ever needs a cheaper, test-scoped form, so it has to
+   * survive the round it was computed in.
+   */
+  route?: string;
+  /**
    * `HEAD` SHA after this round's commit (set only when `committed`); absent
    * on no-op rounds so a reader can distinguish "no commit" from "record lost".
    * Lets "Fixed in `<sha>`" be reconstructed from the audit trail alone, rather

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -80,16 +80,17 @@ export type FinishRoundOutcome =
    */
   | "no-reviewer"
   /**
-   * A re-review was owed and deliberately skipped — today only a `gate` fix
-   * that touched test files exclusively (`gateCommitRoute` → `tests-only`).
+   * A re-review was owed and deliberately skipped.
    *
-   * Distinct from `no-reviewer`, which the same node writes when the fix *is*
-   * routed on to `review_quality`. Without the distinction both wrote
-   * `no-reviewer`, so the audit could not tell a gate fix that was re-reviewed
-   * from one whose re-review was skipped by policy — the #1507 failure mode
-   * surviving on the one path where the omission is intentional, and the path
-   * where a reader most needs to know. Recording it is also what makes "how
-   * often does this fire?" answerable before anyone decides to close the hole.
+   * **No longer emitted.** It described the `gate` → `tests-only` route, which
+   * skipped `review_quality` as a cost tradeoff; #1510 closed that hole, so
+   * every committed gate fix is now re-reviewed and nothing writes this.
+   *
+   * Retained because the audit trail is read, not just written: a project that
+   * ran an earlier nax can hold rounds carrying this outcome, and dropping it
+   * from the union would make those unrenderable. Do not reuse the name for a
+   * new meaning — a reader hitting it in an old artifact must still be told
+   * what it meant when it was written.
    */
   | "review-skipped";
 

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -195,6 +195,13 @@ describe("gate fixes re-enter the quality review", () => {
     expect(gateSwitch().cases.changed).toBe("review_quality");
   });
 
+  // #1510: `tests-only` used to route straight to quality_gates. A gate fix can
+  // turn a red suite green by degrading the tests it repairs, and quality_gates
+  // is satisfied by exactly that — so every committed gate fix is now read.
+  test("a tests-only gate fix also goes back through review_quality", () => {
+    expect(gateSwitch().cases["tests-only"]).toBe("review_quality");
+  });
+
   test("a gate fix that changed nothing skips the re-review", () => {
     expect(gateSwitch().cases.unchanged).toBe("quality_gates");
   });
@@ -205,11 +212,11 @@ describe("gate fixes re-enter the quality review", () => {
   });
 });
 
-// Chosen tradeoff, not an oversight: the re-review is the flow's most expensive
-// node and a gate fix is usually a mechanical test repair. It is a real hole —
-// the defect that motivated the re-entry (rs-stock b6fb66dd) was itself
-// test-only — so these tests pin the boundary precisely.
-describe("gate re-entry is scoped to non-test changes", () => {
+// The classification outlives the skip it used to gate (#1510). Both routes now
+// re-enter review_quality, so these tests pin what a gate fix *touched* — which
+// is what a scoped test-quality prompt would key off if the re-review ever needs
+// to get cheaper — not whether a reviewer runs.
+describe("gate commits are classified by what they touched", () => {
   const originalRun = _gitDeps.run;
   const originalAppend = _resultDeps.appendText;
   afterEach(() => {
@@ -246,13 +253,15 @@ describe("gate re-entry is scoped to non-test changes", () => {
     expect((await runGateCommit(["src/scheduler.ts", "test/unit/scheduler.test.ts"])).route).toBe("changed");
   });
 
-  test("a fix touching only test files skips the re-review", async () => {
+  test("a fix touching only test files is classified tests-only", async () => {
     expect((await runGateCommit(["test/unit/a.test.ts", "test/unit/b.test.ts"])).route).toBe("tests-only");
   });
 
   // Fail-safe: an older nax whose `features resolve` predates testPatterns, or a
-  // config the resolver choked on, must review rather than skip.
-  test("with no patterns to classify by, it reviews rather than skipping", async () => {
+  // config the resolver choked on, classifies as `changed`. Since #1510 both
+  // routes review, so this no longer decides whether a reviewer runs — it still
+  // pins that an unclassifiable fix is never reported as a mere test repair.
+  test("with no patterns to classify by, it falls back to changed", async () => {
     expect((await runGateCommit(["test/unit/a.test.ts"], [])).route).toBe("changed");
   });
 
@@ -260,22 +269,20 @@ describe("gate re-entry is scoped to non-test changes", () => {
     expect((await runGateCommit(["test/unit/a.test.ts"], ["\\.test\\.ts$", "([unclosed"])).route).toBe("tests-only");
   });
 
-  test("an empty file list (git show failed) reviews rather than skipping", async () => {
+  test("an empty file list (git show failed) falls back to changed", async () => {
     expect((await runGateCommit([])).route).toBe("changed");
   });
 
-  // The skip is a deliberate cost tradeoff, but until it says so in the audit
-  // it is indistinguishable from a gate fix that WAS re-reviewed — both wrote
-  // `no-reviewer`. That is the #1507 failure mode surviving on the one path
-  // where the omission is on purpose, which is exactly where a reader most
-  // needs to know. Recording it is also what makes "how often does this fire?"
-  // answerable before anyone decides whether to close the hole.
-  test("a skipped re-review says so in the audit trail", async () => {
+  // Regression for #1510: a tests-only gate fix used to record `review-skipped`,
+  // which was true then and would be a lie now — review_quality reads this diff.
+  // An outcome claiming a review was skipped when one ran is the #1507 failure
+  // mode pointing the other way.
+  test("a tests-only gate fix is no longer recorded as a skipped review", async () => {
     await runGateCommit(["test/unit/a.test.ts"]);
-    expect(gateRounds[0]).toMatchObject({ phase: "gate", outcome: "review-skipped" });
+    expect(gateRounds[0]).toMatchObject({ phase: "gate", outcome: "no-reviewer" });
   });
 
-  test("a gate fix that IS re-reviewed is not marked skipped", async () => {
+  test("a gate fix touching production code is also `no-reviewer`", async () => {
     await runGateCommit(["src/scheduler.ts"]);
     expect(gateRounds[0]).toMatchObject({ phase: "gate", outcome: "no-reviewer" });
   });

--- a/test/unit/flows/nax-finish/flow-commits.test.ts
+++ b/test/unit/flows/nax-finish/flow-commits.test.ts
@@ -287,6 +287,18 @@ describe("gate commits are classified by what they touched", () => {
     expect(gateRounds[0]).toMatchObject({ phase: "gate", outcome: "no-reviewer" });
   });
 
+  // With both routes writing `no-reviewer`, the outcome no longer says what the
+  // fix touched — so the route itself has to reach the trail. Without this the
+  // classification is computed on every gate commit and observed by nobody, and
+  // "how often is a gate fix tests-only?" (the input to making the re-review
+  // cheaper) stops being answerable.
+  test("the classification reaches the audit trail now that outcome no longer carries it", async () => {
+    await runGateCommit(["test/unit/a.test.ts"]);
+    expect(gateRounds[0]).toMatchObject({ route: "tests-only" });
+    await runGateCommit(["src/scheduler.ts"]);
+    expect(gateRounds[0]).toMatchObject({ route: "changed" });
+  });
+
   test("a gate fix that committed nothing is not marked skipped — there was nothing to review", async () => {
     _resultDeps.appendText = async (_p, s) => {
       gateRounds.push(JSON.parse(s));

--- a/test/unit/flows/nax-finish/steps/commit-round.test.ts
+++ b/test/unit/flows/nax-finish/steps/commit-round.test.ts
@@ -17,14 +17,19 @@ describe("commitRoundOutcome", () => {
     expect(commitRoundOutcome("quality", "changed")).toBe("fixed");
   });
 
-  // The distinction this function exists for: both of these are gate rounds
-  // that committed, and only one of them is about to be re-reviewed.
+  // Every gate round that commits is now routed on to review_quality (#1510),
+  // so `changed` and `tests-only` describe what the fix touched, not whether
+  // anyone looked at it. Both therefore carry the same outcome.
   test("a gate fix routed on to the re-review is `no-reviewer`", () => {
     expect(commitRoundOutcome("gate", "changed")).toBe("no-reviewer");
   });
 
-  test("a gate fix whose re-review was skipped by policy is `review-skipped`", () => {
-    expect(commitRoundOutcome("gate", "tests-only")).toBe("review-skipped");
+  // Regression for #1510: this returned `review-skipped` while `tests-only`
+  // bypassed the reviewer. It no longer does, and a round that claims a review
+  // was skipped when one actually ran misleads exactly as `no-reviewer` did
+  // before #1507.
+  test("a tests-only gate fix is re-reviewed, so it is not marked skipped", () => {
+    expect(commitRoundOutcome("gate", "tests-only")).toBe("no-reviewer");
   });
 
   test("a gate fix that committed nothing is not marked skipped — nothing was owed", () => {


### PR DESCRIPTION
Closes #1510.

## What changed

`commit_gate`'s `tests-only` route skipped `review_quality` and went straight to
`quality_gates`. It now re-enters `review_quality`, like `changed` already did.

The behaviour change is three lines; the rest of the diff is the comments and
tests that described the removed route.

## Why

The skip was a cost tradeoff, recorded in the source as a known hole: a gate fix
is usually a mechanical test repair, and the re-review is the flow's most
expensive node. The hole is that a gate fix can turn a red suite green by
degrading the tests it repairs, and `quality_gates` is satisfied by exactly
that — nothing else read that diff. The defect that motivated the re-entry in
the first place was itself test-only (8 copy-pasted stubs across 3 test files),
so the skip would not have caught the very thing it was built for.

#1509 made the skip countable so the decision could rest on data. It now does,
just not in the expected direction: across every finish in the audit trail,
`review-skipped` has fired **zero** times — because exactly **one** `gate` round
has ever fired at all. The skip was saving a review that almost never runs, so
the cheaper scoped-prompt alternative (option 2 on the issue) is not worth its
complexity today.

## Notes for review

- **`gateCommitRoute`'s classification is kept** even though both routes now
  review. It is what a test-quality-scoped reviewer would key off if gate rounds
  ever become frequent enough for the full re-review to hurt; deleting it would
  cascade into `partitionTestFiles` / `filesInCommit` / `testFileRegex` and
  foreclose that option.
- **`commitRoundOutcome` no longer returns `review-skipped`.** With nothing
  skipped, a round claiming a skipped review would mislead in the same way
  `no-reviewer` did before #1507.
- **The second commit records `route` on `FinishRound`.** Collapsing the outcome
  removed the only place the trail said what a gate fix touched, which would
  have left the retained classification computed and observed by nobody. `route`
  is optional so rounds written by an earlier nax still render.
- **`review-skipped` stays in the union**, documented as no longer emitted — the
  audit trail is read as well as written, and a project that ran an earlier nax
  holds rounds carrying it.

## Verification

- Full suite green: unit + integration (1102 pass / 38 skip / 0 fail) + ui.
- `bun run typecheck` clean; all 20 static checks pass, ratchets unmoved
  (`check:test-typecheck` 2025/2025, `check:test-as-unknown-as` 824/824).
- New regression tests: both routes re-enter `review_quality`; a tests-only gate
  fix is no longer recorded as a skipped review; the classification reaches the
  audit trail.