### PR TITLE
fix: atomic tmp+rename write for saveJsonFile (BUG-08)

### DIFF
--- a/src/utils/json-file.ts
+++ b/src/utils/json-file.ts
@@ -59,6 +59,12 @@ export async function loadJsonFile<T>(path: string, context = "json-file"): Prom
  * where a reader mid-write parses truncated JSON and callers coerce that
  * `null` into "no prior history".
  *
+ * Two narrower caveats: the rename is not crash-durable (no `fsync` before
+ * it — a power loss between `Bun.write` and `rename` can still leave a
+ * zero-length destination on some filesystems), and a hard kill between the
+ * two steps leaves an orphaned `<path>.tmp-<uuid>` sibling (the `catch`
+ * cleanup only runs on a thrown error, not a killed process).
+ *
  * @param path - File path to write to
  * @param data - Object to serialize
  * @param context - Logger context (for errors)

--- a/src/utils/json-file.ts
+++ b/src/utils/json-file.ts
@@ -6,6 +6,7 @@
  */
 
 import { existsSync } from "node:fs";
+import { rename, unlink } from "node:fs/promises";
 import { getLogger } from "../logger";
 
 /**
@@ -42,10 +43,21 @@ export async function loadJsonFile<T>(path: string, context = "json-file"): Prom
 }
 
 /**
- * Save an object as JSON to a file.
+ * Save an object as JSON to a file, atomically.
  *
- * Writes formatted JSON (2-space indent) for readability.
- * Creates parent directories if they don't exist.
+ * Writes formatted JSON (2-space indent) for readability. Creates parent
+ * directories if they don't exist. The write goes to a sibling temp file
+ * first, then `rename()`s it over the destination — a concurrent reader
+ * (e.g. another process's {@link loadJsonFile} call) always observes either
+ * the fully-written old content or the fully-written new content, never a
+ * torn/partial write (BUG-08).
+ *
+ * This does not by itself make read-modify-write sequences atomic across
+ * processes — two writers that both read the same prior content and append
+ * to it can still race, with the later `rename()` winning and the earlier
+ * writer's append lost. It only eliminates the *torn read* failure mode,
+ * where a reader mid-write parses truncated JSON and callers coerce that
+ * `null` into "no prior history".
  *
  * @param path - File path to write to
  * @param data - Object to serialize
@@ -58,10 +70,13 @@ export async function loadJsonFile<T>(path: string, context = "json-file"): Prom
  * ```
  */
 export async function saveJsonFile<T>(path: string, data: T, context = "json-file"): Promise<void> {
+  const tmpPath = `${path}.tmp-${crypto.randomUUID()}`;
   try {
     const json = JSON.stringify(data, null, 2);
-    await Bun.write(path, json);
+    await Bun.write(tmpPath, json);
+    await rename(tmpPath, path);
   } catch (err) {
+    await unlink(tmpPath).catch(() => {});
     const logger = getLogger();
     logger.error(context, "Failed to write JSON file", {
       path,

--- a/test/fixtures/json-file-writer.ts
+++ b/test/fixtures/json-file-writer.ts
@@ -1,0 +1,19 @@
+// Standalone writer process for test/unit/utils/json-file.test.ts's cross-process
+// torn-read regression test. Must run in its own OS process — same-process
+// writes complete as a single microtask-scheduled unit, so a same-process
+// reader can never observe a mid-write file regardless of whether the write
+// is atomic.
+import { saveJsonFile } from "../../src/utils/json-file";
+
+const path = process.argv[2];
+if (!path) {
+  throw new Error("usage: bun json-file-writer.ts <path>");
+}
+
+const payload = {
+  items: Array.from({ length: 100_000 }, (_, i) => ({ id: i, note: "x".repeat(100) })),
+};
+
+for (let i = 0; i < 40; i++) {
+  await saveJsonFile(path, payload, "json-file-writer-fixture");
+}

--- a/test/unit/utils/json-file.test.ts
+++ b/test/unit/utils/json-file.test.ts
@@ -1,0 +1,55 @@
+import { mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { loadJsonFile, saveJsonFile } from "../../../src/utils/json-file";
+import { withTempDir } from "../../helpers/temp";
+
+describe("saveJsonFile (BUG-08: atomic write)", () => {
+  test("round-trips data through loadJsonFile", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, "data.json");
+      await saveJsonFile(path, { a: 1, b: [2, 3] }, "test");
+      const loaded = await loadJsonFile<{ a: number; b: number[] }>(path, "test");
+      expect(loaded).toEqual({ a: 1, b: [2, 3] });
+    });
+  });
+
+  test("leaves no leftover .tmp-* file after a successful write", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, "data.json");
+      await saveJsonFile(path, { a: 1 }, "test");
+      const entries = readdirSync(dir);
+      expect(entries).toEqual(["data.json"]);
+    });
+  });
+
+  test("a reader never observes a torn/partial write (rename is atomic)", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, "data.json");
+      const large = { items: Array.from({ length: 5000 }, (_, i) => ({ id: i, note: "x".repeat(50) })) };
+      await saveJsonFile(path, large, "test");
+
+      // A second write races a concurrent load — the loader must always see
+      // either the old complete content or the new complete content.
+      const writePromise = saveJsonFile(path, { items: [{ id: -1, note: "replaced" }] }, "test");
+      const loaded = await loadJsonFile<{ items: unknown[] }>(path, "test");
+      await writePromise;
+
+      expect(loaded).not.toBeNull();
+      expect(Array.isArray(loaded?.items)).toBe(true);
+    });
+  });
+
+  test("cleans up the temp file when the write fails", async () => {
+    await withTempDir(async (dir) => {
+      // Directory as the destination path makes Bun.write fail (EISDIR).
+      const path = join(dir, "subdir");
+      mkdirSync(path);
+
+      await expect(saveJsonFile(path, { a: 1 }, "test")).rejects.toThrow();
+
+      const entries = readdirSync(dir);
+      expect(entries).toEqual(["subdir"]);
+    });
+  });
+});

--- a/test/unit/utils/json-file.test.ts
+++ b/test/unit/utils/json-file.test.ts
@@ -1,8 +1,10 @@
+import { describe, expect, test } from "bun:test";
 import { mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
-import { loadJsonFile, saveJsonFile } from "../../../src/utils/json-file";
-import { withTempDir } from "../../helpers/temp";
+import { loadJsonFile, saveJsonFile } from "@/utils/json-file";
+import { withTempDir } from "@test/helpers";
+
+const WRITER_FIXTURE = join(import.meta.dir, "..", "..", "fixtures", "json-file-writer.ts");
 
 describe("saveJsonFile (BUG-08: atomic write)", () => {
   test("round-trips data through loadJsonFile", async () => {
@@ -23,26 +25,39 @@ describe("saveJsonFile (BUG-08: atomic write)", () => {
     });
   });
 
-  test("a reader never observes a torn/partial write (rename is atomic)", async () => {
+  test("a reader in another process never observes a torn/partial write (rename is atomic)", async () => {
     await withTempDir(async (dir) => {
       const path = join(dir, "data.json");
-      const large = { items: Array.from({ length: 5000 }, (_, i) => ({ id: i, note: "x".repeat(50) })) };
-      await saveJsonFile(path, large, "test");
+      // Seed the file so the first read has something to parse.
+      await saveJsonFile(path, { items: [] }, "test");
 
-      // A second write races a concurrent load — the loader must always see
-      // either the old complete content or the new complete content.
-      const writePromise = saveJsonFile(path, { items: [{ id: -1, note: "replaced" }] }, "test");
-      const loaded = await loadJsonFile<{ items: unknown[] }>(path, "test");
-      await writePromise;
+      const proc = Bun.spawn(["bun", WRITER_FIXTURE, path], { stdout: "ignore", stderr: "inherit" });
 
-      expect(loaded).not.toBeNull();
-      expect(Array.isArray(loaded?.items)).toBe(true);
+      let nullReads = 0;
+      let reads = 0;
+      while (proc.exitCode === null && reads < 5000) {
+        const loaded = await loadJsonFile<{ items: unknown[] }>(path, "test");
+        reads++;
+        if (loaded === null) nullReads++;
+      }
+      await proc.exited;
+      // Drain a few more reads after the writer exits to catch a trailing torn state.
+      for (let i = 0; i < 20; i++) {
+        const loaded = await loadJsonFile<{ items: unknown[] }>(path, "test");
+        reads++;
+        if (loaded === null) nullReads++;
+      }
+
+      expect(proc.exitCode).toBe(0);
+      expect(reads).toBeGreaterThan(0);
+      expect(nullReads).toBe(0);
     });
-  });
+  }, 15000);
 
-  test("cleans up the temp file when the write fails", async () => {
+  test("cleans up the temp file when rename() fails", async () => {
     await withTempDir(async (dir) => {
-      // Directory as the destination path makes Bun.write fail (EISDIR).
+      // The destination is a directory, so Bun.write to the sibling .tmp-*
+      // file succeeds but rename(tmpPath, path) fails with EISDIR.
       const path = join(dir, "subdir");
       mkdirSync(path);
 


### PR DESCRIPTION
## Summary
- Fixes BUG-08 from `docs/reviews/2026-08-11-code-review-latent-bugs-v2.md` (Group 2 — architecture change).
- `saveJsonFile()` previously wrote via `Bun.write(path, json)`, which truncates the destination in place. A concurrent `loadJsonFile()` call from another process (e.g. two parallel `nax` runs sharing `projectOutputDir`) could observe a torn/partial write, fail to parse it, and return `null` — which `src/metrics/tracker.ts` (and the other two callers, `src/cli/routing-calibrate.ts` and `src/prd/index.ts`) coerced into "no prior history", silently wiping accumulated history on the next write.
- Fix: `saveJsonFile()` now writes to a sibling `<path>.tmp-<uuid>` file, then `rename()`s it over the destination (mirrors the existing pattern in `src/plugins/builtin/curator/rollup-prune.ts`). A reader always observes either the fully-written old content or the fully-written new content, never a torn write.
- Per the user's decision on scope: this is the "atomic tmp+rename" fix, not a JSONL-append-store rewrite. It does **not** eliminate the read-modify-write race between two concurrent appenders (both read the same prior array, one write wins, one entry is lost) — only the torn-read/history-wipe failure mode. Documented as a caveat in the docstring.

## Review notes
An independent `code-reviewer` pass caught that the first draft's regression test raced writer and reader in the *same process* — which can never observe a torn write regardless of atomicity, so it passed unchanged against the pre-fix code and gave zero real coverage. Replaced with a cross-process test (`test/fixtures/json-file-writer.ts` spawned as a subprocess) that I verified fails against the pre-fix implementation (2 torn/null reads) and passes against the fix.

## Test plan
- [x] `bun x tsc --noEmit` clean
- [x] `bun run lint` clean (deep-relatives, alias-internals, nax-error, file-size ratchets all hold)
- [x] `bun run test`: 12649 unit + 1102 integration + 24 UI, 0 failures
- [x] New regression test (`test/unit/utils/json-file.test.ts`) empirically confirmed to fail against the pre-fix implementation and pass against the fix