### PR TITLE
fix: parse Vitest's no-colon Tests summary line

### DIFF
--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -183,20 +183,16 @@ function parseBunOutput(output: string): TestSummary {
 /**
  * Parse Jest / Vitest test output.
  *
- * Jest summary line examples:
- *   "Tests:       41 failed, 38 passed, 79 total"
- *   "Tests:       38 passed, 38 total"
- *
- * Vitest summary line examples:
- *   "Test Files  1 failed | 2 passed (3)"
+ * Jest: "Tests:       41 failed, 38 passed, 79 total" (colon-suffixed)
+ * Vitest: "     Tests  41 failed, 38 passed, 79 total" (no colon)
  */
 function parseJestOutput(output: string): TestSummary {
   const failures: TestFailure[] = [];
   let passed = 0;
   let failed = 0;
 
-  // Extract counts from the "Tests:" summary line (use the last occurrence)
-  const summaryMatches = Array.from(output.matchAll(/^\s*Tests:\s+(.*)/gm));
+  // Colon is optional — matches both Jest's "Tests:" and Vitest's "Tests" (no colon).
+  const summaryMatches = Array.from(output.matchAll(/^\s*Tests:?\s+(.*)/gm));
   if (summaryMatches.length > 0) {
     const summaryLine = summaryMatches[summaryMatches.length - 1][1];
     const failedMatch = summaryLine.match(/(\d+)\s+failed/);

--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -192,7 +192,11 @@ function parseJestOutput(output: string): TestSummary {
   let failed = 0;
 
   // Colon is optional — matches both Jest's "Tests:" and Vitest's "Tests" (no colon).
-  const summaryMatches = Array.from(output.matchAll(/^\s*Tests:?\s+(.*)/gm));
+  // Require a leading "<n> passed|failed" immediately after "Tests" so incidental
+  // app-log lines starting with "Tests " (e.g. "Tests  3 items processed") can't
+  // masquerade as the real summary — same class of false-positive guard as the
+  // app-log-noise exclusion in parseCommonOutput below.
+  const summaryMatches = Array.from(output.matchAll(/^\s*Tests:?\s+(\d+\s+(?:passed|failed).*)/gm));
   if (summaryMatches.length > 0) {
     const summaryLine = summaryMatches[summaryMatches.length - 1][1];
     const failedMatch = summaryLine.match(/(\d+)\s+failed/);

--- a/test/unit/utils/test-output-parser.test.ts
+++ b/test/unit/utils/test-output-parser.test.ts
@@ -254,6 +254,17 @@ Error: JS test error
       expect(result.passed).toBe(0);
       expect(result.failed).toBe(0);
     });
+
+    test("ignores app-log noise starting with 'Tests ' that isn't the real summary line", () => {
+      // A line starting with "Tests " but not shaped like "<n> passed|failed" (e.g.
+      // incidental app output) must not be mistaken for the framework summary.
+      const output = `Tests  processed 3 items this run\n\n Test Files  1 passed (1)\n      Tests  5 passed (5)`;
+
+      const result = parseTestOutput(output);
+
+      expect(result.passed).toBe(5);
+      expect(result.failed).toBe(0);
+    });
   });
 
   test("handles alternative check marks (✔ and ✘)", () => {

--- a/test/unit/utils/test-output-parser.test.ts
+++ b/test/unit/utils/test-output-parser.test.ts
@@ -225,6 +225,37 @@ Error: JS test error
     });
   });
 
+  describe("Vitest output — no-colon summary line", () => {
+    test("parses Vitest's real all-passing summary (no colon after 'Tests')", () => {
+      // Reproduces real `vitest run` output — verified against actual CLI output,
+      // not Jest's colon-suffixed format that a shared parser previously assumed.
+      const output = ` RUN  v4.1.9 /repo/apps/web\n\n\n Test Files  1 passed (1)\n      Tests  5 passed (5)\n   Start at  12:37:53\n   Duration  194ms`;
+
+      const result = parseTestOutput(output);
+
+      expect(result.passed).toBe(5);
+      expect(result.failed).toBe(0);
+    });
+
+    test("parses Vitest's mixed pass/fail summary (no colon)", () => {
+      const output = ` Test Files  1 failed | 1 passed (2)\n      Tests  2 failed | 3 passed (5)`;
+
+      const result = parseTestOutput(output);
+
+      expect(result.passed).toBe(3);
+      expect(result.failed).toBe(2);
+    });
+
+    test("parses Vitest's zero-test summary as a genuine zero, not a parse miss", () => {
+      const output = ` Test Files  1 passed (1)\n      Tests  0 passed (0)`;
+
+      const result = parseTestOutput(output);
+
+      expect(result.passed).toBe(0);
+      expect(result.failed).toBe(0);
+    });
+  });
+
   test("handles alternative check marks (✔ and ✘)", () => {
     const output = `
 bun test v1.0.0


### PR DESCRIPTION
## Summary
- `parseJestOutput()` only matched Jest's colon-suffixed `Tests:` summary line. Vitest's real output omits the colon (`     Tests  5 passed (5)`), so a scoped Vitest run always parsed to `passed:0/failed:0` even when tests genuinely ran and passed.
- This tripped the "Scoped run executed no tests — falling back to full suite" guard in `verify-scoped.ts` on every pure-Vitest scope, mislabeling a passing run as inconclusive and forcing an unnecessary (though harmless) full-suite rerun. Diagnosed from a real `rs-stock` run (`web-backend-url-and-color-gates`, run `run-2026-08-12T13-32-56-185Z`) and reproduced directly against `bun vitest run`.
- Self-review follow-up: made the colon optional broadly at first, then tightened the regex to require the `<n> passed|failed` shape immediately after `Tests` so incidental app-log lines starting with "Tests " can't masquerade as the real summary (same guard pattern already used in `parseCommonOutput`).

## Test plan
- [x] `bun test test/unit/utils/test-output-parser.test.ts test/unit/test-runners/parser.test.ts` — new Vitest no-colon summary cases (all-pass, mixed pass/fail, zero-test, app-log-noise guard)
- [x] `bun test test/unit/operations/verify-scoped.test.ts test/unit/operations/quality-gate-packageview.test.ts test/unit/execution/lifecycle-execution.test.ts test/unit/execution/lifecycle/run-regression*.test.ts test/unit/test-runners/ac-parser.test.ts` — all downstream consumers of `parseTestOutput` still pass
- [x] `bun run lint` / `bun run typecheck`
- [x] Reproduced real Vitest summary format against `apps/web` in `rs-stock` to confirm the fix target

## Known follow-up (out of scope here)
- Structured failure extraction in `parseJestOutput` only recognizes Jest's `●` bullet failure format; Vitest's own failure format differs, so per-test failure detail (file/testName/error) likely still isn't extracted for failing Vitest runs even after this fix. Worth a separate issue since `detectFramework` explicitly special-cases `"vitest"`.