### PR TITLE
fix: resolve 3 findings from post-0.78.0 pre-release review

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -150,10 +150,14 @@ export function resolveProject(options: ResolveProjectOptions = {}): ResolvedPro
  * no such key in `NaxConfigSchema`) — commands that read `config.feature` always get
  * `undefined` and fail unconditionally without an explicit flag.
  *
+ * `remediationHint` must describe how *this specific command* actually disambiguates —
+ * not every caller has a `-f`/`--feature` flag (e.g. `nax logs` binds `-f` to
+ * `--follow` and has no feature flag at all; it disambiguates via `-r <runId>` instead).
+ *
  * @throws {NaxError} when there are zero or more than one feature directories —
- *   the caller must pass the flag explicitly in either case.
+ *   the caller must resolve the ambiguity via `remediationHint` in either case.
  */
-export function resolveSingleFeature(naxDir: string): string {
+export function resolveSingleFeature(naxDir: string, remediationHint = "pass -f <name>"): string {
   const featuresDir = join(naxDir, "features");
   const available = existsSync(featuresDir)
     ? readdirSync(featuresDir, { withFileTypes: true })
@@ -165,13 +169,13 @@ export function resolveSingleFeature(naxDir: string): string {
   if (available.length === 1) return available[0];
 
   if (available.length === 0) {
-    throw new NaxError("No feature specified and no features found — pass -f <name>.", "FEATURE_NOT_SPECIFIED", {
+    throw new NaxError(`No feature specified and no features found — ${remediationHint}.`, "FEATURE_NOT_SPECIFIED", {
       featuresDir,
     });
   }
 
   throw new NaxError(
-    `No feature specified and multiple features exist — pass -f <name>.\n\nAvailable features:\n${available.map((f) => `  - ${f}`).join("\n")}`,
+    `No feature specified and multiple features exist — ${remediationHint}.\n\nAvailable features:\n${available.map((f) => `  - ${f}`).join("\n")}`,
     "FEATURE_AMBIGUOUS",
     { featuresDir, available },
   );

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -62,8 +62,9 @@ export async function logsCommand(options: LogsOptions): Promise<void> {
   const naxDir = join(resolved.projectDir, ".nax");
 
   // config.json never carries a feature field — derive the single feature from
-  // .nax/features/* (BUG-02).
-  const featureName = resolveSingleFeature(naxDir);
+  // .nax/features/* (BUG-02). `logs` has no -f/--feature flag (-f is --follow here),
+  // so the only way to disambiguate is -r/--run against the central run registry.
+  const featureName = resolveSingleFeature(naxDir, "pass -r <runId> (see `nax runs list`)");
 
   const featureDir = join(naxDir, "features", featureName);
   const runsDir = join(featureDir, "runs");

--- a/src/execution/parallel-batch.ts
+++ b/src/execution/parallel-batch.ts
@@ -133,6 +133,11 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
   // already created for its siblings (BUG-05). A synthesized failure matches the shape
   // the dependency-prep loop already produces below.
   const preExecutionFailures: RunParallelBatchResult["failed"] = [];
+  // Failure timestamp captured at the moment each pre-execution failure actually
+  // happens, not at batchEndMs (which is stamped after every surviving sibling
+  // finishes) — otherwise an instant worktree-create failure reports a duration
+  // spanning the whole batch's wall-clock time in storyDurations.
+  const preExecutionFailureEndTimes = new Map<string, number>();
   for (const story of stories) {
     storyStartTimes.set(story.id, Date.now());
     try {
@@ -152,6 +157,7 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
           context: { ...pipelineContext, story, stories: [story], workdir } as PipelineContext,
         },
       });
+      preExecutionFailureEndTimes.set(story.id, Date.now());
       continue;
     }
     worktreePaths.set(story.id, path.join(workdir, ".nax-wt", story.id));
@@ -332,7 +338,7 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
     storyEndTimes.set(story.id, batchEndMs);
   }
   for (const { story } of failed) {
-    storyEndTimes.set(story.id, batchEndMs);
+    storyEndTimes.set(story.id, preExecutionFailureEndTimes.get(story.id) ?? batchEndMs);
   }
 
   const mergeConflicts: RunParallelBatchResult["mergeConflicts"] = [];

--- a/src/plugins/builtin/curator/heuristics.ts
+++ b/src/plugins/builtin/curator/heuristics.ts
@@ -195,22 +195,27 @@ function h2PullToolEmptyResult(observations: Observation[], threshold: number): 
       o.payload.keyword.length > 0,
   );
 
-  const byKeyword = new Map<string, { storyIds: string[]; featureId: string }>();
+  // Sites are featureId/storyId composites, not bare story IDs — story IDs are
+  // feature-scoped, so two features' unrelated "US-001" would otherwise dedupe
+  // into one displayed site and understate how widely this empty-keyword pattern
+  // actually recurs (BUG-48; same fix as H1/H4's `sites`).
+  const byKeyword = new Map<string, { sites: string[]; featureId: string }>();
   for (const obs of pulls) {
     const keyword = obs.payload.keyword as string;
+    const site = `${obs.featureId}/${obs.storyId}`;
     const existing = byKeyword.get(keyword);
     if (existing) {
-      existing.storyIds.push(obs.storyId);
+      existing.sites.push(site);
     } else {
-      byKeyword.set(keyword, { storyIds: [obs.storyId], featureId: obs.featureId });
+      byKeyword.set(keyword, { sites: [site], featureId: obs.featureId });
     }
   }
 
   const proposals: Proposal[] = [];
   for (const [keyword, data] of byKeyword.entries()) {
-    if (data.storyIds.length < threshold) continue;
-    const count = data.storyIds.length;
-    const unique = uniqueStoryIds(data.storyIds);
+    if (data.sites.length < threshold) continue;
+    const count = data.sites.length;
+    const unique = uniqueStoryIds(data.sites);
     proposals.push({
       id: "H2",
       severity: "MED",


### PR DESCRIPTION
## Summary

Deep code review of every commit from `v0.78.0` to `main` (pre-release check) surfaced three verified issues that survived an otherwise clean batch of bug fixes. This PR fixes all three.

- **`src/plugins/builtin/curator/heuristics.ts`** — H2 (`h2PullToolEmptyResult`) still keyed evidence by bare `storyId`, missing the BUG-48 cross-feature collision fix already applied to its H1/H3/H4/H6 siblings in this range. Two unrelated features hitting the same empty pull-tool keyword on the same story ID (e.g. `US-001`) collapsed into one evidence entry, attributed to whichever feature was encountered first — understating recurrence and misfiling the proposal's target file. Now keyed by `featureId/storyId` sites, matching its siblings.
- **`src/commands/common.ts` + `src/commands/logs.ts`** — `resolveSingleFeature()`'s ambiguous-feature error always suggested `"pass -f <name>"`, but `nax logs` binds `-f` to `--follow` and has no `--feature` flag at all, making the error unactionable for any multi-feature project running plain `nax logs`. `remediationHint` is now a caller-supplied parameter; `logs` points to `-r <runId>` (via `nax runs list`) instead.
- **`src/execution/parallel-batch.ts`** — a story that failed at worktree-create (near-instant) was stamped with `batchEndMs` as its end time, which is captured only after every surviving sibling in the batch finishes — inflating `storyDurations` telemetry for pre-execution failures to the full batch wall-clock time. Now records the real failure timestamp at the point of failure.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (Biome + all static-check gates) — clean
- [x] `bun test test/unit/plugins/builtin/curator-heuristics.test.ts test/unit/plugins/builtin/curator-heuristics-h1.test.ts test/unit/commands/ test/unit/execution/` — 1521 pass, 0 fail
- [x] Pre-commit hook (typecheck + full static-check suite) passed on commit