### PR TITLE
fix: implement W10 + W11 backlog from the 2026-08-14 deep code review

### DIFF
--- a/docs/architecture/agent-adapters.md
+++ b/docs/architecture/agent-adapters.md
@@ -294,3 +294,53 @@ Wire token fields (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `
 - `inputTokens`, `outputTokens`, `cacheReadInputTokens`, `cacheCreationInputTokens`
 
 The parser (`acp/parser.ts`) handles both the JSON-RPC envelope format (acpx v0.3+) and legacy flat NDJSON for backward compatibility.
+
+---
+
+## §17 Trust Boundary
+
+*Added: 2026-08-14 (deep code review, decision D-1).*
+
+**nax trusts the repository it is pointed at.** An untrusted repo is **NOT** in
+nax's threat model.
+
+Running `nax` on a repo grants that repo the same authority as running its own
+`npm test` — because invoking `quality.commands.*` is literally that. A repo
+can execute code, read the environment, and load plugins. This is the design,
+not a defect.
+
+### What is inside the boundary
+
+| Authority | Where | Why it is granted |
+|:----------|:------|:------------------|
+| Run arbitrary commands | `quality.commands.*` (`src/quality/runner.ts`) | Equivalent to running the repo's own `npm test` — the repo's own commands with the repo's own env |
+| Execute hooks | `src/hooks/runner.ts` | Hooks are repo-authored code the user opted into running |
+| Load plugins in-process | `src/plugins/loader.ts` | Plugin loading is the granted authority |
+| Vendor flow modules | `nax-finish/index.ts` | Same authority as any other repo-supplied code path |
+| Provide tool-result content | `src/agents/acp/adapter-output.ts` | File contents are the repo's own — no prompt-injection delimiter escaping |
+| Override security-sensitive config | project `.nax/config.json` (warned, not blocked — see SEC-2 / D-2) | Project layer wins the merge; the loader warns when a project layer changes `execution.permissionProfile` or `quality.stripEnvVars` from their global values |
+
+### Explicitly NOT being built
+
+Sandboxing, out-of-process plugin isolation, env allowlists, prompt-injection
+delimiter escaping, first-run per-repo trust prompts. Do not raise these again
+in reviews — see the D-1 ruling in `docs/reviews/2026-08-14-deep-code-review.md`.
+
+### Scope limits
+
+The trust model excuses a repo exercising authority the user granted. It does
+**not** excuse:
+
+- nax silently overriding a setting the user deliberately chose (SEC-2/D-2 — warned, not blocked)
+- ordinary correctness bugs that merely happen to live in security-shaped code (SEC-4/D-3)
+- attackers outside the repo boundary, e.g. co-tenant local processes (SEC-8 — webhook rate limiting is real work)
+
+### Interaction plugins
+
+- **Webhook** (`src/interaction/plugins/webhook.ts`): binds `127.0.0.1` with an
+  HMAC-SHA256 secret and a global request rate limit. `requireSecret: false` is
+  supported but warns — the loopback endpoint is then unauthenticated against
+  co-tenant local processes.
+- **Telegram** (`src/interaction/plugins/telegram.ts`): authenticates by chat ID
+  only. Use a **private chat with the bot** — any member of a shared/group chat
+  can tap approve/abort/skip buttons. There is no per-user allowlist.

--- a/docs/reviews/2026-08-14-deep-code-review.md
+++ b/docs/reviews/2026-08-14-deep-code-review.md
@@ -7,7 +7,7 @@
 **Baseline:** 1142 tests pass / 0 fail; `bun run typecheck` clean; `bun run lint` clean (all 12 custom check scripts green)
 **Status:** triaged 2026-08-14 — see **Decisions** and **Work Order**. Implement from the Work Order; the Findings section is background.
 
-> **Implementation status (2026-08-14).** All CRITICAL/HIGH/MEDIUM findings implemented: W1–W9 and GROWTH-1/GROWTH-2 (from W11) are done, plus BUG-11 and BUG-13 (LOW, bundled into W8/W5 respectively). Only W10 (documentation) and the remainder of the W11 LOW backlog (BUG-12, BUG-14, BUG-15, ENH-1, ENH-2, MEM-1/2/3, PERF-2/3) remain unimplemented. Full suite green (13,071 unit + 1,104 integration + 24 UI tests, 0 fail), `bun run typecheck` clean, `bun run lint` clean. See each finding's **Status** line below for detail.
+> **Implementation status (2026-08-14, follow-up).** Everything from the Work Order is implemented: W1–W9, W10 (trust-boundary documentation), and the full W11 backlog — BUG-12, BUG-14, BUG-15, ENH-1, ENH-2, MEM-1/2/3, PERF-2/3 — plus GROWTH-1/GROWTH-2, BUG-11 and BUG-13 (LOW, bundled into W8/W5 respectively). Full suite green (13,160 unit + 1,129 integration/UI tests, 0 fail), `bun run typecheck` clean, `bun run lint` clean. See each finding's **Status** line below for detail.
 
 ---
 
@@ -253,18 +253,18 @@ if (event.cumulative_token_usage) state.tokenUsage = event.cumulative_token_usag
 
 ### 🟢 LOW
 
-- **ENH-1** — `parseAgentError` cannot classify nested `error.data` codes in a pure-JSON envelope (`parse-agent-error.ts:58-63,278-299`): root parse skips the embedded-object scan; JSON-quoted `"acpxCode":"RATE_LIMIT"` defeats the key-value regex. Walk `payload.error.data`.
-- **MEM-1** — Unbounded stderr buffering in spawn-client (`spawn-client.ts:287,337-338`): full stderr becomes the response message content; only the log line is capped. Rolling-tail cap needed.
-- **ENH-2** — `buildSmartTestCommand` `PATH_TAKING_FLAGS` misses `--filter`, `--dir`, `-F` (pnpm/turbo/nx) (`smart-runner.ts:352-374`): monorepo scoping silently breaks for `pnpm --filter ./packages/api test`.
+- **ENH-1** — ✅ FIXED (2026-08-14) — `parseAgentError` now walks `payload.error.data` so JSON-RPC envelopes carrying `acpxCode` in the nested `data` object classify correctly (`parse-agent-error.ts`): `extractJsonCodeTokens` recurses through `error`/`data` sub-objects and `findRetryAfterSeconds` picks up nested `retryAfterSeconds`.
+- **MEM-1** — ✅ FIXED (2026-08-14) — unbounded stderr buffering in spawn-client (`spawn-client.ts`): `readStreamTail` caps stderr to a 64KB rolling tail (UTF-8-safe trim) instead of `new Response(proc.stderr).text()`.
+- **ENH-2** — ✅ FIXED (2026-08-14) — `buildSmartTestCommand` `PATH_TAKING_FLAGS` now includes `--filter`, `--dir`, `-F` (`smart-runner.ts:352`): pnpm/turbo/nx monorepo scoping survives scoped runs.
 - **BUG-11** — ✅ FIXED (2026-08-14, bundled into W8) — `PidRegistry.freeze()` before `onShutdown` drops PIDs spawned during teardown (`crash-signals.ts:89-98`, `pid-registry.ts:53-56`): a hung `acpx stop` spawned during teardown is never SIGKILLed.
-- **BUG-12** — `removeWorktreeDirectory` awaits `proc.exited` without consuming stdout/stderr (`pipeline-result-handler.ts:46-51`): a git error emitting >64KB stalls the child → hang; non-zero exits are also invisible.
+- **BUG-12** — ✅ FIXED (2026-08-14) — `removeWorktreeDirectory` now drains stdout/stderr concurrently with the exit and logs non-zero exits (`pipeline-result-handler.ts`): a git error emitting >64KB can no longer stall the child.
 - **BUG-13** — ✅ FIXED (2026-08-14, bundled into W5) — Parallel batch path skips `statusWriter` update after batch completion (`unified-executor.ts:342-350`): status.json can show stale story counts during long batches; crash loses progress.
-- **BUG-14** — Dead `completedEarly` branch in `runner.ts:284` / `runner-execution.ts:69`: nothing ever sets the flag; delete or wire it up.
-- **BUG-15** — `_runtimeCrashRetryCounts` module map grows across runs (`tier-escalation.ts:350`): never cleared at run teardown.
-- **PERF-2** — Timed-out provider fetch keeps doing work (`context/engine/orchestrator.ts:116-125`): `controller.abort()` exists but built-in providers aren't audited for cooperative cancellation.
-- **PERF-3** — PidRegistry `killAll` spawns `ps`/`kill` subprocesses with no timeout, re-spawned per target (`pid-registry.ts:160-171,176,235,259-278`): shutdown latency scales O(P×6 spawns).
-- **MEM-2** — TUI `escalationLog` is append-only and never pruned (`usePipelineBusEvents.ts:178`); display caps at 5 but array grows for run lifetime.
-- **MEM-3** — `stopHeartbeat` leaves one in-flight uncancellable 60s `Bun.sleep` (`crash-heartbeat.ts:35-37`): harmless in CLI (explicit process.exit) but keeps the event loop alive up to 60s in in-process consumers; use `cancellableDelay`.
+- **BUG-14** — ✅ FIXED (2026-08-14) — dead `completedEarly` branch removed from `runner.ts:284` / `runner-execution.ts:69`: nothing ever set the flag; the early-return skipped `runCompletionPhase` on an unreachable path.
+- **BUG-15** — ✅ FIXED (2026-08-14) — `_runtimeCrashRetryCounts` module map now cleared at run teardown (`tier-escalation.ts`, `resetRuntimeCrashRetryCounts` wired into `cleanupRun`).
+- **PERF-2** — ✅ FIXED (2026-08-14) — timed-out provider fetch no longer keeps doing work: `CodeNeighborProvider` and `GitHistoryProvider` honor the AbortSignal and stop per-file processing on abort (`code-neighbor.ts`, `git-history.ts`).
+- **PERF-3** — ✅ FIXED (2026-08-14) — PidRegistry `ps`/`kill` subprocesses now bounded by a hard deadline (`pid-registry.ts`): shutdown latency no longer scales with wedged children.
+- **MEM-2** — ✅ FIXED (2026-08-14) — TUI `escalationLog` is pruned to 5 entries in the hook (`usePipelineBusEvents.ts`), matching the display cap, instead of growing for the run lifetime.
+- **MEM-3** — ✅ FIXED (2026-08-14) — `stopHeartbeat` aborts the in-flight sleep via `cancellableDelay` + AbortSignal (`crash-heartbeat.ts`): no 60s uncancellable `Bun.sleep` keeps the event loop alive.
 
 
 ### ⚪ CLOSED — no code change
@@ -305,8 +305,8 @@ This supersedes the original priority table. Findings are grouped into stories t
 | **W7** | **Token accounting validation.** Apply the `Number.isFinite` guard that `event.usage` already has to `cumulative_token_usage`, and coerce in `toInternal`/`addTokenUsage` so a string cannot concatenate into the running total. Pure functions — direct unit tests. | BUG-10 | S |
 | **W8** | **Process lifecycle.** `detached: true` + `killProcessGroup` for acpx spawns, following the pattern `verification/executor.ts:91-92,123` already uses; deadline on `trackedSpawn`; register PIDs spawned during teardown. On BUG-11: `freeze()` currently excludes exactly the hung `acpx sessions close` that the very next line claims to kill — read `crash-signals.ts:88-99` before changing the ordering. | ORPHAN-1, PERF-1, BUG-11 | M |
 | **W9** | **Webhook hardening.** Global request rate limit regardless of HMAC; warn when `requireSecret: false`. Not closed by D-1 — the actor is a local process, not the repo. | SEC-8 | S |
-| **W10** | **Documentation: trust boundary.** State D-1 in `docs/architecture/` beside the permission-resolution spec, and note the Telegram private-chat expectation. No code. | D-1, SEC-11 | S |
-| **W11** | **Hardening backlog.** Independent, low-risk, no decisions pending. | BUG-12, BUG-14, BUG-15, ENH-1, ENH-2, MEM-1/2/3, PERF-2/3, GROWTH-1/2 | L |
+| **W10** | **Documentation: trust boundary.** State D-1 in `docs/architecture/` beside the permission-resolution spec, and note the Telegram private-chat expectation. No code. ✅ DONE (2026-08-14) — §17 Trust Boundary in `docs/architecture/agent-adapters.md`. | D-1, SEC-11 | S |
+| **W11** | **Hardening backlog.** Independent, low-risk, no decisions pending. ✅ DONE (2026-08-14) — all members implemented. | BUG-12, BUG-14, BUG-15, ENH-1, ENH-2, MEM-1/2/3, PERF-2/3, GROWTH-1/2 | L |
 
 **Closed — do not implement:** SEC-1, SEC-3, SEC-5, SEC-6, SEC-7, SEC-9, SEC-10, SEC-11 (code portion).
 

--- a/src/agents/acp/index.ts
+++ b/src/agents/acp/index.ts
@@ -38,4 +38,4 @@ export type { ModelSpec } from "./model-spec";
 export { parseSessionIds } from "./session-ids";
 // @internal — test-reachability re-export only; production code imports
 // stdout-line-reader directly from spawn-client.ts.
-export { MAX_BUFFERED_LINE_BYTES, readAndParseLines } from "./stdout-line-reader";
+export { MAX_BUFFERED_LINE_BYTES, readAndParseLines, readStreamTail } from "./stdout-line-reader";

--- a/src/agents/acp/parse-agent-error.ts
+++ b/src/agents/acp/parse-agent-error.ts
@@ -275,26 +275,52 @@ function classifyDirectType(payload: Record<string, unknown>): AgentError | null
   return result;
 }
 
+/**
+ * Collect classification code tokens from a JSON payload (ENH-1).
+ *
+ * Reads top-level code-like fields AND walks `error`/`data` sub-objects so a
+ * JSON-RPC envelope whose classification lives in `error.data.acpxCode`
+ * (e.g. acpx RATE_LIMIT / QUOTA_EXCEEDED) is seen even when the whole string
+ * parses as JSON — the embedded-JSON scan only runs on free text, and the
+ * key-value regex cannot match JSON-quoted values.
+ */
 function extractJsonCodeTokens(payload: Record<string, unknown>): string[] {
   const tokens: string[] = [];
-  const candidates = [
-    payload.code,
-    payload.status,
-    payload.statusCode,
-    payload.httpStatus,
-    payload.errorCode,
-    payload.acpxCode,
-    payload.detailCode,
-  ];
-
-  for (const candidate of candidates) {
+  const pushToken = (candidate: unknown): void => {
     if (typeof candidate === "number" && Number.isFinite(candidate)) {
       tokens.push(String(candidate));
     } else if (typeof candidate === "string" && candidate.trim()) {
       tokens.push(candidate.trim());
     }
-  }
+  };
 
+  // Depth-capped walk: payloads are error envelopes 2-3 levels deep in
+  // practice; a pathological deeply-nested input must not recurse unbounded.
+  const MAX_WALK_DEPTH = 8;
+  const walk = (obj: Record<string, unknown>, depth: number): void => {
+    if (depth > MAX_WALK_DEPTH) return;
+    const candidates = [
+      obj.code,
+      obj.status,
+      obj.statusCode,
+      obj.httpStatus,
+      obj.errorCode,
+      obj.acpxCode,
+      obj.detailCode,
+    ];
+    for (const candidate of candidates) pushToken(candidate);
+
+    // Recurse one level through the JSON-RPC envelope shape
+    // ({error: {data: {...}}}) so nested classification codes are found.
+    for (const key of ["error", "data"] as const) {
+      const nested = obj[key];
+      if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+        walk(nested as Record<string, unknown>, depth + 1);
+      }
+    }
+  };
+
+  walk(payload, 0);
   return tokens;
 }
 
@@ -340,9 +366,7 @@ function classifyFromCodeTokens(tokens: string[], payload?: Record<string, unkno
       token === "QUOTA_EXCEEDED" ||
       token === "RESOURCE_EXHAUSTED"
     ) {
-      const retryAfterSeconds = payload
-        ? toNumber(payload.retryAfterSeconds ?? payload.retry_after_seconds ?? payload.retryAfter)
-        : undefined;
+      const retryAfterSeconds = payload ? findRetryAfterSeconds(payload) : undefined;
       return retryAfterSeconds !== undefined ? { type: "rate-limit", retryAfterSeconds } : { type: "rate-limit" };
     }
 
@@ -367,6 +391,27 @@ function toNumber(value: unknown): number | undefined {
   if (typeof value === "string" && value.trim()) {
     const parsed = Number.parseInt(value, 10);
     if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+/**
+ * ENH-1: find retry-after seconds at the top level or nested in the
+ * JSON-RPC envelope shape ({error: {data: {retryAfterSeconds}}}).
+ */
+function findRetryAfterSeconds(payload: Record<string, unknown>): number | undefined {
+  const topLevel = toNumber(payload.retryAfterSeconds ?? payload.retry_after_seconds ?? payload.retryAfter);
+  if (topLevel !== undefined) return topLevel;
+  const error = payload.error;
+  if (error && typeof error === "object" && !Array.isArray(error)) {
+    const errObj = error as Record<string, unknown>;
+    const inError = toNumber(errObj.retryAfterSeconds ?? errObj.retry_after_seconds ?? errObj.retryAfter);
+    if (inError !== undefined) return inError;
+    const data = errObj.data;
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      const dataObj = data as Record<string, unknown>;
+      return toNumber(dataObj.retryAfterSeconds ?? dataObj.retry_after_seconds ?? dataObj.retryAfter);
+    }
   }
   return undefined;
 }

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -30,7 +30,7 @@ import { parseModelSpec } from "./model-spec";
 import { applyReasoningEffort } from "./reasoning-effort";
 import { parseSessionIds } from "./session-ids";
 import { killProcessTree, runTrackedSpawn } from "./spawn-client-process";
-import { readAndParseLines } from "./stdout-line-reader";
+import { readAndParseLines, readStreamTail } from "./stdout-line-reader";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -302,7 +302,8 @@ export class SpawnAcpSession implements AcpSession {
         : undefined;
       const parseHandle = readAndParseLines(proc.stdout, parseState, onActivity);
       const parsePromise = parseHandle.promise.catch(() => {});
-      const stderrPromise = new Response(proc.stderr).text().catch(() => "");
+      // MEM-1: cap stderr to a 64KB rolling tail instead of buffering the full stream.
+      const stderrPromise = readStreamTail(proc.stderr).catch(() => "");
 
       const exitCode = await proc.exited;
 

--- a/src/agents/acp/stdout-line-reader.ts
+++ b/src/agents/acp/stdout-line-reader.ts
@@ -25,6 +25,59 @@ export const MAX_BUFFERED_LINE_BYTES = 10 * 1024 * 1024; // 10MB
  * `MAX_BUFFERED_LINE_BYTES` above. The sole production caller is
  * `spawn-client.ts`, which imports it directly from this module.
  *
+ * MEM-1: read a stream to string, keeping only a rolling tail of at most
+ * `maxBytes`. Prevents unbounded stderr buffering from becoming the response
+ * message content on failure — a verbose agent can emit many MB before dying,
+ * and the tail is where the actual error lives.
+ */
+export const MAX_BUFFERED_STDERR_BYTES = 64 * 1024; // 64KB rolling tail
+
+export function readStreamTail(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number = MAX_BUFFERED_STDERR_BYTES,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let tail = "";
+
+  const append = (chunk: string): void => {
+    tail += chunk;
+    const bytes = Buffer.byteLength(tail, "utf8");
+    if (bytes <= maxBytes) return;
+    // Keep the last `maxBytes` bytes, never splitting a multi-byte UTF-8
+    // sequence: find the byte cutoff, then walk forward by whole code points
+    // (surrogate pairs count as one) so the slice lands on a clean boundary.
+    let cutoff = bytes - maxBytes;
+    let index = 0;
+    while (index < tail.length && cutoff > 0) {
+      const cp = tail.codePointAt(index) ?? 0;
+      const units = cp > 0xffff ? 2 : 1;
+      index += units;
+      cutoff -= Buffer.byteLength(String.fromCodePoint(cp), "utf8");
+    }
+    tail = tail.slice(index);
+  };
+
+  return (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        append(decoder.decode(value, { stream: true }));
+      }
+      append(decoder.decode());
+      return tail;
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+}
+
+/**
+ * @internal Not part of the `@/agents` public surface — see the note on
+ * `MAX_BUFFERED_LINE_BYTES` above. The sole production caller is
+ * `spawn-client.ts`, which imports it directly from this module.
+ *
  * Read chunks from a stream, split on newlines, and feed each complete line
  * into an AcpxParseState incrementally. Discards raw bytes immediately after
  * parsing so only the extracted fields (strings + numbers) are held in memory.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -28,6 +28,7 @@ export {
   // `@/agents` surface. See src/agents/acp/stdout-line-reader.ts.
   MAX_BUFFERED_LINE_BYTES,
   readAndParseLines,
+  readStreamTail,
 } from "./acp";
 export type { BuildTurnResultInput, ModelSpec } from "./acp";
 export type {

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -499,7 +499,7 @@ export class CodeNeighborProvider implements IContextProvider {
     this.maxGlobFiles = options.maxGlobFiles ?? MAX_GLOB_FILES_DEFAULT;
   }
 
-  async fetch(request: ContextRequest): Promise<ContextProviderResult> {
+  async fetch(request: ContextRequest, signal?: AbortSignal): Promise<ContextProviderResult> {
     const { touchedFiles } = request;
     const workdir = this.neighborScope === "package" ? request.packageDir : request.repoRoot;
     // AC-62: cross-package scanning — detect shared workspace dirs instead of scanning full repoRoot.
@@ -549,6 +549,9 @@ export class CodeNeighborProvider implements IContextProvider {
     const sections: NeighborSection[] = [];
     let anyTruncated = false;
     for (const file of filesToProcess) {
+      // PERF-2: cooperative cancellation — a timed-out fetch must stop doing
+      // work instead of scanning/reading files the orchestrator no longer wants.
+      if (signal?.aborted) break;
       const { neighbors, truncated } = await collectNeighbors(
         file,
         workdir,
@@ -560,6 +563,9 @@ export class CodeNeighborProvider implements IContextProvider {
       if (neighbors.length > 0) {
         sections.push({ file, neighbors });
       }
+    }
+    if (signal?.aborted) {
+      return { chunks: [], pullTools: [] };
     }
 
     // US-002: chunk assembly (and `scopePaths` attribution) lives in

--- a/src/context/engine/providers/git-history.ts
+++ b/src/context/engine/providers/git-history.ts
@@ -65,7 +65,10 @@ function contentHash8(content: string): string {
  * Fetch git log for a single file and return a formatted section.
  * Returns null when the file has no history or git fails.
  */
-async function fetchFileHistory(filePath: string, workdir: string): Promise<string | null> {
+async function fetchFileHistory(filePath: string, workdir: string, signal?: AbortSignal): Promise<string | null> {
+  // PERF-2: cooperative cancellation — a timed-out fetch must not keep
+  // spawning git for files the orchestrator no longer wants.
+  if (signal?.aborted) return null;
   const { stdout, exitCode } = await _gitHistoryDeps.gitWithTimeout(
     ["log", "--oneline", "--follow", "-n", String(MAX_COMMITS), "--", filePath],
     workdir,
@@ -96,7 +99,7 @@ export class GitHistoryProvider implements IContextProvider {
     this.historyScope = options.historyScope ?? "package";
   }
 
-  async fetch(request: ContextRequest): Promise<ContextProviderResult> {
+  async fetch(request: ContextRequest, signal?: AbortSignal): Promise<ContextProviderResult> {
     const { touchedFiles } = request;
     const workdir = this.historyScope === "package" ? request.packageDir : request.repoRoot;
     if (!touchedFiles || touchedFiles.length === 0) {
@@ -116,7 +119,7 @@ export class GitHistoryProvider implements IContextProvider {
       await Promise.all(
         filesToProcess.map(async (file) => ({
           file,
-          section: await fetchFileHistory(file, workdir),
+          section: await fetchFileHistory(file, workdir, signal),
         })),
       )
     ).filter((entry): entry is { file: string; section: string } => entry.section !== null);

--- a/src/execution/crash-heartbeat.ts
+++ b/src/execution/crash-heartbeat.ts
@@ -4,11 +4,12 @@
 
 import { appendFileSync } from "node:fs";
 import { getSafeLogger } from "../logger";
+import { cancellableDelay } from "../utils/bun-deps";
 import type { StatusWriter } from "./status-writer";
 
 /** @internal — test use only */
 export const _heartbeatDeps = {
-  sleep: async (ms: number) => Bun.sleep(ms),
+  sleep: async (ms: number, signal?: AbortSignal) => cancellableDelay(ms, signal),
   getSafeLogger,
 };
 
@@ -17,6 +18,11 @@ export const _heartbeatDeps = {
 // is called again while a prior loop is mid-sleep.
 let _heartbeatGen = 0;
 let _heartbeatActive = false;
+
+// MEM-3: stopHeartbeat() aborts the in-flight sleep via this controller so the
+// 60s Bun.sleep does not keep the event loop alive after the stop — in-process
+// consumers (tests, watch mode) would otherwise wait out the full delay.
+let _heartbeatAbort: AbortController | null = null;
 
 /**
  * Inner loop — runs while both the generation token matches and active flag is set.
@@ -33,7 +39,15 @@ async function heartbeatLoop(
   const logger = _heartbeatDeps.getSafeLogger();
 
   while (gen === _heartbeatGen && _heartbeatActive) {
-    await _heartbeatDeps.sleep(60_000);
+    try {
+      await _heartbeatDeps.sleep(60_000, _heartbeatAbort?.signal);
+    } catch (err) {
+      // MEM-3: stopHeartbeat() aborts the sleep — normal shutdown, exit the loop.
+      // Genuine sleep errors (non-abort) still propagate to the outer catch so
+      // they are logged, not silently swallowed.
+      if (_heartbeatAbort?.signal.aborted) break;
+      throw err;
+    }
     if (gen !== _heartbeatGen || !_heartbeatActive) break;
 
     try {
@@ -78,6 +92,7 @@ export function startHeartbeat(
 
   // Increment generation to invalidate any in-flight loop, then launch a fresh one.
   _heartbeatActive = true;
+  _heartbeatAbort = new AbortController();
   const gen = ++_heartbeatGen;
   heartbeatLoop(gen, statusWriter, getTotalCost, getIterations, jsonlFilePath).catch((err: unknown) => {
     _heartbeatDeps.getSafeLogger()?.warn("crash-recovery", "Heartbeat loop crashed; status updates stopped", {
@@ -95,6 +110,12 @@ export function stopHeartbeat(): void {
   if (_heartbeatActive) {
     _heartbeatActive = false;
     _heartbeatGen++; // invalidate the running loop on its next tick
+    // MEM-3: cancel the in-flight sleep promptly. The controller is NOT nulled
+    // here — the loop's catch checks `_heartbeatAbort?.signal.aborted` to
+    // distinguish a stop-abort from a genuine sleep error, and nulling it first
+    // made every normal stop rethrow and log a spurious "loop crashed" warning.
+    // startHeartbeat() replaces the controller on the next run.
+    _heartbeatAbort?.abort();
     getSafeLogger()?.debug("crash-recovery", "Heartbeat stopped");
   }
 }

--- a/src/execution/escalation/index.ts
+++ b/src/execution/escalation/index.ts
@@ -10,6 +10,7 @@ export {
   handleTierEscalation,
   _tierEscalationDeps,
   _runtimeCrashRetryCounts,
+  resetRuntimeCrashRetryCounts,
   RUNTIME_CRASH_RETRY_CAP,
   type PreIterationCheckResult,
   type EscalationHandlerContext,

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -360,6 +360,18 @@ export const RUNTIME_CRASH_RETRY_CAP = 2;
 export const _runtimeCrashRetryCounts = new Map<string, number>();
 
 /**
+ * BUG-15: Clear the runtime-crash retry budget map.
+ *
+ * Called at run teardown (cleanupRun). Entries for stories that crashed,
+ * retried, and then succeeded without another handleTierEscalation call
+ * would otherwise persist for the process lifetime, starving the next run's
+ * budget in in-process consumers (tests, watch mode).
+ */
+export function resetRuntimeCrashRetryCounts(): void {
+  _runtimeCrashRetryCounts.clear();
+}
+
+/**
  * Swappable dependencies for testing (avoids mock.module() which leaks in Bun 1.x).
  */
 export const _tierEscalationDeps = {

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -88,6 +88,14 @@ export {
   logDeterministicPhaseOutcome,
 } from "./story-orchestrator-logging";
 export { assemblePlanInputs, assemblePlanInputsFromCtx, type PlanInputs } from "./plan-inputs";
+export {
+  handlePipelineFailure,
+  handlePipelineSuccess,
+  _resultHandlerDeps,
+  type PipelineHandlerContext,
+  type PipelineSuccessResult,
+  type PipelineFailureResult,
+} from "./pipeline-result-handler";
 export { runNonBlockingFix } from "./non-blocking-fix";
 export { buildPlanForStrategy, resolveStoryPathAnchors } from "./build-plan-for-strategy";
 export {

--- a/src/execution/lifecycle/run-cleanup.ts
+++ b/src/execution/lifecycle/run-cleanup.ts
@@ -24,6 +24,7 @@ import type {
 } from "@/plugins";
 import { type PRD, countStories } from "@/prd";
 import { errorMessage } from "@/utils/errors";
+import { resetRuntimeCrashRetryCounts } from "../escalation";
 import { releaseLock } from "../helpers";
 
 type PostRunActionOutcome =
@@ -32,7 +33,7 @@ type PostRunActionOutcome =
   | { status: "skipped"; reason: string }
   | { status: "error"; reason: string };
 
-export const _runCleanupDeps = { fireHook };
+export const _runCleanupDeps = { fireHook, resetRuntimeCrashRetryCounts };
 
 export interface RunCleanupOptions {
   runId: string;
@@ -260,6 +261,10 @@ export async function cleanupRun(options: RunCleanupOptions): Promise<void> {
 
   // Release per-workdir feature resolver index to prevent memory leak across runs
   disposeFeatureResolver(workdir);
+
+  // BUG-15: clear the runtime-crash retry budget so the next run in this
+  // process starts with a fresh budget (tests, watch mode).
+  _runCleanupDeps.resetRuntimeCrashRetryCounts();
 
   // Always release lock, even if execution fails
   await releaseLock(workdir);

--- a/src/execution/pid-registry.ts
+++ b/src/execution/pid-registry.ts
@@ -2,14 +2,20 @@
 
 import { existsSync } from "node:fs";
 import { getSafeLogger } from "@/logger";
+import type { SpawnResult } from "@/utils/bun-deps";
 import { errorMessage } from "@/utils/errors";
 
 const PID_REGISTRY_FILE = ".nax-pids";
 const PID_TREE_KILL_GRACE_MS = 250;
+// PERF-3: hard deadline on each ps/kill subprocess exit. Shutdown latency must
+// not scale with wedged subprocesses — a hung `ps` stalls killAll() indefinitely.
+const PROC_EXIT_TIMEOUT_MS = 3_000;
 
 export const _pidRegistryDeps = {
   spawn: Bun.spawn as typeof Bun.spawn,
   sleep: Bun.sleep,
+  /** Hard deadline per subprocess exit — injectable so tests can use a short value. */
+  procExitTimeoutMs: PROC_EXIT_TIMEOUT_MS,
 };
 
 interface PidEntry {
@@ -22,6 +28,70 @@ interface ProcessIdentity {
   pid: number;
   parentPid: number;
   startedAt: string;
+}
+
+/**
+ * PERF-3: read a subprocess to completion with a hard deadline on BOTH the
+ * exit and the stdout drain. A wedged ps/kill child must not stall shutdown —
+ * on timeout the child is SIGKILLed and an empty result is returned (callers
+ * treat exit code -1 as "not found / no output").
+ */
+function boundedProcRead(proc: SpawnResult, timeoutMs: number): Promise<{ exitCode: number; stdout: string }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exitCode: number, stdout: string): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode, stdout });
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // Process may have already exited
+      }
+      finish(-1, "");
+    }, timeoutMs);
+    Promise.all([proc.exited.catch(() => -1), new Response(proc.stdout).text().catch(() => "")]).then(
+      ([exitCode, stdout]) => finish(exitCode, stdout),
+    );
+  });
+}
+
+/**
+ * PERF-3: await a subprocess exit with a hard deadline. Used for the `kill`
+ * subprocesses whose stdout is not read on the success path.
+ */
+function awaitProcExit(proc: SpawnResult, timeoutMs: number): Promise<number> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // Process may have already exited
+      }
+      resolve(-1);
+    }, timeoutMs);
+    proc.exited.then(
+      (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(code);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(-1);
+      },
+    );
+  });
 }
 
 export class PidRegistry {
@@ -177,7 +247,7 @@ export class PidRegistry {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text().catch(() => "")]);
+      const { exitCode, stdout } = await boundedProcRead(proc, _pidRegistryDeps.procExitTimeoutMs);
       if (exitCode !== 0) {
         return [];
       }
@@ -236,7 +306,7 @@ export class PidRegistry {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text().catch(() => "")]);
+      const { exitCode, stdout } = await boundedProcRead(proc, _pidRegistryDeps.procExitTimeoutMs);
       if (exitCode !== 0) {
         return null;
       }
@@ -296,7 +366,7 @@ export class PidRegistry {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const checkCode = await checkProc.exited;
+      const checkCode = await awaitProcExit(checkProc, _pidRegistryDeps.procExitTimeoutMs);
 
       if (checkCode !== 0) {
         logger?.debug("pid-registry", `PID ${pid} not found (already exited)`, { pid });
@@ -308,7 +378,7 @@ export class PidRegistry {
         stderr: "pipe",
       });
 
-      const killCode = await killProc.exited;
+      const killCode = await awaitProcExit(killProc, _pidRegistryDeps.procExitTimeoutMs);
 
       if (killCode === 0) {
         logger?.debug("pid-registry", `Sent SIG${signal} to PID ${pid}`, { pid, signal });

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -48,7 +48,22 @@ async function removeWorktreeDirectory(projectRoot: string, storyId: string): Pr
       stdout: "pipe",
       stderr: "pipe",
     });
-    await proc.exited;
+    // BUG-12: drain both streams concurrently with the exit so a git error
+    // emitting >64KB cannot block the child on a full pipe buffer, and so
+    // non-zero exits are observable instead of invisible.
+    const [exitCode, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text().catch(() => ""),
+      new Response(proc.stderr).text().catch(() => ""),
+    ] as const);
+    if (exitCode !== 0) {
+      logger?.warn("worktree", "Failed to remove worktree directory (non-fatal)", {
+        storyId,
+        worktreePath,
+        exitCode,
+        stderr: stderr.slice(0, 500),
+      });
+    }
   } catch (error) {
     logger?.warn("worktree", "Failed to remove worktree directory (non-fatal)", {
       storyId,

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -66,8 +66,6 @@ export interface RunnerExecutionResult {
   storiesCompleted: number;
   totalCost: number;
   allStoryMetrics: StoryMetrics[];
-  completedEarly?: boolean;
-  durationMs?: number;
   /** End-of-run deferred plugin review result (#1146 G2). Forwarded to the completion phase. */
   deferredReview?: DeferredReviewResult;
   /** Date.now() captured before postrun:phase:started for review was emitted. Forwarded for accurate durationMs (AC9). */

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -276,21 +276,6 @@ export async function run(options: RunOptions): Promise<RunResult> {
     totalCost = executionResult.totalCost;
     allStoryMetrics.push(...executionResult.allStoryMetrics);
 
-    // Return early if parallel execution completed everything.
-    // NOTE: This path skips runCompletionPhase, so run:completed is never emitted
-    // and runCompleted stays false. cleanupRun will fire onRunEnd directly (correct).
-    // If this path is ever activated, also wire run:completed emission here so
-    // reporter subscribers and the on-complete hook fire consistently.
-    if (executionResult.completedEarly && executionResult.durationMs !== undefined) {
-      return {
-        success: isComplete(prd),
-        iterations,
-        storiesCompleted,
-        totalCost,
-        durationMs: executionResult.durationMs,
-      };
-    }
-
     // ── Phase 3: Completion ────────────────────────────────────────────────────
     const completionResult = await runCompletionPhase({
       config,

--- a/src/tui/hooks/usePipelineBusEvents.ts
+++ b/src/tui/hooks/usePipelineBusEvents.ts
@@ -23,6 +23,13 @@ export interface EscalationEntry {
   at: number;
 }
 
+/**
+ * MEM-2: cap on the escalation log. Only the newest entries are kept — a long
+ * run with many escalations must not grow the array for its whole lifetime
+ * (the display already shows at most this many, so nothing is lost).
+ */
+const MAX_ESCALATION_LOG_ENTRIES = 5;
+
 /** Run summary from run:completed event. Export for consumers (e.g. LiveActivityPanel). */
 export interface RunSummary {
   totalStories: number;
@@ -175,7 +182,7 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
       setState((prev) => ({
         ...prev,
         stories: prev.stories.map((s) => (s.story.id === event.storyId ? { ...s, status: "retrying" as const } : s)),
-        escalationLog: [...prev.escalationLog, entry],
+        escalationLog: [...prev.escalationLog, entry].slice(-MAX_ESCALATION_LOG_ENTRIES),
       }));
     });
 

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -344,12 +344,14 @@ function buildTestCandidates(
  * // => "bun test test/"
  * ```
  */
-// BUG-18: flags that take a path argument. A token immediately following one
+// BUG-18/ENH-2: flags that take a path argument. A token immediately following one
 // of these (or a `--flag=<path>` combined form) is a flag's config path, not a
 // positional test-path argument, and must never be replaced by scoped test
 // files — doing so silently drops the flag's value (e.g. `--config
-// ./vitest.config.ts` -> `--config '<test files>'`).
-const PATH_TAKING_FLAGS = ["--config", "-c", "--project", "-p"];
+// ./vitest.config.ts` -> `--config '<test files>'`). ENH-2: pnpm/turbo/nx
+// monorepo scoping flags (`--filter`, `--dir`, `-F`) were missing, silently
+// breaking scoped runs like `pnpm --filter ./packages/api test`.
+const PATH_TAKING_FLAGS = ["--config", "-c", "--project", "-p", "--filter", "--dir", "-F"];
 
 export function buildSmartTestCommand(testFiles: string[], baseCommand: string): string {
   if (testFiles.length === 0) {

--- a/test/ui/usePipelineBusEvents.test.tsx
+++ b/test/ui/usePipelineBusEvents.test.tsx
@@ -129,6 +129,28 @@ describe("usePipelineBusEvents", () => {
     expect(lastFrame()).toContain("escalations:1");
   });
 
+  // MEM-2: escalationLog was append-only and grew for the whole run lifetime;
+  // only the display capped at 5. The hook must prune so a long run with many
+  // escalations cannot grow memory without bound.
+  test("MEM-2: escalationLog is pruned to a bounded cap, keeping the newest entries", () => {
+    const { lastFrame } = render(
+      <HookOutput stories={[makeInitialStory("US-001")]} />
+    );
+
+    for (let i = 0; i < 30; i++) {
+      act(() => {
+        pipelineEventBus.emit({
+          type: "story:escalated",
+          storyId: `US-${i}`,
+          fromTier: "fast",
+          toTier: "balanced",
+        });
+      });
+    }
+
+    expect(lastFrame()).toContain("escalations:5");
+  });
+
   test("run:completed sets runSummary passedStories", () => {
     const { lastFrame } = render(
       <HookOutput stories={[makeInitialStory("US-001")]} />

--- a/test/unit/agents/acp/parse-agent-error.test.ts
+++ b/test/unit/agents/acp/parse-agent-error.test.ts
@@ -154,4 +154,39 @@ describe("parseAgentError", () => {
       expect(parseAgentError(input).type).toBe("unknown");
     });
   });
+
+  // ENH-1: JSON-RPC error envelopes carry the classification code in
+  // error.data.acpxCode, not at the top level. A pure-JSON envelope (whole
+  // string parses as JSON) never reaches the embedded-JSON scan, and the
+  // key-value regex defeats JSON-quoted codes — so the nested object must be
+  // walked explicitly.
+  describe("ENH-1 — nested error.data codes", () => {
+    test("detects rate-limit from error.data.acpxCode in a pure-JSON envelope", () => {
+      const stderr =
+        '{"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":"rate limited","data":{"acpxCode":"RATE_LIMIT","origin":"cli"}}}';
+      const result = parseAgentError(stderr);
+      expect(result.type).toBe("rate-limit");
+    });
+
+    test("detects auth from error.data.acpxCode in a pure-JSON envelope", () => {
+      const stderr =
+        '{"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"auth failed","data":{"acpxCode":"AUTH_FAILED"}}}';
+      const result = parseAgentError(stderr);
+      expect(result.type).toBe("auth");
+    });
+
+    test("walks nested error.data when the envelope is embedded in free text", () => {
+      const stderr =
+        'probe failed: {"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":"quota","data":{"acpxCode":"QUOTA_EXCEEDED","retryAfterSeconds":30}}}';
+      const result = parseAgentError(stderr);
+      expect(result.type).toBe("rate-limit");
+      expect(result.retryAfterSeconds).toBe(30);
+    });
+
+    test("leaves unknown when error.data has no classifiable code", () => {
+      const stderr =
+        '{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"some error","data":{"acpxCode":"RUNTIME"}}}';
+      expect(parseAgentError(stderr).type).toBe("unknown");
+    });
+  });
 });

--- a/test/unit/agents/acp/spawn-client-stderr-cap.test.ts
+++ b/test/unit/agents/acp/spawn-client-stderr-cap.test.ts
@@ -1,0 +1,118 @@
+/**
+ * MEM-1: stderr buffering cap in SpawnAcpClient
+ *
+ * Full stderr was buffered via `new Response(proc.stderr).text()` and became
+ * the response content on failure. A verbose agent can emit many MB — the
+ * buffered stderr must be capped to a rolling tail so failure responses stay
+ * bounded.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { SpawnAcpClient, _spawnClientDeps } from "@/agents/acp";
+import { withDepsRestore } from "@test/helpers";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SAFETY: file-scope process.kill stub (mirrors spawn-client.test.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _originalProcessKill: typeof process.kill;
+
+beforeEach(() => {
+  _originalProcessKill = process.kill;
+  process.kill = ((_pid: number | string, _signal?: NodeJS.Signals | number) => true) as typeof process.kill;
+});
+
+afterEach(() => {
+  process.kill = _originalProcessKill;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Spawn mock helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeSpawnResult(exitCode: number, stdout = ""): ReturnType<typeof _spawnClientDeps.spawn> {
+  const enc = new TextEncoder();
+  const makeStream = (content: string) =>
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        if (content) c.enqueue(enc.encode(content));
+        c.close();
+      },
+    });
+
+  return {
+    stdout: makeStream(stdout),
+    stderr: makeStream(""),
+    stdin: { write: () => 0, end: () => {}, flush: () => {} },
+    exited: Promise.resolve(exitCode),
+    pid: 99999999,
+    kill: () => {},
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SpawnAcpClient — MEM-1: stderr buffering cap", () => {
+  withDepsRestore(_spawnClientDeps, ["spawn"]);
+
+  test("caps buffered stderr on failure responses (rolling tail, not full buffer)", async () => {
+    let callCount = 0;
+    const enc = new TextEncoder();
+
+    const hugeStderr = "verbose agent noise line\n".repeat(20_000); // ~460KB
+
+    _spawnClientDeps.spawn = (_cmd, _opts) => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0); // ensure session
+
+      return {
+        stdout: new ReadableStream<Uint8Array>({ start(c) { c.close(); } }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(c) { c.enqueue(enc.encode(hugeStderr)); c.close(); },
+        }),
+        stdin: { write: () => 0, end: () => {}, flush: () => {} },
+        exited: Promise.resolve(1),
+        pid: 99999999,
+        kill: () => {},
+      };
+    };
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    const response = await session!.prompt("hello");
+
+    expect(response.stopReason).toBe("error");
+    const content = response.messages[0]?.content ?? "";
+    expect(content.length).toBeLessThan(hugeStderr.length);
+    // Rolling tail: the final bytes (the actual error) survive.
+    expect(content.endsWith("verbose agent noise line\n")).toBe(true);
+  });
+
+  test("small stderr passes through unchanged", async () => {
+    let callCount = 0;
+    const enc = new TextEncoder();
+
+    _spawnClientDeps.spawn = (_cmd, _opts) => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0); // ensure session
+
+      return {
+        stdout: new ReadableStream<Uint8Array>({ start(c) { c.close(); } }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(c) { c.enqueue(enc.encode("connection refused")); c.close(); },
+        }),
+        stdin: { write: () => 0, end: () => {}, flush: () => {} },
+        exited: Promise.resolve(1),
+        pid: 99999999,
+        kill: () => {},
+      };
+    };
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    const response = await session!.prompt("hello");
+    expect(response.messages[0]?.content).toBe("connection refused");
+  });
+});

--- a/test/unit/agents/acp/stdout-line-reader.test.ts
+++ b/test/unit/agents/acp/stdout-line-reader.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { MAX_BUFFERED_LINE_BYTES, createParseState, readAndParseLines } from "@/agents";
+import { MAX_BUFFERED_LINE_BYTES, createParseState, readAndParseLines, readStreamTail } from "@/agents";
 
 function makeStream(chunks: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -87,5 +87,67 @@ describe("readAndParseLines", () => {
     await promise;
 
     expect(state.text).toBe("ab");
+  });
+});
+
+describe("readStreamTail (MEM-1)", () => {
+  const enc = new TextEncoder();
+
+  function streamOf(content: string): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(enc.encode(content)); c.close(); },
+    });
+  }
+
+  test("small content passes through unchanged", async () => {
+    const result = await readStreamTail(streamOf("connection refused"), 1024);
+    expect(result).toBe("connection refused");
+  });
+
+  test("content over the cap is trimmed to the last maxBytes", async () => {
+    const big = "x".repeat(10_000) + "TAIL";
+    const result = await readStreamTail(streamOf(big), 100);
+    expect(result.endsWith("TAIL")).toBe(true);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(100);
+  });
+
+  test("never splits a multi-byte UTF-8 sequence at the trim boundary", async () => {
+    const heart = "❤".repeat(5000); // 3 bytes each
+    const result = await readStreamTail(streamOf(heart), 100);
+    // Trimming may drop whole code points, but must never leave a broken
+    // surrogate / invalid sequence — round-trip through a decoder.
+    const reparsed = new TextDecoder().decode(enc.encode(result));
+    expect(reparsed).toBe(result);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(100);
+  });
+
+  test("never splits an astral-plane surrogate pair at the trim boundary", async () => {
+    const clef = "𝄞".repeat(5000); // U+1D11E — 4 bytes, surrogate pair in UTF-16
+    const result = await readStreamTail(streamOf(clef), 100);
+    const reparsed = new TextDecoder().decode(enc.encode(result));
+    expect(reparsed).toBe(result);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(100);
+    // No lone surrogates: every code unit pairs up.
+    for (let i = 0; i < result.length; i++) {
+      const unit = result.charCodeAt(i);
+      if (unit >= 0xd800 && unit <= 0xdbff) {
+        const next = result.charCodeAt(i + 1);
+        expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+      }
+    }
+  });
+
+  test("chunks split mid-UTF-8-sequence are decoded correctly", async () => {
+    const content = "a❤b";
+    const bytes = enc.encode(content);
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(bytes.slice(0, 2)); // splits the 3-byte heart mid-sequence
+        c.enqueue(bytes.slice(2));
+        c.close();
+      },
+    });
+    const result = await readStreamTail(stream, 1024);
+    expect(result).toBe(content);
   });
 });

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -636,3 +636,61 @@ describe("CodeNeighborProvider — naxIgnoreIndex threaded through fetch", () =>
   });
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// PERF-2: cooperative cancellation — an aborted fetch must stop doing work
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("CodeNeighborProvider — cooperative cancellation (PERF-2)", () => {
+  test("an already-aborted signal skips per-file neighbor collection entirely", async () => {
+    let readCalls = 0;
+    _codeNeighborDeps.fileExists = async () => {
+      readCalls++;
+      return true;
+    };
+    _codeNeighborDeps.readFile = async () => {
+      readCalls++;
+      return 'import "./dep"';
+    };
+    _codeNeighborDeps.glob = () => ({ files: ["src/a.ts", "src/b.ts"], truncated: false });
+    _codeNeighborDeps.detectLanguage = async () => undefined;
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const p = new CodeNeighborProvider();
+    const result = await p.fetch(
+      makeRequest({ touchedFiles: ["src/foo.ts", "src/bar.ts"] }),
+      controller.signal,
+    );
+
+    // The fetch must bail out before reading any file or scanning neighbors.
+    expect(result.chunks).toHaveLength(0);
+    expect(readCalls).toBe(0);
+  });
+
+  test("an abort mid-fetch stops further per-file processing", async () => {
+    const reads: string[] = [];
+    let abortAfterFirst = false;
+    const controller = new AbortController();
+
+    _codeNeighborDeps.fileExists = async () => true;
+    _codeNeighborDeps.readFile = async (path: string) => {
+      reads.push(path);
+      if (abortAfterFirst) controller.abort();
+      abortAfterFirst = true;
+      return 'import "./dep"';
+    };
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+    _codeNeighborDeps.detectLanguage = async () => undefined;
+
+    const p = new CodeNeighborProvider();
+    await p.fetch(
+      makeRequest({ touchedFiles: ["src/foo.ts", "src/bar.ts", "src/baz.ts"] }),
+      controller.signal,
+    );
+
+    // After the first file triggers the abort, no further files are processed.
+    expect(reads.length).toBeLessThan(3);
+  });
+});
+

--- a/test/unit/context/engine/providers/git-history.test.ts
+++ b/test/unit/context/engine/providers/git-history.test.ts
@@ -407,3 +407,51 @@ describe("GitHistoryProvider — SEC-503 path traversal prevention", () => {
     expect(result.chunks).toHaveLength(0);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PERF-2: cooperative cancellation — an aborted fetch must stop doing work
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("GitHistoryProvider — cooperative cancellation (PERF-2)", () => {
+  test("an already-aborted signal never spawns git", async () => {
+    let gitCalls = 0;
+    _gitHistoryDeps.gitWithTimeout = async () => {
+      gitCalls++;
+      return { stdout: "abc1234 feat: something", stderr: "", exitCode: 0 };
+    };
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const p = new GitHistoryProvider();
+    const result = await p.fetch(
+      makeRequest({ touchedFiles: ["src/a.ts", "src/b.ts"] }),
+      controller.signal,
+    );
+
+    expect(result.chunks).toHaveLength(0);
+    expect(gitCalls).toBe(0);
+  });
+
+  test("an abort mid-fetch stops further per-file git spawns", async () => {
+    const queried: string[] = [];
+    const controller = new AbortController();
+    let first = true;
+
+    _gitHistoryDeps.gitWithTimeout = async (args: string[]) => {
+      queried.push(args[args.length - 1] ?? "");
+      if (first) controller.abort();
+      first = false;
+      return { stdout: "abc1234 feat: something", stderr: "", exitCode: 0 };
+    };
+
+    const p = new GitHistoryProvider();
+    await p.fetch(
+      makeRequest({ touchedFiles: ["src/a.ts", "src/b.ts", "src/c.ts"] }),
+      controller.signal,
+    );
+
+    // The first spawn aborts the signal; no further files are queried.
+    expect(queried).toEqual(["src/a.ts"]);
+  });
+});

--- a/test/unit/execution/completed-early-dead.test.ts
+++ b/test/unit/execution/completed-early-dead.test.ts
@@ -1,0 +1,41 @@
+/**
+ * BUG-14: dead `completedEarly` branch
+ *
+ * `RunnerExecutionResult.completedEarly` was never assigned anywhere —
+ * `runExecutionPhase` never set it, and `executeUnified`'s result carries no
+ * such field — so the early-return branch in `runner.ts` was dead code that
+ * skipped `runCompletionPhase` (and with it `run:completed`, metrics, hooks)
+ * on a path that could never activate. Deleted per the review's
+ * "delete or wire it up".
+ */
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dir, "../../../src");
+
+async function readSrc(relativePath: string): Promise<string> {
+  const file = Bun.file(join(SRC, relativePath));
+  return (await file.exists()) ? await file.text() : "";
+}
+
+describe("BUG-14: completedEarly dead branch removed", () => {
+  test("RunnerExecutionResult no longer declares completedEarly", async () => {
+    const src = await readSrc("execution/runner-execution.ts");
+    expect(src).not.toContain("completedEarly");
+  });
+
+  test("runner.ts no longer early-returns on a completedEarly flag", async () => {
+    const src = await readSrc("execution/runner.ts");
+    expect(src).not.toContain("completedEarly");
+  });
+
+  test("no source file references completedEarly anymore", async () => {
+    // Read every .ts file under src/execution and assert none mention it.
+    const walk = new Bun.Glob(`${SRC}/execution/**/*.ts`);
+    for await (const path of walk.scan()) {
+      const text = await Bun.file(path).text();
+      expect(text).not.toContain("completedEarly");
+    }
+  });
+});

--- a/test/unit/execution/crash-heartbeat.test.ts
+++ b/test/unit/execution/crash-heartbeat.test.ts
@@ -51,4 +51,68 @@ describe("crash-heartbeat — startHeartbeat", () => {
     // The catch handler must log "crashed" / "stopped", not swallow silently.
     expect(warnings.some((w) => w.includes("crashed") || w.includes("stopped"))).toBe(true);
   });
+
+  // MEM-3: stopHeartbeat left one in-flight uncancellable 60s Bun.sleep running —
+  // the loop checked `_heartbeatActive` only AFTER the sleep resolved, so the
+  // timer kept the event loop alive up to 60s in in-process consumers. The stop
+  // must abort the in-flight sleep via an AbortSignal so it settles promptly.
+  test("MEM-3: stopHeartbeat aborts the in-flight sleep instead of leaving a 60s timer armed", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let sleepSettled = false;
+
+    _heartbeatDeps.sleep = (_ms: number, signal?: AbortSignal) => {
+      capturedSignal = signal;
+      // Hang until aborted — never resolve, so the loop stays parked in the
+      // sleep and no busy-spin starves the event loop.
+      return new Promise<void>((resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          sleepSettled = true;
+          reject(signal.reason);
+        });
+      });
+    };
+
+    startHeartbeat({ update: async () => {} } as any, () => 0, () => 0);
+    // Let the loop reach the sleep call.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(capturedSignal).toBeDefined();
+
+    stopHeartbeat();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // The abort must reach the in-flight sleep (and settle it promptly —
+    // no 60s wait).
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(sleepSettled).toBe(true);
+  });
+
+  // Regression: the stop-abort rejection must not be rethrown. When
+  // stopHeartbeat() nulled the controller before the loop's catch ran, every
+  // normal stop logged a spurious "Heartbeat loop crashed" warning.
+  test("MEM-3: a normal stop does not log a spurious 'loop crashed' warning", async () => {
+    const warnings: string[] = [];
+
+    _heartbeatDeps.getSafeLogger = () =>
+      ({
+        warn: (_stage: string, msg: string) => {
+          warnings.push(msg);
+        },
+        debug: () => {},
+        info: () => {},
+        error: () => {},
+      }) as any;
+
+    _heartbeatDeps.sleep = (_ms: number, signal?: AbortSignal) =>
+      new Promise<void>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason));
+      });
+
+    startHeartbeat({ update: async () => {} } as any, () => 0, () => 0);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    stopHeartbeat();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(warnings).toEqual([]);
+  });
 });

--- a/test/unit/execution/escalation/tier-escalation-retry-cap.test.ts
+++ b/test/unit/execution/escalation/tier-escalation-retry-cap.test.ts
@@ -185,4 +185,82 @@ describe("handleTierEscalation — runtime-crash retry cap", () => {
       _runtimeCrashRetryCounts.delete(storyId);
     }
   });
+
+  test("BUG-15: resets the retry cap map when a story succeeds after a retry-same", async () => {
+    const mod = await import("@/execution/escalation");
+    const { handleTierEscalation, _tierEscalationDeps, _runtimeCrashRetryCounts, RUNTIME_CRASH_RETRY_CAP, resetRuntimeCrashRetryCounts } =
+      mod;
+
+    const storyId = "US-002-retry-cap-succeed";
+    const origSavePRD = _tierEscalationDeps.savePRD;
+    _tierEscalationDeps.savePRD = () => Promise.resolve();
+    _runtimeCrashRetryCounts.delete(storyId);
+
+    try {
+      const story = {
+        id: storyId,
+        title: "Story",
+        description: "Test",
+        acceptanceCriteria: [],
+        tags: [],
+        dependencies: [],
+        status: "in-progress" as const,
+        passes: false,
+        escalations: [],
+        attempts: 1,
+        routing: { modelTier: "fast", testStrategy: "test-after" },
+      };
+
+      const prd = {
+        project: "test",
+        feature: "f",
+        branchName: "b",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        userStories: [story],
+      };
+
+      const buildCtx = () => ({
+        story,
+        storiesToExecute: [story],
+        isBatchExecution: false,
+        routing: { modelTier: "fast", testStrategy: "test-after" },
+        pipelineResult: { reason: "Bun runtime crash", context: { tddFailureCategory: "runtime-crash" } },
+        config: {
+          autoMode: {
+            escalation: {
+              enabled: true,
+              tierOrder: [
+                { tier: "fast", attempts: 2 },
+                { tier: "balanced", attempts: 3 },
+              ],
+            },
+          },
+          routing: { llm: { mode: "per-story" }, strategy: "keyword" },
+          models: {},
+        },
+        prd,
+        prdPath: "/tmp/test-prd-us002-retry-cap-succeed.json",
+        featureDir: undefined,
+        hooks: { hooks: {} },
+        feature: "f",
+        totalCost: 0,
+        workdir: "/tmp",
+        runtimeCrashResult: { status: "RUNTIME_CRASH", success: false },
+      });
+
+      // Seed the map with a mid-cap count (story crashed once, then a later
+      // run in the same process retries it).
+      _runtimeCrashRetryCounts.set(storyId, 1);
+
+      // Simulates run teardown between two runs in one process (BUG-15):
+      // the map must be emptied so the next run starts with a fresh budget.
+      resetRuntimeCrashRetryCounts();
+
+      expect(_runtimeCrashRetryCounts.size).toBe(0);
+    } finally {
+      _tierEscalationDeps.savePRD = origSavePRD;
+      _runtimeCrashRetryCounts.delete(storyId);
+    }
+  });
 });

--- a/test/unit/execution/lifecycle/run-cleanup.test.ts
+++ b/test/unit/execution/lifecycle/run-cleanup.test.ts
@@ -587,3 +587,24 @@ function makePluginLogger(): import("../../../../src/plugins/types").PluginLogge
     error: mock(() => {}),
   } as unknown as import("../../../../src/plugins/types").PluginLogger;
 }
+
+// ============================================================================
+// BUG-15: runtime-crash retry budget is reset at run teardown
+// ============================================================================
+
+describe("cleanupRun — resets runtime-crash retry budget (BUG-15)", () => {
+  test("calls resetRuntimeCrashRetryCounts during teardown", async () => {
+    const { resetRuntimeCrashRetryCounts } = await import("@/execution/escalation");
+    const resetMock = mock(() => {});
+    const originalReset = _runCleanupDeps.resetRuntimeCrashRetryCounts;
+    _runCleanupDeps.resetRuntimeCrashRetryCounts = resetMock;
+
+    try {
+      const pluginRegistry = makePluginRegistry();
+      await cleanupRun(makeCleanupOptions({ pluginRegistry }));
+      expect(resetMock).toHaveBeenCalled();
+    } finally {
+      _runCleanupDeps.resetRuntimeCrashRetryCounts = originalReset;
+    }
+  });
+});

--- a/test/unit/execution/pid-registry.test.ts
+++ b/test/unit/execution/pid-registry.test.ts
@@ -376,3 +376,71 @@ describe("PidRegistry", () => {
     expect(entry2.pid).toBe(22222);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PERF-3: ps/kill subprocesses must be bounded by a timeout
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PidRegistry — PERF-3: bounded ps/kill subprocesses", () => {
+  test("killAll() resolves within the deadline when `ps -eo` never exits", async () => {
+    _pidRegistryDeps.spawn = mock(() => {
+      return {
+        pid: 2000,
+        stdout: new ReadableStream<Uint8Array>({ start() {} }), // never closes
+        stderr: new ReadableStream<Uint8Array>({ start() {} }),
+        exited: new Promise<number>(() => {}), // wedged — never resolves
+      } as unknown as ReturnType<typeof Bun.spawn>;
+    }) as unknown as typeof Bun.spawn; // test-ratchet-allow: as-unknown-as (mock cast, mirrors lines 241/296)
+    _pidRegistryDeps.sleep = mock(async () => {}) as typeof Bun.sleep;
+    _pidRegistryDeps.procExitTimeoutMs = 50;
+
+    const registry = new PidRegistry(TEST_WORKDIR);
+    await registry.register(172446);
+
+    const MARGIN_MS = 500;
+    const timed = Symbol("timed");
+    const result = await Promise.race([
+      registry.killAll(),
+      new Promise<typeof timed>((resolve) => setTimeout(() => resolve(timed), MARGIN_MS)),
+    ]);
+
+    // killAll() must resolve within the deadline, not hang on the wedged ps.
+    expect(result).not.toBe(timed);
+    expect(registry.getPids()).toEqual([]);
+  });
+
+  test("killAll() resolves when a per-pid `ps -p` never exits", async () => {
+    _pidRegistryDeps.spawn = mock((cmd: string[]) => {
+      if (cmd[0] === "ps" && cmd[1] === "-eo") {
+        return {
+          pid: 2000,
+          stdout: makeStream("172446 1 Thu May 15 11:52:44 2026\n"),
+          stderr: makeStream(),
+          exited: Promise.resolve(0),
+        } as unknown as ReturnType<typeof Bun.spawn>;
+      }
+      // Per-pid identity lookup: wedged — never exits.
+      return {
+        pid: 2001,
+        stdout: new ReadableStream<Uint8Array>({ start() {} }),
+        stderr: new ReadableStream<Uint8Array>({ start() {} }),
+        exited: new Promise<number>(() => {}),
+      } as unknown as ReturnType<typeof Bun.spawn>;
+    }) as unknown as typeof Bun.spawn; // test-ratchet-allow: as-unknown-as (mock cast, mirrors lines 241/296)
+    _pidRegistryDeps.sleep = mock(async () => {}) as typeof Bun.sleep;
+    _pidRegistryDeps.procExitTimeoutMs = 50;
+
+    const registry = new PidRegistry(TEST_WORKDIR);
+    await registry.register(172446);
+
+    const MARGIN_MS = 500;
+    const timed = Symbol("timed");
+    const result = await Promise.race([
+      registry.killAll(),
+      new Promise<typeof timed>((resolve) => setTimeout(() => resolve(timed), MARGIN_MS)),
+    ]);
+
+    expect(result).not.toBe(timed);
+    expect(registry.getPids()).toEqual([]);
+  });
+});

--- a/test/unit/execution/pipeline-result-handler-bug12.test.ts
+++ b/test/unit/execution/pipeline-result-handler-bug12.test.ts
@@ -1,0 +1,156 @@
+/**
+ * BUG-12: worktree removal must drain stdout/stderr and surface non-zero exits
+ *
+ * removeWorktreeDirectory previously awaited `proc.exited` without consuming
+ * stdout/stderr — a git error emitting >64KB fills the pipe buffer, the child
+ * blocks writing, and the handler hangs. Non-zero exits were also invisible.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { DEFAULT_CONFIG } from "@/config";
+import { makeMockRuntime, makeLogger, makePRD, makeStory } from "@test/helpers";
+import * as loggerModule from "@/logger";
+import type { UserStory } from "@/prd";
+import {
+  _resultHandlerDeps,
+  handlePipelineFailure,
+  type PipelineHandlerContext,
+} from "@/execution";
+import type { PipelineRunResult } from "@/pipeline";
+import { PluginRegistry } from "@/plugins";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(story: UserStory, overrides: Partial<PipelineHandlerContext> = {}): PipelineHandlerContext {
+  const prd = makePRD({ userStories: [story] });
+  return {
+    config: DEFAULT_CONFIG,
+    prd,
+    prdPath: "/tmp/prd.json",
+    workdir: "/tmp/repo",
+    hooks: { hooks: [] } as unknown as PipelineHandlerContext["hooks"], // test-ratchet-allow: as-unknown-as
+    feature: "test-feature",
+    totalCost: 0,
+    startTime: Date.now(),
+    runId: "run-001",
+    pluginRegistry: new PluginRegistry([]),
+    story,
+    storiesToExecute: [story],
+    routing: { complexity: "simple", modelTier: "standard", testStrategy: "test-after", reasoning: "" },
+    isBatchExecution: false,
+    allStoryMetrics: [],
+    storyGitRef: "abc123",
+    runtime: makeMockRuntime(),
+    ...overrides,
+  } as unknown as PipelineHandlerContext; // test-ratchet-allow: as-unknown-as (agentManager/sessionManager are optional in tests)
+}
+
+const WORKTREE_CONFIG = {
+  ...DEFAULT_CONFIG,
+  execution: { ...DEFAULT_CONFIG.execution, storyIsolation: "worktree" as const },
+};
+
+const failResult: PipelineRunResult = {
+  success: false,
+  finalAction: "fail",
+  reason: "Tests failed",
+  context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
+};
+
+let origResultSpawn: typeof _resultHandlerDeps.spawn;
+
+beforeEach(() => {
+  origResultSpawn = _resultHandlerDeps.spawn;
+});
+
+afterEach(() => {
+  _resultHandlerDeps.spawn = origResultSpawn;
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handlePipelineFailure — worktree removal drains streams (BUG-12)", () => {
+  test("consumes stdout and stderr so >64KB git output cannot stall the child", async () => {
+    const story = makeStory({ id: "US-bug12", status: "pending", passes: false, attempts: 2 });
+    const ctx = makeCtx(story, {
+      config: {
+        ...WORKTREE_CONFIG,
+        execution: {
+          ...WORKTREE_CONFIG.execution,
+          rectification: { ...WORKTREE_CONFIG.execution.rectification, maxAttemptsTotal: 1 },
+        },
+      },
+    });
+
+    // BUG-12: the handler awaited `proc.exited` without consuming stdout or
+    // stderr. A git error emitting >64KB fills the pipe; the child can never
+    // finish writing, and the handler hangs. Reproduce that contract: `exited`
+    // only resolves after both streams have been fully read, so an undrained
+    // handler trips the deadline race below.
+    const encoder = new TextEncoder();
+    const bigOutput = "fatal: path is in use\n".repeat(16_384); // ~330KB
+    const onRead = (() => {
+      let resolveRead!: () => void;
+      const promise = new Promise<void>((res) => { resolveRead = res; });
+      return { promise, resolveRead };
+    })();
+    _resultHandlerDeps.spawn = mock(() => ({
+      stdout: new ReadableStream<Uint8Array>({
+        start(c) { c.enqueue(encoder.encode("warning: dirty worktree\n")); },
+        pull(c) { onRead.resolveRead(); c.close(); },
+      }),
+      stderr: new ReadableStream<Uint8Array>({
+        start(c) { c.enqueue(encoder.encode(bigOutput)); },
+        pull(c) { onRead.resolveRead(); c.close(); },
+      }),
+      // Resolves only once BOTH streams have been read to completion.
+      exited: Promise.all([onRead.promise, onRead.promise]).then(() => 0),
+      kill: mock(() => {}),
+    })) as unknown as typeof _resultHandlerDeps.spawn; // test-ratchet-allow: as-unknown-as (mock spawn cast)
+
+    await Promise.race([
+      handlePipelineFailure(ctx, failResult),
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new Error("BUG-12: worktree removal hung on undrained streams")), 3000),
+      ),
+    ]);
+  });
+
+  test("logs a warning when git worktree remove exits non-zero", async () => {
+    const logger = makeLogger();
+    const loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const story = makeStory({ id: "US-bug12", status: "pending", passes: false, attempts: 2 });
+    const ctx = makeCtx(story, {
+      config: {
+        ...WORKTREE_CONFIG,
+        execution: {
+          ...WORKTREE_CONFIG.execution,
+          rectification: { ...WORKTREE_CONFIG.execution.rectification, maxAttemptsTotal: 1 },
+        },
+      },
+    });
+
+    _resultHandlerDeps.spawn = mock(() => {
+      const encoder = new TextEncoder();
+      return {
+        stdout: new ReadableStream<Uint8Array>({ start(c) { c.close(); } }),
+        stderr: new ReadableStream<Uint8Array>({ start(c) { c.enqueue(encoder.encode("fatal: worktree is dirty\n")); c.close(); } }),
+        exited: Promise.resolve(128),
+        kill: mock(() => {}),
+      };
+    }) as unknown as typeof _resultHandlerDeps.spawn; // test-ratchet-allow: as-unknown-as (mock spawn cast)
+
+    await handlePipelineFailure(ctx, failResult);
+
+    const warnCall = logger.calls.find((c) => c.level === "warn" && String(c.message).includes("worktree"));
+    expect(warnCall).toBeDefined();
+    expect(warnCall?.data?.exitCode ?? warnCall?.data?.exit ?? warnCall?.data?.code).toBe(128);
+    loggerSpy.mockRestore();
+  });
+});

--- a/test/unit/verification/smart-runner.test.ts
+++ b/test/unit/verification/smart-runner.test.ts
@@ -59,6 +59,44 @@ describe("buildSmartTestCommand", () => {
     const result = buildSmartTestCommand(testFiles as string[], command);
     expect(result).toBe(expected);
   });
+
+  // ENH-2: pnpm/turbo/nx monorepo scoping flags take a path argument and must
+  // never be replaced by scoped test files.
+  test.each([
+    [
+      "pnpm --filter ./packages/api — filter preserved, tests appended",
+      ["packages/api/test/unit/foo.test.ts"],
+      "pnpm --filter ./packages/api test",
+      "pnpm --filter ./packages/api test 'packages/api/test/unit/foo.test.ts'",
+    ],
+    [
+      "pnpm --filter=<pkg> combined form — filter preserved",
+      ["test/unit/foo.test.ts"],
+      "pnpm --filter=@scope/api test",
+      "pnpm --filter=@scope/api test 'test/unit/foo.test.ts'",
+    ],
+    [
+      "pnpm -F ./packages/api short form — filter preserved",
+      ["packages/api/test/unit/foo.test.ts"],
+      "pnpm -F ./packages/api test",
+      "pnpm -F ./packages/api test 'packages/api/test/unit/foo.test.ts'",
+    ],
+    [
+      "turbo --filter <pkg> followed by a flag — filter preserved",
+      ["test/unit/foo.test.ts"],
+      "turbo run test --filter=@scope/api --continue",
+      "turbo run test --filter=@scope/api --continue 'test/unit/foo.test.ts'",
+    ],
+    [
+      "pnpm --dir packages/api — dir preserved, tests appended",
+      ["test/unit/foo.test.ts"],
+      "pnpm --dir packages/api test",
+      "pnpm --dir packages/api test 'test/unit/foo.test.ts'",
+    ],
+  ])("%s", (_label, testFiles, command, expected) => {
+    const result = buildSmartTestCommand(testFiles as string[], command);
+    expect(result).toBe(expected);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes out the remaining work from the 2026-08-14 deep code review work order: **W10** (trust-boundary documentation) and the full **W11** hardening backlog.

## W10 — Documentation

- **`docs/architecture/agent-adapters.md` §17 Trust Boundary**: states the D-1 ruling (nax trusts the repository it is pointed at), what is inside the boundary, what is explicitly not being built (so reviewers don't re-raise it), and the scope limits. Notes the webhook rate-limit/HMAC posture and the Telegram private-chat expectation.

## W11 — Hardening backlog

All items TDD (RED test first, then minimal fix):

| ID | Fix |
|:---|:---|
| **BUG-12** | `removeWorktreeDirectory` drains stdout/stderr concurrently with the exit and logs non-zero exits — a git error emitting >64KB can no longer stall the child on a full pipe buffer |
| **BUG-14** | Deleted the dead `completedEarly` early-return in `runner.ts` / `runner-execution.ts` — nothing ever set the flag; the branch skipped `runCompletionPhase` on an unreachable path |
| **BUG-15** | `resetRuntimeCrashRetryCounts()` clears the runtime-crash retry budget at run teardown (wired into `cleanupRun`) instead of leaking entries across runs in one process |
| **ENH-1** | `parseAgentError` walks `payload.error`/`data` sub-objects (depth-capped) so JSON-RPC envelopes carrying `acpxCode` in `error.data` classify correctly; nested `retryAfterSeconds` is honored |
| **ENH-2** | `PATH_TAKING_FLAGS` gains `--filter`/`--dir`/`-F` so pnpm/turbo/nx monorepo scoping survives `buildSmartTestCommand` |
| **MEM-1** | `readStreamTail` caps stderr to a 64KB rolling tail (code-point-safe trim) instead of buffering the full stream into failure responses |
| **MEM-2** | TUI `escalationLog` is pruned to 5 entries in the hook, matching the display cap, instead of growing for the run lifetime |
| **MEM-3** | `stopHeartbeat` aborts the in-flight sleep via `cancellableDelay` + AbortSignal; a normal stop no longer logs a spurious "loop crashed" warning |
| **PERF-2** | `CodeNeighborProvider` + `GitHistoryProvider` honor the AbortSignal and stop per-file work when a fetch times out |
| **PERF-3** | `ps`/`kill` subprocesses in `PidRegistry` are bounded by a hard deadline so wedged children cannot stall shutdown |

## Self-review

Performed a code review of the changes before this PR:
- Found + fixed: `stopHeartbeat` nulled the abort controller before the loop's catch read it, so every normal stop rethrew the abort and logged a spurious "Heartbeat loop crashed" warning
- Found + fixed: `extractJsonCodeTokens` walk had no recursion depth cap (pathological deeply-nested payloads)
- Found + fixed: tail trim could split astral-plane surrogate pairs; now walks whole code points
- Tests refactored onto shared helpers (`makeStory`/`makePRD`) to satisfy the inline-mock ratchet

## Verification

- Full suite: **14,291 tests** (13,160 unit + 1,129 integration/UI), 0 fail
- `bun run typecheck` clean (both tsconfigs)
- `bun run lint` clean (all ratchet checks at/below baseline)
- `bun run build` clean