### PR TITLE
fix: move LLM routing-decision cache from module singleton to runtime scope (BUG-19)

### DIFF
--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -231,8 +231,11 @@ export async function preIterationTierCheck(
       toTier: escalatedTier,
     });
 
-    // Clear routing cache for story to avoid returning old cached decision
-    clearCacheForStory(story.id);
+    // Routing-cache invalidation now needs a NaxRuntime (BUG-19: the cache is
+    // runtime-scoped, not a module singleton) — preIterationTierCheck has no
+    // runtime parameter, matching the hybrid re-route immediately below, which
+    // already passes `runtime: undefined` and no-ops. Both are inert pending
+    // BUG-04 (this function has zero production callers).
 
     // Hybrid mode: re-route story after escalation
     if (routingMode === "hybrid") {
@@ -524,8 +527,11 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
   await _tierEscalationDeps.savePRD(updatedPrd, ctx.prdPath);
 
   // Clear routing cache for all escalated stories to avoid returning old cached decisions
-  for (const story of storiesToEscalate) {
-    clearCacheForStory(story.id);
+  if (ctx.runtime) {
+    const routingCache = ctx.runtime.routingCache;
+    for (const story of storiesToEscalate) {
+      clearCacheForStory(routingCache, story.id);
+    }
   }
 
   // Hybrid mode: re-route escalated stories

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -16,7 +16,6 @@ import { getSafeLogger } from "../../logger";
 import type { PRD, StructuredFailure, UserStory } from "../../prd";
 import { markStoryFailed, savePRD } from "../../prd";
 import { tryLlmBatchRoute } from "../../routing";
-import { clearCacheForStory } from "../../routing/strategies/llm";
 import type { FailureCategory } from "../../tdd/types";
 import { calculateMaxIterations, escalateTier, getTierConfig } from "../escalation";
 import { hookCtx } from "../helpers";
@@ -231,11 +230,13 @@ export async function preIterationTierCheck(
       toTier: escalatedTier,
     });
 
-    // Routing-cache invalidation now needs a NaxRuntime (BUG-19: the cache is
-    // runtime-scoped, not a module singleton) — preIterationTierCheck has no
-    // runtime parameter, matching the hybrid re-route immediately below, which
-    // already passes `runtime: undefined` and no-ops. Both are inert pending
-    // BUG-04 (this function has zero production callers).
+    // No routing-cache invalidation needed here: resolveRouting's "PRD wins"
+    // branch (router.ts) short-circuits on story.routing.complexity +
+    // testStrategy, which this function sets on the story above and never
+    // clears. Any story reaching escalation has already been routed, so its
+    // cache entry — if any — is never read again regardless of whether it's
+    // cleared. The hybrid re-route immediately below (`runtime: undefined`)
+    // is inert for the same reason, independent of its missing runtime.
 
     // Hybrid mode: re-route story after escalation
     if (routingMode === "hybrid") {
@@ -526,13 +527,11 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
 
   await _tierEscalationDeps.savePRD(updatedPrd, ctx.prdPath);
 
-  // Clear routing cache for all escalated stories to avoid returning old cached decisions
-  if (ctx.runtime) {
-    const routingCache = ctx.runtime.routingCache;
-    for (const story of storiesToEscalate) {
-      clearCacheForStory(routingCache, story.id);
-    }
-  }
+  // No routing-cache invalidation needed here, for the same reason as
+  // preIterationTierCheck above: updatedRouting preserves complexity and
+  // testStrategy, so resolveRouting's "PRD wins" short-circuit means any
+  // cache entry for an escalated story is never read again regardless of
+  // whether it's cleared.
 
   // Hybrid mode: re-route escalated stories
   if (routingMode === "hybrid") {

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -14,7 +14,6 @@
 
 import path from "node:path";
 import { pipelineEventBus } from "@/pipeline";
-import { clearCache as clearRoutingCache } from "@/routing";
 import { discoverWorkspacePackages, resolveTestFilePatterns } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
 import type { NaxConfig } from "../../config";
@@ -420,11 +419,8 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
       config.reporters,
     );
 
-    // Clear LLM routing cache at run start — prevents cross-run pollution
-    // when story IDs repeat across features, and fixes the parallel-mode race
-    // where the per-story guard (ctx.story.id === stories[0]?.id) could miss
-    // stories that start routing before the first story clears the cache.
-    clearRoutingCache();
+    // The LLM routing cache is run-scoped (runtime.routingCache, BUG-19) and
+    // already starts empty for this run — no explicit clear needed here.
 
     // Log plugins loaded
     logger?.info("plugins", `Loaded ${pluginRegistry.plugins.length} plugins`, {

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -15,7 +15,6 @@ import type { AgentGetFn } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins/registry";
 import type { PRD } from "../prd";
 import { tryLlmBatchRoute } from "../routing";
-import { clearCache as clearLlmCache } from "../routing/strategies/llm";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { SessionManager } from "../session";
 import { precomputeBatchPlan } from "./batching";
@@ -123,8 +122,8 @@ export async function runExecutionPhase(
     batchingEnabled: options.useBatch,
   });
 
-  // Clear LLM routing cache at start of new run
-  clearLlmCache();
+  // The LLM routing cache is run-scoped (options.runtime.routingCache, BUG-19)
+  // and already starts empty — no explicit clear needed here.
 
   // Create package directories for stories targeting not-yet-existing packages
   // (new feature on a new package). Must run before any session opens — both the

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -14,7 +14,7 @@
 import { isGreenfieldStory } from "@/context";
 import { getLogger } from "@/logger";
 import { savePRD } from "@/prd";
-import { clearCache, complexityToModelTier, isSecurityCriticalStory, resolveRouting } from "@/routing";
+import { complexityToModelTier, isSecurityCriticalStory, resolveRouting } from "@/routing";
 import { resolveTestFilePatterns } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
 import { packageDirRelative } from "@/utils/paths";
@@ -27,11 +27,9 @@ export const routingStage: PipelineStage = {
   async execute(ctx: PipelineContext): Promise<StageResult> {
     const logger = getLogger();
 
-    // Clear LLM routing cache at the start of each run (first story only) to prevent
-    // cross-run cache pollution when story IDs repeat across features (e.g. "us-001").
-    if (ctx.story.id === ctx.stories[0]?.id) {
-      _routingDeps.clearCache();
-    }
+    // The LLM routing cache lives on ctx.runtime.routingCache (BUG-19) — a
+    // fresh Map per createRuntime() call — so it already starts empty for
+    // this run. No explicit clear-on-first-story step is needed here.
 
     // Classify story via resolveRouting() (plugin routers > LLM > keyword)
     const decision = await _routingDeps.resolveRouting(ctx.story, ctx.config, ctx.plugins, ctx);
@@ -193,6 +191,5 @@ export const _routingDeps = {
   complexityToModelTier,
   isGreenfieldStory,
   resolveTestFilePatterns,
-  clearCache,
   savePRD,
 };

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -20,7 +20,7 @@ import type { NaxRuntime } from "../runtime";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import type { RoutingDecision } from "./decision";
 export type { RoutingDecision } from "./decision";
-import { MAX_CACHE_SIZE, cachedDecisions, evictOldest } from "./strategies/llm-cache";
+import { MAX_CACHE_SIZE, evictOldest } from "./strategies/llm-cache";
 
 // Pure classification logic lives in classify.ts (no agent-registry dep) — re-exported here for back-compat.
 export { classifyComplexity, determineTestStrategy, isSecurityCriticalStory } from "./classify";
@@ -188,13 +188,14 @@ export async function resolveRouting(
   // 2. LLM fallback (if configured)
   if (config.routing.strategy === "llm" && dispatchContext.runtime) {
     const llmConfig = config.routing.llm;
+    const routingCache = dispatchContext.runtime.routingCache;
     if (llmConfig) {
       try {
         const mode = llmConfig.mode ?? "hybrid";
 
         // Cache hit: return cached decision with fresh testStrategy
-        if (llmConfig.cacheDecisions && cachedDecisions.has(story.id)) {
-          const cached = cachedDecisions.get(story.id);
+        if (llmConfig.cacheDecisions && routingCache.has(story.id)) {
+          const cached = routingCache.get(story.id);
           if (cached) {
             const tddStrategy = config.tdd?.strategy ?? "auto";
             const freshTestStrategy = determineTestStrategy(
@@ -234,8 +235,8 @@ export async function resolveRouting(
           });
 
           if (llmConfig.cacheDecisions) {
-            if (cachedDecisions.size >= MAX_CACHE_SIZE) evictOldest();
-            cachedDecisions.set(story.id, decision);
+            if (routingCache.size >= MAX_CACHE_SIZE) evictOldest(routingCache);
+            routingCache.set(story.id, decision);
           }
 
           logger?.info("routing", "LLM classified story", {
@@ -380,9 +381,10 @@ export async function tryLlmBatchRoute(
     const decisions = await callOp(ctx, classifyRouteBatchOp, needsRouting);
 
     if (llmConfig.cacheDecisions) {
+      const routingCache = runtime.routingCache;
       for (const [storyId, decision] of decisions.entries()) {
-        if (cachedDecisions.size >= MAX_CACHE_SIZE) evictOldest();
-        cachedDecisions.set(storyId, decision);
+        if (routingCache.size >= MAX_CACHE_SIZE) evictOldest(routingCache);
+        routingCache.set(storyId, decision);
       }
     }
 

--- a/src/routing/strategies/llm-cache.ts
+++ b/src/routing/strategies/llm-cache.ts
@@ -1,41 +1,55 @@
 /**
  * LLM Routing Cache
  *
- * Module-level cache for routing decisions.
+ * Helpers for the run-scoped routing-decision cache (BUG-19). The cache
+ * itself lives on `NaxRuntime.routingCache` — a fresh `Map` per `createRuntime()`
+ * call — rather than as a module-level singleton. A module-level `Map` persisted
+ * across every `createRuntime()` call in the same process, so a decision cached
+ * for `story.id` "US-001" in one run/feature could be served back to an
+ * unrelated run/feature whose story ids happened to collide (e.g. two features
+ * both starting from "US-001"), gated only by a per-story-id "first story of
+ * the run" clear heuristic that itself missed parallel-routing and
+ * skipped/paused-first-story cases. Scoping the `Map` to the runtime removes
+ * both problems: each run starts with an empty cache, so no clear-on-first-story
+ * heuristic is needed at all.
+ *
  * Extracted from llm.ts so router.ts can import it without pulling in the full
  * LLM strategy dependencies (IAgentManager, Bun.spawn, etc.).
  */
 
 import type { RoutingDecision } from "../decision";
 
-/** Module-level cache for routing decisions (PERF-1 fix: max 100 entries LRU) */
-export const cachedDecisions = new Map<string, RoutingDecision>();
+/** Max entries per run-scoped cache before LRU eviction kicks in (PERF-1). */
 export const MAX_CACHE_SIZE = 100;
 
-/** Clear the routing cache (for testing or new runs) */
-export function clearCache(): void {
-  cachedDecisions.clear();
+/** Clear every entry in a routing cache. */
+export function clearCache(cache: Map<string, RoutingDecision>): void {
+  cache.clear();
 }
 
-/** Get the current cache size (for testing) */
-export function getCacheSize(): number {
-  return cachedDecisions.size;
+/** Get the current size of a routing cache (for testing). */
+export function getCacheSize(cache: Map<string, RoutingDecision>): number {
+  return cache.size;
 }
 
-/** Clear routing cache entry for a specific story (used on tier escalation) */
-export function clearCacheForStory(storyId: string): void {
-  cachedDecisions.delete(storyId);
+/** Clear a routing cache entry for a specific story (used on tier escalation). */
+export function clearCacheForStory(cache: Map<string, RoutingDecision>, storyId: string): void {
+  cache.delete(storyId);
 }
 
-/** Inject a cache entry directly (test helper only) */
-export function injectCacheEntry(storyId: string, decision: RoutingDecision): void {
-  cachedDecisions.set(storyId, decision);
+/** Inject a cache entry directly (test helper only). */
+export function injectCacheEntry(
+  cache: Map<string, RoutingDecision>,
+  storyId: string,
+  decision: RoutingDecision,
+): void {
+  cache.set(storyId, decision);
 }
 
-/** Evict oldest entry when cache is full (LRU) */
-export function evictOldest(): void {
-  const firstKey = cachedDecisions.keys().next().value;
+/** Evict the oldest entry when a routing cache is full (LRU). */
+export function evictOldest(cache: Map<string, RoutingDecision>): void {
+  const firstKey = cache.keys().next().value;
   if (firstKey !== undefined) {
-    cachedDecisions.delete(firstKey);
+    cache.delete(firstKey);
   }
 }

--- a/src/routing/strategies/llm-cache.ts
+++ b/src/routing/strategies/llm-cache.ts
@@ -19,7 +19,7 @@
 
 import type { RoutingDecision } from "../decision";
 
-/** Max entries per run-scoped cache before LRU eviction kicks in (PERF-1). */
+/** Max entries per run-scoped cache before eviction kicks in (PERF-1). */
 export const MAX_CACHE_SIZE = 100;
 
 /** Clear every entry in a routing cache. */
@@ -32,7 +32,7 @@ export function getCacheSize(cache: Map<string, RoutingDecision>): number {
   return cache.size;
 }
 
-/** Clear a routing cache entry for a specific story (used on tier escalation). */
+/** Clear a routing cache entry for a specific story. */
 export function clearCacheForStory(cache: Map<string, RoutingDecision>, storyId: string): void {
   cache.delete(storyId);
 }
@@ -46,7 +46,12 @@ export function injectCacheEntry(
   cache.set(storyId, decision);
 }
 
-/** Evict the oldest entry when a routing cache is full (LRU). */
+/**
+ * Evict the oldest-inserted entry when a routing cache is full. FIFO by
+ * insertion order (`Map` iteration order), not true LRU — a cache hit does
+ * not move an entry to the back, so a frequently-reread early entry can still
+ * be evicted before a write-once-never-read later one.
+ */
 export function evictOldest(cache: Map<string, RoutingDecision>): void {
   const firstKey = cache.keys().next().value;
   if (firstKey !== undefined) {

--- a/src/routing/strategies/llm.ts
+++ b/src/routing/strategies/llm.ts
@@ -15,7 +15,6 @@ export { validateRoutingDecision, stripCodeFences, parseRoutingResponse } from "
 
 // Re-export cache utilities (now live in llm-cache.ts) — backward compat
 export {
-  cachedDecisions,
   MAX_CACHE_SIZE,
   clearCache,
   getCacheSize,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -83,6 +83,7 @@ import { getLogger } from "../logger";
 import type { Logger } from "../logger";
 import { ReviewAuditor, createNoOpReviewAuditor } from "../review/review-audit";
 import type { IReviewAuditor } from "../review/review-audit";
+import type { RoutingDecision } from "../routing/decision";
 import type { ISessionManager } from "../session";
 import { SessionManager } from "../session";
 import { type QuarantineMemo, createQuarantineMemo } from "../verification/flake-triage";
@@ -156,6 +157,17 @@ export interface NaxRuntime {
    * failed revert blocks anything.
    */
   readonly dirtyWorktrees: Set<string>;
+  /**
+   * Run-scoped LLM routing-decision cache (BUG-19). Previously a module-level
+   * singleton keyed by bare `story.id`, which persisted across `createRuntime()`
+   * calls in the same process and could leak a decision from one feature/run
+   * into another whose first story happened to route concurrently (or whose
+   * `stories[0]` was skipped/paused) — see BUG-19 in
+   * docs/reviews/2026-08-11-code-review-latent-bugs-v2.md for the full
+   * mechanism. Scoping the cache to the runtime means each run starts with
+   * an empty cache; no explicit "clear on first story" heuristic is needed.
+   */
+  readonly routingCache: Map<string, RoutingDecision>;
   close(): Promise<void>;
 }
 
@@ -282,6 +294,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const storyFixHistory = createStoryFixHistory();
   const mutationSummaries = new Map<string, MutationStorySummary>();
   const dirtyWorktrees = new Set<string>();
+  const routingCache = new Map<string, RoutingDecision>();
 
   let closed = false;
 
@@ -311,6 +324,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     storyFixHistory,
     mutationSummaries,
     dirtyWorktrees,
+    routingCache,
 
     get signal() {
       return controller.signal;

--- a/test/unit/routing/llm-batch-route.test.ts
+++ b/test/unit/routing/llm-batch-route.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { UserStory } from "../../../src/prd/types";
 import { _callOpDeps } from "../../../src/operations";
-import { tryLlmBatchRoute } from "../../../src/routing/router";
-import { makeNaxConfig, makeStory } from "../../helpers";
+import { resolveRouting, tryLlmBatchRoute } from "../../../src/routing/router";
+import { makeMockAgentManager, makeNaxConfig, makeStory } from "../../helpers";
 import { makeMockRuntime } from "../../helpers/runtime";
+import type { DispatchContext } from "../../../src/runtime/dispatch-context";
 import type { NaxRuntime } from "../../../src/runtime";
 
 // The mock runtime makes the routing LLM call fail, which the classify-route op
@@ -91,5 +92,86 @@ describe("tryLlmBatchRoute", () => {
     };
 
     await expect(tryLlmBatchRoute(config, [story], "routing", deps)).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveRouting <-> runtime.routingCache instance-identity (BUG-19)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("resolveRouting reads runtime.routingCache, scoped per runtime instance", () => {
+  const cacheConfig = makeNaxConfig({
+    routing: {
+      strategy: "llm",
+      llm: { model: "fast", fallbackToKeywords: true, cacheDecisions: true, mode: "hybrid", timeoutMs: 5000 },
+    },
+  });
+
+  function makeDispatchContext(runtime: NaxRuntime): DispatchContext {
+    return {
+      agentManager: runtime.agentManager,
+      sessionManager: runtime.sessionManager,
+      runtime,
+      abortSignal: runtime.signal,
+    };
+  }
+
+  test("a cache hit on this runtime's routingCache never calls the agent", async () => {
+    const completeAsFn = mock(async () => {
+      throw new Error("should not be called — cache hit expected");
+    });
+    const runtime = makeMockRuntime({
+      config: cacheConfig,
+      agentManager: makeMockAgentManager({ completeAsFn }),
+    });
+    createdRuntimes.push(runtime);
+
+    runtime.routingCache.set("US-cache-hit", {
+      complexity: "complex",
+      modelTier: "powerful",
+      testStrategy: "three-session-tdd",
+      reasoning: "pre-cached",
+    });
+    const story: UserStory = { ...makeStory(), id: "US-cache-hit" };
+
+    const decision = await resolveRouting(story, cacheConfig, undefined, makeDispatchContext(runtime));
+
+    expect(decision.complexity).toBe("complex");
+    expect(decision.modelTier).toBe("powerful");
+    expect(completeAsFn).not.toHaveBeenCalled();
+  });
+
+  test("an entry cached on one runtime is invisible to resolveRouting on a different runtime", async () => {
+    const runtimeA = makeMockRuntime({ config: cacheConfig });
+    const completeAsFn = mock(async () => ({
+      output: JSON.stringify({ complexity: "simple", modelTier: "fast", reasoning: "fresh classification" }),
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      estimatedCostUsd: 0,
+    }));
+    const runtimeB = makeMockRuntime({
+      config: cacheConfig,
+      agentManager: makeMockAgentManager({ completeAsFn }),
+    });
+    createdRuntimes.push(runtimeA, runtimeB);
+
+    // Populated on runtime A only — the BUG-19 scenario is a decision cached
+    // under one runtime being served back under an unrelated one.
+    runtimeA.routingCache.set("US-cross-runtime", {
+      complexity: "complex",
+      modelTier: "powerful",
+      testStrategy: "three-session-tdd",
+      reasoning: "cached on runtime A",
+    });
+    const story: UserStory = { ...makeStory(), id: "US-cross-runtime" };
+
+    const decision = await resolveRouting(story, cacheConfig, undefined, makeDispatchContext(runtimeB));
+
+    // runtimeB's cache is empty, so resolveRouting must fall through to real
+    // classification instead of returning runtime A's cached decision.
+    expect(decision.complexity).toBe("simple");
+    expect(decision.modelTier).toBe("fast");
+    expect(completeAsFn).toHaveBeenCalledTimes(1);
+    expect(runtimeB.routingCache.has("US-cross-runtime")).toBe(true);
+    expect(runtimeA.routingCache.get("US-cross-runtime")?.complexity).toBe("complex");
   });
 });

--- a/test/unit/routing/routing-advanced.test.ts
+++ b/test/unit/routing/routing-advanced.test.ts
@@ -4,84 +4,92 @@
  *
  * Consolidated test suite for routing system including:
  * - LLM cache clearing (BUG-028)
+ * - Run-scoped cache utilities (BUG-19) — each test builds its own Map instead
+ *   of sharing a module-level singleton, mirroring how NaxRuntime.routingCache
+ *   is a fresh instance per run.
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
-import {
-  clearCache,
-  clearCacheForStory,
-  getCacheSize,
-} from "../../../src/routing/strategies/llm";
+import { describe, expect, test } from "bun:test";
+import { clearCache, clearCacheForStory, getCacheSize, injectCacheEntry } from "../../../src/routing/strategies/llm";
+import type { RoutingDecision } from "../../../src/routing/decision";
 
-// ============================================================================
-// LLM Cache Clearing Tests (BUG-028 fix)
-// ============================================================================
+const DECISION: RoutingDecision = {
+  complexity: "simple",
+  modelTier: "fast",
+  testStrategy: "tdd-simple",
+  reasoning: "test fixture",
+};
 
 describe("LLM Cache Clearing on Tier Escalation", () => {
-  beforeEach(() => {
-    // Clear cache before each test
-    clearCache();
-  });
-
   test("cache starts empty before any routing decisions", () => {
-    // Verify initial cache state
-    expect(getCacheSize()).toBe(0);
-
-    // Note: We're testing the behavior through the exported functions
-    // In a real scenario, the LLM strategy would populate the cache
-    // For this test, we verify the cache clearing mechanism works
+    const cache = new Map<string, RoutingDecision>();
+    expect(getCacheSize(cache)).toBe(0);
   });
 
   test("clearCacheForStory removes cache entry", () => {
+    const cache = new Map<string, RoutingDecision>();
     const storyId = "US-cache-002";
+    injectCacheEntry(cache, storyId, DECISION);
+    expect(getCacheSize(cache)).toBe(1);
 
-    // Clear cache first
-    clearCache();
-    expect(getCacheSize()).toBe(0);
-
-    // Clear non-existent entry should not throw
-    clearCacheForStory(storyId);
-    expect(getCacheSize()).toBe(0);
+    clearCacheForStory(cache, storyId);
+    expect(getCacheSize(cache)).toBe(0);
   });
 
   test("clearCacheForStory after tier escalation forces re-routing", () => {
+    const cache = new Map<string, RoutingDecision>();
     const storyId = "US-cache-003";
+    injectCacheEntry(cache, storyId, DECISION);
 
-    // Clear all caches
-    clearCache();
-    expect(getCacheSize()).toBe(0);
+    clearCacheForStory(cache, storyId);
 
-    // Simulate clearing for escalation
-    clearCacheForStory(storyId);
-
-    // Cache should still be empty
-    expect(getCacheSize()).toBe(0);
+    expect(cache.has(storyId)).toBe(false);
   });
 
   test("clearing one story does not affect other cached stories", () => {
-    clearCache();
-
+    const cache = new Map<string, RoutingDecision>();
     const story1Id = "US-escalate-1";
     const story2Id = "US-escalate-2";
+    injectCacheEntry(cache, story1Id, DECISION);
+    injectCacheEntry(cache, story2Id, DECISION);
 
-    // Verify we can clear individual stories
-    clearCacheForStory(story1Id);
-    clearCacheForStory(story2Id);
+    clearCacheForStory(cache, story1Id);
 
-    expect(getCacheSize()).toBe(0);
+    expect(cache.has(story1Id)).toBe(false);
+    expect(cache.has(story2Id)).toBe(true);
+    expect(getCacheSize(cache)).toBe(1);
   });
 
   test("clearCacheForStory is idempotent", () => {
+    const cache = new Map<string, RoutingDecision>();
     const storyId = "US-idempotent";
+    injectCacheEntry(cache, storyId, DECISION);
 
-    clearCache();
-    expect(getCacheSize()).toBe(0);
+    clearCacheForStory(cache, storyId);
+    clearCacheForStory(cache, storyId);
+    clearCacheForStory(cache, storyId);
 
-    // Clear multiple times should be safe
-    clearCacheForStory(storyId);
-    clearCacheForStory(storyId);
-    clearCacheForStory(storyId);
+    expect(getCacheSize(cache)).toBe(0);
+  });
 
-    expect(getCacheSize()).toBe(0);
+  test("clearCache empties every entry regardless of story id", () => {
+    const cache = new Map<string, RoutingDecision>();
+    injectCacheEntry(cache, "US-1", DECISION);
+    injectCacheEntry(cache, "US-2", DECISION);
+
+    clearCache(cache);
+
+    expect(getCacheSize(cache)).toBe(0);
+  });
+
+  test("two independent caches (simulating two runtimes) never see each other's entries", () => {
+    const runA = new Map<string, RoutingDecision>();
+    const runB = new Map<string, RoutingDecision>();
+
+    // Same story id colliding across two "runs" — the BUG-19 scenario.
+    injectCacheEntry(runA, "US-001", { ...DECISION, reasoning: "run A" });
+
+    expect(runB.has("US-001")).toBe(false);
+    expect(getCacheSize(runB)).toBe(0);
   });
 });

--- a/test/unit/routing/routing-advanced.test.ts
+++ b/test/unit/routing/routing-advanced.test.ts
@@ -82,14 +82,10 @@ describe("LLM Cache Clearing on Tier Escalation", () => {
     expect(getCacheSize(cache)).toBe(0);
   });
 
-  test("two independent caches (simulating two runtimes) never see each other's entries", () => {
-    const runA = new Map<string, RoutingDecision>();
-    const runB = new Map<string, RoutingDecision>();
-
-    // Same story id colliding across two "runs" — the BUG-19 scenario.
-    injectCacheEntry(runA, "US-001", { ...DECISION, reasoning: "run A" });
-
-    expect(runB.has("US-001")).toBe(false);
-    expect(getCacheSize(runB)).toBe(0);
-  });
+  // Instance-identity coverage — two real NaxRuntime instances never sharing a
+  // cache, and resolveRouting() actually reading/writing per-runtime — lives in
+  // test/unit/runtime/runtime.test.ts and test/unit/routing/llm-batch-route.test.ts.
+  // A test built from two bare `new Map()`s here would prove nothing about
+  // production wiring — two different Maps are trivially different regardless
+  // of whether the fix exists.
 });

--- a/test/unit/routing/strategies/llm.test.ts
+++ b/test/unit/routing/strategies/llm.test.ts
@@ -53,40 +53,41 @@ afterEach(() => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("LLM routing cache utilities", () => {
+  // Each test builds its own Map — the cache is run-scoped (NaxRuntime.routingCache,
+  // BUG-19), not a module-level singleton, so there's nothing to reset between tests.
+
   test("clearCache empties the cache", async () => {
     const { clearCache, getCacheSize, injectCacheEntry } = await import("../../../../src/routing/strategies/llm");
-    injectCacheEntry("CACHE-UTIL-001", {
+    const cache = new Map();
+    injectCacheEntry(cache, "CACHE-UTIL-001", {
       complexity: "simple",
       modelTier: "fast",
       testStrategy: "tdd-simple",
       reasoning: "test",
     });
-    expect(getCacheSize()).toBeGreaterThan(0);
-    clearCache();
-    expect(getCacheSize()).toBe(0);
+    expect(getCacheSize(cache)).toBeGreaterThan(0);
+    clearCache(cache);
+    expect(getCacheSize(cache)).toBe(0);
   });
 
   test("clearCacheForStory removes only that entry", async () => {
-    const { clearCache, getCacheSize, injectCacheEntry, clearCacheForStory } = await import(
-      "../../../../src/routing/strategies/llm"
-    );
-    clearCache();
-    injectCacheEntry("CACHE-A", {
+    const { getCacheSize, injectCacheEntry, clearCacheForStory } = await import("../../../../src/routing/strategies/llm");
+    const cache = new Map();
+    injectCacheEntry(cache, "CACHE-A", {
       complexity: "simple",
       modelTier: "fast",
       testStrategy: "tdd-simple",
       reasoning: "a",
     });
-    injectCacheEntry("CACHE-B", {
+    injectCacheEntry(cache, "CACHE-B", {
       complexity: "medium",
       modelTier: "balanced",
       testStrategy: "tdd-simple",
       reasoning: "b",
     });
-    expect(getCacheSize()).toBe(2);
-    clearCacheForStory("CACHE-A");
-    expect(getCacheSize()).toBe(1);
-    clearCache();
+    expect(getCacheSize(cache)).toBe(2);
+    clearCacheForStory(cache, "CACHE-A");
+    expect(getCacheSize(cache)).toBe(1);
   });
 });
 

--- a/test/unit/runtime/runtime.test.ts
+++ b/test/unit/runtime/runtime.test.ts
@@ -47,6 +47,31 @@ describe("createRuntime", () => {
     expect(rt.mutationSummaries.size).toBe(0);
   });
 
+  test("runtime initializes an empty routing-decision cache (BUG-19)", () => {
+    const rt = makeRuntime(DEFAULT_CONFIG, "/tmp/test");
+    expect(rt.routingCache).toBeInstanceOf(Map);
+    expect(rt.routingCache.size).toBe(0);
+  });
+
+  test("two runtimes never share a routing cache, even with colliding story ids (BUG-19)", () => {
+    // The original defect: cachedDecisions was a module-level singleton, so a
+    // decision cached under "US-001" in one run/feature could be served back
+    // to an unrelated run/feature whose story ids happened to collide.
+    const runA = makeRuntime(DEFAULT_CONFIG, "/tmp/test-a");
+    const runB = makeRuntime(DEFAULT_CONFIG, "/tmp/test-b");
+
+    runA.routingCache.set("US-001", {
+      complexity: "simple",
+      modelTier: "fast",
+      testStrategy: "tdd-simple",
+      reasoning: "run A",
+    });
+
+    expect(runA.routingCache.has("US-001")).toBe(true);
+    expect(runB.routingCache.has("US-001")).toBe(false);
+    expect(runB.routingCache.size).toBe(0);
+  });
+
   test("packages.repo() returns root-equivalent view", () => {
     const rt = makeRuntime(DEFAULT_CONFIG, "/tmp/test");
     const view = rt.packages.repo();


### PR DESCRIPTION
## Summary
- Fixes BUG-19 from `docs/reviews/2026-08-11-code-review-latent-bugs-v2.md` (Group 2 — architecture change).
- `cachedDecisions` was a module-level `Map<string, RoutingDecision>` keyed by bare `story.id`. Because it's a module singleton, it persisted across every `createRuntime()` call in the same process — a decision cached for e.g. "US-001" in one run/feature could be served back to an unrelated run/feature whose story ids happened to collide. The only invalidation was a conditional clear in the routing pipeline stage (`ctx.story.id === ctx.stories[0]?.id`) that missed parallel-routing and skipped/paused-first-story cases, and two more ad-hoc "clear the whole cache at run start" call sites existed elsewhere and still weren't sufficient.
- Fix: moved the cache onto `NaxRuntime.routingCache` — a fresh `Map` per `createRuntime()` call, following the same pattern as the runtime's other run-scoped maps (`adversarialIterations`, `mutationSummaries`, etc.). Every run now starts with a genuinely empty cache by construction, so all three "clear at run start" call sites were deleted outright. Per-story invalidation on tier escalation now reads/writes `ctx.runtime.routingCache` instead of a global. `llm-cache.ts`'s helpers now take the cache `Map` as an explicit parameter.

## Review notes
An independent `code-reviewer` pass (in an isolated worktree, since this session had unrelated branch-switching happening concurrently) found:
- **HIGH**: a comment claiming `preIterationTierCheck` "has zero production callers" was stale — BUG-04 was wired by a separate PR (#1550) after the review doc's snapshot, making the function reachable. Corrected the comment to state the *actual* reason the removal is safe: `resolveRouting`'s "PRD wins" short-circuit means any story that reaches escalation has already been routed, so its cache entry is never re-read regardless of whether it's cleared.
- **MEDIUM**: `handleTierEscalation`'s new `if (ctx.runtime)` guard was dead on the only production path (the caller never passes `runtime` on `EscalationHandlerContext`). Removed the guard/clear entirely rather than leave code that looks live but isn't, per the same PRD-wins reasoning.
- **MEDIUM**: a new test built two bare `new Map()`s and asserted they don't share entries — true of any two Maps regardless of the fix, so it gave zero real coverage. Deleted, and replaced with tests against a real `resolveRouting()` + `NaxRuntime` call path (cache hit skips the agent call; a decision cached on one runtime is invisible to another).
- **LOW**: `evictOldest`'s docstring called itself "LRU" when it's actually FIFO by insertion order (no touch-on-read). Corrected.

## Test plan
- [x] `bun x tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `bun run test`: unit + integration + UI, 0 failures
- [x] New tests verify the actual production read/write path (`resolveRouting` + real `NaxRuntime` instances), not just Map identity