### PR TITLE
fix(agents): discover acpx effort option per agent instead of hardcoding

### DIFF
--- a/src/agents/acp/reasoning-effort.ts
+++ b/src/agents/acp/reasoning-effort.ts
@@ -1,10 +1,16 @@
 /**
- * Reasoning-effort application for codex sessions.
+ * Reasoning-effort application for ACP sessions.
  *
- * acpx 0.13+ selects codex models through the config-option channel, where the
- * model id is bare and effort is a sibling option. --model is re-sent on every
+ * acpx 0.13+ selects models through the config-option channel, where the model
+ * id is bare and effort is a sibling option. --model is re-sent on every
  * prompt, but effort has no per-prompt carrier, so it is set once when a session
- * is acquired.
+ * is acquired. The option's name is agent-specific — acpx advertises it on the
+ * session record as a config option with category "thought_level" (confirmed via
+ * `acpx --format json <agent> sessions show <name>`: codex -> "reasoning_effort",
+ * claude/opencode -> "effort", pi -> "thought_level"). We ask acpx for the real
+ * name first; EFFORT_OPTION_BY_AGENT only backstops discovery failure (older
+ * acpx without `sessions show` config_options, a transient spawn error, or a
+ * session that hasn't negotiated capabilities yet).
  *
  * Lives outside spawn-client.ts deliberately: that file is at its file-size
  * ratchet ceiling, and a free function with an injected spawn is unit-testable
@@ -13,24 +19,98 @@
 
 import { getSafeLogger } from "@/logger";
 
+/** category acpx uses on the config option that controls reasoning effort. */
+const THOUGHT_LEVEL_CATEGORY = "thought_level";
+
+/**
+ * Fallback acpx config-option name for reasoning effort, keyed by agent. Used
+ * only when live discovery via `sessions show` fails. Agents not listed here
+ * don't expose a known effort option and are skipped.
+ */
+export const EFFORT_OPTION_BY_AGENT: Record<string, string> = {
+  codex: "reasoning_effort",
+  claude: "effort",
+  opencode: "effort",
+  pi: "thought_level",
+};
+
+type Spawn = (cmd: string[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+
+/**
+ * Ask acpx which config option this agent's session uses for reasoning effort,
+ * by matching category "thought_level" in `sessions show`'s config_options.
+ * Returns undefined on any discovery failure (spawn failure, malformed JSON,
+ * missing/malformed acpx.config_options, or no thought_level entry) so the
+ * caller can fall back to the static map.
+ */
+async function discoverEffortOptionId(params: {
+  agentName: string;
+  sessionName: string;
+  cwd: string;
+  storyId?: string;
+  spawn: Spawn;
+}): Promise<string | undefined> {
+  const { agentName, sessionName, cwd, storyId, spawn } = params;
+  const cmd = ["acpx", "--cwd", cwd, "--format", "json", agentName, "sessions", "show", sessionName];
+
+  try {
+    const { exitCode, stdout, stderr } = await spawn(cmd);
+    if (exitCode !== 0) {
+      getSafeLogger()?.debug("acp-adapter", "Could not list session config options; falling back to static map", {
+        storyId,
+        agentName,
+        cause: stdout || stderr,
+      });
+      return undefined;
+    }
+
+    const parsed = JSON.parse(stdout) as { acpx?: { config_options?: Array<{ id?: unknown; category?: unknown }> } };
+    const options = parsed.acpx?.config_options;
+    const match = Array.isArray(options) ? options.find((o) => o?.category === THOUGHT_LEVEL_CATEGORY) : undefined;
+    return typeof match?.id === "string" ? match.id : undefined;
+  } catch (err) {
+    // Covers both a rejected spawn() (e.g. transient IPC error) and a JSON.parse
+    // failure — either way, discovery is best-effort and must not break session
+    // creation. The caller falls back to the static map.
+    getSafeLogger()?.debug("acp-adapter", "Effort option discovery failed; falling back to static map", {
+      storyId,
+      agentName,
+      cause: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
 export async function applyReasoningEffort(params: {
   effort: string | undefined;
   agentName: string;
   sessionName: string;
   cwd: string;
   storyId?: string;
-  spawn: (cmd: string[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  spawn: Spawn;
 }): Promise<void> {
   const { effort, agentName, sessionName, cwd, storyId, spawn } = params;
   if (!effort) return;
 
-  const cmd = ["acpx", "--cwd", cwd, agentName, "set", "reasoning_effort", effort, "-s", sessionName];
+  const optionName =
+    (await discoverEffortOptionId({ agentName, sessionName, cwd, storyId, spawn })) ??
+    EFFORT_OPTION_BY_AGENT[agentName];
+  if (!optionName) {
+    getSafeLogger()?.debug("acp-adapter", "Agent has no known effort option; skipping", {
+      storyId,
+      agentName,
+      effort,
+    });
+    return;
+  }
+
+  const cmd = ["acpx", "--cwd", cwd, agentName, "set", optionName, effort, "-s", sessionName];
   const { exitCode, stdout, stderr } = await spawn(cmd);
 
   // Best-effort: a failure leaves the session at the adapter default rather than
   // failing the whole run. The warning is what keeps that downgrade visible.
   if (exitCode !== 0) {
-    getSafeLogger()?.warn("acp-adapter", "Failed to set reasoning_effort; continuing at adapter default", {
+    getSafeLogger()?.warn("acp-adapter", `Failed to set ${optionName}; continuing at adapter default`, {
       storyId,
       effort,
       session: sessionName,

--- a/test/unit/agents/acp/spawn-client-reasoning-effort.test.ts
+++ b/test/unit/agents/acp/spawn-client-reasoning-effort.test.ts
@@ -6,6 +6,13 @@
  *   - the original string stays on the agent.call_started event so headless and
  *     TUI keep showing the effort,
  *   - the effort is applied once when the session is acquired (Task 4).
+ *
+ * The option name applied ("reasoning_effort" vs "effort" vs "thought_level") is
+ * discovered live from `acpx sessions show --format json`'s config_options
+ * (matched by category "thought_level"), with EFFORT_OPTION_BY_AGENT as a
+ * fallback when discovery fails. Tests that don't care about discovery reuse
+ * the plain ENSURE_JSON mock, which has no config_options and so exercises the
+ * fallback path implicitly; tests below assert discovery explicitly.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -22,6 +29,16 @@ const ENSURE_JSON = JSON.stringify({
 });
 
 const TURN_JSON = JSON.stringify({ result: "done", stopReason: "end_turn" });
+
+/** `sessions show --format json` payload shape acpx returns; only the fields discovery reads. */
+function showJson(configOptions: Array<{ id: string; category: string }>): string {
+  return JSON.stringify({ acpx: { config_options: configOptions } });
+}
+
+const CODEX_SHOW_JSON = showJson([{ id: "reasoning_effort", category: "thought_level" }]);
+const CLAUDE_SHOW_JSON = showJson([{ id: "effort", category: "thought_level" }]);
+const PI_SHOW_JSON = showJson([{ id: "thought_level", category: "thought_level" }]);
+const NO_THOUGHT_LEVEL_SHOW_JSON = showJson([{ id: "mode", category: "mode" }]);
 
 function makeSpawnResult(exitCode = 0, stdout = ""): ReturnType<typeof _spawnClientDeps.spawn> {
   const enc = new TextEncoder();
@@ -51,12 +68,30 @@ function makeSpawnResult(exitCode = 0, stdout = ""): ReturnType<typeof _spawnCli
  */
 let calls: string[][] = [];
 
+/**
+ * Sole bridge from bun:test's `mock()` return type to the real
+ * `_spawnClientDeps.spawn` type. Every install helper and ad-hoc test mock in
+ * this file routes through here so the file needs exactly one such cast.
+ */
+function setSpawn(impl: (cmd: string[]) => ReturnType<typeof _spawnClientDeps.spawn>): void {
+  _spawnClientDeps.spawn = mock(impl) as unknown as typeof _spawnClientDeps.spawn;
+}
+
 /** Install a spawn mock that records argv and returns `stdout`. */
 function installSpawn(stdout: string, exitCode = 0): void {
-  _spawnClientDeps.spawn = mock((cmd: string[]) => {
+  setSpawn((cmd) => {
     calls.push(cmd);
     return makeSpawnResult(exitCode, stdout);
-  }) as unknown as typeof _spawnClientDeps.spawn;
+  });
+}
+
+/** Install a spawn mock that dispatches a different response per command shape. */
+function installDispatchSpawn(dispatch: (cmd: string[]) => { stdout: string; exitCode?: number }): void {
+  setSpawn((cmd) => {
+    calls.push(cmd);
+    const { stdout, exitCode } = dispatch(cmd);
+    return makeSpawnResult(exitCode ?? 0, stdout);
+  });
 }
 
 withDepsRestore(_spawnClientDeps, ["spawn"]);
@@ -181,11 +216,36 @@ describe("SpawnAcpClient - effort suffix", () => {
     expect(calls.filter((c) => c.includes("set"))).toHaveLength(1);
   });
 
+  test("falls back to the claude-specific static option name when discovery yields nothing", async () => {
+    const client = new SpawnAcpClient("acpx --model opus[high] claude", "/tmp/wd");
+    await client.createSession({ agentName: "claude", permissionMode: "approve-all", sessionName: "s1" });
+
+    const sets = calls.filter((c) => c.includes("set"));
+    expect(sets).toHaveLength(1);
+    expect(sets[0]).toEqual(["acpx", "--cwd", "/tmp/wd", "claude", "set", "effort", "high", "-s", "s1"]);
+  });
+
+  test("falls back to the pi-specific static option name when discovery yields nothing", async () => {
+    const client = new SpawnAcpClient("acpx --model pi-model[deep] pi", "/tmp/wd");
+    await client.createSession({ agentName: "pi", permissionMode: "approve-all", sessionName: "s1" });
+
+    const sets = calls.filter((c) => c.includes("set"));
+    expect(sets).toHaveLength(1);
+    expect(sets[0]).toEqual(["acpx", "--cwd", "/tmp/wd", "pi", "set", "thought_level", "deep", "-s", "s1"]);
+  });
+
+  test("skips the set call for agents with no known effort option", async () => {
+    const client = new SpawnAcpClient("acpx --model g[high] gemini", "/tmp/wd");
+    await client.createSession({ agentName: "gemini", permissionMode: "approve-all", sessionName: "s1" });
+
+    expect(calls.filter((c) => c.includes("set"))).toHaveLength(0);
+  });
+
   test("session creation survives a failing set call", async () => {
-    _spawnClientDeps.spawn = mock((cmd: string[]) => {
+    setSpawn((cmd) => {
       calls.push(cmd);
       return cmd.includes("set") ? makeSpawnResult(1, "boom") : makeSpawnResult(0, ENSURE_JSON);
-    }) as unknown as typeof _spawnClientDeps.spawn;
+    });
 
     const client = new SpawnAcpClient("acpx --model gpt-5.6-luna[high] codex", "/tmp/wd");
     const session = await client.createSession({
@@ -194,5 +254,126 @@ describe("SpawnAcpClient - effort suffix", () => {
       sessionName: "s1",
     });
     expect(session).toBeDefined();
+  });
+
+  describe("live discovery via sessions show", () => {
+    /** Route each acpx subcommand to its fixture: ensure/show/set/prompt. */
+    function installAgentSpawn(showStdout: string): void {
+      installDispatchSpawn((cmd) => {
+        if (cmd.includes("show")) return { stdout: showStdout };
+        if (cmd.includes("ensure")) return { stdout: ENSURE_JSON };
+        return { stdout: TURN_JSON };
+      });
+    }
+
+    test("uses the discovered id even when it disagrees with the static map", async () => {
+      // codex's static fallback is "reasoning_effort" — prove the discovered id wins.
+      installAgentSpawn(showJson([{ id: "custom_effort_id", category: "thought_level" }]));
+
+      const client = new SpawnAcpClient("acpx --model gpt-5.6-luna[high] codex", "/tmp/wd");
+      await client.createSession({ agentName: "codex", permissionMode: "approve-all", sessionName: "s1" });
+
+      const sets = calls.filter((c) => c.includes("set"));
+      expect(sets).toHaveLength(1);
+      expect(sets[0]).toEqual(["acpx", "--cwd", "/tmp/wd", "codex", "set", "custom_effort_id", "high", "-s", "s1"]);
+    });
+
+    test("discovers the option id for an agent absent from the static map", async () => {
+      installAgentSpawn(showJson([{ id: "reasoning_intensity", category: "thought_level" }]));
+
+      const client = new SpawnAcpClient("acpx --model m[high] kimi", "/tmp/wd");
+      await client.createSession({ agentName: "kimi", permissionMode: "approve-all", sessionName: "s1" });
+
+      const sets = calls.filter((c) => c.includes("set"));
+      expect(sets).toHaveLength(1);
+      expect(sets[0]).toEqual(["acpx", "--cwd", "/tmp/wd", "kimi", "set", "reasoning_intensity", "high", "-s", "s1"]);
+    });
+
+    test("matches the correct option per agent shape (codex/claude/pi)", async () => {
+      for (const [agentName, showStdout, expectedId] of [
+        ["codex", CODEX_SHOW_JSON, "reasoning_effort"],
+        ["claude", CLAUDE_SHOW_JSON, "effort"],
+        ["pi", PI_SHOW_JSON, "thought_level"],
+      ] as const) {
+        calls = [];
+        installAgentSpawn(showStdout);
+        const client = new SpawnAcpClient(`acpx --model m[high] ${agentName}`, "/tmp/wd");
+        await client.createSession({ agentName, permissionMode: "approve-all", sessionName: "s1" });
+
+        const sets = calls.filter((c) => c.includes("set"));
+        expect(sets).toHaveLength(1);
+        expect(sets[0]?.[5]).toBe(expectedId);
+      }
+    });
+
+    test("falls back to the static map when sessions show has no thought_level entry", async () => {
+      installAgentSpawn(NO_THOUGHT_LEVEL_SHOW_JSON);
+
+      const client = new SpawnAcpClient("acpx --model m[high] codex", "/tmp/wd");
+      await client.createSession({ agentName: "codex", permissionMode: "approve-all", sessionName: "s1" });
+
+      const sets = calls.filter((c) => c.includes("set"));
+      expect(sets).toHaveLength(1);
+      expect(sets[0]?.[5]).toBe("reasoning_effort");
+    });
+
+    test("falls back to the static map when sessions show fails", async () => {
+      installDispatchSpawn((cmd) => {
+        if (cmd.includes("show")) return { stdout: "boom", exitCode: 1 };
+        if (cmd.includes("ensure")) return { stdout: ENSURE_JSON };
+        return { stdout: TURN_JSON };
+      });
+
+      const client = new SpawnAcpClient("acpx --model m[high] codex", "/tmp/wd");
+      await client.createSession({ agentName: "codex", permissionMode: "approve-all", sessionName: "s1" });
+
+      const sets = calls.filter((c) => c.includes("set"));
+      expect(sets).toHaveLength(1);
+      expect(sets[0]?.[5]).toBe("reasoning_effort");
+    });
+
+    test("falls back to the static map when sessions show returns malformed JSON", async () => {
+      installAgentSpawn("not json");
+
+      const client = new SpawnAcpClient("acpx --model m[high] codex", "/tmp/wd");
+      await client.createSession({ agentName: "codex", permissionMode: "approve-all", sessionName: "s1" });
+
+      const sets = calls.filter((c) => c.includes("set"));
+      expect(sets).toHaveLength(1);
+      expect(sets[0]?.[5]).toBe("reasoning_effort");
+    });
+
+    test("skips entirely when discovery and the static map both come up empty", async () => {
+      installAgentSpawn(NO_THOUGHT_LEVEL_SHOW_JSON);
+
+      const client = new SpawnAcpClient("acpx --model m[high] gemini", "/tmp/wd");
+      await client.createSession({ agentName: "gemini", permissionMode: "approve-all", sessionName: "s1" });
+
+      expect(calls.filter((c) => c.includes("set"))).toHaveLength(0);
+    });
+
+    test("falls back to the static map when the show spawn call rejects outright", async () => {
+      // Distinct from a non-zero exit code: this simulates spawn() itself throwing
+      // (e.g. a transient process-launch error), which must not propagate out of
+      // createSession and abort session acquisition.
+      setSpawn((cmd) => {
+        calls.push(cmd);
+        if (cmd.includes("show")) throw new Error("spawn ENOENT");
+        if (cmd.includes("ensure")) return makeSpawnResult(0, ENSURE_JSON);
+        return makeSpawnResult(0, TURN_JSON);
+      });
+
+      const client = new SpawnAcpClient("acpx --model m[high] codex", "/tmp/wd");
+      const session = await client.createSession({
+        agentName: "codex",
+        permissionMode: "approve-all",
+        sessionName: "s1",
+      });
+
+      expect(session).toBeDefined();
+      const sets = calls.filter((c) => c.includes("set"));
+      expect(sets).toHaveLength(1);
+      expect(sets[0]?.[5]).toBe("reasoning_effort");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- acpx exposes the reasoning-effort config option under a different id per agent (codex="reasoning_effort", claude/opencode="effort", pi="thought_level") but tags all of them with the same `category: "thought_level"`. `applyReasoningEffort` now discovers the real id live via `acpx --format json <agent> sessions show <name>` and matches on that category, instead of relying solely on a hardcoded per-agent table.
- `EFFORT_OPTION_BY_AGENT` is kept as a fallback, used only when discovery fails (spawn error, malformed JSON, or no `thought_level` entry) — so older acpx versions or an unexpected agent shape still degrade gracefully instead of silently doing nothing.
- Fixes a real bug found during review: the discovery spawn call was awaited outside any `try/catch`, so a *rejected* spawn (as opposed to a non-zero exit code) would propagate out of `createSession`/`loadSession` and abort session acquisition instead of falling back. Now wrapped so any discovery failure mode degrades to the static map.
- Verified against a live acpx install: codex/claude/opencode/pi all report their effort option under `category: "thought_level"` with agent-specific ids, and setting it via the discovered id round-trips correctly (`currentValue` reflects the applied effort).
- Confirmed the resend of `--model` on every prompt does not clobber the effort setting: nax resends the same bare model id per prompt, and acpx's own `applyPromptModelIfAdvertised` is a no-op once `current_model_id` already matches — and even when it does re-set the model, that's a separate `configId` from effort/`thought_level`, so the two never interact.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` (unit + integration + ui, ~14k tests) — 0 failures
- [x] Added targeted tests in `test/unit/agents/acp/spawn-client-reasoning-effort.test.ts`: discovered-id precedence over the static map, discovery for an agent absent from the static map, per-agent id matching (codex/claude/pi), fallback on missing `thought_level` entry / failed `sessions show` / malformed JSON / a rejected spawn call, and the all-empty skip case.
- [x] `check:test-as-unknown-as` ratchet — net improvement (830 → 829) after consolidating mock-install helpers to a single cast site.