### PR TITLE
fix(context): repair the dead fragment read path and keep files in truncated bodies

### DIFF
--- a/.nax/features/feature-context-fragments/.nax-acceptance.test.ts
+++ b/.nax/features/feature-context-fragments/.nax-acceptance.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { ZodError } from "zod";
 import { formatFragmentsInspect, formatFragmentsPrune } from "../../../src/cli/context-fragments";
 import { NaxConfigSchema } from "../../../src/config/schemas";
-import { _featureContextV2Deps, FeatureContextProviderV2 } from "../../../src/context/engine/providers/feature-context";
+import { FeatureContextProviderV2 } from "../../../src/context/engine/providers/feature-context";
 import { _featureContextDeps } from "../../../src/context/providers/feature-context";
 import {
   deleteFragment,
@@ -23,6 +23,7 @@ const FEATURE_ID = "feature-context-fragments";
 const STORY_ID = "S1";
 const MAX_TOKENS = 20;
 let projectDir = "";
+let repoRoot = "";
 
 function story(id: string, dependencies: string[] = []): UserStory {
   return {
@@ -51,8 +52,8 @@ function enabledConfig(overrides: Record<string, unknown> = {}) {
 }
 
 async function writeFeatureFile(path: string, content: string): Promise<void> {
-  await mkdir(join(projectDir, ".nax", "features", FEATURE_ID), { recursive: true });
-  await Bun.write(join(projectDir, ".nax", "features", FEATURE_ID, path), content);
+  await mkdir(join(projectDir, "features", FEATURE_ID), { recursive: true });
+  await Bun.write(join(projectDir, "features", FEATURE_ID, path), content);
 }
 
 async function writePrd(dependencies: Record<string, string[]>): Promise<void> {
@@ -71,8 +72,8 @@ async function fetchFragments(storyId: string, config = enabledConfig()) {
   const result = await provider.fetch({
     storyId,
     featureId: FEATURE_ID,
-    repoRoot: projectDir,
-    packageDir: projectDir,
+    repoRoot,
+    packageDir: repoRoot,
     stage: "execution",
     budgetTokens: 8_000,
     role: "implementer",
@@ -95,9 +96,9 @@ function completionContext(config = enabledConfig()): PipelineContext {
     story: completed,
     stories: [completed],
     routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
-    workdir: projectDir,
+    workdir: repoRoot,
     projectDir,
-    prdPath: join(projectDir, "prd.json"),
+    prdPath: join(repoRoot, "prd.json"),
     agentResult: { success: true, output: "", stderr: "", exitCode: 0, rateLimited: false, estimatedCostUsd: 0 },
     hooks: {},
     storyStartTime: new Date().toISOString(),
@@ -112,35 +113,18 @@ const originalCompletionDeps = {
   writeFragment: _completionDeps.writeFragment,
 };
 
-const originalListFragmentStoryIds = _featureContextV2Deps.listFragmentStoryIds;
-const originalReadFragment = _featureContextV2Deps.readFragment;
 const originalResolveFeatureId = _featureContextDeps.resolveFeatureId;
 
 beforeEach(async () => {
-  projectDir = await mkdtemp("/tmp/nax-fragments-acceptance-");
-  // Workaround: listFragmentStoryIds uses Bun.file(dir).exists() which
-  // returns false for directories. Mock the provider's deps to use fs-level
-  // operations reading from the test's projectDir (the provider passes
-  // `${repoRoot}/.nax` as projectDir, so strip `.nax` to get the test root).
-  _featureContextV2Deps.listFragmentStoryIds = async (projectDir: string, featureId: string) => {
-    const repoRoot = projectDir.replace(/\/.nax$/, "");
-    const fragmentsDirPath = join(repoRoot, "features", featureId, "fragments");
-    try {
-      const files = await fs.readdir(fragmentsDirPath);
-      return files.map((f) => f.replace(/\.md$/, ""));
-    } catch {
-      return [];
-    }
-  };
-  _featureContextV2Deps.readFragment = async (projectDir: string, featureId: string, storyId: string) => {
-    const repoRoot = projectDir.replace(/\/.nax$/, "");
-    const path = join(repoRoot, "features", featureId, "fragments", `${storyId}.md`);
-    try {
-      return await fs.readFile(path, "utf-8");
-    } catch {
-      return null;
-    }
-  };
+  // Mirror production layout: `projectDir` IS the `.nax` dir under the repo
+  // root, which is what `completionStage` passes to `writeFragment` and what
+  // the provider derives as `${repoRoot}/.nax`. The store's real read path is
+  // exercised directly — it previously had to be stubbed here because
+  // `listFragmentStoryIds` gated on `Bun.file(dir).exists()`, which is false
+  // for a directory. That defect is fixed; the stub is gone with it.
+  repoRoot = await mkdtemp("/tmp/nax-fragments-acceptance-");
+  projectDir = join(repoRoot, ".nax");
+  await mkdir(projectDir, { recursive: true });
   _featureContextDeps.resolveFeatureId = async (_story: UserStory, _workdir: string, activeFeature?: string) => {
     return activeFeature ?? null;
   };
@@ -150,10 +134,8 @@ afterEach(async () => {
   _completionDeps.savePRD = originalCompletionDeps.savePRD;
   _completionDeps.getDiffText = originalCompletionDeps.getDiffText;
   _completionDeps.writeFragment = originalCompletionDeps.writeFragment;
-  _featureContextV2Deps.listFragmentStoryIds = originalListFragmentStoryIds;
-  _featureContextV2Deps.readFragment = originalReadFragment;
   _featureContextDeps.resolveFeatureId = originalResolveFeatureId;
-  await rm(projectDir, { recursive: true, force: true });
+  await rm(repoRoot, { recursive: true, force: true });
 });
 
 describe("feature-context-fragments acceptance", () => {
@@ -379,8 +361,8 @@ describe("feature-context-fragments acceptance", () => {
     const result = await provider.fetch({
       storyId: "S1",
       featureId: FEATURE_ID,
-      repoRoot: projectDir,
-      packageDir: projectDir,
+      repoRoot,
+      packageDir: repoRoot,
       stage: "execution",
       budgetTokens: 8_000,
       role: "implementer",

--- a/src/context/fragments/store.ts
+++ b/src/context/fragments/store.ts
@@ -11,7 +11,7 @@
  * and cross-feature memory are deferred to later specs (US-002+).
  */
 
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { estimateTokens } from "@/optimizer";
 
@@ -20,6 +20,18 @@ export const _fragmentStoreDeps = {
   mkdirp: (path: string): Promise<string | undefined> => mkdir(path, { recursive: true }),
   writeFile: (path: string, content: string): Promise<number> => Bun.write(path, content),
   fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
+  /**
+   * Directory existence. Deliberately NOT `Bun.file(dir).exists()` — that
+   * returns `false` for a directory, which silently disabled the entire
+   * fragment read path (`listFragmentStoryIds` always returned `[]`).
+   */
+  directoryExists: async (path: string): Promise<boolean> => {
+    try {
+      return (await stat(path)).isDirectory();
+    } catch {
+      return false;
+    }
+  },
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
   listFragments: async (fragmentsDir: string): Promise<string[]> => {
     const files: string[] = [];
@@ -81,7 +93,11 @@ export function truncateToFragmentBudget(body: string, maxTokens: number): strin
     budget -= 1;
     candidate = body.slice(0, budget);
   }
-  return candidate;
+  // Prefer a line boundary so a fragment never ends mid-sentence. A single
+  // line longer than the whole budget has no boundary to fall back to, so
+  // the hard character cut stands rather than yielding an empty body.
+  const lastBreak = candidate.lastIndexOf("\n");
+  return lastBreak > 0 ? candidate.slice(0, lastBreak) : candidate;
 }
 
 /** Write a fragment body for a story, truncating if the body exceeds the budget. */
@@ -113,7 +129,7 @@ export async function listFragmentStoryIds(projectDir: string, featureId: string
   // fragments" case and must return []. Other I/O failures (permissions,
   // corrupt paths) propagate so persistence problems aren't hidden as a
   // silent empty result.
-  if (!(await _fragmentStoreDeps.fileExists(dir))) return [];
+  if (!(await _fragmentStoreDeps.directoryExists(dir))) return [];
   const files = await _fragmentStoreDeps.listFragments(dir);
   return files.map((file) => file.replace(/\.md$/, ""));
 }
@@ -137,11 +153,18 @@ export async function deleteFragment(projectDir: string, featureId: string, stor
  * Layout:
  *   # <storyId> — <title>
  *
+ *   ## Files touched
+ *   - <changed-file-path>  (one per item, in order)
+ *
  *   ## Acceptance criteria
  *   - <criterion>  (one per item, in order)
  *
- *   ## Files touched
- *   - <changed-file-path>  (one per item, in order)
+ * Files come first deliberately. Bodies are truncated from the tail, and the
+ * acceptance-criteria list is both the longer section and the one that blows
+ * the budget — measured over real features, most bodies exceed the default
+ * `maxTokens` and used to lose the file list entirely. The file list is the
+ * shorter section and tells a dependent story where its dependency landed, so
+ * it is the half worth keeping when only one survives.
  */
 export function renderFragmentBody(
   storyId: string,
@@ -151,5 +174,5 @@ export function renderFragmentBody(
 ): string {
   const criteriaLines = acceptanceCriteria.map((c) => `- ${c}`).join("\n");
   const filesLines = changedFiles.map((f) => `- ${f}`).join("\n");
-  return `# ${storyId} — ${title}\n\n## Acceptance criteria\n${criteriaLines}\n\n## Files touched\n${filesLines}\n`;
+  return `# ${storyId} — ${title}\n\n## Files touched\n${filesLines}\n\n## Acceptance criteria\n${criteriaLines}\n`;
 }

--- a/test/unit/cli/context-fragments.test.ts
+++ b/test/unit/cli/context-fragments.test.ts
@@ -327,7 +327,8 @@ describe("fragmentsPruneCommand — feature-wide (US-004 AC5, AC6)", () => {
       return content.length;
     };
     const dirPath = "/repo/.nax/features/feat-x/fragments";
-    _fragmentStoreDeps.fileExists = async (p) => writes.has(p) || p === dirPath;
+    _fragmentStoreDeps.fileExists = async (p) => writes.has(p);
+    _fragmentStoreDeps.directoryExists = async (p) => p === dirPath;
     _fragmentStoreDeps.readFile = async (p) => writes.get(p) ?? "";
     _fragmentStoreDeps.listFragments = async () => ["US-001.md", "US-002.md", "US-003.md"];
     _fragmentStoreDeps.removeFile = async (p) => {
@@ -422,7 +423,7 @@ describe("fragmentsInspectCommand — exit code (US-004 AC2)", () => {
 
 describe("_contextFragmentsDeps — loadPRD override for AC3 (US-004 AC3)", () => {
   test("[US-004 AC3] inspect command reads the PRD and lists transitive dependents", async () => {
-    _fragmentStoreDeps.fileExists = async () => true;
+    _fragmentStoreDeps.directoryExists = async () => true;
     _fragmentStoreDeps.listFragments = async () => ["US-001.md"];
 
     // US-001 → US-002 → US-003
@@ -457,7 +458,7 @@ describe("_contextFragmentsDeps — loadPRD override for AC3 (US-004 AC3)", () =
   });
 
   test("[US-004 AC1] inspect command lists both fragment story ids", async () => {
-    _fragmentStoreDeps.fileExists = async () => true;
+    _fragmentStoreDeps.directoryExists = async () => true;
     _fragmentStoreDeps.listFragments = async () => ["US-001.md", "US-002.md"];
 
     _contextFragmentsDeps.loadPRD = async () => ({ kind: "missing" });
@@ -523,7 +524,7 @@ describe("formatFragmentsInspect — PRD load error surfaced", () => {
 
 describe("fragmentsInspectCommand — PRD load failure is visible (not silent)", () => {
   test("load error is surfaced in the output and the command still exits 0", async () => {
-    _fragmentStoreDeps.fileExists = async () => true;
+    _fragmentStoreDeps.directoryExists = async () => true;
     _fragmentStoreDeps.listFragments = async () => ["US-001.md"];
 
     _contextFragmentsDeps.loadPRD = async (): Promise<LoadPRDResult> => ({

--- a/test/unit/context/fragments/store-realfs.test.ts
+++ b/test/unit/context/fragments/store-realfs.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Fragment store — real-filesystem behaviour.
+ *
+ * The sibling `store.test.ts` injects an in-memory `_fragmentStoreDeps`, which
+ * is why the production read path could ship broken: `fileExists` was
+ * `Bun.file(path).exists()`, and `Bun.file(dir).exists()` is `false` for a
+ * directory, so `listFragmentStoryIds` always returned `[]` against a real
+ * disk. The feature's own acceptance test documented the defect in a comment
+ * and stubbed around it rather than failing.
+ *
+ * These tests therefore use the REAL deps against a REAL temp directory. Do
+ * not add dep injection here — that would reintroduce the blind spot.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  listFragmentStoryIds,
+  readFragment,
+  renderFragmentBody,
+  truncateToFragmentBudget,
+  writeFragment,
+} from "@/context/fragments";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+const FEATURE_ID = "feat-fragments";
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = makeTempDir();
+});
+
+afterEach(() => {
+  cleanupTempDir(projectDir);
+});
+
+describe("fragment store — real filesystem", () => {
+  test("listFragmentStoryIds returns the ids of fragments written to disk", async () => {
+    await writeFragment(projectDir, FEATURE_ID, "US-001", "first", 400);
+    await writeFragment(projectDir, FEATURE_ID, "US-002", "second", 400);
+
+    expect(await listFragmentStoryIds(projectDir, FEATURE_ID)).toEqual(["US-001", "US-002"]);
+  });
+
+  test("listFragmentStoryIds returns an empty list when the feature has no fragments dir", async () => {
+    expect(await listFragmentStoryIds(projectDir, "never-captured")).toEqual([]);
+  });
+
+  test("readFragment round-trips a body written to disk", async () => {
+    await writeFragment(projectDir, FEATURE_ID, "US-001", "body text", 400);
+
+    expect(await readFragment(projectDir, FEATURE_ID, "US-001")).toBe("body text");
+  });
+});
+
+describe("renderFragmentBody — section order", () => {
+  test("lists the touched files before the acceptance criteria", () => {
+    const body = renderFragmentBody("US-001", "Add the store", ["criterion one"], ["src/a.ts"]);
+
+    expect(body.indexOf("## Files touched")).toBeLessThan(body.indexOf("## Acceptance criteria"));
+  });
+
+  test("keeps the files section intact when truncation drops the tail", () => {
+    const criteria = Array.from({ length: 40 }, (_, i) => `criterion number ${i} padded out to be long`);
+    const body = renderFragmentBody("US-001", "Add the store", criteria, ["src/a.ts", "src/b.ts"]);
+
+    const truncated = truncateToFragmentBudget(body, 100);
+
+    expect(truncated).toContain("src/a.ts");
+    expect(truncated).toContain("src/b.ts");
+  });
+});
+
+describe("truncateToFragmentBudget — line boundary", () => {
+  test("does not cut a body mid-line", () => {
+    const body = ["line one is fairly long", "line two is also long", "line three trails"].join("\n");
+
+    const truncated = truncateToFragmentBudget(body, 8);
+
+    const truncatedLines = truncated.split("\n");
+    const lastLine = truncatedLines[truncatedLines.length - 1] ?? "";
+
+    expect(truncated.length).toBeGreaterThan(0);
+    expect(body.split("\n")).toContain(lastLine);
+  });
+
+  test("returns a body shorter than the budget unchanged", () => {
+    const body = "short body\nsecond line";
+
+    expect(truncateToFragmentBudget(body, 400)).toBe(body);
+  });
+});

--- a/test/unit/context/fragments/store.test.ts
+++ b/test/unit/context/fragments/store.test.ts
@@ -125,7 +125,7 @@ describe("fragment store — writeFragment / readFragment (US-001)", () => {
 
 describe("fragment store — listFragmentStoryIds (US-001)", () => {
   test("[US-001 AC 9] listFragmentStoryIds returns both story ids when two fragments exist", async () => {
-    _fragmentStoreDeps.fileExists = async () => true;
+    _fragmentStoreDeps.directoryExists = async () => true;
     _fragmentStoreDeps.listFragments = async () => ["US-001.md", "US-002.md"];
 
     const ids = await listFragmentStoryIds("/repo", "feat-auth");
@@ -133,7 +133,7 @@ describe("fragment store — listFragmentStoryIds (US-001)", () => {
   });
 
   test("listFragmentStoryIds returns [] when no fragments exist", async () => {
-    _fragmentStoreDeps.fileExists = async () => true;
+    _fragmentStoreDeps.directoryExists = async () => true;
     _fragmentStoreDeps.listFragments = async () => [];
     const ids = await listFragmentStoryIds("/repo", "feat-auth");
     expect(ids).toEqual([]);
@@ -141,7 +141,7 @@ describe("fragment store — listFragmentStoryIds (US-001)", () => {
 
   test("listFragmentStoryIds returns [] when the fragments dir has not been created yet (cold start)", async () => {
     let listCalled = false;
-    _fragmentStoreDeps.fileExists = async () => false;
+    _fragmentStoreDeps.directoryExists = async () => false;
     _fragmentStoreDeps.listFragments = async () => {
       listCalled = true;
       return [];
@@ -153,7 +153,7 @@ describe("fragment store — listFragmentStoryIds (US-001)", () => {
   });
 
   test("listFragmentStoryIds propagates I/O errors from the scan", async () => {
-    _fragmentStoreDeps.fileExists = async () => true;
+    _fragmentStoreDeps.directoryExists = async () => true;
     _fragmentStoreDeps.listFragments = async () => {
       throw new Error("EACCES: permission denied");
     };
@@ -162,7 +162,7 @@ describe("fragment store — listFragmentStoryIds (US-001)", () => {
   });
 
   test("listFragmentStoryIds strips the .md suffix", async () => {
-    _fragmentStoreDeps.fileExists = async () => true;
+    _fragmentStoreDeps.directoryExists = async () => true;
     _fragmentStoreDeps.listFragments = async () => ["US-abc-1.md", "story-with-dashes.md"];
     const ids = await listFragmentStoryIds("/repo", "feat-auth");
     expect(ids).toEqual(["US-abc-1", "story-with-dashes"]);


### PR DESCRIPTION
## What

`listFragmentStoryIds` always returned `[]` against a real filesystem, so the entire feature-context fragment **read** path was inert in production. This fixes that, and fixes what the revived path would have delivered.

## Why

`_fragmentStoreDeps.fileExists` is `Bun.file(path).exists()`, which returns **`false` for a directory**:

```
dir listing:              [ US-001.md, US-002.md, US-003.md ]
Bun.file(dir).exists()  => false
Glob scan of dir        => [ US-001.md, US-002.md, US-003.md ]   <- works fine
```

`listFragmentStoryIds` gated on that check and returned `[]` before reaching the `Bun.Glob` scan that would have worked. Three production consumers were affected:

| Caller | Effect |
|:---|:---|
| `feature-context.ts:316` `collectFragmentChunks` | early return, so **no fragment ever reached an assembled bundle** — the whole US-003 read path |
| `cli/context-fragments.ts:270` inspect | always reported zero fragments |
| `cli/context-fragments.ts:329` prune | always found nothing to prune |

The **write** path was never affected: `completionStage`'s guard is sound and fragments would accumulate on disk, unread.

### How it passed CI

`.nax-acceptance.test.ts` carried this comment, then stubbed `listFragmentStoryIds` with an `fs.readdir` substitute:

> `// Workaround: listFragmentStoryIds uses Bun.file(dir).exists() which returns false for directories.`

The defect was identified during the original run and worked around *in the test* instead of fixed in the source, so every US-003 acceptance criterion passed against a substitute implementation. The unit tests missed it independently — they back `fileExists` with an in-memory `Map` (which has no directory key) and hardcode `listFragments` to `[]`.

## How

- **`directoryExists` dep** backed by `stat().isDirectory()`; `listFragmentStoryIds` gates on it. `fileExists` is retained for the two file-path checks, where it is correct.
- **Body section order** — `renderFragmentBody` now emits `## Files touched` before `## Acceptance criteria`.
- **Line-boundary truncation** — `truncateToFragmentBudget` falls back to the last `\n` within budget, with a documented hard-cut fallback for a single line longer than the entire budget.

The layout change is measured, not stylistic. Replaying capture over 14 real features / 44 stories in this repo (per-story changed files reconstructed from `(US-00N)`-tagged commits):

- **59%** of fragment bodies exceed the default `maxTokens` of 400 (raw p50 = 435, max 1139)
- truncation cuts from the tail, so **38.6%** lost their `## Files touched` section entirely and **59%** ended mid-sentence with no ellipsis
- the file list is the shorter section and tells a dependent story where its dependency landed, so it is the half worth keeping when only one survives

For context on what was *not* changed: forced fragment tokens measured p50 = 400 / max = 1200 against an 8k stage budget, and max dependency distance was 3. The deferred summarizer is not yet justified.

## Testing

- [x] `bun run test` passes (13020 unit + 1104 integration + 24 UI, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] All 38 acceptance tests in `.nax/features/feature-context-fragments/` pass **with the workaround stub removed**

New `test/unit/context/fragments/store-realfs.test.ts` exercises the store with **real deps against a real temp directory** — no dependency injection, since injection is precisely the blind spot that let this ship. Its header says so, to stop the seam being reintroduced.

The acceptance test's workaround is removed and its temp layout re-aligned to mirror production (`projectDir` **is** the `.nax` dir under the repo root, which is what `completionStage` passes to `writeFragment`).

## Notes

This does not enable fragments. `context.v2.fragments.enabled` still defaults to `false` and this repo's own config does not set it, so the subsystem stays inert until explicitly turned on.

`.nax/features/feature-context-fragments/.nax-acceptance.test.ts` has pre-existing type errors and sits outside `tsconfig.test.json` (whose `include` is `test/` and `scripts/` only), so that suite is not gated by CI. Left as-is.