### PR TITLE
fix: resolve 55 mechanical findings from latent-bugs review

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -85,6 +85,7 @@ import { countStories, loadPRD } from "../src/prd";
 import { AgentStreamEventBus, projectOutputDir } from "../src/runtime";
 import { resolveScheduleGate, waitForSchedule } from "../src/schedule";
 import { PipelineEventEmitter, type StoryDisplayState, renderTui } from "../src/tui";
+import { validateFeatureName } from "../src/utils/feature-name";
 import { NAX_BUILD_INFO, NAX_VERSION } from "../src/version";
 
 const program = new Command();
@@ -424,6 +425,16 @@ program
     new Option("--no-resume", "Alias for --fresh: never auto-resume from a prior checkpoint").default("__UNSET__"),
   )
   .action(async (options) => {
+    // Reject path-traversal / multi-segment names before they become a directory
+    // segment under .nax/features/ — `nax run -f ../x` would otherwise mkdir
+    // outside the features tree the same way `nax features create` could (BUG-35).
+    try {
+      validateFeatureName(options.feature);
+    } catch (err) {
+      console.error(chalk.red(`Invalid feature name: ${(err as Error).message}`));
+      process.exit(1);
+    }
+
     // Validate directory path
     let workdir: string;
     try {
@@ -548,6 +559,13 @@ program
       console.error(chalk.red("nax not initialized. Run: nax init"));
       process.exit(1);
     }
+    // Resolved project root (naxDir's parent) — plan strategies build their own
+    // `.nax` path as `join(workdir, ".nax")` without walking up, so passing the
+    // raw (possibly-subdirectory) `workdir` here lands prd.json in
+    // <subdir>/.nax/... while the run-side read-back above already correctly
+    // resolved naxDir by walking up — the two disagree and "run" then can't find
+    // the PRD it just planned (BUG-36).
+    const projectRoot = join(naxDir, "..");
 
     const featureDir = join(naxDir, "features", options.feature);
     const prdPath = join(featureDir, "prd.json");
@@ -585,7 +603,7 @@ program
         console.log(chalk.dim(`   [Plan log: ${planLogPath}]`));
 
         console.log(chalk.dim("   [Planning phase: generating PRD from spec]"));
-        const planResult = await planCommand(workdir, config, {
+        const planResult = await planCommand(projectRoot, config, {
           from: options.from,
           feature: options.feature,
           auto: options.oneShot ?? false, // interactive by default; --one-shot skips Q&A
@@ -920,6 +938,16 @@ features
   .description("Create a new feature")
   .option("-d, --dir <path>", "Project directory", process.cwd())
   .action(async (name, options) => {
+    // Reject path-traversal / multi-segment names before they become a directory
+    // segment under .nax/features/ — `nax features create ../../evil` would
+    // otherwise write outside the features tree (BUG-35).
+    try {
+      validateFeatureName(name);
+    } catch (err) {
+      console.error(chalk.red(`Invalid feature name: ${(err as Error).message}`));
+      process.exit(1);
+    }
+
     // Validate directory path
     let workdir: string;
     try {
@@ -1124,6 +1152,11 @@ program
       console.error(chalk.red("nax not initialized. Run: nax init"));
       process.exit(1);
     }
+    // Resolved project root (naxDir's parent) — see the `run --plan` comment above
+    // (BUG-36): planCommand/planDecomposeCommand build `.nax` as
+    // `join(workdir, ".nax")` without walking up, so a raw subdirectory workdir
+    // writes prd.json where findProjectDir's naxDir won't be able to read it back.
+    const projectRoot = join(naxDir, "..");
 
     // Load config — --profile accepts a chain (comma-separated or repeated flags).
     const cliOverrides: Record<string, unknown> = {};
@@ -1131,7 +1164,7 @@ program
     if (cliProfiles.length > 0) {
       cliOverrides.profile = cliProfiles;
     }
-    const config = await loadConfig(workdir, cliOverrides);
+    const config = await loadConfig(projectRoot, cliOverrides);
 
     // Initialize logger — writes to nax/features/<feature>/plan/<timestamp>.jsonl
     const featureLogDir = join(naxDir, "features", options.feature, "plan");
@@ -1143,7 +1176,7 @@ program
 
     try {
       if (options.decompose) {
-        await planDecomposeCommand(workdir, config, {
+        await planDecomposeCommand(projectRoot, config, {
           feature: options.feature,
           storyId: options.decompose,
         });
@@ -1154,7 +1187,7 @@ program
           console.error(chalk.red("Error: --from <spec-path> is required unless --decompose is used"));
           process.exit(1);
         }
-        const planResult = await planCommand(workdir, config, {
+        const planResult = await planCommand(projectRoot, config, {
           from: options.from,
           feature: options.feature,
           auto: options.auto || options.oneShot, // --auto and --one-shot are aliases

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -812,25 +812,35 @@ program
       process.exit(exitOutcome);
     }
 
-    const result = await run({
-      prdPath,
-      workdir,
-      config,
-      hooks,
-      feature: options.feature,
-      featureDir,
-      dryRun: options.dryRun,
-      useBatch: options.batch ?? true,
-      parallel,
-      eventEmitter,
-      statusFile: statusFilePath,
-      logFilePath,
-      formatterMode: useHeadless ? formatterMode : undefined,
-      headless: useHeadless,
-      skipPrecheck: options.skipPrecheck ?? false,
-      agentStreamEvents,
-      resumeMode: options.fresh === true || options.resume === false ? "fresh" : "auto",
-    });
+    let result: Awaited<ReturnType<typeof run>>;
+    try {
+      result = await run({
+        prdPath,
+        workdir,
+        config,
+        hooks,
+        feature: options.feature,
+        featureDir,
+        dryRun: options.dryRun,
+        useBatch: options.batch ?? true,
+        parallel,
+        eventEmitter,
+        statusFile: statusFilePath,
+        logFilePath,
+        formatterMode: useHeadless ? formatterMode : undefined,
+        headless: useHeadless,
+        skipPrecheck: options.skipPrecheck ?? false,
+        agentStreamEvents,
+        resumeMode: options.fresh === true || options.resume === false ? "fresh" : "auto",
+      });
+    } finally {
+      // Unmount the TUI even when run() throws — otherwise a thrown error prints
+      // over the still-mounted TUI frame instead of a clean error message, and the
+      // headless summary below never runs either (BUG-51).
+      if (tuiInstance) {
+        tuiInstance.unmount();
+      }
+    }
 
     // Create/update latest.jsonl symlink
     const latestSymlink = join(runsDir, "latest.jsonl");
@@ -845,11 +855,6 @@ program
       });
     } catch (error) {
       console.error(chalk.yellow(`Warning: Failed to create latest.jsonl symlink: ${error}`));
-    }
-
-    // Cleanup TUI if it was rendered
-    if (tuiInstance) {
-      tuiInstance.unmount();
     }
 
     // Summary (only in headless mode; TUI shows summary itself)

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -144,9 +144,15 @@ async function promptForConfirmation(question: string): Promise<boolean> {
       process.stdin.pause();
       process.stdin.removeListener("data", handler);
 
-      const answer = char.toLowerCase();
       process.stdout.write("\n");
 
+      if (char === "") {
+        // Ctrl+C — treat as cancellation, not confirmation
+        resolve(false);
+        process.exit(130);
+      }
+
+      const answer = char.toLowerCase();
       if (answer === "n") {
         resolve(false);
       } else {
@@ -677,7 +683,12 @@ program
       config.agent ??= {};
       config.agent.default = options.agent;
     }
-    config.execution.maxIterations = Number.parseInt(options.maxIterations, 10);
+    const maxIterations = Number.parseInt(options.maxIterations, 10);
+    if (!Number.isFinite(maxIterations) || maxIterations < 1) {
+      console.error(chalk.red("--max-iterations must be a positive integer"));
+      process.exit(1);
+    }
+    config.execution.maxIterations = maxIterations;
     if (options.maxCost !== undefined) {
       const maxCost = Number(options.maxCost);
       if (!Number.isFinite(maxCost) || maxCost <= 0) {

--- a/src/acceptance/fix-generator.ts
+++ b/src/acceptance/fix-generator.ts
@@ -71,11 +71,13 @@ export interface FixStory {
  */
 export function findRelatedStories(failedAC: string, prd: PRD): string[] {
   const relatedStoryIds: string[] = [];
+  const escapedAC = failedAC.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const acPattern = new RegExp(`(?<![\\w-])${escapedAC}(?!\\d)`);
 
   // Strategy 1: Find stories with this AC in their acceptanceCriteria
   for (const story of prd.userStories) {
     for (const ac of story.acceptanceCriteria) {
-      if (ac.includes(failedAC)) {
+      if (acPattern.test(ac)) {
         relatedStoryIds.push(story.id);
         break;
       }

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -45,6 +45,7 @@ import {
 } from "./adapter-lifecycle";
 import { buildTurnResult, extractContextToolCall, extractOutput, extractQuestion } from "./adapter-output";
 import { resolveRegistryEntry } from "./agent-entries";
+import { classifyCompleteError } from "./parse-agent-error";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Backward-compat re-exports (consumers import from this file via barrel)
@@ -156,7 +157,9 @@ export class AcpAgentAdapter implements AgentAdapter {
 
         let response: import("./adapter-session-types").AcpSessionResponse;
         try {
-          response = await Promise.race([session.prompt(prompt), timeoutPromise]);
+          const promptPromise = session.prompt(prompt);
+          promptPromise.catch(() => {});
+          response = await Promise.race([promptPromise, timeoutPromise]);
         } finally {
           clearTimeout(timeoutId);
         }
@@ -175,7 +178,8 @@ export class AcpAgentAdapter implements AgentAdapter {
               cancelled: true,
             };
           }
-          throw new CompleteError("complete() failed: stop reason is error");
+          // response.retryable may be undefined vs explicit false — preserved as-is (see classifyCompleteError).
+          throw new CompleteError("complete() failed: stop reason is error", undefined, response.retryable);
         }
 
         const text = response.messages
@@ -202,7 +206,9 @@ export class AcpAgentAdapter implements AgentAdapter {
           ? this._mapper.toInternal(response.cumulative_token_usage)
           : { inputTokens: 0, outputTokens: 0 };
         const estimatedCostUsd =
-          tokenUsage.inputTokens > 0 ? estimateCostFromTokenUsage(tokenUsage, _options.modelDef.model) : 0;
+          tokenUsage.inputTokens > 0 || tokenUsage.outputTokens > 0
+            ? estimateCostFromTokenUsage(tokenUsage, _options.modelDef.model)
+            : 0;
         const exactCostUsd = response.exactCostUsd;
 
         if (exactCostUsd !== undefined) {
@@ -234,6 +240,10 @@ export class AcpAgentAdapter implements AgentAdapter {
       return await tryOneAgent(this.name);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      if (error instanceof CompleteError) {
+        const classified = classifyCompleteError(error);
+        if (classified) return classified;
+      }
       const parsed = _fallbackDeps.parseAgentError(error.message);
       if (parsed.type === "auth") {
         return {

--- a/src/agents/acp/parse-agent-error.ts
+++ b/src/agents/acp/parse-agent-error.ts
@@ -1,4 +1,29 @@
-import type { AgentError } from "../types";
+import type { AgentError, CompleteError, CompleteResult } from "../types";
+
+/**
+ * Classify a `CompleteError` that already carries a transport-level retryable
+ * verdict (set by the acp adapter when acpx's stop-reason-error response included
+ * `retryable`). Returning `null` means the caller should fall back to
+ * `parseAgentError(error.message)`'s stderr-pattern classification instead.
+ */
+export function classifyCompleteError(error: CompleteError): CompleteResult | null {
+  if (error.retryable === undefined) return null;
+  // Transport (acpx) already classified this stop-reason-error turn as
+  // retryable or not — preserve that instead of falling through to the
+  // stderr-pattern-matching classifier, which has nothing to match on
+  // for this constant message and would misreport it as "unknown".
+  return {
+    output: error.message,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    estimatedCostUsd: 0,
+    adapterFailure: {
+      category: "quality",
+      outcome: "fail-adapter-error",
+      retriable: error.retryable,
+      message: error.message.slice(0, 500),
+    },
+  };
+}
 
 /**
  * Parse structured adapter error output to identify agent error type.

--- a/src/agents/acp/parser.ts
+++ b/src/agents/acp/parser.ts
@@ -42,6 +42,8 @@ export interface AcpxParseState {
   error: string | undefined;
   /** True if the acpx error response explicitly set retryable=true (e.g. QUEUE_DISCONNECTED). */
   retryable: boolean;
+  /** True once at least one line has parsed as valid NDJSON — gates the legacy-text fallback below. */
+  sawJsonLine: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -56,6 +58,7 @@ export function createParseState(): AcpxParseState {
     stopReason: undefined,
     error: undefined,
     retryable: false,
+    sawJsonLine: false,
   };
 }
 
@@ -69,6 +72,13 @@ export function createParseState(): AcpxParseState {
 export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLineActivity | undefined {
   try {
     const event = JSON.parse(line);
+    if (!state.sawJsonLine) {
+      // First real NDJSON line: drop any legacy-text fallback content an
+      // earlier unparseable banner/reconnect-notice line may have stashed in
+      // state.text, so it can't become a permanent prefix of the real response.
+      state.text = "";
+      state.sawJsonLine = true;
+    }
 
     // ── JSON-RPC envelope format (acpx v0.3+) ──────────────────────────────
     if (event.jsonrpc === "2.0") {
@@ -148,12 +158,17 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLine
 
         if (result.usage && typeof result.usage === "object") {
           const u = result.usage as Record<string, unknown>;
+          const asNumber = (...values: unknown[]): number => {
+            for (const v of values) {
+              if (typeof v === "number" && Number.isFinite(v)) return v;
+            }
+            return 0;
+          };
           state.tokenUsage = {
-            input_tokens: (u.inputTokens as number) ?? (u.input_tokens as number) ?? 0,
-            output_tokens: (u.outputTokens as number) ?? (u.output_tokens as number) ?? 0,
-            cache_read_input_tokens: (u.cachedReadTokens as number) ?? (u.cache_read_input_tokens as number) ?? 0,
-            cache_creation_input_tokens:
-              (u.cachedWriteTokens as number) ?? (u.cache_creation_input_tokens as number) ?? 0,
+            input_tokens: asNumber(u.inputTokens, u.input_tokens),
+            output_tokens: asNumber(u.outputTokens, u.output_tokens),
+            cache_read_input_tokens: asNumber(u.cachedReadTokens, u.cache_read_input_tokens),
+            cache_creation_input_tokens: asNumber(u.cachedWriteTokens, u.cache_creation_input_tokens),
           };
         }
       }
@@ -206,7 +221,10 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLine
         typeof event.error === "string" ? event.error : (event.error.message ?? JSON.stringify(event.error));
     }
   } catch {
-    if (!state.text) state.text = line;
+    // Only treat an unparseable line as legacy plain-text output when no NDJSON
+    // line has been seen yet — otherwise a stray banner/reconnect-notice line
+    // becomes a permanent prefix of an otherwise-successful JSON-RPC response.
+    if (!state.text && !state.sawJsonLine) state.text = line;
   }
   return undefined;
 }

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -17,12 +17,10 @@ import {
   type AcpClient,
   type AcpClientOptions,
   type AcpLineActivity,
-  type AcpParseState,
   type AcpSession,
   type AcpSessionResponse,
   createParseState,
   finalizeParseState,
-  parseAcpxJsonLine,
 } from "@/agents";
 import { getSafeLogger } from "@/logger";
 import type { AgentStreamEvent } from "@/runtime";
@@ -31,6 +29,7 @@ import { buildAllowedEnv } from "../shared/env";
 import { parseModelSpec } from "./model-spec";
 import { applyReasoningEffort } from "./reasoning-effort";
 import { parseSessionIds } from "./session-ids";
+import { readAndParseLines } from "./stdout-line-reader";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -54,52 +53,7 @@ export const _spawnClientDeps = {
 // Line-reader helper
 // ─────────────────────────────────────────────────────────────────────────────
 
-/**
- * Read chunks from a stream, split on newlines, and feed each complete line
- * into an AcpxParseState incrementally. Discards raw bytes immediately after
- * parsing so only the extracted fields (strings + numbers) are held in memory.
- *
- * The caller races this promise against a drain timeout to handle the Bun bug
- * where piped streams may not close after SIGTERM.
- *
- * When onActivity is provided, it is called immediately for each line that
- * produces activity metadata
- * (message_update, thinking_update, usage_update, tool_call_update).
- */
-async function readAndParseLines(
-  stream: ReadableStream<Uint8Array>,
-  state: AcpParseState,
-  onActivity?: (activity: AcpLineActivity) => void,
-): Promise<void> {
-  const decoder = new TextDecoder();
-  let remainder = "";
-  const reader = stream.getReader();
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      remainder += decoder.decode(value, { stream: true });
-      for (;;) {
-        const nl = remainder.indexOf("\n");
-        if (nl < 0) break;
-        const line = remainder.slice(0, nl);
-        remainder = remainder.slice(nl + 1);
-        if (line.trim()) {
-          const activity = parseAcpxJsonLine(line, state);
-          if (activity && onActivity) onActivity(activity);
-        }
-      }
-    }
-    // Flush decoder and process any content after the last newline
-    remainder += decoder.decode();
-    if (remainder.trim()) {
-      const activity = parseAcpxJsonLine(remainder.trim(), state);
-      if (activity && onActivity) onActivity(activity);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-}
+// readAndParseLines lives in ./stdout-line-reader (split out to stay under the file-size limit).
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Env builder
@@ -328,7 +282,8 @@ export class SpawnAcpSession implements AcpSession {
             }
           }
         : undefined;
-      const parsePromise = readAndParseLines(proc.stdout, parseState, onActivity).catch(() => {});
+      const parseHandle = readAndParseLines(proc.stdout, parseState, onActivity);
+      const parsePromise = parseHandle.promise.catch(() => {});
       const stderrPromise = new Response(proc.stderr).text().catch(() => "");
 
       const exitCode = await proc.exited;
@@ -347,10 +302,17 @@ export class SpawnAcpSession implements AcpSession {
       };
       const drainA = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
       const drainB = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
-      const [, stderr] = await Promise.all([
-        Promise.race([parsePromise, drainA.promise]).finally(() => drainA.cancel()),
+      const stdoutRaceResult = Promise.race([
+        parsePromise.then(() => "parsed" as const),
+        drainA.promise.then(() => "drain" as const),
+      ]).finally(() => drainA.cancel());
+      const [stdoutWinner, stderr] = await Promise.all([
+        stdoutRaceResult,
         Promise.race([stderrPromise, drainB.promise]).finally(() => drainB.cancel()),
       ]);
+      // Drain timeout won the race: cancel the stdout reader so its pending read()
+      // settles and the reader/lock isn't held for the rest of the process (BUG-46).
+      if (stdoutWinner === "drain") parseHandle.cancel();
 
       // Emit process_update(exited) after exit code is known
       emit?.({ ...baseEvent, kind: "agent.process_update", status: "exited", exitCode, timestamp: now() });

--- a/src/agents/acp/stdout-line-reader.ts
+++ b/src/agents/acp/stdout-line-reader.ts
@@ -1,0 +1,66 @@
+/**
+ * Incremental NDJSON stdout line reader for the spawn-based ACP client.
+ * Split out of spawn-client.ts to keep that file under the source-file size limit.
+ */
+
+import type { AcpLineActivity, AcpParseState } from "@/agents";
+import { parseAcpxJsonLine } from "@/agents";
+
+/**
+ * Read chunks from a stream, split on newlines, and feed each complete line
+ * into an AcpxParseState incrementally. Discards raw bytes immediately after
+ * parsing so only the extracted fields (strings + numbers) are held in memory.
+ *
+ * The caller races the returned promise against a drain timeout to handle the
+ * Bun bug where piped streams may not close after SIGTERM.
+ *
+ * When onActivity is provided, it is called immediately for each line that
+ * produces activity metadata
+ * (message_update, thinking_update, usage_update, tool_call_update).
+ *
+ * Returns a `{ promise, cancel }` pair rather than a bare Promise so the caller can cancel
+ * the underlying reader when a drain-timeout race is lost (BUG-46) — otherwise the pending
+ * `reader.read()` never settles and the reader/lock is held for the life of the process.
+ */
+export function readAndParseLines(
+  stream: ReadableStream<Uint8Array>,
+  state: AcpParseState,
+  onActivity?: (activity: AcpLineActivity) => void,
+): { promise: Promise<void>; cancel: () => void } {
+  const decoder = new TextDecoder();
+  let remainder = "";
+  const reader = stream.getReader();
+  const promise = (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        remainder += decoder.decode(value, { stream: true });
+        for (;;) {
+          const nl = remainder.indexOf("\n");
+          if (nl < 0) break;
+          const line = remainder.slice(0, nl);
+          remainder = remainder.slice(nl + 1);
+          if (line.trim()) {
+            const activity = parseAcpxJsonLine(line, state);
+            if (activity && onActivity) onActivity(activity);
+          }
+        }
+      }
+      // Flush decoder and process any content after the last newline
+      remainder += decoder.decode();
+      if (remainder.trim()) {
+        const activity = parseAcpxJsonLine(remainder.trim(), state);
+        if (activity && onActivity) onActivity(activity);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+  return {
+    promise,
+    cancel: () => {
+      reader.cancel().catch(() => {});
+    },
+  };
+}

--- a/src/agents/retry/hop-retry-policy.ts
+++ b/src/agents/retry/hop-retry-policy.ts
@@ -108,7 +108,12 @@ export function trySameAgentRetry(
         outcome: "timeout-retry",
         timeoutRetryAttempts: newAttempts,
         kind: { kind: "timeout-retry", attempt: newAttempts },
-        currentRunOptions: resolveTimeoutRetryOptions(currentRunOptions, timeoutConfig, config.execution),
+        currentRunOptions: resolveTimeoutRetryOptions(
+          currentRunOptions,
+          timeoutConfig,
+          config.execution,
+          requestRunOptions,
+        ),
         fallbackRecord: {
           outcome: result.adapterFailure?.outcome ?? "fail-timeout",
           category: result.adapterFailure?.category ?? "quality",
@@ -158,9 +163,14 @@ export function resolveTimeoutRetryOptions(
   prev: AgentRunOptions,
   timeoutConfig: TimeoutRetryConfig,
   executionConfig?: { sessionTimeoutSeconds?: number },
+  baseRunOptions?: AgentRunOptions,
 ): AgentRunOptions {
-  const budget =
-    prev.timeoutSeconds ?? executionConfig?.sessionTimeoutSeconds ?? DEFAULT_CONFIG.execution.sessionTimeoutSeconds;
+  // Always reduce from the ORIGINAL request budget, never from a previously-reduced
+  // `prev.timeoutSeconds` — otherwise the budget compounds on every retry
+  // (3600s -> 1800s -> 900s), making later retries time out faster than the
+  // original failure they're supposed to recover from.
+  const baseBudget = baseRunOptions?.timeoutSeconds ?? prev.timeoutSeconds;
+  const budget = baseBudget ?? executionConfig?.sessionTimeoutSeconds ?? DEFAULT_CONFIG.execution.sessionTimeoutSeconds;
   return { ...prev, timeoutSeconds: budget * timeoutConfig.budgetMultiplier };
 }
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -338,6 +338,8 @@ export class CompleteError extends Error {
   constructor(
     message: string,
     public readonly exitCode?: number,
+    /** True/false when the transport (acpx) classified the failure as retryable; undefined when unknown. */
+    public readonly retryable?: boolean,
   ) {
     super(message);
     this.name = "CompleteError";

--- a/src/cli/config-profile.ts
+++ b/src/cli/config-profile.ts
@@ -128,6 +128,13 @@ export async function profileUseCommand(profileName: string, startDir: string): 
     return "Profile reset to default.";
   }
 
+  // Verify the profile actually exists before poisoning .nax/config.json with a
+  // dangling reference — loadProfile throws a NaxError naming the available
+  // profiles when it doesn't, which is exactly what a typo'd name needs (BUG-50).
+  // A typo previously broke the next `nax run` with a confusing downstream error
+  // instead of failing here where the mistake was made.
+  await loadProfile(profileName, startDir);
+
   const updated = { ...existing, profile: profileName };
   await Bun.write(configPath, JSON.stringify(updated, null, 2));
   return `Now using profile: ${profileName}`;

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -145,6 +145,39 @@ export function resolveProject(options: ResolveProjectOptions = {}): ResolvedPro
 }
 
 /**
+ * Derives the single feature name from `.nax/features/*` when the caller didn't pass
+ * `-f`/`--feature` explicitly. `config.json` never carries a `feature` field (there is
+ * no such key in `NaxConfigSchema`) — commands that read `config.feature` always get
+ * `undefined` and fail unconditionally without an explicit flag.
+ *
+ * @throws {NaxError} when there are zero or more than one feature directories —
+ *   the caller must pass the flag explicitly in either case.
+ */
+export function resolveSingleFeature(naxDir: string): string {
+  const featuresDir = join(naxDir, "features");
+  const available = existsSync(featuresDir)
+    ? readdirSync(featuresDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort()
+    : [];
+
+  if (available.length === 1) return available[0];
+
+  if (available.length === 0) {
+    throw new NaxError("No feature specified and no features found — pass -f <name>.", "FEATURE_NOT_SPECIFIED", {
+      featuresDir,
+    });
+  }
+
+  throw new NaxError(
+    `No feature specified and multiple features exist — pass -f <name>.\n\nAvailable features:\n${available.map((f) => `  - ${f}`).join("\n")}`,
+    "FEATURE_AMBIGUOUS",
+    { featuresDir, available },
+  );
+}
+
+/**
  * Resolves a project by name from the global identity registry (~/.nax/<name>/.identity).
  * Falls back to path-based resolution when the value looks like a filesystem path.
  *

--- a/src/commands/logs-reader.ts
+++ b/src/commands/logs-reader.ts
@@ -29,18 +29,36 @@ export async function resolveRunFileFromRegistry(runId: string): Promise<string 
     throw new Error(`Run not found in registry: ${runId}`);
   }
 
-  let matched: MetaJson | null = null;
+  // Exact match wins immediately and unambiguously. Otherwise collect every prefix
+  // match instead of taking the first one — `entries` order is whatever readdir()
+  // returns (not sorted, not deterministic across filesystems), so silently picking
+  // the first prefix match could return an arbitrary run among several sharing that
+  // prefix (BUG-54). Error on genuine ambiguity instead.
+  let exactMatch: MetaJson | null = null;
+  const prefixMatches: MetaJson[] = [];
   for (const entry of entries) {
     const metaPath = join(runsDir, entry, "meta.json");
     try {
       const meta: MetaJson = await Bun.file(metaPath).json();
-      if (meta.runId === runId || meta.runId.startsWith(runId)) {
-        matched = meta;
+      if (meta.runId === runId) {
+        exactMatch = meta;
         break;
+      }
+      if (meta.runId.startsWith(runId)) {
+        prefixMatches.push(meta);
       }
     } catch {
       // skip unreadable meta.json entries
     }
+  }
+
+  let matched: MetaJson | null = exactMatch;
+  if (!matched) {
+    if (prefixMatches.length > 1) {
+      const candidates = prefixMatches.map((m) => m.runId).join(", ");
+      throw new Error(`Ambiguous run ID "${runId}" matches multiple runs: ${candidates}`);
+    }
+    matched = prefixMatches[0] ?? null;
   }
 
   if (!matched) {

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -10,7 +10,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { LogLevel } from "../logger/types";
-import { resolveProject } from "./common";
+import { resolveProject, resolveSingleFeature } from "./common";
 import { displayLogs, displayRunsList, followLogs } from "./logs-formatter";
 import { resolveRunFileFromRegistry, selectRunFile } from "./logs-reader";
 
@@ -61,15 +61,9 @@ export async function logsCommand(options: LogsOptions): Promise<void> {
   const resolved = resolveProject({ dir: options.dir });
   const naxDir = join(resolved.projectDir, ".nax");
 
-  // Read config to get feature name
-  const configPath = resolved.configPath;
-  const configFile = Bun.file(configPath);
-  const config = await configFile.json();
-  const featureName = config.feature;
-
-  if (!featureName) {
-    throw new Error("No feature specified in config.json");
-  }
+  // config.json never carries a feature field — derive the single feature from
+  // .nax/features/* (BUG-02).
+  const featureName = resolveSingleFeature(naxDir);
 
   const featureDir = join(naxDir, "features", featureName);
   const runsDir = join(featureDir, "runs");

--- a/src/commands/precheck.ts
+++ b/src/commands/precheck.ts
@@ -11,7 +11,7 @@ import chalk from "chalk";
 import { loadConfig } from "../config";
 import { loadPRD } from "../prd";
 import { EXIT_CODES, runEnvironmentPrecheck, runPrecheck } from "../precheck";
-import { resolveProject } from "./common";
+import { resolveProject, resolveSingleFeature } from "./common";
 
 /**
  * Options for precheck command
@@ -49,22 +49,20 @@ export async function precheckCommand(options: PrecheckOptions): Promise<void> {
     process.exit(result.passed ? EXIT_CODES.SUCCESS : EXIT_CODES.BLOCKER);
   }
 
-  // Determine feature name (from flag or config)
+  // Get feature directory
+  const naxDir = join(resolved.projectDir, ".nax");
+
+  // Determine feature name (from flag, or derived from .nax/features/* — config.json
+  // never carries a feature field, BUG-02).
   let featureName = options.feature;
   if (!featureName) {
-    // Read from config.json
-    const configFile = Bun.file(resolved.configPath);
-    const config = await configFile.json();
-    featureName = config.feature;
-
-    if (!featureName) {
-      console.error(chalk.red("No feature specified. Use -f flag or set feature in config.json"));
+    try {
+      featureName = resolveSingleFeature(naxDir);
+    } catch (err) {
+      console.error(chalk.red(err instanceof Error ? err.message : String(err)));
       process.exit(1);
     }
   }
-
-  // Get feature directory
-  const naxDir = join(resolved.projectDir, ".nax");
   const featureDir = join(naxDir, "features", featureName);
   const prdPath = join(featureDir, "prd.json");
 

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -142,10 +142,11 @@ export function registerResumeCommand(program: Command): void {
       const { findProjectDir } = await import("../config");
       const { run } = await import("../execution");
       const { applyResumeModeDeps } = await import("../execution/checkpoint");
-      const { existsSync } = await import("node:fs");
+      const { existsSync, mkdirSync } = await import("node:fs");
       const { loadConfig } = await import("../config");
       const { loadPRD } = await import("../prd");
       const { loadHooksConfig } = await import("../hooks");
+      const { initLogger } = await import("../logger");
 
       const naxDir = findProjectDir(cmdOpts.dir);
       if (!naxDir) {
@@ -180,6 +181,16 @@ export function registerResumeCommand(program: Command): void {
           const outputDir = projectOutputDir(projectKey, config.outputDir);
           const statusFilePath = join(outputDir, "status.json");
 
+          // Mirror bin/nax.ts's `nax run` logger init — without it, `getLogger()`
+          // returns the silent noopLogger for the whole resumed run: no console
+          // output, no runs/<id>.jsonl, so crash-recovery/replay have nothing to
+          // read for a resumed run (BUG-38).
+          const runsDir = join(outputDir, "features", feature, "runs");
+          mkdirSync(runsDir, { recursive: true });
+          const runId = new Date().toISOString().replace(/:/g, "-").replace(/\..+/, "");
+          const logFilePath = join(runsDir, `${runId}.jsonl`);
+          initLogger({ level: "info", filePath: logFilePath, useChalk: true, headless: true, suppressConsole: false });
+
           const result = await run({
             prdPath,
             workdir: cmdOpts.dir,
@@ -190,7 +201,7 @@ export function registerResumeCommand(program: Command): void {
             dryRun: false,
             useBatch: true,
             statusFile: statusFilePath,
-            logFilePath: undefined,
+            logFilePath,
             formatterMode: "normal",
             headless: true,
             skipPrecheck: false,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -15,6 +15,7 @@ import {
   rejectLegacyRectificationKeys,
   rejectUnimplementedScopedProfile,
 } from "./config-guards";
+import { resolveEnvVars } from "./dotenv";
 import { mergePackageConfig } from "./merge";
 import { deepMergeConfig } from "./merger";
 import { migrateLegacyReviewModelKey, migrateLegacyTestPattern } from "./migrations";
@@ -312,9 +313,18 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   // profile file throws fail-fast (loadProfile). "default"-only chains apply no overlay.
   for (const name of overlayChain) {
     const profileData = await loadProfile(name, projectRoot);
-    rawConfig = deepMergeConfig(rawConfig, profileData);
-    // Load companion .env for $VAR resolution — do NOT write to process.env (AC 9)
-    await loadProfileEnv(name, projectRoot);
+    // Load companion .env for $VAR resolution — do NOT write to process.env (AC 9).
+    // Must resolve BEFORE merging, otherwise a "$MODEL_FAST"-style reference lands
+    // in the run config as the literal unresolved string (BUG-17) — the load path
+    // previously discarded loadProfileEnv's return value and never called
+    // resolveEnvVars, so this only ever worked via the separate `config profile show
+    // --unmask` command path.
+    const profileEnv = await loadProfileEnv(name, projectRoot);
+    const resolvedProfileData =
+      Object.keys(profileEnv).length > 0
+        ? (resolveEnvVars(profileData, profileEnv) as Record<string, unknown>)
+        : profileData;
+    rawConfig = deepMergeConfig(rawConfig, resolvedProfileData);
   }
 
   // Layer 4: CLI overrides (highest priority)

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -17,11 +17,11 @@ import type { NaxConfig } from "./schema";
  * - models: per-agent model tier mappings (deep)
  * - routing: strategy, llm (deep)
  * - execution: smartTestRunner, regressionGate (deep), flakeDetection (deep),
- *   mutationCheck (deep), verificationTimeoutSeconds
- * - review: enabled, checks, commands (deep), semantic (deep)
- * - acceptance: enabled, generateTests, testPath
- * - quality: commands (deep), testing (deep)
- * - context: testCoverage (deep)
+ *   mutationCheck (deep), rectification (deep), verificationTimeoutSeconds
+ * - review: enabled, checks, commands (deep), semantic (deep), adversarial (deep)
+ * - acceptance: enabled, generateTests, testPath, fix (deep)
+ * - quality: commands (deep), testing (deep), autofix (deep), lintOutput (deep)
+ * - context: testCoverage (deep), v2.stages (deep), v2.rules (deep)
  * - project: type, language, frameworks
  *
  * Root-only sections (autoMode, generate, tdd, decompose, plan, constitution,
@@ -94,6 +94,10 @@ export function mergePackageConfig(root: NaxConfig, packageOverride: Partial<Nax
         ...root.execution.mutationCheck,
         ...packageOverride.execution?.mutationCheck,
       },
+      rectification: {
+        ...root.execution.rectification,
+        ...packageOverride.execution?.rectification,
+      },
     },
     review: {
       ...root.review,
@@ -140,10 +144,18 @@ export function mergePackageConfig(root: NaxConfig, packageOverride: Partial<Nax
         packageOverride.review?.semantic !== undefined
           ? { ...root.review.semantic, ...packageOverride.review.semantic }
           : root.review.semantic,
+      adversarial:
+        packageOverride.review?.adversarial !== undefined
+          ? { ...root.review.adversarial, ...packageOverride.review.adversarial }
+          : root.review.adversarial,
     },
     acceptance: {
       ...root.acceptance,
       ...packageOverride.acceptance,
+      fix:
+        packageOverride.acceptance?.fix !== undefined
+          ? { ...root.acceptance.fix, ...packageOverride.acceptance.fix }
+          : root.acceptance.fix,
     },
     quality: {
       ...root.quality,
@@ -156,6 +168,14 @@ export function mergePackageConfig(root: NaxConfig, packageOverride: Partial<Nax
         packageOverride.quality?.testing !== undefined
           ? { ...root.quality.testing, ...packageOverride.quality.testing }
           : root.quality.testing,
+      autofix:
+        packageOverride.quality?.autofix !== undefined
+          ? { ...root.quality.autofix, ...packageOverride.quality.autofix }
+          : root.quality.autofix,
+      lintOutput:
+        packageOverride.quality?.lintOutput !== undefined
+          ? { ...root.quality.lintOutput, ...packageOverride.quality.lintOutput }
+          : root.quality.lintOutput,
     },
     context: {
       ...root.context,
@@ -170,6 +190,10 @@ export function mergePackageConfig(root: NaxConfig, packageOverride: Partial<Nax
         stages: {
           ...root.context.v2?.stages,
           ...packageOverride.context?.v2?.stages,
+        },
+        rules: {
+          ...root.context.v2?.rules,
+          ...packageOverride.context?.v2?.rules,
         },
       },
     },

--- a/src/context/injector.ts
+++ b/src/context/injector.ts
@@ -235,9 +235,13 @@ export async function buildProjectMetadata(workdir: string, config: NaxConfig): 
     name: detected?.name,
     language: detected?.lang,
     dependencies: detected?.dependencies ?? [],
-    testCommand: config.execution?.testCommand ?? undefined,
-    lintCommand: config.execution?.lintCommand ?? undefined,
-    typecheckCommand: config.execution?.typecheckCommand ?? undefined,
+    // execution.testCommand/lintCommand/typecheckCommand were moved to
+    // quality.commands.{test,lint,typecheck} — Zod strips the old keys silently,
+    // so reading them here always returned undefined and the generated
+    // CLAUDE.md/AGENTS.md **Commands:** line was never emitted (BUG-43).
+    testCommand: config.quality?.commands?.test ?? undefined,
+    lintCommand: config.quality?.commands?.lint ?? undefined,
+    typecheckCommand: config.quality?.commands?.typecheck ?? undefined,
   };
 }
 

--- a/src/debate/runner-plan-helpers.ts
+++ b/src/debate/runner-plan-helpers.ts
@@ -333,7 +333,14 @@ export async function finalizePlanRun(
 
   let finalOutcome = outcome.outcome;
   let winningOutput: string | undefined = outcome.output ?? finalizedProposals[0]?.output;
-  winningOutput = await readWinnerOutput(selectionSummary.winnerOutputPath ?? outputPaths[0], winningOutput);
+  // Only read the winner FILE when the verifier-pick selector actually named one.
+  // Falling back to outputPaths[0] here would silently swap the synthesized/merged
+  // PRD (from resolveOutcome's synthesis pass, with its AC-merge/preservation rules)
+  // for debater 0's raw individual file on every default (non-verifier-pick) run,
+  // since that file exists in the normal flow (BUG-15).
+  if (selectionSummary.winnerOutputPath) {
+    winningOutput = await readWinnerOutput(selectionSummary.winnerOutputPath, winningOutput);
+  }
 
   let runCostUsd = totalCostUsd;
   if (config.postDebateVerifier && winningOutput) {

--- a/src/debate/runner-plan.ts
+++ b/src/debate/runner-plan.ts
@@ -240,6 +240,8 @@ export async function runPlan(
     for (const resolver of selectionResolvers) resolver.resolve({});
     const proposalBarriers = resolved.map(() => Promise.withResolvers<string>());
     const rebuttalBarriers = resolved.map(() => Promise.withResolvers<string>());
+    // Mark observed up front — a lone/early-failing debater's barrier can otherwise reject with no subscriber.
+    for (const barrier of proposalBarriers) barrier.promise.catch(() => {});
 
     const rebutBuilder = new DebatePromptBuilder(
       { taskContext, outputFormat: "", stage: "plan" },

--- a/src/debate/runner-plan.ts
+++ b/src/debate/runner-plan.ts
@@ -276,12 +276,15 @@ export async function runPlan(
     });
 
     // Propagate callOp settlement to rebuttalBarriers (mirrors AC9 from Path A).
+    // Also reject proposalBarriers[i] on failure — otherwise peers can block forever
+    // in `Promise.all(proposalBarriers...)` waiting on a barrier that never settles (BUG-14).
     for (let i = 0; i < callOpPromisesB.length; i++) {
       callOpPromisesB[i].then(
         (result) => {
           rebuttalBarriers[i].resolve(result.rebut ?? "");
         },
         (err) => {
+          proposalBarriers[i].reject(err);
           rebuttalBarriers[i].reject(err);
         },
       );

--- a/src/debate/runner-plan.ts
+++ b/src/debate/runner-plan.ts
@@ -194,7 +194,8 @@ export async function runPlan(
 
     for (let i = 0; i < settled.length; i++) {
       const res = settled[i];
-      if (res.status === "fulfilled") {
+      const succeeded = res.status === "fulfilled" && res.value.success;
+      if (succeeded && res.status === "fulfilled") {
         successful.push({
           debater: resolved[i].debater,
           agentName: resolved[i].agentName,
@@ -220,7 +221,12 @@ export async function runPlan(
             stage: ctx.stage,
             debaterIndex: i,
             agent: resolved[i].debater.agent,
-            error: res.reason instanceof Error ? res.reason.message : String(res.reason),
+            error:
+              res.status === "rejected"
+                ? res.reason instanceof Error
+                  ? res.reason.message
+                  : String(res.reason)
+                : `debate op returned success:false — ${res.value.rebut}`,
           });
         }
       }

--- a/src/debate/runner-stateful.ts
+++ b/src/debate/runner-stateful.ts
@@ -65,7 +65,6 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
 
   const signal = resolveStatefulSignal(ctx);
   const noopBuildRebutPrompt = (): string => "";
-  const localProposalBarrier = () => [Promise.withResolvers<string>()];
   const debaterRole = (index: number) => `debate-${ctx.stage}-${index}` as SessionRole;
   const debaterCallContext = (agentName: string, index: number): CallContext => ({
     ...createDebaterCallContext(ctx, agentName),
@@ -78,6 +77,13 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
     }
   };
 
+  // One barrier array shared by every debater in this round, sized to the
+  // participant count — each debater resolves its OWN slot by `index` (BUG-12:
+  // a fresh 1-element array per debater meant every debater but #0 indexed past
+  // the end and threw inside hopBody, which allSettledBounded then dropped
+  // silently, leaving only debater 0's proposal to ever succeed).
+  const proposalBarriers = resolved.map(() => Promise.withResolvers<string>());
+
   const proposalSettled = await allSettledBounded(
     resolved.map(
       ({ debater, agentName }, index) =>
@@ -88,7 +94,7 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
               index,
               proposePrompt: proposalBuilder.buildProposalPrompt(index),
               buildRebutPrompt: noopBuildRebutPrompt,
-              proposalBarriers: localProposalBarrier(),
+              proposalBarriers,
               signal,
               storyId: ctx.storyId,
               skipRebuttal: true,
@@ -169,6 +175,11 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
     return buildFailedResult(ctx.storyId, ctx.stage, ctx.stageConfig, 0);
   }
 
+  // Same sizing fix as the proposal round above — one shared array, sized to
+  // this round's participant count (survivors of the proposal round), not a
+  // fresh 1-element array per debater.
+  const rebuttalRoundBarriers = successfulProposals.map(() => Promise.withResolvers<string>());
+
   const rebuttals = shouldRunRebuttal
     ? (
         await allSettledBounded(
@@ -186,7 +197,7 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
                     })),
                   ),
                   buildRebutPrompt: noopBuildRebutPrompt,
-                  proposalBarriers: localProposalBarrier(),
+                  proposalBarriers: rebuttalRoundBarriers,
                   signal,
                   storyId: ctx.storyId,
                   skipRebuttal: true,

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -391,7 +391,7 @@ export async function runAcceptanceLoop(ctx: AcceptanceLoopContext): Promise<Acc
 
   const { acceptanceStage } = await _runAcceptanceTestsOnceDeps.importAcceptanceStage();
 
-  while (acceptanceRetries < maxRetries) {
+  do {
     // ── 1. Run acceptance ────────────────────────────────────────────────
     // Stamp the attempt index onto a per-iteration copy so the stage's verdict
     // reports a real retry count. Fix-cycle re-validations reuse this same copy
@@ -594,7 +594,7 @@ export async function runAcceptanceLoop(ctx: AcceptanceLoopContext): Promise<Acc
       acceptanceRetries + totalInternalIterations,
       finalCheck.missingTargets,
     );
-  }
+  } while (acceptanceRetries < maxRetries);
 
   return buildResult(false, prd, totalCost, iterations, storiesCompleted, prdDirty);
 }

--- a/src/execution/lifecycle/run-regression-triage.ts
+++ b/src/execution/lifecycle/run-regression-triage.ts
@@ -13,7 +13,7 @@ import type { Finding } from "@/findings";
 import { getSafeLogger } from "@/logger";
 import { detectFramework } from "@/test-runners";
 import type { TestSummary } from "@/test-runners";
-import { resolveFlakeBaselineDiff } from "@/verification";
+import type { resolveFlakeBaselineDiff } from "@/verification";
 import type { FlakeQuarantineReport, QuarantineMemo, triageFlakyFindings } from "@/verification/flake-triage";
 import type { DeferredRegressionResult } from "./run-regression";
 
@@ -33,9 +33,10 @@ export type RegressionTriageOutcome =
  * passes with warnings, no attribution, no fix cycles) or whether real
  * failures remain for the attribution pipeline in `runDeferredRegression`.
  *
- * `triageFn` is `_regressionDeps.triageFlakyFindings` from the caller — kept
- * as a parameter (not imported here) so existing tests that stub
- * `_regressionDeps.triageFlakyFindings` continue to intercept the call.
+ * `triageFn` and `resolveBaselineDiffFn` are `_regressionDeps.triageFlakyFindings`
+ * / `_regressionDeps.resolveFlakeBaselineDiff` from the caller — kept as
+ * parameters (not imported here) so existing tests that stub `_regressionDeps`
+ * continue to intercept the calls.
  */
 export async function runRegressionFlakeTriage(params: {
   regressionFindings: Finding[];
@@ -46,6 +47,7 @@ export async function runRegressionFlakeTriage(params: {
   testCommand: string;
   quarantineMemo: QuarantineMemo;
   triageFn: (input: Parameters<typeof triageFlakyFindings>[0]) => ReturnType<typeof triageFlakyFindings>;
+  resolveBaselineDiffFn: typeof resolveFlakeBaselineDiff;
   flakeDetection: FlakeDetectionConfig;
 }): Promise<RegressionTriageOutcome> {
   const {
@@ -57,10 +59,11 @@ export async function runRegressionFlakeTriage(params: {
     testCommand,
     quarantineMemo,
     triageFn,
+    resolveBaselineDiffFn,
     flakeDetection,
   } = params;
   const logger = getSafeLogger();
-  const baselineDiff = await resolveFlakeBaselineDiff(config, workdir);
+  const baselineDiff = await resolveBaselineDiffFn(config, workdir);
   if (baselineDiff === null) {
     // Fail closed: skip triage entirely rather than substituting an empty
     // diff, which would make every failing test look pre-existing (see

--- a/src/execution/lifecycle/run-regression.ts
+++ b/src/execution/lifecycle/run-regression.ts
@@ -24,6 +24,7 @@ import {
   NULL_QUARANTINE_MEMO,
   type QuarantineMemo,
   fullSuite,
+  resolveFlakeBaselineDiff,
   triageFlakyFindings,
 } from "@/verification";
 import { runRegressionFlakeTriage } from "./run-regression-triage";
@@ -71,6 +72,7 @@ export const _regressionDeps = {
   triageFlakyFindings: triageFlakyFindings as (
     input: Parameters<typeof triageFlakyFindings>[0],
   ) => ReturnType<typeof triageFlakyFindings>,
+  resolveFlakeBaselineDiff,
 };
 
 /**
@@ -352,6 +354,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
     testCommand,
     quarantineMemo,
     triageFn: _regressionDeps.triageFlakyFindings,
+    resolveBaselineDiffFn: _regressionDeps.resolveFlakeBaselineDiff,
     flakeDetection: config.execution.flakeDetection,
   });
   if (triageOutcome.shortCircuit) {

--- a/src/execution/parallel-batch.ts
+++ b/src/execution/parallel-batch.ts
@@ -127,6 +127,12 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
   const worktreeManager = await _parallelBatchDeps.createWorktreeManager();
   const worktreePaths = new Map<string, string>();
   const storyStartTimes = new Map<string, number>();
+  // Contained per-story like every other failure path below (preExecutionFailures is
+  // declared here, not further down, so this loop can push into it too) — one story's
+  // worktree-creation failure must not abort the whole batch and strand the worktrees
+  // already created for its siblings (BUG-05). A synthesized failure matches the shape
+  // the dependency-prep loop already produces below.
+  const preExecutionFailures: RunParallelBatchResult["failed"] = [];
   for (const story of stories) {
     storyStartTimes.set(story.id, Date.now());
     try {
@@ -136,7 +142,17 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
         storyId: story.id,
         error: error instanceof Error ? error.message : String(error),
       });
-      throw error;
+      preExecutionFailures.push({
+        story,
+        pipelineResult: {
+          success: false,
+          finalAction: "fail",
+          reason: error instanceof Error ? error.message : String(error),
+          stoppedAtStage: "worktree-create",
+          context: { ...pipelineContext, story, stories: [story], workdir } as PipelineContext,
+        },
+      });
+      continue;
     }
     worktreePaths.set(story.id, path.join(workdir, ".nax-wt", story.id));
   }
@@ -181,7 +197,6 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
 
   const dependencyContexts = new Map<string, WorktreeDependencyContext>();
   const readyStories: UserStory[] = [];
-  const preExecutionFailures: RunParallelBatchResult["failed"] = [];
   for (const story of stories) {
     const worktreeRoot = worktreePaths.get(story.id);
     if (!worktreeRoot) continue;

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -165,8 +165,14 @@ export async function run(options: RunOptions): Promise<RunResult> {
   // enter the inner try block below.
   const origLoadCheckpoints = _storyOrchestratorDeps.loadCheckpoints;
   const origRecordGreen = _storyOrchestratorDeps.recordGreen;
-  applyResumeModeDeps(featureDir ?? "", resumeMode);
-  applyRecordGreenDeps(featureDir ?? "", runId);
+  // Feature-less runs have no directory to durably record checkpoints under —
+  // `join("", "checkpoint.jsonl")` resolves to a bare relative path, which lands in
+  // whatever the process CWD happens to be and cross-seeds unrelated runs (BUG-40).
+  // Leave the default no-op stubs wired in that case instead of pointing them at CWD.
+  if (featureDir) {
+    applyResumeModeDeps(featureDir, resumeMode);
+    applyRecordGreenDeps(featureDir, runId);
+  }
   let iterations = 0;
   let storiesCompleted = 0;
   let totalCost = 0;

--- a/src/execution/story-selector.ts
+++ b/src/execution/story-selector.ts
@@ -45,8 +45,21 @@ export function selectNextStories(
     );
 
     if (storiesToExecute.length === 0) {
-      // Batch exhausted — signal caller to stop (no more work in this batch)
-      return null;
+      // Batch exhausted for this slot (e.g. only a `decomposed` parent left, whose
+      // sub-stories live outside this batch) — fall through to the single-story
+      // fallback instead of ending the run with pending sub-stories still queued.
+      const fallbackStory = getNextStory(prd, lastStoryId, config.execution.rectification?.maxAttemptsTotal ?? 12);
+      if (!fallbackStory) return null;
+
+      return {
+        selection: {
+          story: fallbackStory,
+          storiesToExecute: [fallbackStory],
+          routing: buildPreviewRouting(fallbackStory, config),
+          isBatchExecution: false,
+        },
+        nextBatchIndex: currentBatchIndex + 1,
+      };
     }
 
     const story = storiesToExecute[0];

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -248,7 +248,6 @@ export async function executeUnified(
           const batchStartedAt = new Date().toISOString();
           const storyStartMs = new Map<string, number>();
           for (const s of batch) storyStartMs.set(s.id, Date.now());
-
           const batchResult = await _unifiedExecutorDeps.runParallelBatch({
             stories: batch,
             ctx: {
@@ -277,11 +276,11 @@ export async function executeUnified(
             },
             prd,
           });
-
           // Route parallel failures through handlePipelineFailure (AC-6)
           for (const { story, pipelineResult } of batchResult.failed) {
             const storyRouting = prd.userStories.find((s) => s.id === story.id)?.routing;
-            await handlePipelineFailure(
+            // BUG-04: capture the escalated prd, or canEscalate never trips.
+            const failureResult = await handlePipelineFailure(
               {
                 config: ctx.config,
                 prd,
@@ -313,13 +312,14 @@ export async function executeUnified(
               },
               pipelineResult,
             );
+            // (Cost not re-added: batchResult.totalCost below already includes it.)
+            prd = failureResult.prd;
           }
 
           // Single-writer PRD reconciliation (H-1): worktree pipelines skipped
           // persistence, so record completed + merge-conflict outcomes here.
           reconcileBatchOutcome(prd, batchResult);
           await savePRD(prd, ctx.prdPath);
-
           await pipelineEventBus.drain();
           totalCost += batchResult.totalCost;
           storiesCompleted +=
@@ -335,7 +335,6 @@ export async function executeUnified(
               }
             }
           }
-
           // Build per-story metrics for completed parallel batch stories
           const batchCompletedAt = new Date().toISOString();
           for (const story of batchResult.completed) {

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -322,9 +322,9 @@ export async function executeUnified(
 
           await pipelineEventBus.drain();
           totalCost += batchResult.totalCost;
-          storiesCompleted += batchResult.completed.length;
+          storiesCompleted +=
+            batchResult.completed.length + batchResult.mergeConflicts.filter((c) => c.rectified).length;
           prdDirty = true;
-
           if (ctx.sessionManager) {
             for (const story of batchResult.completed) {
               await closeStorySessions(ctx.sessionManager, story.id, ctx.agentGetFn);

--- a/src/hooks/runner.ts
+++ b/src/hooks/runner.ts
@@ -14,6 +14,8 @@ import type { HookContext, HookDef, HookEvent, HooksConfig } from "./types";
 
 const DEFAULT_TIMEOUT = 5000;
 const STREAM_DRAIN_TIMEOUT_MS = 2000;
+/** Grace period after SIGTERM before escalating to SIGKILL for a hook that ignores it. */
+const HOOK_KILL_GRACE_MS = 5000;
 
 function createDrainDeadline(deadlineMs: number): { promise: Promise<string>; cancel: () => void } {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -220,17 +222,23 @@ async function executeHook(
     env: buildAllowedEnv({ env }),
   });
 
-  // Timeout handling
+  // Timeout handling. A single SIGTERM is not a deadline — a hook that traps or
+  // ignores it (or a daemon it spawned) leaves `proc.exited` unresolved forever,
+  // hanging the run's completion phase indefinitely. Escalate to SIGKILL if the
+  // process hasn't exited within the grace period.
   let timedOut = false;
+  let killTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutId = setTimeout(() => {
     timedOut = true;
     killProcessGroup(proc.pid, "SIGTERM");
+    killTimeoutId = setTimeout(() => killProcessGroup(proc.pid, "SIGKILL"), HOOK_KILL_GRACE_MS);
   }, timeout);
 
   const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
   const stderrPromise = new Response(proc.stderr).text().catch(() => "");
   const exitCode = await proc.exited;
   clearTimeout(timeoutId);
+  clearTimeout(killTimeoutId);
 
   const [stdout, stderr] = timedOut
     ? await (async () => {

--- a/src/interaction/plugins/auto.ts
+++ b/src/interaction/plugins/auto.ts
@@ -268,10 +268,19 @@ export class AutoInteractionPlugin implements InteractionPlugin {
       });
     }
 
-    if (parsed.confidence < 0 || parsed.confidence > 1) {
-      throw new NaxError(`Invalid confidence: ${parsed.confidence} (must be 0-1)`, "AUTO_APPROVE_PARSE_FAILED", {
-        stage: "run",
-      });
+    if (
+      typeof parsed.confidence !== "number" ||
+      !Number.isFinite(parsed.confidence) ||
+      parsed.confidence < 0 ||
+      parsed.confidence > 1
+    ) {
+      throw new NaxError(
+        `Invalid confidence: ${parsed.confidence} (must be a number 0-1)`,
+        "AUTO_APPROVE_PARSE_FAILED",
+        {
+          stage: "run",
+        },
+      );
     }
 
     return parsed;

--- a/src/interaction/plugins/telegram.ts
+++ b/src/interaction/plugins/telegram.ts
@@ -403,9 +403,10 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
     // Check callback query (button click)
     if (update.callback_query) {
       const data = update.callback_query.data;
-      if (!data.startsWith(requestId)) return null;
-
       const parts = data.split(":");
+      // Exact match on the id segment — startsWith let one tap answer the wrong
+      // prompt whenever one request's id was a prefix of another's (BUG-34).
+      if (parts[0] !== requestId) return null;
       if (parts.length < 2) return null;
 
       const action = parts[1] as InteractionResponse["action"];

--- a/src/interaction/plugins/webhook.ts
+++ b/src/interaction/plugins/webhook.ts
@@ -60,11 +60,17 @@ function installServePortZeroCompat(): void {
   const originalFetch = globalThis.fetch.bind(globalThis);
   const patchedServe = ((options: ServeCompatOptions): ServeCompatReturn => {
     const requestedPort = typeof options.port === "number" ? options.port : 0;
-    if (requestedPort !== 0 && !inMemoryServers.has(requestedPort)) {
+    // Route port 0 through the real Bun.serve too — the OS assigns a real available
+    // port for it same as any other bind, so there is nothing to compat-shim there.
+    // Only fall back to the in-memory server when Bun.serve genuinely fails (e.g. no
+    // network permission in a sandboxed environment) — previously port 0 was routed
+    // to the in-memory server unconditionally, so a real webhook responder posting to
+    // the advertised callback URL could never reach it: ECONNREFUSED every time (BUG-24).
+    if (!inMemoryServers.has(requestedPort)) {
       try {
         return originalServe(options);
       } catch {
-        return createInMemoryServer(options, requestedPort);
+        return createInMemoryServer(options, requestedPort === 0 ? nextCompatPort() : requestedPort);
       }
     }
 

--- a/src/interaction/triggers.ts
+++ b/src/interaction/triggers.ts
@@ -86,7 +86,11 @@ export function createTriggerRequest(
   const { fallback, timeout } = getTriggerConfig(trigger, config);
 
   const summary = substituteTemplate(metadata.defaultSummary, context);
-  const id = `trigger-${trigger}-${Date.now()}`;
+  // crypto.randomUUID() entropy — Date.now() alone collides for two same-name
+  // triggers firing in the same millisecond under parallel stories, and the
+  // second receive() then takes the supersede path and fabricates a `skip`
+  // for the first prompt (BUG-34).
+  const id = `trigger-${trigger}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
 
   return {
     id,

--- a/src/operations/debate-hybrid.ts
+++ b/src/operations/debate-hybrid.ts
@@ -80,13 +80,19 @@ export const hybridDebaterOp: RunOperation<DebateHybridInput, DebateHybridOutput
         return { ...proposal, output: `Agent "failed" during rebuttal`, estimatedCostUsd: totalCostUsd };
       }
       if (round < ctx.input.rounds) {
+        // allSettled here too (see the proposal-round comment above) — Promise.all would
+        // let one failing peer's rejected barrier cascade into every surviving debater's
+        // hopBody, aborting their own callOp and rejecting THEIR barriers in turn
+        // (BUG-13), turning a single proposal/rebuttal-stage failure into a total
+        // hybrid-debate failure despite the documented allSettled intent.
         const settledRound = await raceAgainstAbort(
-          Promise.all(ctx.input.rebutBarriers[round - 1].map((b) => b.promise)),
+          Promise.allSettled(ctx.input.rebutBarriers[round - 1].map((b) => b.promise)),
           ctx.input.signal,
           ctx.input.storyId,
         );
-        priorRoundOutputs.push(settledRound);
-        roundInputs = settledRound;
+        const roundOutputs = settledRound.map((r) => (r.status === "fulfilled" ? r.value : ""));
+        priorRoundOutputs.push(roundOutputs);
+        roundInputs = roundOutputs;
       }
     }
     return { ...lastTurn, estimatedCostUsd: totalCostUsd };

--- a/src/operations/debate-plan.ts
+++ b/src/operations/debate-plan.ts
@@ -56,11 +56,16 @@ export const planDebaterOp: RunOperation<DebatePlanInput, DebatePlanOutput, Deba
       }
     }
 
-    const peerProposals = await raceAgainstAbort(
-      Promise.all(ctx.input.proposalBarriers.map((barrier) => barrier.promise)),
+    // allSettled — a rejected peer barrier (own send failure, or the runner rejecting
+    // it on that debater's callOp failure) must not cascade into every surviving
+    // debater's Promise.all and abort their own callOp in turn (BUG-14, same failure
+    // shape as BUG-13 in the hybrid runner).
+    const peerProposalsSettled = await raceAgainstAbort(
+      Promise.allSettled(ctx.input.proposalBarriers.map((barrier) => barrier.promise)),
       ctx.input.signal,
       ctx.input.storyId,
     );
+    const peerProposals = peerProposalsSettled.map((r) => (r.status === "fulfilled" ? r.value : ""));
 
     const rebutResult = ctx.input.turnSemaphore
       ? await ctx.input.turnSemaphore.run(() => ctx.send(ctx.input.buildRebutPrompt(peerProposals)))

--- a/src/optimizer/rule-based.optimizer.ts
+++ b/src/optimizer/rule-based.optimizer.ts
@@ -177,24 +177,28 @@ export class RuleBasedOptimizer implements IPromptOptimizer {
       remainingChars -= sections.acceptanceCriteria.length;
     }
 
-    // Add as much context as fits
-    if (sections.context && remainingChars > 0) {
+    // Add as much context as fits. nax's real prompts use headers like "# Role:
+    // Implementer" / "# INSTRUCTIONS" that extractSections doesn't recognize, so
+    // task/context/AC are frequently all undefined and the whole prompt lands in
+    // `other` — treat that the same as context (truncate-to-fit) rather than the
+    // old all-or-nothing gate, which silently dropped it whenever it didn't fit
+    // in one piece (BUG-20).
+    const trimmable = sections.context ?? sections.other;
+    if (trimmable && remainingChars > 0) {
       // Reserve space for the trimmed message if we're going to add it
-      const reserveForMessage = sections.context.length > remainingChars ? trimmedMessage.length : 0;
+      const reserveForMessage = trimmable.length > remainingChars ? trimmedMessage.length : 0;
       const maxContextChars = Math.max(0, remainingChars - reserveForMessage);
-      const trimmedContext = sections.context.substring(0, maxContextChars);
+      const trimmedContext = trimmable.substring(0, maxContextChars);
       result += trimmedContext;
-      if (trimmedContext.length < sections.context.length) {
+      if (trimmedContext.length < trimmable.length) {
         result += trimmedMessage;
       }
     }
 
-    // Add other sections if there's room
-    if (sections.other && remainingChars > sections.other.length) {
-      result += sections.other;
-    }
-
-    return result;
+    // Never hand back a blank prompt — if nothing survived trimming (e.g. maxTokens
+    // is smaller than the reserved task/AC sections alone), bail out and send the
+    // untrimmed prompt rather than an empty one.
+    return result.trim() ? result : prompt;
   }
 
   /**

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -30,6 +30,7 @@ import { NaxError } from "@/errors";
 import { getSafeLogger } from "@/logger";
 import { callOp as _callOp, acceptanceGenerateOp, acceptanceRefineOp } from "@/operations";
 import { autoCommitIfDirty as _autoCommitIfDirty } from "@/utils/git";
+import { executeWithTimeout, shellQuoteArg } from "@/verification";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -130,19 +131,20 @@ export const _acceptanceSetupDeps = {
     _testPath: string,
     _workdir: string,
     _cmd: string[],
+    timeoutMs = 1_800_000,
   ): Promise<{ exitCode: number; output: string }> => {
-    const cmd = _cmd;
-    const proc = Bun.spawn(cmd, {
-      cwd: _workdir,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [exitCode, stdout, stderr] = await Promise.all([
-      proc.exited,
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
-    return { exitCode, output: `${stdout}\n${stderr}` };
+    const execution = await executeWithTimeout(
+      _cmd.map(shellQuoteArg).join(" "),
+      Math.ceil(timeoutMs / 1000),
+      undefined,
+      {
+        cwd: _workdir,
+      },
+    );
+    return {
+      exitCode: execution.exitCode ?? (execution.success ? 0 : 1),
+      output: execution.output ?? "",
+    };
   },
   callOp: async (
     pipelineCtx: PipelineContext,
@@ -486,7 +488,12 @@ async function runAcceptanceSetup(
       cmd: runCmd.join(" "),
       packageDir,
     });
-    const { exitCode } = await _acceptanceSetupDeps.runTest(testPath, packageDir, runCmd);
+    const { exitCode } = await _acceptanceSetupDeps.runTest(
+      testPath,
+      packageDir,
+      runCmd,
+      ctx.config.acceptance.timeoutMs,
+    );
     if (exitCode !== 0) {
       redFailCount++;
     }

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -37,6 +37,7 @@ import { getLogger } from "@/logger";
 import { countStories } from "@/prd";
 import { parseTestFailures as _parseTestFailures } from "@/test-runners";
 import { logTestOutput } from "@/utils/log-test-output";
+import { executeWithTimeout, shellQuoteArg } from "@/verification";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 /** Injectable deps for testability */
@@ -215,19 +216,15 @@ export const acceptanceStage: PipelineStage = {
         cmd: testCmdParts.join(" "),
         packageDir,
       });
-      const proc = Bun.spawn(testCmdParts, {
-        cwd: packageDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+      const execution = await executeWithTimeout(
+        testCmdParts.map(shellQuoteArg).join(" "),
+        Math.ceil(ctx.config.acceptance.timeoutMs / 1000),
+        undefined,
+        { cwd: packageDir },
+      );
 
-      const [exitCode, stdout, stderr] = await Promise.all([
-        proc.exited,
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-
-      const output = `${stdout}\n${stderr}`;
+      const exitCode = execution.exitCode ?? (execution.success ? 0 : 1);
+      const output = execution.output ?? "";
       allOutputParts.push(output);
 
       const failedACs = parseTestFailures(output);

--- a/src/plugins/builtin/curator/heuristics.ts
+++ b/src/plugins/builtin/curator/heuristics.ts
@@ -228,25 +228,30 @@ function h2PullToolEmptyResult(observations: Observation[], threshold: number): 
 function h3RepeatedRectification(observations: Observation[], threshold: number): Proposal[] {
   const cycles = observations.filter((o): o is RectifyCycleObservation => o.kind === "rectify-cycle");
 
-  const byStory = new Map<string, { count: number; featureId: string }>();
+  // Keyed by featureId/storyId — story IDs are feature-scoped ("US-001" exists in
+  // every feature), so grouping by the bare storyId merges unrelated features'
+  // rectify counts into one fabricated recurrence (BUG-48; see H1's crossFeatureKey
+  // comment for the same issue).
+  const byStory = new Map<string, { count: number; featureId: string; storyId: string }>();
   for (const obs of cycles) {
-    const existing = byStory.get(obs.storyId);
+    const key = `${obs.featureId}/${obs.storyId}`;
+    const existing = byStory.get(key);
     if (existing) {
       existing.count++;
     } else {
-      byStory.set(obs.storyId, { count: 1, featureId: obs.featureId });
+      byStory.set(key, { count: 1, featureId: obs.featureId, storyId: obs.storyId });
     }
   }
 
   const proposals: Proposal[] = [];
-  for (const [storyId, data] of byStory.entries()) {
-    if (data.count < threshold) continue;
+  for (const { count, featureId, storyId } of byStory.values()) {
+    if (count < threshold) continue;
     proposals.push({
       id: "H3",
       severity: "HIGH",
-      target: { canonicalFile: `.nax/features/${data.featureId}/context.md`, action: "add" },
-      description: `Repeated rectification cycle: story ${storyId} required ${data.count} rectify attempts`,
-      evidence: `Story ${storyId} triggered ${data.count} rectify cycles`,
+      target: { canonicalFile: `.nax/features/${featureId}/context.md`, action: "add" },
+      description: `Repeated rectification cycle: story ${storyId} required ${count} rectify attempts`,
+      evidence: `Story ${storyId} triggered ${count} rectify cycles`,
       sourceKinds: ["rectify-cycle"],
       storyIds: [storyId],
     });
@@ -258,22 +263,27 @@ function h3RepeatedRectification(observations: Observation[], threshold: number)
 function h4EscalationChain(observations: Observation[], threshold: number): Proposal[] {
   const escalations = observations.filter((o): o is EscalationObservation => o.kind === "escalation");
 
-  const byPath = new Map<string, { storyIds: string[]; featureId: string }>();
+  // Sites are featureId/storyId composites, not bare story IDs — story IDs are
+  // feature-scoped, so two features' unrelated "US-001" would otherwise dedupe
+  // into one displayed site and understate how widely this escalation path
+  // actually recurs (BUG-48; same fix as H1's `sites`).
+  const byPath = new Map<string, { sites: string[]; featureId: string }>();
   for (const obs of escalations) {
     const key = `${obs.payload.from}->${obs.payload.to}`;
+    const site = `${obs.featureId}/${obs.storyId}`;
     const existing = byPath.get(key);
     if (existing) {
-      existing.storyIds.push(obs.storyId);
+      existing.sites.push(site);
     } else {
-      byPath.set(key, { storyIds: [obs.storyId], featureId: obs.featureId });
+      byPath.set(key, { sites: [site], featureId: obs.featureId });
     }
   }
 
   const proposals: Proposal[] = [];
   for (const [escalationPath, data] of byPath.entries()) {
-    if (data.storyIds.length < threshold) continue;
-    const count = data.storyIds.length;
-    const unique = uniqueStoryIds(data.storyIds);
+    if (data.sites.length < threshold) continue;
+    const count = data.sites.length;
+    const unique = uniqueStoryIds(data.sites);
     proposals.push({
       id: "H4",
       severity: "MED",
@@ -326,18 +336,24 @@ function h5StaleChunk(observations: Observation[], threshold: number): Proposal[
 function h6FixCycleUnchanged(observations: Observation[], threshold: number): Proposal[] {
   const iterations = observations.filter((o): o is FixCycleIterationObservation => o.kind === "fix-cycle-iteration");
 
+  // Keyed by featureId/storyId (BUG-48) — grouping by the bare storyId here is the
+  // most severe instance of this bug: it doesn't just inflate a count, it interleaves
+  // two unrelated features' iterations (whose iterationNum both restart from 1) into
+  // one fabricated streak.
   const byStory = new Map<string, FixCycleIterationObservation[]>();
   for (const obs of iterations) {
-    const existing = byStory.get(obs.storyId);
+    const key = `${obs.featureId}/${obs.storyId}`;
+    const existing = byStory.get(key);
     if (existing) {
       existing.push(obs);
     } else {
-      byStory.set(obs.storyId, [obs]);
+      byStory.set(key, [obs]);
     }
   }
 
   const proposals: Proposal[] = [];
-  for (const [storyId, storyIterations] of byStory.entries()) {
+  for (const storyIterations of byStory.values()) {
+    const storyId = storyIterations[0].storyId;
     const ordered = [...storyIterations].sort(
       (a, b) => (a.payload.iterationNum ?? a.payload.iteration) - (b.payload.iterationNum ?? b.payload.iteration),
     );

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -118,6 +118,21 @@ export async function loadPlugins(
   const effectiveProjectRoot = projectRoot || projectDir;
   const pluginNames = new Set<string>();
   const disabledSet = new Set(disabledPlugins ?? []);
+
+  // Registers a plugin, replacing any earlier entry with the same name instead of
+  // appending a duplicate — a name collision is logged as "overrides", but every
+  // call site previously pushed anyway, so both stayed registered and each ran
+  // twice per run (getPostRunActions()/getReporters() return all matches), breaking
+  // the "each finding appears exactly once" invariant recurrence heuristics rely on.
+  const registerLoadedPlugin = (entry: LoadedPlugin): void => {
+    const existingIndex = loadedPlugins.findIndex((p) => p.plugin.name === entry.plugin.name);
+    if (existingIndex >= 0) {
+      loadedPlugins[existingIndex] = entry;
+    } else {
+      loadedPlugins.push(entry);
+    }
+    pluginNames.add(entry.plugin.name);
+  };
   const logger = getSafeLogger();
 
   // 0. Load built-in plugins.
@@ -223,11 +238,10 @@ export async function loadPlugins(
       if (pluginNames.has(validated.name)) {
         logger?.warn("plugins", `Plugin name collision: '${validated.name}' (global directory)`);
       }
-      loadedPlugins.push({
+      registerLoadedPlugin({
         plugin: validated,
         source: { type: "global", path: plugin.path },
       });
-      pluginNames.add(validated.name);
     }
   }
 
@@ -244,11 +258,10 @@ export async function loadPlugins(
       if (pluginNames.has(validated.name)) {
         logger?.warn("plugins", `Plugin name collision: '${validated.name}' (project directory overrides global)`);
       }
-      loadedPlugins.push({
+      registerLoadedPlugin({
         plugin: validated,
         source: { type: "project", path: plugin.path },
       });
-      pluginNames.add(validated.name);
     }
   }
 
@@ -271,11 +284,10 @@ export async function loadPlugins(
       if (pluginNames.has(validated.name)) {
         logger?.warn("plugins", `Plugin name collision: '${validated.name}' (config entry overrides previous)`);
       }
-      loadedPlugins.push({
+      registerLoadedPlugin({
         plugin: validated,
         source: { type: "config", path: entry.module },
       });
-      pluginNames.add(validated.name);
     }
   }
 

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -66,6 +66,13 @@ export async function loadPRD(path: string): Promise<PRD> {
 
   const prd: PRD = await Bun.file(path).json();
 
+  if (!Array.isArray(prd.userStories)) {
+    throw new NaxError(`PRD file is missing or has a corrupt "userStories" array: ${path}`, "PRD_INVALID", {
+      stage: "prd",
+      path,
+    });
+  }
+
   // @design: BUG-21: Normalize story fields to prevent null/undefined arithmetic issues
   // @design: BUG-004: Auto-default optional PRD fields in-memory (tags, status, acceptanceCriteria, storyPoints)
   for (const story of prd.userStories) {
@@ -158,6 +165,7 @@ export function getNextStory(prd: PRD, currentStoryId?: string | null, maxRetrie
       s.status !== "failed" &&
       s.status !== "paused" &&
       s.status !== "decomposed" &&
+      s.status !== "regression-failed" &&
       hasSatisfiedDependencies(s, storyIds, completedIds),
   );
 
@@ -232,7 +240,8 @@ export function markStoryPassed(prd: PRD, storyId: string, _statusWriter?: PostR
     const parent = prd.userStories.find((s) => s.id === parentId);
     if (parent && parent.status === "decomposed") {
       const siblings = prd.userStories.filter((s) => s.parentStoryId === parentId);
-      const allSiblingsPassed = siblings.length > 0 && siblings.every((s) => s.passes || s.status === "passed");
+      const allSiblingsPassed =
+        siblings.length > 0 && siblings.every((s) => s.passes || s.status === "passed" || s.status === "skipped");
       if (allSiblingsPassed) {
         parent.passes = true;
         parent.status = "passed";

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -218,7 +218,7 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
 
   // Validate dependency references (against already-known IDs)
   for (const dep of dependencies) {
-    if (!allIds.has(dep)) {
+    if (!allIds.has(normalizeStoryId(dep))) {
       throw new NaxError(
         `[schema] story[${index}].dependencies references unknown story ID "${dep}"`,
         "SCHEMA_VALIDATION_FAILED",

--- a/src/review/adversarial-helpers.ts
+++ b/src/review/adversarial-helpers.ts
@@ -81,9 +81,18 @@ export function validateAdversarialShape(parsed: unknown): AdversarialLLMRespons
   const acks = extractAcks(obj.acks);
   return {
     passed: obj.passed,
-    findings: obj.findings as AdversarialLLMFinding[],
+    // Mirrors semantic-helpers.ts's validateLLMShape: `findings: [null]` and
+    // `findings: ["prose"]` are both shapes an LLM produces, and every downstream
+    // reader (e.g. filterByAcQuote) dereferences `.severity` unguarded — a malformed
+    // entry that survives this cast becomes a crash mid-review (BUG-49).
+    findings: (obj.findings as unknown[]).filter(isAdversarialFindingShaped),
     ...(acks.length > 0 && { acks }),
   };
+}
+
+/** A finding must at least be an object; field-level validity is the consumer's business. */
+function isAdversarialFindingShaped(f: unknown): f is AdversarialLLMFinding {
+  return typeof f === "object" && f !== null && !Array.isArray(f);
 }
 
 /**

--- a/src/review/scoped-lint.ts
+++ b/src/review/scoped-lint.ts
@@ -63,7 +63,13 @@ function appendFilesToCommand(command: string, files: readonly string[]): string
 
 async function listChangedFiles(workdir: string, baseRef: string): Promise<string[] | null> {
   const proc = Bun.spawn({
-    cmd: ["git", "diff", "--name-only", `${baseRef}..HEAD`],
+    // --relative: git emits paths relative to the repo root by default, even when run
+    // from a subdirectory. In a monorepo `workdir` is the package dir, and
+    // filterFilesToScope() below does `join(workdir, relPath)` — without --relative
+    // that double-prefixes every path (e.g. packages/api/packages/api/src/foo.ts),
+    // so every file fails the existence check and the scope comes back empty — a
+    // false-green "lint skipped" with zero lint actually run (BUG-31).
+    cmd: ["git", "diff", "--relative", "--name-only", `${baseRef}..HEAD`],
     cwd: workdir,
     stdout: "pipe",
     stderr: "pipe",

--- a/src/review/severity.ts
+++ b/src/review/severity.ts
@@ -7,9 +7,9 @@ export const SEVERITY_RANK: Record<string, number> = {
   info: 0,
   unverifiable: 0,
   low: 1,
-  warning: 1,
-  error: 2,
-  critical: 3,
+  warning: 2,
+  error: 3,
+  critical: 4,
 };
 
 export function isBlockingSeverity(sev: string, threshold: "error" | "warning" | "info" = "error"): boolean {

--- a/src/routing/strategies/llm-parsing.ts
+++ b/src/routing/strategies/llm-parsing.ts
@@ -35,7 +35,9 @@ export function validateRoutingDecision(
   }
 
   const modelTier = parsed.modelTier as string;
-  const tierExistsInAnyAgent = Object.values(config.models).some((agentTiers) => modelTier in agentTiers);
+  const tierExistsInAnyAgent = Object.values(config.models).some(
+    (agentTiers) => typeof modelTier === "string" && Object.hasOwn(agentTiers, modelTier),
+  );
   if (!tierExistsInAnyAgent) {
     throw new Error(`Invalid modelTier: ${modelTier} (not found in any agent's tier map)`);
   }

--- a/src/tdd/cleanup.ts
+++ b/src/tdd/cleanup.ts
@@ -57,6 +57,32 @@ export async function getPgid(pid: number): Promise<number | null> {
 }
 
 /**
+ * Check whether any process still belongs to the given process group.
+ *
+ * Unlike re-checking the original leader's own PGID (which goes stale the moment
+ * SIGTERM kills the leader while a SIGTERM-trapping sibling survives in the same
+ * group), this lists group MEMBERS directly, so a survived sibling is still
+ * detected even after the leader itself is gone.
+ *
+ * @param pgid - Process group ID to check
+ * @returns true if at least one process in the group is still alive
+ */
+export async function hasLiveGroupMembers(pgid: number): Promise<boolean> {
+  try {
+    const proc = _cleanupDeps.spawn(["ps", "-o", "pid=", "-g", String(pgid)], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await Bun.readableStreamToText(proc.stdout);
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return false;
+    return output.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Clean up an entire process tree by killing all processes in the process group.
  *
  * Uses SIGTERM first (graceful shutdown), then SIGKILL after a delay if processes persist.
@@ -94,15 +120,11 @@ export async function cleanupProcessTree(pid: number, gracePeriodMs = 3000): Pro
     // Wait for graceful shutdown
     await _cleanupDeps.sleep(gracePeriodMs);
 
-    // Re-check PGID before SIGKILL to prevent race condition
-    // If the original process exited and a new process inherited its PID,
-    // we don't want to kill the wrong process group
-    const pgidAfterWait = await getPgid(pid);
-
-    // Only send SIGKILL if:
-    // 1. Process still exists (pgidAfterWait is not null)
-    // 2. PGID hasn't changed (still the same process group)
-    if (pgidAfterWait && pgidAfterWait === pgid) {
+    // Re-check the GROUP (not just the original leader pid) before SIGKILL. SIGTERM
+    // commonly kills the leader while a SIGTERM-trapping child survives in the same
+    // group — re-checking only the leader's own PGID would see it gone and skip the
+    // SIGKILL escalation, orphaning that survivor (BUG-23).
+    if (await hasLiveGroupMembers(pgid)) {
       _cleanupDeps.killProcessGroupFn(pgid, "SIGKILL");
     }
   } catch (error) {

--- a/src/tdd/isolation.ts
+++ b/src/tdd/isolation.ts
@@ -11,6 +11,7 @@
  * DEFAULT_TEST_FILE_PATTERNS for backward compatibility.
  */
 
+import { NaxError } from "../errors";
 import { DEFAULT_TEST_FILE_PATTERNS, isTestFileByPatterns } from "../test-runners";
 import { spawn } from "../utils/bun-deps";
 import type { IsolationCheck } from "./types";
@@ -37,8 +38,26 @@ export async function getChangedFiles(workdir: string, fromRef = "HEAD"): Promis
   // Use Bun.readableStreamToText — more reliable than new Response(stream).text()
   // with both real pipes and mocked ReadableStreams across Bun versions.
   // Must read BEFORE awaiting proc.exited to avoid stream-closed-on-exit issues.
-  const output = await Bun.readableStreamToText(proc.stdout);
-  await proc.exited;
+  // Drain stdout+stderr concurrently with proc.exited — sequential reads would
+  // deadlock on a pipe-buffer-sized stderr (~64KB), and stderr must be read
+  // regardless of exit code so a failure isn't silently discarded.
+  const [output, stderr, exitCode] = await Promise.all([
+    Bun.readableStreamToText(proc.stdout),
+    Bun.readableStreamToText(proc.stderr),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    throw new NaxError(
+      `git diff --name-only ${fromRef} failed (exit ${exitCode}): ${stderr.trim()}`,
+      "GIT_DIFF_FAILED",
+      {
+        stage: "tdd-isolation",
+        fromRef,
+        exitCode,
+      },
+    );
+  }
 
   return output.trim().split("\n").filter(Boolean);
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -188,7 +188,7 @@ export function App({ feature, version, stories: initialStories, events, queueFi
   };
 
   // Custom input handler for confirmation dialogs
-  useInput((input) => {
+  useInput((input, key) => {
     // Handle confirmation dialogs
     if (showQuitConfirm || showAbortConfirm) {
       const inputKey = input.toLowerCase();
@@ -199,7 +199,7 @@ export function App({ feature, version, stories: initialStories, events, queueFi
           writeQueueCommand(queueFilePath, { type: "ABORT" });
           setShowAbortConfirm(false);
         }
-      } else if (inputKey === "n" || input === "\x1b") {
+      } else if (inputKey === "n" || key.escape) {
         // n or Esc cancels
         setShowQuitConfirm(false);
         setShowAbortConfirm(false);

--- a/src/tui/hooks/usePipelineBusEvents.ts
+++ b/src/tui/hooks/usePipelineBusEvents.ts
@@ -113,16 +113,24 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
     // story:completed — mark story passed/failed, set cost, clear step
     const unsubCompleted = pipelineEventBus.on("story:completed", (event) => {
       setState((prev) => {
+        // Add this completion's cost onto the story's running total instead of
+        // replacing it — a story that completes more than once (e.g. a retried
+        // attempt) would otherwise have its earlier attempt's cost silently
+        // dropped the moment the later cost overwrites it (BUG-55: "a $0.50 then
+        // $0.30 story" ends up contributing only $0.30 to the running total).
+        // A no-op for the common single-completion case (prevStoryCost is 0).
+        const prevStoryCost = prev.stories.find((s) => s.story.id === event.storyId)?.cost ?? 0;
+        const costDelta = event.cost ?? 0;
+        const storyCost = prevStoryCost + costDelta;
+        const totalCost = prev.totalCost + costDelta;
         const newStories = prev.stories.map((s) => {
           if (s.story.id === event.storyId) {
             const status = event.passed ? ("passed" as const) : ("failed" as const);
-            const storyCost = event.cost ?? s.cost;
             return { ...s, status, cost: storyCost };
           }
           return s;
         });
 
-        const totalCost = newStories.reduce((sum, s) => sum + (s.cost ?? 0), 0);
         const { [event.storyId]: _removed, ...remainingSteps } = prev.storySteps;
         // Mirror the status mapping above: a `passed:false` completion is a failure,
         // so it arms the retry target too. In practice terminal failures arrive via

--- a/src/verification/executor.ts
+++ b/src/verification/executor.ts
@@ -83,6 +83,12 @@ export async function executeWithTimeout(
     stderr: "pipe",
     env: env || normalizeEnvironment(process.env as Record<string, string | undefined>),
     cwd: options?.cwd,
+    // Bun.spawn does not setpgid children into their own group by default, so
+    // killProcessGroup(-pid) below would target a group the shell isn't actually
+    // the leader of (ESRCH -> falls back to killing only the /bin/sh wrapper,
+    // leaking the real test-runner grandchild). `detached` makes this process a
+    // session/group leader via setsid(), so its own pid IS the real pgid.
+    detached: true,
   });
 
   // Rule 07: drain stdout+stderr concurrently with proc.exited to prevent

--- a/src/verification/flake-baseline-diff.ts
+++ b/src/verification/flake-baseline-diff.ts
@@ -9,10 +9,11 @@
  */
 
 import type { NaxConfig } from "../config";
+import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
 import { resolveTestFilePatterns } from "../test-runners";
 import { errorMessage } from "../utils/errors";
-import { getMergeBase } from "../utils/git";
+import { getMergeBase, gitWithTimeout } from "../utils/git";
 import type { FlakeTriageDiff } from "./flake-triage";
 import { getChangedNonTestFiles, getChangedTestFiles, mapSourceToTests } from "./smart-runner";
 
@@ -36,6 +37,32 @@ export async function resolveFlakeBaselineDiff(
   try {
     const resolved = await resolveTestFilePatterns(config, workdir, storyWorkdir);
     const baseRef = await getMergeBase(workdir);
+    if (baseRef === undefined) {
+      // getMergeBase() exhausted every fallback (no origin/main, no origin/master, no
+      // initial commit) — there is no diff to trust. Substituting "HEAD~1" here would
+      // silently diff against the wrong ref; substituting an empty diff would be the
+      // fail-OPEN direction this function exists to avoid. Fail closed instead.
+      throw new NaxError("getMergeBase() found no usable ref (empty/detached repo)", "FLAKE_BASELINE_NO_MERGE_BASE", {
+        stage: "flake-triage",
+        workdir,
+      });
+    }
+    // Preflight the actual diff command so a git failure (non-zero exit) is caught
+    // here and fails closed — getChangedTestFiles/getChangedNonTestFiles swallow git
+    // errors into `[]`, which is indistinguishable from a genuinely empty diff and
+    // would otherwise flow through as the fail-OPEN empty-diff case this guards against.
+    const preflight = await gitWithTimeout(["diff", "--name-only", baseRef], workdir);
+    if (preflight.exitCode !== 0) {
+      throw new NaxError(
+        `git diff --name-only ${baseRef} failed (exit ${preflight.exitCode})`,
+        "FLAKE_BASELINE_GIT_DIFF_FAILED",
+        {
+          stage: "flake-triage",
+          baseRef,
+          exitCode: preflight.exitCode,
+        },
+      );
+    }
     const changedTestFiles = await getChangedTestFiles(workdir, workdir, baseRef, storyWorkdir, [...resolved.regex]);
     const changedNonTestFiles = await getChangedNonTestFiles(
       workdir,

--- a/src/verification/flake-probe.ts
+++ b/src/verification/flake-probe.ts
@@ -18,6 +18,18 @@ import type { TestFailure } from "../test-runners/types";
 import { executeWithTimeout } from "./executor";
 import type { TestExecutionResult } from "./types";
 
+// Frameworks that exit 0 for "zero tests matched the isolation filter" (primarily `go
+// test -run '^Name$'` when the name doesn't round-trip the filter) need this check so an
+// undetectable-but-still-failing test isn't declared "flaky" from a probe that never ran
+// it. Conservative on purpose: only the well-known zero-match phrasing counts, so a
+// framework whose real failure output happens to differ isn't misclassified as clean.
+const NO_TESTS_EXECUTED_MARKERS = [/no tests? to run/i, /^ran 0 tests?/im];
+
+function probeRanNoTests(output: string | undefined): boolean {
+  if (!output) return false;
+  return NO_TESTS_EXECUTED_MARKERS.some((re) => re.test(output));
+}
+
 export type FlakeProbeVerdict =
   | { verdict: "flaky"; probeRuns: number; probePasses: number }
   | { verdict: "consistent-failure"; probeRuns: number }
@@ -154,7 +166,7 @@ export async function runFlakeProbe(input: FlakeProbeInput): Promise<FlakeProbeV
       // environmental, not an attributable flake signal.
       continue;
     }
-    if (result.success && result.countsTowardEscalation) {
+    if (result.success && result.countsTowardEscalation && !probeRanNoTests(result.output)) {
       probePasses += 1;
     }
   }

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -13,3 +13,4 @@ export * from "./flake-probe";
 export * from "./flake-triage";
 export * from "./flake-baseline-diff";
 export * from "./mutation";
+export * from "./shell-quote";

--- a/src/verification/shell-quote.ts
+++ b/src/verification/shell-quote.ts
@@ -1,0 +1,4 @@
+/** POSIX single-quote a shell argument so it survives `/bin/sh -c`. */
+export function shellQuoteArg(arg: string): string {
+  return `'${arg.replaceAll("'", `'\\''`)}'`;
+}

--- a/test/integration/cli/cli-precheck-command.test.ts
+++ b/test/integration/cli/cli-precheck-command.test.ts
@@ -273,7 +273,12 @@ describe("CLI precheck command", () => {
   });
 
   test("should handle missing feature flag with error", async () => {
-    const { projectDir, naxDir } = setupTestProject("test-no-feature");
+    const { projectDir, naxDir, featureDir } = setupTestProject("test-no-feature");
+
+    // BUG-02: -f omitted now derives the feature from .nax/features/* — remove the
+    // fixture's auto-created "test-feature" dir so there is genuinely nothing to
+    // derive, exercising the same "no feature specified" error this test intends.
+    rmSync(featureDir, { recursive: true, force: true });
 
     await Bun.write(
       join(naxDir, "config.json"),

--- a/test/integration/plugins/loader.test.ts
+++ b/test/integration/plugins/loader.test.ts
@@ -650,8 +650,12 @@ export default {
 
       const registry = await loadPlugins(globalDir, projectDir, []);
 
-      // Both plugins are loaded (last loaded wins in registry getters)
-      expect(registry.plugins).toHaveLength(2);
+      // BUG-25: the later entry replaces the earlier one on a name collision — it
+      // used to log "overrides" but push both anyway, so the earlier one stayed
+      // registered too and ran twice per invocation of getPostRunActions()/
+      // getReporters(), breaking the "each finding appears exactly once" invariant.
+      expect(registry.plugins).toHaveLength(1);
+      expect(registry.plugins[0].extensions?.optimizer?.name).toBe("project");
     });
   });
 });

--- a/test/unit/cli/config-profile.test.ts
+++ b/test/unit/cli/config-profile.test.ts
@@ -201,6 +201,7 @@ describe("profileUseCommand", () => {
   });
 
   test("writes 'profile' field into .nax/config.json and returns non-empty confirmation message", async () => {
+    await writeJsonAsync(join(tempDir, ".nax", "profiles", "fast.json"), { model: "fast" });
     const result = await profileUseCommand("fast", tempDir);
 
     const config = await Bun.file(join(tempDir, ".nax", "config.json")).json();
@@ -225,6 +226,7 @@ describe("profileUseCommand", () => {
   });
 
   test("creates config.json if it does not exist; preserves existing fields when writing profile", async () => {
+    await writeJsonAsync(join(tempDir, ".nax", "profiles", "fast.json"), { model: "fast" });
     const configPath = join(tempDir, ".nax", "config.json");
     await profileUseCommand("fast", tempDir);
     expect(await Bun.file(configPath).exists()).toBe(true);
@@ -235,6 +237,12 @@ describe("profileUseCommand", () => {
     const config = await Bun.file(configPath).json();
     expect(config.profile).toBe("fast");
     expect(config.timeout).toBe(5000);
+  });
+
+  // BUG-50: a typo'd profile name must not silently poison config.json.
+  test("rejects a profile name with no matching profile file", async () => {
+    await expect(profileUseCommand("does-not-exist", tempDir)).rejects.toThrow(/not found/i);
+    expect(await Bun.file(join(tempDir, ".nax", "config.json")).exists()).toBe(false);
   });
 });
 

--- a/test/unit/commands/logs.test.ts
+++ b/test/unit/commands/logs.test.ts
@@ -21,7 +21,11 @@ import { type LogsOptions, _deps, logsCommand } from "../../../src/commands/logs
 const TEST_WORKSPACE = join(import.meta.dir, "..", "..", "tmp", "logs-test");
 
 function setupTestProject(featureName: string): string {
-  const projectDir = join(TEST_WORKSPACE, `project-${Date.now()}`);
+  // Random suffix, not just Date.now() — two calls in the same test tick can share a
+  // millisecond, colliding into the same directory and merging their .nax/features/
+  // entries (surfaced by BUG-02: logs now derives the feature by listing
+  // .nax/features/*, so a merged fixture becomes a spurious "ambiguous" failure).
+  const projectDir = join(TEST_WORKSPACE, `project-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`);
   const naxDir = join(projectDir, ".nax");
   const featureDir = join(naxDir, "features", featureName);
   const runsDir = join(featureDir, "runs");

--- a/test/unit/debate/runner-plan.test.ts
+++ b/test/unit/debate/runner-plan.test.ts
@@ -912,6 +912,8 @@ describe("runner-plan — postDebateVerifier and tag-expert rewrite", () => {
     _runPlanDeps.resolvePostDebateVerifier = origResolvePostDebateVerifier;
   });
 
+  // BUG-15: no file-read fallback anymore — stub both debaters' proposals directly.
+  const stubDebatePlanOp = (output: string) => spyOn(callModule, "callOp").mockImplementation(async (_c, op: any) => (op?.name === "debate-plan" ? { success: true, rebut: output } : Promise.reject(new Error(op?.name))) as never);
   function makeRunWithVerifier(verifierFn: () => Promise<{ outcome: string; costUsd: number }>) {
     const verifierCalled: string[] = [];
     _runPlanDeps.resolvePostDebateVerifier = mock((_kind: string) => {
@@ -978,8 +980,7 @@ describe("runner-plan — postDebateVerifier and tag-expert rewrite", () => {
       runInSession: mock(async () => ({ output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 })) as any,
       nameFor: mock((req: any) => `nax-${req?.role ?? "unknown"}`),
     });
-    _debateSessionDeps.readFile = mock(async () => prdOutput);
-
+    stubDebatePlanOp(prdOutput);
     const config = { ...TEST_CONFIG, debate: { enabled: true, agents: 2, maxConcurrentDebaters: 2 } } as unknown as NaxConfig;
     const agentManager = makeMockAgentManager();
 
@@ -1018,8 +1019,7 @@ describe("runner-plan — postDebateVerifier and tag-expert rewrite", () => {
       runInSession: mock(async () => ({ output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 })) as any,
       nameFor: mock((req: any) => `nax-${req?.role ?? "unknown"}`),
     });
-    _debateSessionDeps.readFile = mock(async () => prdOutput);
-
+    stubDebatePlanOp(prdOutput);
     const config = { ...TEST_CONFIG, debate: { enabled: true, agents: 2, maxConcurrentDebaters: 2 } } as unknown as NaxConfig;
     const agentManager = makeMockAgentManager();
 

--- a/test/unit/execution/lifecycle/run-regression-flake-triage.test.ts
+++ b/test/unit/execution/lifecycle/run-regression-flake-triage.test.ts
@@ -69,6 +69,12 @@ function makeOptions(opts: {
 let savedDeps: typeof _regressionDeps;
 beforeEach(() => {
   savedDeps = { ..._regressionDeps };
+  // BUG-08 hardened resolveFlakeBaselineDiff to fail closed (return null) when git
+  // commands fail — this suite's workdir ("/tmp/test-workdir") isn't a real git repo,
+  // so the real implementation would now skip triage entirely before ever reaching
+  // the mocked triageFlakyFindings below. Stub a valid empty diff so these tests keep
+  // exercising the triage-wiring integration they're actually about.
+  _regressionDeps.resolveFlakeBaselineDiff = mock(async () => ({ changedTestFiles: [], mappedTestFiles: [] }));
 });
 afterEach(() => {
   Object.assign(_regressionDeps, savedDeps);

--- a/test/unit/operations/implementer.test.ts
+++ b/test/unit/operations/implementer.test.ts
@@ -225,6 +225,7 @@ describe("implementerOp.verify — isolation", () => {
     const origSpawn = _isolationDeps.spawn;
     _isolationDeps.spawn = ((_cmd: string[]) => ({
       stdout: new Response("src/foo.ts\ntest/foo.test.ts\n").body,
+      stderr: new Response("").body,
       exited: Promise.resolve(0),
     })) as any;
 
@@ -262,6 +263,7 @@ describe("implementerOp.verify — isolation", () => {
     const origSpawn = _isolationDeps.spawn;
     _isolationDeps.spawn = ((_cmd: string[]) => ({
       stdout: new Response("src/foo.ts\n").body,
+      stderr: new Response("").body,
       exited: Promise.resolve(0),
     })) as any;
 

--- a/test/unit/operations/verify-op.test.ts
+++ b/test/unit/operations/verify-op.test.ts
@@ -231,6 +231,7 @@ describe("verifierOp.verify — isolation", () => {
     const origSpawn = _isolationDeps.spawn;
     _isolationDeps.spawn = ((_cmd: string[]) => ({
       stdout: new Response("src/foo.ts\n").body,
+      stderr: new Response("").body,
       exited: Promise.resolve(0),
     })) as any;
 

--- a/test/unit/operations/write-test-op.test.ts
+++ b/test/unit/operations/write-test-op.test.ts
@@ -191,6 +191,7 @@ describe("testWriterOp.verify — isolation", () => {
     const origSpawn = _isolationDeps.spawn;
     _isolationDeps.spawn = ((_cmd: string[]) => ({
       stdout: new Response("test/foo.test.ts\n").body,
+      stderr: new Response("").body,
       exited: Promise.resolve(0),
     })) as any;
 
@@ -229,6 +230,7 @@ describe("testWriterOp.verify — isolation", () => {
     const origSpawn = _isolationDeps.spawn;
     _isolationDeps.spawn = ((_cmd: string[]) => ({
       stdout: new Response("src/foo.ts\ntest/foo.test.ts\n").body,
+      stderr: new Response("").body,
       exited: Promise.resolve(0),
     })) as any;
 

--- a/test/unit/pipeline/stages/acceptance-missing-target.test.ts
+++ b/test/unit/pipeline/stages/acceptance-missing-target.test.ts
@@ -11,6 +11,7 @@ import { acceptanceStage } from "@/pipeline/stages";
 import type { PipelineContext } from "@/pipeline/types";
 import { DEFAULT_CONFIG } from "@/config";
 import { addSink, initLogger, resetLogger } from "@/logger";
+import { _executorDeps } from "@/verification";
 import { makeStory } from "@test/helpers";
 
 afterEach(() => {
@@ -262,8 +263,8 @@ describe("US-003: missing acceptance target fails the run", () => {
   test("AC-9: every group present and passing → continue", async () => {
     const present = new Set(["/tmp/a.test.ts", "/tmp/b.test.ts"]);
     const restoreFile = stubFileExists(present);
-    const origSpawn = Bun.spawn;
-    (Bun as any).spawn = (_cmd: string[], _opts: any) => ({
+    const origSpawn = _executorDeps.spawn;
+    _executorDeps.spawn = ((_cmd: string[], _opts: any) => ({
       exited: Promise.resolve(0),
       stdout: new ReadableStream({
         start(c) {
@@ -272,7 +273,7 @@ describe("US-003: missing acceptance target fails the run", () => {
         },
       }),
       stderr: new ReadableStream({ start(c) { c.close(); } }),
-    });
+    })) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
     try {
       const ctx = makeCtx({
         acceptanceTestPaths: [
@@ -283,7 +284,7 @@ describe("US-003: missing acceptance target fails the run", () => {
       const result = await acceptanceStage.execute(ctx);
       expect(result.action).toBe("continue");
     } finally {
-      (Bun as any).spawn = origSpawn;
+      _executorDeps.spawn = origSpawn;
       restoreFile();
     }
   });
@@ -295,8 +296,8 @@ describe("US-003: missing acceptance target fails the run", () => {
     // preserved in failedACs alongside the missing-target signal.
     const present = new Set(["/tmp/present.test.ts"]);
     const restoreFile = stubFileExists(present);
-    const origSpawn = Bun.spawn;
-    (Bun as any).spawn = (_cmd: string[], _opts: any) => ({
+    const origSpawn = _executorDeps.spawn;
+    _executorDeps.spawn = ((_cmd: string[], _opts: any) => ({
       exited: Promise.resolve(1),
       stdout: new ReadableStream({
         start(c) {
@@ -305,7 +306,7 @@ describe("US-003: missing acceptance target fails the run", () => {
         },
       }),
       stderr: new ReadableStream({ start(c) { c.close(); } }),
-    });
+    })) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
     try {
       const ctx = makeCtx({
         acceptanceTestPaths: [
@@ -328,7 +329,7 @@ describe("US-003: missing acceptance target fails the run", () => {
       expect(ctx.acceptanceFailures?.failedACs ?? []).toContain("AC-2");
       expect(ctx.acceptanceFailures?.missingTargets ?? []).toContain("/missing");
     } finally {
-      (Bun as any).spawn = origSpawn;
+      _executorDeps.spawn = origSpawn;
       restoreFile();
     }
   });

--- a/test/unit/pipeline/stages/acceptance.test.ts
+++ b/test/unit/pipeline/stages/acceptance.test.ts
@@ -10,6 +10,7 @@ import { acceptanceStage, parseTestFailures } from "../../../../src/pipeline/sta
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 import { addSink, initLogger, resetLogger } from "@/logger";
+import { _executorDeps } from "@/verification";
 import { makeStory } from "../../../helpers";
 
 // ---------------------------------------------------------------------------
@@ -59,8 +60,8 @@ describe("US-002: per-package acceptance runner", () => {
     const spawnCalls: Array<{ cwd: string; cmd: string[] }> = [];
 
     // Patch Bun.spawn for this test
-    const origSpawn = Bun.spawn;
-    (Bun as any).spawn = (cmd: string[], opts: any) => {
+    const origSpawn = _executorDeps.spawn;
+    _executorDeps.spawn = ((cmd: string[], opts: any) => {
       spawnCalls.push({ cwd: opts.cwd, cmd });
       const mockProc = {
         exited: Promise.resolve(0),
@@ -77,7 +78,7 @@ describe("US-002: per-package acceptance runner", () => {
         }),
       };
       return mockProc;
-    };
+    }) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
 
     const ctx = makeCtx({
       acceptanceTestPaths: [
@@ -98,7 +99,7 @@ describe("US-002: per-package acceptance runner", () => {
       expect(spawnCalls.some((c) => c.cwd === "/tmp/test-workdir/apps/api")).toBe(true);
       expect(spawnCalls.some((c) => c.cwd === "/tmp/test-workdir/apps/cli")).toBe(true);
     } finally {
-      (Bun as any).spawn = origSpawn;
+      _executorDeps.spawn = origSpawn;
       (Bun as any).file = origFile;
     }
   });
@@ -119,8 +120,8 @@ describe("US-002: per-package acceptance runner", () => {
   });
 
   test("AC-4: all packages passing returns continue", async () => {
-    const origSpawn = Bun.spawn;
-    (Bun as any).spawn = (_cmd: string[], _opts: any) => ({
+    const origSpawn = _executorDeps.spawn;
+    _executorDeps.spawn = ((_cmd: string[], _opts: any) => ({
       exited: Promise.resolve(0),
       stdout: new ReadableStream({
         start(controller) {
@@ -133,7 +134,7 @@ describe("US-002: per-package acceptance runner", () => {
           controller.close();
         },
       }),
-    });
+    })) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
 
     const origFile = Bun.file;
     (Bun as any).file = (_p: string) => ({
@@ -152,7 +153,7 @@ describe("US-002: per-package acceptance runner", () => {
       const result = await acceptanceStage.execute(ctx);
       expect(result.action).toBe("continue");
     } finally {
-      (Bun as any).spawn = origSpawn;
+      _executorDeps.spawn = origSpawn;
       (Bun as any).file = origFile;
     }
   });
@@ -160,15 +161,15 @@ describe("US-002: per-package acceptance runner", () => {
   test("AC-5: per-package testFramework is used when building run command", async () => {
     const spawnCalls: Array<{ cmd: string[]; cwd: string }> = [];
 
-    const origSpawn = Bun.spawn;
-    (Bun as any).spawn = (cmd: string[], opts: any) => {
+    const origSpawn = _executorDeps.spawn;
+    _executorDeps.spawn = ((cmd: string[], opts: any) => {
       spawnCalls.push({ cmd, cwd: opts.cwd });
       return {
         exited: Promise.resolve(0),
         stdout: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("1 pass\n")); c.close(); } }),
         stderr: new ReadableStream({ start(c) { c.close(); } }),
       };
-    };
+    }) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
 
     const origFile = Bun.file;
     (Bun as any).file = (_p: string) => ({
@@ -200,22 +201,22 @@ describe("US-002: per-package acceptance runner", () => {
       const apiCall = spawnCalls.find((c) => c.cwd === "/tmp/test-workdir/apps/api");
       const webCall = spawnCalls.find((c) => c.cwd === "/tmp/test-workdir/apps/web");
 
-      // apps/api should use npx jest
-      expect(apiCall?.cmd[0]).toBe("npx");
-      expect(apiCall?.cmd[1]).toBe("jest");
+      // apps/api should use npx jest — spawn args are [shell, "-c", shellQuotedCommand]
+      expect(apiCall?.cmd[2]).toContain("npx");
+      expect(apiCall?.cmd[2]).toContain("jest");
 
       // apps/web should fall back to bun test (no testFramework)
-      expect(webCall?.cmd[0]).toBe("bun");
-      expect(webCall?.cmd[1]).toBe("test");
+      expect(webCall?.cmd[2]).toContain("bun");
+      expect(webCall?.cmd[2]).toContain("test");
     } finally {
-      (Bun as any).spawn = origSpawn;
+      _executorDeps.spawn = origSpawn;
       (Bun as any).file = origFile;
     }
   });
 
   test("records failed package metadata in acceptanceFailures for downstream fix routing", async () => {
-    const origSpawn = Bun.spawn;
-    (Bun as any).spawn = (cmd: string[], opts: any) => {
+    const origSpawn = _executorDeps.spawn;
+    _executorDeps.spawn = ((cmd: string[], opts: any) => {
       const isApi = opts.cwd === "/tmp/test-workdir/apps/api";
       const output = isApi ? "FAIL AC-2" : "1 pass\n";
       const exitCode = isApi ? 1 : 0;
@@ -233,7 +234,7 @@ describe("US-002: per-package acceptance runner", () => {
           },
         }),
       };
-    };
+    }) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
 
     const origFile = Bun.file;
     (Bun as any).file = (_p: string) => ({
@@ -272,14 +273,14 @@ describe("US-002: per-package acceptance runner", () => {
         },
       ]);
     } finally {
-      (Bun as any).spawn = origSpawn;
+      _executorDeps.spawn = origSpawn;
       (Bun as any).file = origFile;
     }
   });
 
   test("records per-package output and failedACs on each failed package entry", async () => {
-    const origSpawn = Bun.spawn;
-    (Bun as any).spawn = (_cmd: string[], opts: any) => {
+    const origSpawn = _executorDeps.spawn;
+    _executorDeps.spawn = ((_cmd: string[], opts: any) => {
       const isApi = opts.cwd === "/tmp/test-workdir/apps/api";
       const output = isApi ? "FAIL AC-1 api boom\n" : "FAIL AC-2 web boom\n";
       return {
@@ -296,7 +297,7 @@ describe("US-002: per-package acceptance runner", () => {
           },
         }),
       };
-    };
+    }) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
 
     const origFile = Bun.file;
     (Bun as any).file = (_p: string) => ({
@@ -333,7 +334,7 @@ describe("US-002: per-package acceptance runner", () => {
       expect(web?.failedACs).toEqual(["AC-2"]);
       expect(ctx.acceptanceFailures?.failedACs).toEqual(["AC-1", "AC-2"]);
     } finally {
-      (Bun as any).spawn = origSpawn;
+      _executorDeps.spawn = origSpawn;
       (Bun as any).file = origFile;
     }
   });
@@ -501,7 +502,7 @@ describe("acceptance verdict logger emit", () => {
     { testPath: "/tmp/test-workdir/apps/api/.nax-acceptance.test.ts", packageDir: "/tmp/test-workdir/apps/api" },
   ];
 
-  let origSpawn: typeof Bun.spawn;
+  let origSpawn: typeof _executorDeps.spawn;
   let origFile: typeof Bun.file;
   let unsubscribe: (() => void) | null = null;
   let verdicts: Array<Record<string, unknown>> = [];
@@ -519,10 +520,10 @@ describe("acceptance verdict logger emit", () => {
 
   /** Stub the test command to pass (exit 0) or fail on AC-2 (exit 1). */
   function stubRun(pass: boolean): void {
-    origSpawn = Bun.spawn;
+    origSpawn = _executorDeps.spawn;
     origFile = Bun.file;
     const out = pass ? "1 pass\n" : "  (fail) AC-2: handles empty input\n";
-    (Bun as any).spawn = (_cmd: string[], _opts: any) => ({
+    _executorDeps.spawn = ((_cmd: string[], _opts: any) => ({
       exited: Promise.resolve(pass ? 0 : 1),
       stdout: new ReadableStream({
         start(controller) {
@@ -535,7 +536,7 @@ describe("acceptance verdict logger emit", () => {
           controller.close();
         },
       }),
-    });
+    })) as unknown as typeof _executorDeps.spawn;  // test-ratchet-allow: as-unknown-as
     (Bun as any).file = (_p: string) => ({
       exists: () => Promise.resolve(true),
       text: () => Promise.resolve(""),
@@ -551,7 +552,7 @@ describe("acceptance verdict logger emit", () => {
     unsubscribe?.();
     unsubscribe = null;
     resetLogger();
-    if (origSpawn) (Bun as any).spawn = origSpawn;
+    if (origSpawn) _executorDeps.spawn = origSpawn;
     if (origFile) (Bun as any).file = origFile;
   });
 

--- a/test/unit/verification/unit-isolation.test.ts
+++ b/test/unit/verification/unit-isolation.test.ts
@@ -166,6 +166,11 @@ describe("verifyTestWriterIsolation: strict vs. lite mode", () => {
             controller.close();
           },
         }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
         exited: Promise.resolve(0),
       } as unknown as ReturnType<typeof Bun.spawn>;
     }) as unknown as typeof _isolationDeps.spawn;


### PR DESCRIPTION
## Summary

Fixes 55 of the 57 findings in `docs/20260811-review-latent-bugs.md` (BUG-01 and BUG-37 were already fixed on `main`). Every finding was re-verified against current source before being fixed — none required an architectural decision, so none were deferred.

Grouped into 6 commits by subsystem:

- `7c6cdd46` — BUG-18,19,26,27,32,33,39,41,42,45,52,53,56,57 — CLI validation, PRD sibling/dependency handling, severity ranking, debate success-check, TUI escape key
- `1ff0bec1` — BUG-10,11,28,29,30,44,46,47 — ACP adapter retryable classification, NDJSON parser state, stdout reader cancellation, retry-budget compounding
- `cfe876e9` — BUG-06,07,08,09,21,22,23 — hook SIGKILL escalation, acceptance spawn → `executeWithTimeout`, process-group cleanup, flake-baseline fail-closed, PRD userStories guard
- `197e43fa` — BUG-12,13,14,15 — debate proposal/rebuttal barrier sizing and rejection propagation, winner-file-read fallback
- `c51a36af` — BUG-02,16,17,24,25,34,35,36,38,50 — feature-name resolution/validation, profile env-var resolution order, webhook port-0 routing, plugin name-collision replace-not-append, resume logger init
- `7202c57f` — BUG-04,05,20,31,40,43,48,49,51,54,55 — TUI unmount on error, parallel-batch per-story worktree failures, curator feature-scoped keying, adversarial finding shape guard, run-log ambiguous-prefix handling

## Test plan

- [x] All 6 commits pass the full pre-commit gate (typecheck, lint, ratchets, file-size checks)
- [x] Full suite (`bun run test`): 12,497 pass / 1 pre-existing unrelated fail (`test/unit/cli/plan-callop.test.ts` AC-7, confirmed present on `main` before this branch) / 13 skip
- [x] Manual code review of the full diff against each finding's justification — no regressions found; two self-introduced regressions from earlier batches (flake-triage test fixture, `handlePipelineFailure`/`_regressionDeps` seam) were caught by the full suite run and fixed within this branch before opening the PR