### PR TITLE
fix: stop judging and announcing a story's rung before classification runs (#1575)

### DIFF
--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -140,6 +140,19 @@ export async function preIterationTierCheck(
   runtime?: import("../../runtime").NaxRuntime,
 ): Promise<PreIterationCheckResult> {
   const logger = _tierEscalationDeps.getSafeLogger();
+
+  // @design: #1575 — a first attempt has no rung to judge yet. The routing stage
+  // (pipeline/stages/routing.ts) is the only writer of story.routing.modelTier and
+  // runs strictly AFTER this check, so any value here predates classification; under
+  // a cross-agent ladder it pairs a stale tier with the profile's agent and warns
+  // "budget is unbounded" for a rung the story never runs on. Behaviour-preserving:
+  // tierOrder rungs carry attempts >= 1 (TierConfigSchema), so `0 < tierCfg.attempts`
+  // always holds here — the check can never skip, escalate, or dirty the PRD at
+  // attempts === 0. Any future tightening of the !tierCfg branch must keep this guard.
+  if ((story.attempts ?? 0) === 0) {
+    return { shouldSkipIteration: false, prdDirty: false, prd };
+  }
+
   const currentTier = story.routing?.modelTier ?? routing.modelTier;
   const tierOrder = config.autoMode?.escalation?.tierOrder || [];
   const hasAgentRungs = tierOrder.some((r) => r.agent !== undefined);

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -4,6 +4,7 @@
  * Extracted from sequential-executor.ts to slim it below 200 lines.
  */
 
+import { resolveDefaultAgent } from "../agents";
 import type { NaxConfig } from "../config";
 import type { LoadedHooksConfig } from "../hooks";
 import type { InteractionChain } from "../interaction/chain";
@@ -13,6 +14,7 @@ import type { RoutingResult } from "../pipeline/types";
 import type { AgentGetFn } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
 import type { PRD, UserStory } from "../prd/types";
+import { complexityToModelTier, resolveOperatingTier } from "../routing";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
 import type { StoryBatch } from "./batching";
@@ -71,19 +73,41 @@ export interface SequentialExecutionResult {
  * Build a preview routing from cached story.routing or config defaults.
  * The pipeline routing stage performs full classification and overwrites ctx.routing.
  * This preview is used only for logging, status display, and event emission.
+ *
+ * #1575: the tier goes through the same precedence the routing stage applies
+ * (resolveOperatingTier), so a profile-assigned story is announced at its
+ * profile's tier rather than at a stale persisted one — and the derived tier is
+ * looked up from the story's OWN cached complexity, not a hardcoded band.
+ * Classification itself has not run yet, so the derived tier remains an estimate.
  */
 export function buildPreviewRouting(story: UserStory, config: NaxConfig): RoutingResult {
   const cached = story.routing;
-  const defaultComplexity = "medium" as const;
-  const defaultTier = "balanced" as const;
   const defaultStrategy = "test-after" as const;
+  const complexity = (cached?.complexity as RoutingResult["complexity"]) ?? "medium";
+  // This is a display path: a partially-populated config must degrade to the
+  // default band, never throw. The schema makes complexityRouting required, so
+  // the guard only matters for hand-built configs.
+  const derivedTier = config.autoMode?.complexityRouting ? complexityToModelTier(complexity, config) : "balanced";
+  const { tier } = resolveOperatingTier({
+    previousTier: cached?.modelTier,
+    profileTier: cached?.profileModelTier,
+    derivedTier,
+    hasEscalationRecords: (story.escalations?.length ?? 0) > 0,
+  });
   return {
-    complexity: (cached?.complexity as RoutingResult["complexity"]) ?? defaultComplexity,
-    modelTier:
-      (cached?.modelTier as RoutingResult["modelTier"]) ??
-      (config.autoMode.complexityRouting?.[defaultComplexity] as RoutingResult["modelTier"]) ??
-      defaultTier,
+    complexity,
+    modelTier: tier as RoutingResult["modelTier"],
     testStrategy: (cached?.testStrategy as RoutingResult["testStrategy"]) ?? defaultStrategy,
     reasoning: cached ? "cached from story.routing" : "preview (pending pipeline routing stage)",
   };
+}
+
+/**
+ * Agent a story will actually run as: its own assignment, else the run default.
+ *
+ * #1575: under cross-agent profiles the run default is not what executes a
+ * profile-assigned story, so announcing it misreports every such story.
+ */
+export function agentFor(story: UserStory, ctx: SequentialExecutionContext): string {
+  return story.routing?.agent ?? ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);
 }

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -134,3 +134,4 @@ export {
   type PostRunInspectionResult,
   type InspectionOptions,
 } from "./post-run";
+export { buildPreviewRouting } from "./executor-types";

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -1,7 +1,6 @@
 /** Unified Story Executor (ADR-005, Phase 4) — sequential loop with optional parallel dispatch. */
 
 import { pipelineEventBus } from "@/pipeline";
-import { resolveDefaultAgent } from "../agents";
 import { checkCostExceeded, checkPreMerge, isTriggerEnabled } from "../interaction/triggers";
 import { getSafeLogger } from "../logger";
 import type { StoryMetrics } from "../metrics";
@@ -406,7 +405,8 @@ export async function executeUnified(
               storyId: story.id,
               complexity: story.routing?.complexity ?? "medium",
               modelTier: story.routing?.modelTier ?? "balanced",
-              modelUsed: ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config),
+              // #1575: the story's own agent — these metrics feed per-agent cost attribution.
+              modelUsed: agentFor(story, ctx),
               attempts: 1,
               finalTier: story.routing?.modelTier ?? "balanced",
               success: true,
@@ -428,7 +428,7 @@ export async function executeUnified(
                 storyId: conflict.story.id,
                 complexity: conflict.story.routing?.complexity ?? "medium",
                 modelTier: conflict.story.routing?.modelTier ?? "balanced",
-                modelUsed: ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config),
+                modelUsed: agentFor(conflict.story, ctx),
                 attempts: 1,
                 finalTier: conflict.story.routing?.modelTier ?? "balanced",
                 success: true,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -24,7 +24,7 @@ import type { DeferredReviewResult } from "./deferred-review";
 import { runBatchPreChecks } from "./escalation";
 import { preIterationTierCheck } from "./escalation/tier-escalation";
 import type { SequentialExecutionContext, SequentialExecutionResult } from "./executor-types";
-import { buildPreviewRouting } from "./executor-types";
+import { agentFor, buildPreviewRouting } from "./executor-types";
 import { getAllReadyStories } from "./helpers";
 import { runIteration } from "./iteration-runner";
 import type { RunParallelBatchOptions, RunParallelBatchResult } from "./parallel-batch";
@@ -256,14 +256,12 @@ export async function executeUnified(
         const batch = retryStory ? [retryStory] : selectBatch(readyStories, ctx.parallelCount as number);
         if (batch.length > 1) {
           // Emit story:started for each batch story before dispatch (AC-5)
-          const batchAgent = ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);
           const batchCounts = countStories(prd);
           const batchBaseDone = batchCounts.total - batchCounts.pending;
           for (const [batchIndex, story] of batch.entries()) {
-            const modelTier =
-              story.routing?.modelTier ??
-              ctx.config.autoMode.complexityRouting?.[story.routing?.complexity ?? "medium"] ??
-              "balanced";
+            // #1575: announce the tier/agent the story will actually run as.
+            const modelTier = buildPreviewRouting(story, ctx.config).modelTier;
+            const batchAgent = agentFor(story, ctx);
             pipelineEventBus.emit({
               type: "story:started",
               storyId: story.id,
@@ -480,7 +478,7 @@ export async function executeUnified(
           }
 
           const modelTier = singleSelection.routing.modelTier;
-          const singleAgent = ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);
+          const singleAgent = agentFor(singleStory, ctx);
           const singleCounts = countStories(prd);
           pipelineEventBus.emit({
             type: "story:started",
@@ -573,7 +571,7 @@ export async function executeUnified(
       }
 
       const modelTier = selection.routing.modelTier;
-      const seqAgent = ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);
+      const seqAgent = agentFor(selection.story, ctx);
       const seqCounts = countStories(prd);
       pipelineEventBus.emit({
         type: "story:started",

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -14,7 +14,7 @@
 import { isGreenfieldStory } from "@/context";
 import { getLogger } from "@/logger";
 import { savePRD } from "@/prd";
-import { complexityToModelTier, isSecurityCriticalStory, resolveRouting } from "@/routing";
+import { complexityToModelTier, isSecurityCriticalStory, resolveOperatingTier, resolveRouting } from "@/routing";
 import { resolveTestFilePatterns } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
 import { packageDirRelative } from "@/utils/paths";
@@ -34,41 +34,25 @@ export const routingStage: PipelineStage = {
     // Classify story via resolveRouting() (plugin routers > LLM > keyword)
     const decision = await _routingDeps.resolveRouting(ctx.story, ctx.config, ctx.plugins, ctx);
 
-    // @design: BUG-032: Only preserve a previously-stored modelTier when it represents an escalation
-    // (i.e., a higher tier than the candidate baseline). This prevents stale tiers
-    // from sticking when complexity changes between runs, while still honoring explicit
-    // escalations set by handleTierEscalation.
-    const TIER_RANK: Record<string, number> = { fast: 0, balanced: 1, powerful: 2 };
-    const derivedTier = decision.modelTier;
-
-    // Open Item B: a selected profile's target tier seeds the STARTING rung and
-    // overrides the complexity-derived tier. Genuine escalation still wins below.
-    const profileTier = ctx.story.routing?.profileModelTier;
-    const candidateTier = profileTier ?? derivedTier;
-    const candidateRank = TIER_RANK[candidateTier];
-
-    const previousTier = ctx.story.routing?.modelTier;
-    const previousRank = previousTier !== undefined ? TIER_RANK[previousTier] : undefined;
+    // @design: BUG-032 / Open Item B / #1522 — the profile target seeds the starting
+    // rung, a genuine escalation is preserved, and a stale leftover tier is not.
+    // The precedence itself lives in resolveOperatingTier so that the executor's
+    // pre-classification preview announces the same tier this stage resolves (#1575).
     const hasEscalationRecords = (ctx.story.escalations?.length ?? 0) > 0;
-    if (previousTier !== undefined && previousRank === undefined && !hasEscalationRecords) {
+    const operating = _routingDeps.resolveOperatingTier({
+      previousTier: ctx.story.routing?.modelTier,
+      profileTier: ctx.story.routing?.profileModelTier,
+      derivedTier: decision.modelTier,
+      hasEscalationRecords,
+    });
+    if (operating.unknownPreviousTier) {
       logger?.warn("routing", "Ignoring unknown previousTier — not escalating", {
         storyId: ctx.story.id,
-        previousTier,
-        candidateTier,
+        previousTier: ctx.story.routing?.modelTier,
+        candidateTier: operating.candidateTier,
       });
     }
-    // Preserve a previously-stored tier only when it is a genuine escalation:
-    // - an escalation record exists for this story -> honor it outright. A cross-agent
-    //   rung ladder can escalate sideways or down (e.g. agentA/powerful -> agentB/balanced),
-    //   so rank comparison alone would discard a real escalation whose tier does not
-    //   outrank the freshly-derived candidate (#1522).
-    // - no escalation record -> fall back to rank comparison, so a stale tier left over
-    //   from a prior, unrelated run does not stick around just because it ranks higher
-    const isEscalated =
-      previousTier !== undefined &&
-      (hasEscalationRecords ||
-        (previousRank !== undefined && candidateRank !== undefined && previousRank > candidateRank));
-    const modelTier = isEscalated ? previousTier : candidateTier;
+    const modelTier = operating.tier;
 
     // PRD-assigned agent wins (plan-time selection, Delta C3). decision.agent is
     // the Part A run-time classifier's choice and applies only when the PRD
@@ -193,6 +177,7 @@ export const routingStage: PipelineStage = {
  */
 export const _routingDeps = {
   resolveRouting,
+  resolveOperatingTier,
   complexityToModelTier,
   isGreenfieldStory,
   resolveTestFilePatterns,

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -39,7 +39,7 @@ export const routingStage: PipelineStage = {
     // The precedence itself lives in resolveOperatingTier so that the executor's
     // pre-classification preview announces the same tier this stage resolves (#1575).
     const hasEscalationRecords = (ctx.story.escalations?.length ?? 0) > 0;
-    const operating = _routingDeps.resolveOperatingTier({
+    const operating = resolveOperatingTier({
       previousTier: ctx.story.routing?.modelTier,
       profileTier: ctx.story.routing?.profileModelTier,
       derivedTier: decision.modelTier,
@@ -177,7 +177,6 @@ export const routingStage: PipelineStage = {
  */
 export const _routingDeps = {
   resolveRouting,
-  resolveOperatingTier,
   complexityToModelTier,
   isGreenfieldStory,
   resolveTestFilePatterns,

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -83,7 +83,14 @@ export interface StoryRouting {
   initialComplexity?: Complexity;
   /** Content hash of story fields at time of routing — used to detect stale cached routing (RRP-003) */
   contentHash?: string;
-  /** Model tier (derived at runtime from config, not persisted) */
+  /**
+   * The rung the story currently operates on. Seeded from `profileModelTier` or
+   * the complexity classification and bumped by escalation — see
+   * `resolveOperatingTier`. It IS persisted (written by the routing stage and by
+   * decompose-mapper), which is what lets escalation survive across runs and what
+   * `resetFailedStoriesToPending` restores from `initialModelTier`. Absent until
+   * a story has been routed at least once.
+   */
   modelTier?: ModelTier;
   testStrategy: TestStrategy;
   /** Required when testStrategy is "no-test" — explains why tests are unnecessary for this story */

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -21,6 +21,11 @@ export {
   _tryLlmBatchRouteDeps,
 } from "./router";
 
+// SSOT for the profile/escalation/persisted tier precedence — shared by the
+// routing stage and the executor's pre-classification preview (#1575).
+export { resolveOperatingTier } from "./operating-tier";
+export type { OperatingTierInput, OperatingTierResult } from "./operating-tier";
+
 // Calibration primitives (US-002 + US-003)
 export { computeBandStats } from "./calibrate/band-stats";
 export type { ComplexityMapping } from "./calibrate/band-stats";

--- a/src/routing/operating-tier.ts
+++ b/src/routing/operating-tier.ts
@@ -1,0 +1,72 @@
+/**
+ * Operating-tier resolution — SSOT for "which rung will this story run at?".
+ *
+ * Two callers must answer this identically:
+ * - the routing stage (`src/pipeline/stages/routing.ts`), authoritatively, once
+ *   classification has produced a derived tier;
+ * - `buildPreviewRouting` (`src/execution/executor-types.ts`), ahead of the
+ *   pipeline, to announce the story (story.start log, story:started event,
+ *   status display, dry run).
+ *
+ * When the two diverge, a run announces one tier and executes another — the
+ * reporting half of #1575. Keeping the rule here means the preview can only be
+ * wrong about the *derived* tier (which needs classification), never about the
+ * precedence between profile, escalation, and persisted values.
+ */
+
+/** Rank used to tell a genuine escalation from a stale leftover tier. */
+const TIER_RANK: Record<string, number> = { fast: 0, balanced: 1, powerful: 2 };
+
+export interface OperatingTierInput {
+  /** Tier persisted on the story by a previous iteration or run, if any. */
+  previousTier?: string;
+  /** Tier the story's agent profile targets — seeds the starting rung. */
+  profileTier?: string;
+  /** Tier derived from this story's complexity classification. */
+  derivedTier: string;
+  /** Whether the story carries at least one escalation record. */
+  hasEscalationRecords: boolean;
+}
+
+export interface OperatingTierResult {
+  /** The rung the story operates on. */
+  tier: string;
+  /** True when `previousTier` was kept because it represents a real escalation. */
+  isEscalated: boolean;
+  /** The tier that would have been used had no escalation been in play. */
+  candidateTier: string;
+  /** `previousTier` was set but unrankable and unbacked by an escalation record. */
+  unknownPreviousTier: boolean;
+}
+
+/**
+ * Resolve the tier a story operates on.
+ *
+ * - A profile target seeds the STARTING rung and overrides the complexity-derived
+ *   tier (agent-profile routing, Open Item B).
+ * - A genuine escalation still wins. An escalation record is honoured outright,
+ *   because a cross-agent ladder can escalate sideways or down — e.g.
+ *   agentA/powerful -> agentB/balanced — and rank comparison alone would discard
+ *   that as "not an escalation" (#1522). With no record, a higher-ranked previous
+ *   tier is kept so an escalation that predates record-keeping survives, while a
+ *   lower-ranked leftover from an unrelated run does not stick.
+ */
+export function resolveOperatingTier(input: OperatingTierInput): OperatingTierResult {
+  const { previousTier, profileTier, derivedTier, hasEscalationRecords } = input;
+
+  const candidateTier = profileTier ?? derivedTier;
+  const candidateRank = TIER_RANK[candidateTier];
+  const previousRank = previousTier !== undefined ? TIER_RANK[previousTier] : undefined;
+
+  const isEscalated =
+    previousTier !== undefined &&
+    (hasEscalationRecords ||
+      (previousRank !== undefined && candidateRank !== undefined && previousRank > candidateRank));
+
+  return {
+    tier: isEscalated ? previousTier : candidateTier,
+    isEscalated,
+    candidateTier,
+    unknownPreviousTier: previousTier !== undefined && previousRank === undefined && !hasEscalationRecords,
+  };
+}

--- a/test/unit/execution/escalation/tier-escalation-first-iteration.test.ts
+++ b/test/unit/execution/escalation/tier-escalation-first-iteration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Issue #1575: preIterationTierCheck must not judge a story's rung before that
+ * story's routing stage has run.
+ *
+ * On a first iteration `story.routing.modelTier` is stale by construction — the
+ * per-iteration routing stage (src/pipeline/stages/routing.ts) is the writer, and
+ * it runs strictly AFTER this check. Under a cross-agent profile ladder the check
+ * therefore pairs the profile's agent with a non-profile tier, producing a rung
+ * that is absent from tierOrder and a false "escalation budget is unbounded"
+ * WARN on the story's very first attempt.
+ *
+ * The guard is safe because every tierOrder rung has attempts >= 1
+ * (TierConfigSchema, src/config/schemas-model.ts) — so at attempts === 0 the
+ * budget comparison `0 < tierCfg.attempts` always holds and the check can never
+ * skip, escalate, or dirty the PRD. Pinned by the schema test at the bottom.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { TierConfig } from "@/config";
+import { TierConfigSchema } from "@/config";
+import { _tierEscalationDeps, preIterationTierCheck } from "@/execution/escalation";
+import type { StoryRouting, UserStory } from "@/prd";
+import { makeInProgressStory, makeNaxConfig, makePRD } from "@test/helpers";
+
+// ---------------------------------------------------------------------------
+// Scaffolding
+// ---------------------------------------------------------------------------
+
+/** A cross-agent ladder: no `pi@fast` rung exists, only `pi@balanced`. */
+const CROSS_AGENT_LADDER: TierConfig[] = [
+  { tier: "balanced", agent: "pi", attempts: 2 },
+  { tier: "powerful", agent: "claude", attempts: 2 },
+];
+
+/**
+ * A profile-assigned story carrying a stale tier ("fast") from an earlier write,
+ * paired with the profile's agent — the exact shape that produced the #1575 warning.
+ */
+function makeProfileStory(attempts: number, routing: Partial<StoryRouting> = {}): UserStory {
+  return makeInProgressStory({
+    id: "US-1575",
+    attempts,
+    routing: {
+      complexity: "medium",
+      modelTier: "fast",
+      profileModelTier: "balanced",
+      agent: "pi",
+      agentProfileId: "pi-balanced",
+      testStrategy: "test-after",
+      reasoning: "",
+      ...routing,
+    },
+  });
+}
+
+function buildConfig(tierOrder: TierConfig[]) {
+  return makeNaxConfig({
+    models: {
+      pi: { fast: "pi-fast", balanced: "pi-balanced", powerful: "pi-powerful" },
+      claude: { fast: "haiku", balanced: "sonnet", powerful: "opus" },
+    },
+    autoMode: { escalation: { enabled: true, tierOrder } },
+  });
+}
+
+function asHooks() {
+  // Only read on the "no next tier" branch, which none of these cases reach.
+  return {} as unknown as Parameters<typeof preIterationTierCheck>[6]; // test-ratchet-allow: as-unknown-as
+}
+
+/** Captured warn calls, so a test can assert on the absence of a diagnostic. */
+type WarnCall = { stage: string; message: string; meta?: Record<string, unknown> };
+let warns: WarnCall[];
+let origSavePRD: typeof _tierEscalationDeps.savePRD;
+let origGetSafeLogger: typeof _tierEscalationDeps.getSafeLogger;
+
+beforeEach(() => {
+  warns = [];
+  origSavePRD = _tierEscalationDeps.savePRD;
+  origGetSafeLogger = _tierEscalationDeps.getSafeLogger;
+  // No-op persistence so the test never touches real disk.
+  _tierEscalationDeps.savePRD = () => Promise.resolve();
+  _tierEscalationDeps.getSafeLogger = () =>
+    ({
+      warn: (stage: string, message: string, meta?: Record<string, unknown>) => warns.push({ stage, message, meta }),
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+    }) as unknown as ReturnType<typeof origGetSafeLogger>; // test-ratchet-allow: as-unknown-as
+});
+
+afterEach(() => {
+  _tierEscalationDeps.savePRD = origSavePRD;
+  _tierEscalationDeps.getSafeLogger = origGetSafeLogger;
+});
+
+async function runPreIter(story: UserStory, tierOrder: TierConfig[], previewTier = "balanced") {
+  return await preIterationTierCheck(
+    story,
+    { modelTier: previewTier },
+    buildConfig(tierOrder),
+    makePRD({ userStories: [story] }),
+    "/tmp/test-prd-1575.json",
+    undefined,
+    asHooks(),
+    "f",
+    0,
+    "/tmp",
+  );
+}
+
+const UNBOUNDED_WARN = "Current rung not found in tierOrder";
+
+function unboundedWarnings(): WarnCall[] {
+  return warns.filter((w) => w.message.includes(UNBOUNDED_WARN));
+}
+
+// ---------------------------------------------------------------------------
+// The bug: false warning on a story's first iteration
+// ---------------------------------------------------------------------------
+
+describe("#1575: first iteration does not judge a pre-classification rung", () => {
+  test("does not warn about an unbounded budget when attempts === 0 and the stale tier is off-ladder", async () => {
+    const result = await runPreIter(makeProfileStory(0), CROSS_AGENT_LADDER);
+
+    expect(unboundedWarnings()).toEqual([]);
+    expect(result.shouldSkipIteration).toBe(false);
+  });
+
+  test("leaves the PRD untouched when attempts === 0", async () => {
+    const story = makeProfileStory(0);
+    const result = await runPreIter(story, CROSS_AGENT_LADDER);
+
+    expect(result.prdDirty).toBe(false);
+    const unchanged = result.prd.userStories.find((s) => s.id === story.id);
+    expect(unchanged?.attempts).toBe(0);
+    // The stale tier is neither acted on nor rewritten — the routing stage owns it.
+    expect(unchanged?.routing?.modelTier).toBe("fast");
+  });
+
+  test("does not warn at attempts === 0 even when the ladder has no agent-qualified rungs", async () => {
+    const result = await runPreIter(makeProfileStory(0), [{ tier: "balanced", attempts: 2 }]);
+
+    expect(unboundedWarnings()).toEqual([]);
+    expect(result.shouldSkipIteration).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The diagnostic must survive where it is genuine
+// ---------------------------------------------------------------------------
+
+describe("#1575: the unbounded-budget warning still fires once the rung is authoritative", () => {
+  test("warns when attempts > 0 and the story's rung is absent from tierOrder", async () => {
+    // attempts > 0 means an iteration ran, so routing.ts has written and persisted
+    // an authoritative modelTier — an off-ladder rung here is a real config gap.
+    const story = makeProfileStory(1, { modelTier: "fast", profileModelTier: undefined });
+
+    const result = await runPreIter(story, CROSS_AGENT_LADDER);
+
+    expect(unboundedWarnings()).toHaveLength(1);
+    expect(unboundedWarnings()[0]?.meta).toMatchObject({ storyId: "US-1575", currentTier: "fast", agent: "pi" });
+    expect(result.shouldSkipIteration).toBe(false);
+  });
+
+  test("still escalates a story that has exhausted its rung budget", async () => {
+    const story = makeProfileStory(2, { modelTier: "balanced" });
+
+    const result = await runPreIter(story, CROSS_AGENT_LADDER);
+
+    expect(result.shouldSkipIteration).toBe(true);
+    const escalated = result.prd.userStories.find((s) => s.id === story.id);
+    expect(escalated?.routing?.modelTier).toBe("powerful");
+    expect(escalated?.routing?.agent).toBe("claude");
+    expect(escalated?.attempts).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The invariant the guard rests on
+// ---------------------------------------------------------------------------
+
+describe("#1575: tierOrder rungs always carry a non-zero attempt budget", () => {
+  test("TierConfigSchema rejects attempts: 0, so `0 < tierCfg.attempts` always holds at attempts === 0", () => {
+    expect(TierConfigSchema.safeParse({ tier: "fast", attempts: 0 }).success).toBe(false);
+    expect(TierConfigSchema.safeParse({ tier: "fast", attempts: 1 }).success).toBe(true);
+  });
+});

--- a/test/unit/execution/executor-types.test.ts
+++ b/test/unit/execution/executor-types.test.ts
@@ -1,0 +1,74 @@
+/**
+ * buildPreviewRouting — the tier/complexity a story is ANNOUNCED with before its
+ * routing stage runs (story.start log, story:started event, status display, dry run).
+ *
+ * #1575 follow-up: the preview must predict what the routing stage will resolve.
+ * It previously read only the persisted modelTier and, failing that, looked up the
+ * hardcoded "medium" complexity — so a profile-assigned story was announced at the
+ * stale/default tier and executed at the profile's tier.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildPreviewRouting } from "@/execution";
+import type { UserStory } from "@/prd";
+import { makeNaxConfig, makeStory } from "@test/helpers";
+
+const config = makeNaxConfig({
+  autoMode: {
+    complexityRouting: { simple: "fast", medium: "balanced", complex: "powerful", expert: "powerful" },
+  },
+});
+
+function storyWith(routing: Partial<UserStory["routing"]>, escalations: UserStory["escalations"] = []): UserStory {
+  return makeStory({
+    escalations,
+    routing: { complexity: "medium", testStrategy: "test-after", reasoning: "", ...routing },
+  });
+}
+
+describe("buildPreviewRouting: tier prediction", () => {
+  test("announces the profile's tier, not a stale persisted tier (#1575)", () => {
+    const story = storyWith({ complexity: "expert", modelTier: "fast", profileModelTier: "balanced" });
+
+    expect(buildPreviewRouting(story, config).modelTier).toBe("balanced");
+  });
+
+  test("derives the tier from the story's own complexity when it has no profile", () => {
+    const story = storyWith({ complexity: "expert" });
+
+    // Previously "balanced" — the lookup was hardcoded to the "medium" band.
+    expect(buildPreviewRouting(story, config).modelTier).toBe("powerful");
+  });
+
+  test("keeps an escalated tier so the preview does not walk the story back down", () => {
+    const story = storyWith({ complexity: "simple", modelTier: "powerful", profileModelTier: "fast" }, [
+      { fromTier: "fast", toTier: "powerful", reason: "budget", timestamp: new Date(0).toISOString() },
+    ]);
+
+    expect(buildPreviewRouting(story, config).modelTier).toBe("powerful");
+  });
+
+  test("falls back to the default band when the story carries no routing at all", () => {
+    const story = makeStory({ routing: undefined });
+
+    const preview = buildPreviewRouting(story, config);
+    expect(preview.complexity).toBe("medium");
+    expect(preview.modelTier).toBe("balanced");
+  });
+});
+
+describe("buildPreviewRouting: passthrough fields", () => {
+  test("carries the story's cached complexity and test strategy", () => {
+    const story = storyWith({ complexity: "complex", testStrategy: "tdd-simple" });
+
+    const preview = buildPreviewRouting(story, config);
+    expect(preview.complexity).toBe("complex");
+    expect(preview.testStrategy).toBe("tdd-simple");
+  });
+
+  test("marks the reasoning as a preview when the story has never been routed", () => {
+    const preview = buildPreviewRouting(makeStory({ routing: undefined }), config);
+
+    expect(preview.reasoning).toContain("preview");
+  });
+});

--- a/test/unit/execution/unified-executor-logging.test.ts
+++ b/test/unit/execution/unified-executor-logging.test.ts
@@ -8,13 +8,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import * as loggerModule from "../../../src/logger";
+import * as loggerModule from "@/logger";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test fixture helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makePendingStory(id: string) {
+function makePendingStory(id: string, routing?: Record<string, unknown>) {
   return {
     id,
     title: `Story ${id}`,
@@ -25,8 +25,27 @@ function makePendingStory(id: string) {
     status: "pending" as const,
     passes: false,
     attempts: 0,
+    escalations: [],
     priorFailures: [],
+    ...(routing ? { routing } : {}),
   };
+}
+
+/**
+ * A story assigned to a cross-agent profile, carrying a stale persisted tier —
+ * the #1575 shape. It must be announced as pi@balanced, not as the run default
+ * agent at the leftover "fast" tier.
+ */
+function makeProfileStory(id: string) {
+  return makePendingStory(id, {
+    complexity: "medium",
+    testStrategy: "test-after",
+    reasoning: "",
+    modelTier: "fast",
+    profileModelTier: "balanced",
+    agent: "pi",
+    agentProfileId: "pi-balanced",
+  });
 }
 
 function makePrd(stories: ReturnType<typeof makePendingStory>[]) {
@@ -50,7 +69,12 @@ function makeCtx(overrides: { parallelCount?: number } = {}) {
         iterationDelayMs: 0,
         rectification: { maxAttemptsTotal: 2 },
       },
-      autoMode: { defaultAgent: "claude-code" },
+      // complexityRouting is required by NaxConfigSchema; buildPreviewRouting resolves
+      // the announced tier through it, so the fixture must carry the real bands.
+      autoMode: {
+        defaultAgent: "claude-code",
+        complexityRouting: { simple: "fast", medium: "balanced", complex: "powerful", expert: "powerful" },
+      },
       interaction: {},
     },
     hooks: {},
@@ -301,5 +325,102 @@ describe("story.start logging — sequential (single-story) dispatch", () => {
     });
     expect(call?.data).toHaveProperty("complexity");
     expect(call?.data).toHaveProperty("modelTier");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// story.start announcement — agent and tier must match what will actually run
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("story.start announcement — profile-assigned stories (#1575)", () => {
+  let deps: Record<string, unknown>;
+  let origRunIteration: unknown;
+  let origRunParallelBatch: unknown;
+  let origSelectIndependentBatch: unknown;
+  let loggerSpy: ReturnType<typeof spyOn>;
+  let executeUnified: typeof import("../../../src/execution/unified-executor").executeUnified;
+
+  interface LogCall {
+    stage: string;
+    message: string;
+    data?: Record<string, unknown>;
+  }
+
+  let infoCalls: LogCall[];
+
+  function installLoggerSpy() {
+    infoCalls = [];
+    const logger = {
+      info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+        infoCalls.push({ stage, message, data });
+      }),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    };
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as ReturnType<typeof loggerModule.getSafeLogger>);
+  }
+
+  beforeEach(async () => {
+    // unified-executor is not re-exported from the execution barrel, so this
+    // stays a direct module import; capture executeUnified here so each test
+    // does not repeat it.
+    const mod = await import("../../../src/execution/unified-executor");
+    deps = (mod as Record<string, unknown>)._unifiedExecutorDeps as Record<string, unknown>;
+    executeUnified = mod.executeUnified;
+    origRunIteration = deps.runIteration;
+    origRunParallelBatch = deps.runParallelBatch;
+    origSelectIndependentBatch = deps.selectIndependentBatch;
+    installLoggerSpy();
+  });
+
+  afterEach(() => {
+    if (deps) {
+      deps.runIteration = origRunIteration;
+      deps.runParallelBatch = origRunParallelBatch;
+      deps.selectIndependentBatch = origSelectIndependentBatch;
+    }
+    loggerSpy?.mockRestore();
+    mock.restore();
+  });
+
+  test("single-story dispatch announces the story's own agent and its profile tier", async () => {
+    const story = makeProfileStory("US-001");
+
+    deps.selectIndependentBatch = mock(() => [story]);
+    deps.runIteration = mock(async () => ({
+      prd: makePrd([]),
+      storiesCompletedDelta: 1,
+      costDelta: 0,
+      prdDirty: false,
+    }));
+
+    await executeUnified(makeCtx({ parallelCount: 2 }) as never, makePrd([story]) as never).catch(() => {});
+
+    const call = infoCalls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-001");
+    expect(call?.data).toMatchObject({ agent: "pi", modelTier: "balanced" });
+  });
+
+  test("parallel batch announces each story's own agent and tier", async () => {
+    const profiled = makeProfileStory("US-001");
+    const plain = makePendingStory("US-002");
+
+    deps.selectIndependentBatch = mock(() => [profiled, plain]);
+    deps.runParallelBatch = mock(async () => ({
+      completed: [profiled, plain],
+      failed: [],
+      mergeConflicts: [],
+      storyCosts: new Map([[profiled.id, 0], [plain.id, 0]]),
+      totalCost: 0,
+    }));
+
+    await executeUnified(makeCtx({ parallelCount: 2 }) as never, makePrd([profiled, plain]) as never).catch(() => {});
+
+    const profiledCall = infoCalls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-001");
+    expect(profiledCall?.data).toMatchObject({ agent: "pi", modelTier: "balanced" });
+
+    // A story with no profile still falls back to the run's default agent.
+    const plainCall = infoCalls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-002");
+    expect(plainCall?.data?.agent).not.toBe("pi");
   });
 });

--- a/test/unit/execution/unified-executor-results.test.ts
+++ b/test/unit/execution/unified-executor-results.test.ts
@@ -16,7 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mock } from "bun:test";
-import { makeNaxConfig, makePRD, makeStory } from "../../helpers";
+import { makeNaxConfig, makePRD, makeStory } from "@test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixture helpers — delegate to shared factories (test-helpers.md); local
@@ -202,6 +202,35 @@ describe("results AC-1 / AC-4 / exec AC-29: completed stories produce correct me
     // source is 'parallel' for batch-completed stories
     expect(m1?.source).toBe("parallel");
     expect(m2?.source).toBe("parallel");
+  });
+
+  test("#1575: modelUsed records the story's own agent, not the run default", async () => {
+    // Under a cross-agent profile the run default is not what executed the story;
+    // booking it to the default misattributes per-agent cost.
+    const profiled = makeStory({
+      id: "US-PROFILE",
+      routing: { complexity: "medium", testStrategy: "test-after", reasoning: "", agent: "pi" },
+    });
+    const plain = makePendingStory("US-PLAIN");
+
+    deps.selectIndependentBatch = mock(() => [profiled, plain]);
+    deps.runParallelBatch = mock(async () => ({
+      completed: [profiled, plain],
+      failed: [],
+      mergeConflicts: [],
+      storyCosts: new Map([
+        [profiled.id, 0.1],
+        [plain.id, 0.1],
+      ]),
+      totalCost: 0.2,
+    }));
+
+    const mod = await import("../../../src/execution/unified-executor");
+    const result = await mod.executeUnified(makeCtx() as never, makePrd([profiled, plain]) as never);
+
+    expect(result.allStoryMetrics.find((m) => m.storyId === profiled.id)?.modelUsed).toBe("pi");
+    // A story with no assigned agent still falls back to the run default.
+    expect(result.allStoryMetrics.find((m) => m.storyId === plain.id)?.modelUsed).not.toBe("pi");
   });
 
   test("exec AC-29: per-story cost != (totalCost / storyCount) when costs are unequal", async () => {

--- a/test/unit/routing/operating-tier.test.ts
+++ b/test/unit/routing/operating-tier.test.ts
@@ -1,0 +1,121 @@
+/**
+ * resolveOperatingTier — the SSOT for "which rung will this story run at?".
+ *
+ * Both the routing stage (authoritative, post-classification) and
+ * buildPreviewRouting (pre-classification, display only) answer this question.
+ * When they disagree the run announces one tier and executes another (#1575),
+ * so the rule lives in one place and both callers are pinned to it here.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { resolveOperatingTier } from "@/routing";
+
+describe("resolveOperatingTier: profile target seeds the starting rung", () => {
+  test("profile tier overrides the complexity-derived tier when nothing is persisted", () => {
+    const result = resolveOperatingTier({
+      profileTier: "balanced",
+      derivedTier: "fast",
+      hasEscalationRecords: false,
+    });
+
+    expect(result.tier).toBe("balanced");
+    expect(result.isEscalated).toBe(false);
+  });
+
+  test("derived tier is used when the story has no profile", () => {
+    const result = resolveOperatingTier({ derivedTier: "powerful", hasEscalationRecords: false });
+
+    expect(result.tier).toBe("powerful");
+    expect(result.isEscalated).toBe(false);
+  });
+
+  test("profile tier beats a stale lower-ranked persisted tier (the #1575 shape)", () => {
+    // prd.json still carries modelTier "fast" from an earlier write; the story's
+    // profile targets balanced and has never escalated.
+    const result = resolveOperatingTier({
+      previousTier: "fast",
+      profileTier: "balanced",
+      derivedTier: "fast",
+      hasEscalationRecords: false,
+    });
+
+    expect(result.tier).toBe("balanced");
+    expect(result.isEscalated).toBe(false);
+  });
+});
+
+describe("resolveOperatingTier: a genuine escalation wins", () => {
+  test("an escalation record is honoured outright, even escalating sideways or down (#1522)", () => {
+    // Cross-agent ladders escalate agentA/powerful -> agentB/balanced; rank
+    // comparison alone would discard that as "not an escalation".
+    const result = resolveOperatingTier({
+      previousTier: "balanced",
+      profileTier: "powerful",
+      derivedTier: "powerful",
+      hasEscalationRecords: true,
+    });
+
+    expect(result.tier).toBe("balanced");
+    expect(result.isEscalated).toBe(true);
+  });
+
+  test("without escalation records, a higher-ranked persisted tier is still kept", () => {
+    const result = resolveOperatingTier({
+      previousTier: "powerful",
+      derivedTier: "fast",
+      hasEscalationRecords: false,
+    });
+
+    expect(result.tier).toBe("powerful");
+    expect(result.isEscalated).toBe(true);
+  });
+
+  test("without escalation records, a lower-ranked persisted tier does not stick", () => {
+    const result = resolveOperatingTier({
+      previousTier: "fast",
+      derivedTier: "powerful",
+      hasEscalationRecords: false,
+    });
+
+    expect(result.tier).toBe("powerful");
+    expect(result.isEscalated).toBe(false);
+  });
+});
+
+describe("resolveOperatingTier: unknown persisted tiers", () => {
+  test("an unrankable persisted tier is reported and not treated as an escalation", () => {
+    const result = resolveOperatingTier({
+      previousTier: "turbo",
+      derivedTier: "balanced",
+      hasEscalationRecords: false,
+    });
+
+    expect(result.tier).toBe("balanced");
+    expect(result.isEscalated).toBe(false);
+    expect(result.unknownPreviousTier).toBe(true);
+  });
+
+  test("an unrankable persisted tier backed by an escalation record is honoured, not flagged", () => {
+    const result = resolveOperatingTier({
+      previousTier: "turbo",
+      derivedTier: "balanced",
+      hasEscalationRecords: true,
+    });
+
+    expect(result.tier).toBe("turbo");
+    expect(result.isEscalated).toBe(true);
+    expect(result.unknownPreviousTier).toBe(false);
+  });
+
+  test("candidateTier is returned so callers can log what was rejected", () => {
+    const result = resolveOperatingTier({
+      previousTier: "powerful",
+      profileTier: "fast",
+      derivedTier: "balanced",
+      hasEscalationRecords: false,
+    });
+
+    expect(result.candidateTier).toBe("fast");
+    expect(result.tier).toBe("powerful");
+  });
+});


### PR DESCRIPTION
Fixes #1575.

## The bug

`preIterationTierCheck` read `story.routing.modelTier` before the per-iteration routing stage had run for that story, then paired that stale tier with the story's profile agent. Under a cross-agent ladder the resulting rung (`pi@fast`) is absent from `tierOrder`, so the run logged `escalation budget is unbounded for this story` for a rung the story never runs on — 40ms before classification resolved the real tier (`pi@balanced`).

Two corrections to the issue's analysis, both load-bearing:

- **`modelTier` IS persisted**, by `routing.ts:88-106` and `decompose-mapper.ts:76`. The `types.ts` doc comment claiming otherwise is what makes the issue's suggested fix #3 (strip the field) look viable — it would break escalation preservation and the ADR-025 reset path. Fixed the comment instead.
- **`TierConfigSchema.attempts` is `min(1)`**, which makes the whole pre-check a provable no-op at `attempts === 0`. The false warning was the only thing it did on a first attempt.

## The fix

**1. Guard the budget check on `attempts === 0`** (`tier-escalation.ts`). Behaviour-preserving by construction: `0 < tierCfg.attempts` always holds, so the check could never skip, escalate, or dirty the PRD there. `attempts` only becomes non-zero via `markStoryFailed` — i.e. after an iteration ran and routing persisted an authoritative tier — so surviving warnings are genuine config gaps rather than noise.

**2. Make the announcement agree with execution.** The same defect had a reporting half: a profile story was announced at a stale tier under the run's default agent, then executed at its profile tier under its own agent.

- New `resolveOperatingTier` (`src/routing/operating-tier.ts`) is the SSOT for the profile → escalation → persisted precedence. The routing stage's inline copy is replaced by a call to it (behaviour unchanged); `buildPreviewRouting` now applies the identical rule instead of an approximation.
- `buildPreviewRouting` also derives its fallback band from the story's **own** cached complexity — the lookup was hardcoded to the `"medium"` band, so an expert story with no persisted tier previewed as `balanced`.
- `story.start` / `story:started` announce the story's assigned agent (`agentFor`), and the parallel-batch path uses the shared preview instead of a third inline copy of the tier fallback.

**3. Self-review found the same misattribution in metrics.** The parallel-batch builder recorded `modelUsed` as the run default for every completed and rectified-conflict story. These entries feed per-agent cost attribution, so under a cross-agent profile every story was booked to the wrong agent. `post-run.ts:180` already used the correct idiom; these two sites were the outliers.

## Why not the issue's other options

- **Option 1 (run routing before the pre-check)** — routing does LLM classification, `savePRD`, and greenfield disk scans. Hoisting it means paying a classification call for a story the gate may immediately skip, and it inverts the stage-ordering contract.
- **Option 3 (strip the field)** — see above; `modelTier` is persisted on purpose.

## Tests

25 new tests, each confirmed RED before its fix (verified by stashing the source change):

| File | Covers |
|:--|:--|
| `tier-escalation-first-iteration.test.ts` | no warning at `attempts === 0` (cross-agent and plain ladders), PRD untouched, warning **still fires** at `attempts > 0`, budget exhaustion still escalates `pi@balanced → claude@powerful`, plus a schema test pinning the `attempts >= 1` invariant the guard rests on |
| `operating-tier.test.ts` | profile seeds the starting rung; escalation records win outright including sideways/down (#1522); rank comparison without records; unknown persisted tiers |
| `executor-types.test.ts` | preview tier prediction and passthrough |
| `unified-executor-logging.test.ts` | single-story and batch dispatch announce the story's agent and tier; unprofiled stories still fall back to the run default |
| `unified-executor-results.test.ts` | `modelUsed` attribution |

Full suite green: unit 13185 pass / integration 1104 pass, 38 skip / ui 25 pass, **0 fail**. Typecheck, lint, and all 20 pre-commit checks pass with no ratchet growth.

## Notes for the reviewer

- Routing `buildPreviewRouting` through `complexityToModelTier` initially broke 19 existing executor tests whose fixtures build sparse configs without `complexityRouting`, which the old optional-chained code tolerated. The schema makes that field required so it can't happen at runtime; the preview stays tolerant (a display path should degrade to the default band, not throw) and the one fixture needing real bands for its assertions was fixed.
- `unified-executor.ts` is grandfathered at 739 lines against a 600 limit and cannot grow, so `agentFor` lives in `executor-types.ts` — which already owns `SequentialExecutionContext` and `buildPreviewRouting`.