### PR TITLE
fix: split trackedSpawn deadline into startup/teardown, make it configurable

### DIFF
--- a/src/agents/acp/adapter-close-physical.ts
+++ b/src/agents/acp/adapter-close-physical.ts
@@ -1,0 +1,36 @@
+/**
+ * AcpAgentAdapter.closePhysicalSession implementation — split out of adapter.ts
+ * to stay under the file-size ratchet.
+ */
+
+import { getSafeLogger } from "@/logger";
+import { _acpAdapterDeps } from "./adapter-lifecycle";
+
+export async function closePhysicalSession(
+  agentName: string,
+  handle: string,
+  workdir: string,
+  options?: { force?: boolean; signal?: AbortSignal },
+): Promise<void> {
+  const cmdStr = `acpx ${agentName}`;
+  const client = _acpAdapterDeps.createClient(cmdStr, workdir, undefined, undefined);
+  try {
+    await client.start();
+    try {
+      if (client.closeSession) {
+        await client.closeSession(handle, agentName, options?.signal);
+        // AC-83: hard-terminate (acpx stop) when force=true, e.g. for errored sessions
+        if (options?.force) {
+          await (client as { forceStop?: (agentName: string) => Promise<void> }).forceStop?.(agentName).catch(() => {});
+        }
+      } else if (client.loadSession) {
+        const session = await client.loadSession(handle, agentName, "approve-reads");
+        if (session) await session.close({ forceTerminate: options?.force, signal: options?.signal }).catch(() => {});
+      }
+    } catch (err) {
+      getSafeLogger()?.warn("acp-adapter", `[close] Failed to close session ${handle}`, { error: String(err) });
+    }
+  } finally {
+    await client.close().catch(() => {});
+  }
+}

--- a/src/agents/acp/adapter-session-types.ts
+++ b/src/agents/acp/adapter-session-types.ts
@@ -66,6 +66,19 @@ export interface AcpClientOptions {
   storyId?: string;
   /** Pipeline stage threaded into all stream events for log correlation. */
   stage?: PipelineStage;
+  /**
+   * trackedSpawn hard deadline (ms) for teardown ops (sessions close/stop/cancel).
+   * Resolved by the wiring layer from config.agent.acp.trackedSpawnDeadlineMs.
+   * Falls back to the spawn-client module default when omitted (#1583).
+   */
+  trackedSpawnDeadlineMs?: number;
+  /**
+   * trackedSpawn hard deadline (ms) for startup ops (sessions ensure —
+   * createSession/loadSession/applyReasoningEffort). Resolved by the wiring
+   * layer from config.agent.acp.trackedSpawnStartupDeadlineMs. Falls back to
+   * the spawn-client module default when omitted (#1583).
+   */
+  trackedSpawnStartupDeadlineMs?: number;
 }
 
 export interface AcpClient {

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -28,6 +28,7 @@ import type {
   TurnResult,
 } from "../types";
 import { CompleteError, SessionTurnError } from "../types";
+import { closePhysicalSession as closePhysicalSessionImpl } from "./adapter-close-physical";
 import { defaultAcpTokenUsageMapper } from "./token-mapper";
 import type { SessionTokenUsage } from "./wire-types";
 
@@ -140,6 +141,8 @@ export class AcpAgentAdapter implements AgentAdapter {
         {
           onStreamActivity: _options.onStreamActivity,
           onActiveCall: _options.onActiveCall,
+          trackedSpawnDeadlineMs: _options.trackedSpawnDeadlineMs,
+          trackedSpawnStartupDeadlineMs: _options.trackedSpawnStartupDeadlineMs,
         },
       );
       await client.start();
@@ -289,29 +292,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     workdir: string,
     options?: { force?: boolean; signal?: AbortSignal },
   ): Promise<void> {
-    const cmdStr = `acpx ${this.name}`;
-    const client = _acpAdapterDeps.createClient(cmdStr, workdir, undefined, undefined);
-    try {
-      await client.start();
-      try {
-        if (client.closeSession) {
-          await client.closeSession(handle, this.name, options?.signal);
-          // AC-83: hard-terminate (acpx stop) when force=true, e.g. for errored sessions
-          if (options?.force) {
-            await (client as { forceStop?: (agentName: string) => Promise<void> })
-              .forceStop?.(this.name)
-              .catch(() => {});
-          }
-        } else if (client.loadSession) {
-          const session = await client.loadSession(handle, this.name, "approve-reads");
-          if (session) await session.close({ forceTerminate: options?.force, signal: options?.signal }).catch(() => {});
-        }
-      } catch (err) {
-        getSafeLogger()?.warn("acp-adapter", `[close] Failed to close session ${handle}`, { error: String(err) });
-      }
-    } finally {
-      await client.close().catch(() => {});
-    }
+    return closePhysicalSessionImpl(this.name, handle, workdir, options);
   }
 
   async openSession(name: string, opts: OpenSessionOpts): Promise<SessionHandle> {
@@ -343,6 +324,8 @@ export class AcpAgentAdapter implements AgentAdapter {
       {
         onStreamActivity: opts.onStreamActivity,
         onActiveCall: opts.onActiveCall,
+        trackedSpawnDeadlineMs: opts.trackedSpawnDeadlineMs,
+        trackedSpawnStartupDeadlineMs: opts.trackedSpawnStartupDeadlineMs,
       },
     );
     let session: import("./adapter-session-types").AcpSession | undefined;

--- a/src/agents/acp/spawn-client-deps.ts
+++ b/src/agents/acp/spawn-client-deps.ts
@@ -1,0 +1,46 @@
+/**
+ * Injectable spawn/teardown/startup dependencies shared by SpawnAcpClient
+ * (spawn-client.ts) and SpawnAcpSession (spawn-client-session.ts). Split out
+ * to a standalone module so both files can import it without an import cycle
+ * between them.
+ */
+
+import { typedSpawn } from "@/utils/bun-deps";
+
+// Grace period for stream drain after acpx exits — handles Bun bug where
+// piped streams may not close after SIGTERM (e.g. cancelActivePrompt).
+const ACPX_STREAM_DRAIN_TIMEOUT_MS = 5_000;
+
+// ORPHAN-1: SIGTERM->SIGKILL escalation grace period for killProcessTree() (see
+// spawn-client-process.ts). Shorter than executor.ts's since close()/
+// cancelActivePrompt() are already tearing the session down.
+const KILL_TREE_GRACE_MS = 250;
+
+// PERF-1: hard deadline on trackedSpawn's proc.exited await (see
+// spawn-client-process.ts) — bounds the normal-exit teardown path the same way
+// the crash-signal path's outer 10s hard deadline bounds crash-signals.ts.
+// Issue #1583: this bound is for TEARDOWN ops only (sessions close/stop/cancel
+// via SpawnAcpSession.trackedSpawn) — do not reuse for startup ops, see
+// TRACKED_SPAWN_STARTUP_DEADLINE_MS below. Config default lives at
+// config.agent.acp.trackedSpawnDeadlineMs (src/config/schemas-infra.ts).
+const TRACKED_SPAWN_DEADLINE_MS = 10_000;
+
+// Issue #1583: `sessions ensure` (createSession/loadSession/applyReasoningEffort
+// via SpawnAcpClient.trackedSpawn) is a STARTUP op, not teardown — it measured a
+// real-world median of 8.15s. Reusing the 10s teardown deadline left ~1.85s of
+// margin, and under concurrency nax was SIGTERMing healthy-but-slow acpx
+// processes and silently falling back to context-less sessions. Config default
+// lives at config.agent.acp.trackedSpawnStartupDeadlineMs.
+const TRACKED_SPAWN_STARTUP_DEADLINE_MS = 30_000;
+
+export const _spawnClientDeps = {
+  spawn: typedSpawn,
+  /** Stream drain timeout after proc.exited — injectable so tests can use a short value. */
+  streamDrainTimeoutMs: ACPX_STREAM_DRAIN_TIMEOUT_MS,
+  /** SIGTERM->SIGKILL escalation grace period — injectable so tests can use a short value. */
+  killTreeGraceMs: KILL_TREE_GRACE_MS,
+  /** trackedSpawn hard deadline for teardown ops — injectable so tests can use a short value. */
+  trackedSpawnDeadlineMs: TRACKED_SPAWN_DEADLINE_MS,
+  /** trackedSpawn hard deadline for startup ops (#1583) — injectable so tests can use a short value. */
+  trackedSpawnStartupDeadlineMs: TRACKED_SPAWN_STARTUP_DEADLINE_MS,
+};

--- a/src/agents/acp/spawn-client-session.ts
+++ b/src/agents/acp/spawn-client-session.ts
@@ -1,0 +1,416 @@
+/**
+ * SpawnAcpSession — live acpx session backed by SpawnAcpClient.createSession /
+ * loadSession. Split out of spawn-client.ts to stay under the file-size ratchet.
+ * Each prompt() call spawns: acpx --cwd ... <agent> prompt -s <name> --file -
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  type AcpLineActivity,
+  type AcpSession,
+  type AcpSessionResponse,
+  createParseState,
+  finalizeParseState,
+} from "@/agents";
+import { getSafeLogger } from "@/logger";
+import type { AgentStreamEvent } from "@/runtime";
+import { _spawnClientDeps } from "./spawn-client-deps";
+import { killProcessTree, runTrackedSpawn } from "./spawn-client-process";
+import { readAndParseLines, readStreamTail } from "./stdout-line-reader";
+
+export class SpawnAcpSession implements AcpSession {
+  private readonly agentName: string;
+  private readonly sessionName: string;
+  private readonly cwd: string;
+  private readonly model: string;
+  /** Original profile model string, including any [effort] suffix. Display only. */
+  private readonly modelLabel: string;
+  private readonly timeoutSeconds: number;
+  private readonly promptRetries: number;
+  private readonly permissionMode: string;
+  private readonly env: Record<string, string | undefined>;
+  private readonly onPidSpawned?: (pid: number) => void;
+  private readonly onPidExited?: (pid: number) => void;
+  private readonly onStreamActivity?: (event: AgentStreamEvent) => void;
+  private readonly onActiveCall?: (callId: string, cancel: () => Promise<void>) => void;
+  private readonly runId: string;
+  private readonly storyId?: string;
+  private readonly stage?: import("../../config/permissions").PipelineStage;
+  /** Resolved teardown deadline (ms) — config.agent.acp.trackedSpawnDeadlineMs, falling back to the module default (#1583). */
+  private readonly trackedSpawnDeadlineMs: number;
+  private activeProc: { pid: number; kill(signal?: number): void; exited?: Promise<number> } | null = null;
+  /**
+   * Transport fact: `cancelActivePrompt()` was invoked during the in-flight
+   * prompt(). The resulting AcpSessionResponse is stamped with `cancelled: true`
+   * so the wiring layer (above the adapter) can classify the failure.
+   * Cleared at the start of each prompt() invocation.
+   */
+  private _externallyCancelled = false;
+  /** Volatile Claude Code session ID (acpxSessionId) — updated on reconnect. */
+  readonly id?: string;
+  /** Stable record ID (acpxRecordId) — assigned at creation, never changes. */
+  readonly recordId?: string;
+
+  constructor(opts: {
+    agentName: string;
+    sessionName: string;
+    cwd: string;
+    model: string;
+    modelLabel?: string;
+    timeoutSeconds: number;
+    promptRetries: number;
+    permissionMode: string;
+    env: Record<string, string | undefined>;
+    onPidSpawned?: (pid: number) => void;
+    onPidExited?: (pid: number) => void;
+    id?: string;
+    recordId?: string;
+    onStreamActivity?: (event: AgentStreamEvent) => void;
+    onActiveCall?: (callId: string, cancel: () => Promise<void>) => void;
+    runId?: string;
+    storyId?: string;
+    stage?: import("../../config/permissions").PipelineStage;
+    trackedSpawnDeadlineMs?: number;
+  }) {
+    this.agentName = opts.agentName;
+    this.sessionName = opts.sessionName;
+    this.cwd = opts.cwd;
+    this.model = opts.model;
+    this.modelLabel = opts.modelLabel ?? opts.model;
+    this.timeoutSeconds = opts.timeoutSeconds;
+    this.promptRetries = opts.promptRetries;
+    this.permissionMode = opts.permissionMode;
+    this.env = opts.env;
+    this.onPidSpawned = opts.onPidSpawned;
+    this.onPidExited = opts.onPidExited;
+    this.onStreamActivity = opts.onStreamActivity;
+    this.onActiveCall = opts.onActiveCall;
+    this.runId = opts.runId ?? "";
+    this.storyId = opts.storyId;
+    this.stage = opts.stage;
+    this.id = opts.id;
+    this.recordId = opts.recordId;
+    this.trackedSpawnDeadlineMs = opts.trackedSpawnDeadlineMs ?? _spawnClientDeps.trackedSpawnDeadlineMs;
+  }
+
+  async prompt(text: string): Promise<AcpSessionResponse> {
+    const callId = randomUUID();
+    const emit = this.onStreamActivity;
+    const now = () => Date.now();
+    // Each prompt() starts with a fresh cancellation state — a stale flag from
+    // a prior cancelled prompt must not leak into the next call.
+    this._externallyCancelled = false;
+    const baseEvent = {
+      callId,
+      runId: this.runId,
+      agentName: this.agentName,
+      sessionName: this.sessionName,
+      storyId: this.storyId,
+      stage: this.stage,
+    } as const;
+
+    const cmd = [
+      "acpx",
+      "--cwd",
+      this.cwd,
+      "--format",
+      "json",
+      ...(this.permissionMode === "approve-all" ? ["--approve-all"] : []),
+      "--model",
+      this.model,
+      "--timeout",
+      String(this.timeoutSeconds),
+      ...(this.promptRetries > 0 ? ["--prompt-retries", String(this.promptRetries)] : []),
+      this.agentName,
+      "prompt",
+      "-s",
+      this.sessionName,
+      "--file",
+      "-",
+    ];
+
+    getSafeLogger()?.info("acp-adapter", "Sending prompt", {
+      session: this.sessionName,
+      permission: this.permissionMode,
+      cmd: cmd.join(" "),
+    });
+    getSafeLogger()?.debug("acp-adapter", `Sending prompt to session: ${this.sessionName}`);
+
+    let proc: ReturnType<typeof _spawnClientDeps.spawn>;
+    try {
+      proc = _spawnClientDeps.spawn(cmd, {
+        cwd: this.cwd,
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: this.env,
+        // ORPHAN-1: real process-group leader — close()/cancelActivePrompt() can
+        // killProcessTree() the whole group instead of leaking descendants.
+        detached: true,
+      });
+    } catch (spawnErr) {
+      // Spawn threw before a PID was obtained — AC9: emit call_ended without a prior call_started
+      emit?.({ ...baseEvent, kind: "agent.call_ended", status: "error", timestamp: now() });
+      throw spawnErr;
+    }
+
+    this.activeProc = proc;
+    const processPid = proc.pid;
+    this.onPidSpawned?.(processPid);
+
+    // Register the watchdog cancel function only after spawn succeeds and we have a live PID.
+    // Registering before spawn would leave a stale registry entry if spawn throws (#2).
+    this.onActiveCall?.(callId, () => this.cancelActivePrompt());
+
+    // AC5/AC6: Emit call_started after spawn succeeds (PID obtained), before process_update
+    emit?.({
+      ...baseEvent,
+      kind: "agent.call_started",
+      model: this.modelLabel,
+      timeoutSeconds: this.timeoutSeconds,
+      timestamp: now(),
+    });
+
+    // AC6: Emit process_update(spawned) AFTER PID registration
+    emit?.({
+      ...baseEvent,
+      kind: "agent.process_update",
+      status: "spawned",
+      pid: processPid,
+      timestamp: now(),
+    });
+
+    let exitNotified = false;
+    const notifyExit = (): void => {
+      if (exitNotified) return;
+      exitNotified = true;
+      try {
+        this.onPidExited?.(processPid);
+      } catch {
+        // unregister is best-effort — never let it surface from prompt()
+      }
+    };
+
+    // AC8: Guard to ensure call_ended is emitted exactly once across all terminal paths
+    let callEndedEmitted = false;
+
+    try {
+      try {
+        proc.stdin?.write(text);
+        proc.stdin?.end();
+      } catch {
+        // acpx exited before nax could write the prompt (EPIPE / broken pipe).
+        // This is expected when the subprocess crashes on startup.
+        // Do not rethrow — let proc.exited report the real exit code and stderr.
+        getSafeLogger()?.warn("acp-adapter", "Failed to write prompt to acpx stdin (subprocess exited early)", {
+          session: this.sessionName,
+        });
+      }
+
+      // Line-reader: parse stdout incrementally as lines arrive instead of buffering
+      // the full NDJSON output. Only extracted fields (strings + numbers) are held in
+      // memory — raw bytes are discarded immediately after each line is processed.
+      // .catch(() => {}) guards against stream errors (e.g. acpx crash mid-run).
+      // AC7: Emit activity events during stdout reading.
+      const parseState = createParseState();
+      const onActivity = emit
+        ? (activity: AcpLineActivity) => {
+            if (activity.kind === "message_update") {
+              emit({ ...baseEvent, kind: "agent.message_update", deltaBytes: activity.deltaBytes, timestamp: now() });
+            } else if (activity.kind === "thinking_update") {
+              emit({ ...baseEvent, kind: "agent.thinking_update", deltaBytes: activity.deltaBytes, timestamp: now() });
+            } else if (activity.kind === "usage_update") {
+              emit({
+                ...baseEvent,
+                kind: "agent.usage_update",
+                inputTokens: activity.inputTokens,
+                outputTokens: activity.outputTokens,
+                costUsd: activity.costUsd,
+                timestamp: now(),
+              });
+            } else if (activity.kind === "tool_call_update") {
+              emit({
+                ...baseEvent,
+                kind: "agent.tool_call_update",
+                toolName: activity.toolName,
+                timestamp: now(),
+              });
+            }
+          }
+        : undefined;
+      const parseHandle = readAndParseLines(proc.stdout, parseState, onActivity);
+      const parsePromise = parseHandle.promise.catch(() => {});
+      // MEM-1: cap stderr to a 64KB rolling tail instead of buffering the full stream.
+      const stderrPromise = readStreamTail(proc.stderr).catch(() => "");
+
+      const exitCode = await proc.exited;
+
+      // Bun bug: piped streams may not close after kill (e.g. cancelActivePrompt SIGTERM).
+      // Race each stream against its own cancellable drain timer so prompt() always resolves
+      // instead of hanging. Timers are cancelled as soon as the stream resolves to avoid
+      // keeping uncancellable timers alive across multi-turn sessions.
+      const makeDrain = (ms: number): { promise: Promise<string>; cancel: () => void } => {
+        let id: ReturnType<typeof setTimeout> | undefined;
+        const promise = new Promise<string>((resolve) => {
+          id = setTimeout(() => resolve(""), ms);
+        });
+        // Promise executor runs synchronously — id is set before return.
+        return { promise, cancel: () => clearTimeout(id) };
+      };
+      const drainA = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
+      const drainB = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
+      const stdoutRaceResult = Promise.race([
+        parsePromise.then(() => "parsed" as const),
+        drainA.promise.then(() => "drain" as const),
+      ]).finally(() => drainA.cancel());
+      const [stdoutWinner, stderr] = await Promise.all([
+        stdoutRaceResult,
+        Promise.race([stderrPromise, drainB.promise]).finally(() => drainB.cancel()),
+      ]);
+      // Drain timeout won the race: cancel the stdout reader so its pending read()
+      // settles and the reader/lock isn't held for the rest of the process (BUG-46).
+      if (stdoutWinner === "drain") parseHandle.cancel();
+
+      // Emit process_update(exited) after exit code is known
+      emit?.({ ...baseEvent, kind: "agent.process_update", status: "exited", exitCode, timestamp: now() });
+
+      if (exitCode !== 0) {
+        // Prefer parsed stdout error (JSON-RPC error response from acpx) over raw stderr.
+        // stderr at this point is typically the acpx session banner ("agent needs reconnect")
+        // which describes connection state, not the actual failure reason.
+        const parsedOnError = finalizeParseState(parseState);
+        // Prefer the parsed JSON-RPC error from stdout over raw stderr.
+        // Do NOT fall back to parsedOnError.text — it may be partial streaming content
+        // accumulated before the crash and would mislead error classification callers.
+        const errorContent = parsedOnError.error || stderr || `Exit code ${exitCode}`;
+        getSafeLogger()?.warn("acp-adapter", `Session prompt exited with code ${exitCode}`, {
+          exitCode,
+          error: errorContent.slice(0, 500),
+          ...(stderr && stderr !== errorContent ? { banner: stderr.trim().slice(0, 200) } : {}),
+        });
+        // AC8: Emit call_ended on non-zero exit path
+        callEndedEmitted = true;
+        emit?.({ ...baseEvent, kind: "agent.call_ended", status: "error", exitCode, timestamp: now() });
+        const errResponse: AcpSessionResponse = {
+          messages: [{ role: "assistant", content: errorContent }],
+          stopReason: "error",
+          retryable: parsedOnError.retryable,
+          exitCode,
+        };
+        if (this._externallyCancelled) errResponse.cancelled = true;
+        return errResponse;
+      }
+
+      try {
+        const parsed = finalizeParseState(parseState);
+        // AC8/BUG-2: an exit-0 turn that was externally cancelled (agent exited
+        // cleanly on cancelActivePrompt()'s SIGTERM) is not a clean success.
+        callEndedEmitted = true;
+        const cancelled = this._externallyCancelled;
+        emit?.({ ...baseEvent, kind: "agent.call_ended", status: cancelled ? "error" : "success", timestamp: now() });
+        // BUG-1: carry parsed.error/retryable through even on the success path —
+        // finalizeParseState can capture a JSON-RPC error envelope on an exit-0 turn.
+        const successResponse: AcpSessionResponse = {
+          messages: [{ role: "assistant", content: parsed.text || "" }],
+          stopReason: cancelled ? "error" : (parsed.stopReason ?? "end_turn"),
+          cumulative_token_usage: parsed.tokenUsage,
+          exactCostUsd: parsed.exactCostUsd,
+          error: parsed.error,
+          retryable: parsed.retryable,
+        };
+        if (cancelled) successResponse.cancelled = true;
+        return successResponse;
+      } catch (err) {
+        getSafeLogger()?.warn("acp-adapter", "Failed to parse session prompt response", {
+          stderr: stderr.slice(0, 200),
+        });
+        throw err;
+      }
+    } catch (err) {
+      // AC8: Emit call_ended exactly once for all thrown paths (stream errors, parse failure, etc.)
+      if (!callEndedEmitted) {
+        callEndedEmitted = true;
+        emit?.({ ...baseEvent, kind: "agent.call_ended", status: "error", timestamp: now() });
+      }
+      throw err;
+    } finally {
+      this.activeProc = null;
+      notifyExit();
+    }
+  }
+
+  /**
+   * Spawn an acpx command. Drains stdout/stderr concurrently to avoid pipe-buffer
+   * deadlock. PERF-1: bounded by a hard deadline — see runTrackedSpawn's doc comment.
+   */
+  private async trackedSpawn(
+    cmd: string[],
+    opts?: Parameters<typeof _spawnClientDeps.spawn>[1],
+    signal?: AbortSignal,
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    // Issue #1583: teardown ops (close/cancel) use the resolved teardown
+    // deadline, never the startup deadline — see trackedSpawnDeadlineMs field.
+    return runTrackedSpawn(
+      { ..._spawnClientDeps, trackedSpawnDeadlineMs: this.trackedSpawnDeadlineMs },
+      cmd,
+      opts,
+      this.onPidSpawned,
+      this.onPidExited,
+      signal,
+    );
+  }
+
+  /** ORPHAN-1: terminate the in-flight prompt's process tree — see killProcessTree's doc comment. */
+  private killActiveProcTree(): void {
+    if (!this.activeProc) return;
+    // BUG-6: pass `exited` so killProcessTree skips SIGKILL if already exited.
+    killProcessTree(this.activeProc.pid, _spawnClientDeps.killTreeGraceMs, this.activeProc.exited);
+  }
+
+  async close(options?: { forceTerminate?: boolean; signal?: AbortSignal }): Promise<void> {
+    // Kill in-flight prompt process tree first (if any)
+    if (this.activeProc) {
+      this.killActiveProcTree();
+      this.activeProc = null;
+    }
+
+    const cmd = ["acpx", "--cwd", this.cwd, this.agentName, "sessions", "close", this.sessionName];
+    getSafeLogger()?.debug("acp-adapter", `Closing session: ${this.sessionName}`);
+
+    const { exitCode, stderr } = await this.trackedSpawn(cmd, undefined, options?.signal);
+
+    if (exitCode !== 0) {
+      getSafeLogger()?.warn("acp-adapter", "Failed to close session", {
+        sessionName: this.sessionName,
+        stderr: stderr.slice(0, 200),
+      });
+    }
+
+    if (options?.forceTerminate) {
+      try {
+        await this.trackedSpawn(["acpx", this.agentName, "stop"], undefined, options?.signal);
+      } catch (err) {
+        getSafeLogger()?.debug("acp-adapter", "acpx stop failed (swallowed)", { cause: String(err) });
+      }
+    }
+  }
+
+  async cancelActivePrompt(): Promise<void> {
+    // Mark the in-flight prompt as externally cancelled so the resulting
+    // AcpSessionResponse is stamped with `cancelled: true`. The wiring layer
+    // above the adapter classifies _why_ (e.g. fail-stale when the watchdog
+    // triggered the cancel).
+    this._externallyCancelled = true;
+
+    // Kill in-flight prompt process tree directly (faster than acpx cancel)
+    if (this.activeProc) {
+      this.killActiveProcTree();
+      this.activeProc = null; // LOW: null out after kill, matching close()
+    }
+
+    const cmd = ["acpx", this.agentName, "cancel"];
+    getSafeLogger()?.debug("acp-adapter", `Cancelling active prompt: ${this.sessionName}`);
+
+    await this.trackedSpawn(cmd);
+  }
+}

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -1,15 +1,12 @@
 /**
  * Spawn-based ACP Client — default production implementation.
  *
- * Implements AcpClient/AcpSession interfaces by shelling out to acpx CLI.
- * This is the real transport; createClient injectable defaults to this.
- * Tests override createClient with mock implementations.
- *
- * CLI commands used:
- *   acpx <agent> sessions ensure --name <name>      → ensureSession
- *   acpx --cwd <dir> ... <agent> prompt -s <name>   → session.prompt()
- *   acpx <agent> sessions close <name>              → session.close()
- *   acpx <agent> cancel                             → session.cancelActivePrompt()
+ * Implements AcpClient by shelling out to acpx CLI (`sessions ensure` /
+ * `sessions close`). This is the real transport; createClient injectable
+ * defaults to this. Tests override createClient with mock implementations.
+ * The AcpSession side (`prompt` / `close` / `cancelActivePrompt`, i.e. `acpx
+ * ... prompt -s <name>` / `sessions close <name>` / `cancel`) is implemented
+ * by SpawnAcpSession in ./spawn-client-session.
  */
 
 import type { AcpClient, AcpClientOptions, AcpSession } from "@/agents";

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -12,461 +12,19 @@
  *   acpx <agent> cancel                             → session.cancelActivePrompt()
  */
 
-import { randomUUID } from "node:crypto";
-import {
-  type AcpClient,
-  type AcpClientOptions,
-  type AcpLineActivity,
-  type AcpSession,
-  type AcpSessionResponse,
-  createParseState,
-  finalizeParseState,
-} from "@/agents";
+import type { AcpClient, AcpClientOptions, AcpSession } from "@/agents";
 import { getSafeLogger } from "@/logger";
 import type { AgentStreamEvent } from "@/runtime";
-import { typedSpawn } from "@/utils/bun-deps";
 import { buildAllowedEnv } from "../shared/env";
 import { parseModelSpec } from "./model-spec";
 import { applyReasoningEffort } from "./reasoning-effort";
 import { parseSessionIds } from "./session-ids";
-import { killProcessTree, runTrackedSpawn } from "./spawn-client-process";
-import { readAndParseLines, readStreamTail } from "./stdout-line-reader";
+import { _spawnClientDeps } from "./spawn-client-deps";
+import { runTrackedSpawn } from "./spawn-client-process";
+import { SpawnAcpSession } from "./spawn-client-session";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Constants
-// ─────────────────────────────────────────────────────────────────────────────
-
-// Grace period for stream drain after acpx exits — handles Bun bug where
-// piped streams may not close after SIGTERM (e.g. cancelActivePrompt).
-const ACPX_STREAM_DRAIN_TIMEOUT_MS = 5_000;
-
-// ORPHAN-1: SIGTERM->SIGKILL escalation grace period for killProcessTree() (see
-// spawn-client-process.ts). Shorter than executor.ts's since close()/
-// cancelActivePrompt() are already tearing the session down.
-const KILL_TREE_GRACE_MS = 250;
-
-// PERF-1: hard deadline on trackedSpawn's proc.exited await (see
-// spawn-client-process.ts) — bounds the normal-exit teardown path the same way
-// the crash-signal path's outer 10s hard deadline bounds crash-signals.ts.
-const TRACKED_SPAWN_DEADLINE_MS = 10_000;
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Spawn helper (injectable for future testing if needed)
-// ─────────────────────────────────────────────────────────────────────────────
-
-export const _spawnClientDeps = {
-  spawn: typedSpawn,
-  /** Stream drain timeout after proc.exited — injectable so tests can use a short value. */
-  streamDrainTimeoutMs: ACPX_STREAM_DRAIN_TIMEOUT_MS,
-  /** SIGTERM->SIGKILL escalation grace period — injectable so tests can use a short value. */
-  killTreeGraceMs: KILL_TREE_GRACE_MS,
-  /** trackedSpawn hard deadline — injectable so tests can use a short value. */
-  trackedSpawnDeadlineMs: TRACKED_SPAWN_DEADLINE_MS,
-};
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Line-reader helper
-// ─────────────────────────────────────────────────────────────────────────────
-
-// readAndParseLines lives in ./stdout-line-reader (split out to stay under the file-size limit).
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Env builder
-// ─────────────────────────────────────────────────────────────────────────────
-
-// buildAllowedEnv imported from ../shared/env — single canonical implementation
-
-// ─────────────────────────────────────────────────────────────────────────────
-// SpawnAcpSession
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * An ACP session backed by acpx CLI spawn.
- * Each prompt() call spawns: acpx --cwd ... <agent> prompt -s <name> --file -
- */
-export class SpawnAcpSession implements AcpSession {
-  private readonly agentName: string;
-  private readonly sessionName: string;
-  private readonly cwd: string;
-  private readonly model: string;
-  /** Original profile model string, including any [effort] suffix. Display only. */
-  private readonly modelLabel: string;
-  private readonly timeoutSeconds: number;
-  private readonly promptRetries: number;
-  private readonly permissionMode: string;
-  private readonly env: Record<string, string | undefined>;
-  private readonly onPidSpawned?: (pid: number) => void;
-  private readonly onPidExited?: (pid: number) => void;
-  private readonly onStreamActivity?: (event: AgentStreamEvent) => void;
-  private readonly onActiveCall?: (callId: string, cancel: () => Promise<void>) => void;
-  private readonly runId: string;
-  private readonly storyId?: string;
-  private readonly stage?: import("../../config/permissions").PipelineStage;
-  private activeProc: { pid: number; kill(signal?: number): void; exited?: Promise<number> } | null = null;
-  /**
-   * Transport fact: `cancelActivePrompt()` was invoked during the in-flight
-   * prompt(). The resulting AcpSessionResponse is stamped with `cancelled: true`
-   * so the wiring layer (above the adapter) can classify the failure.
-   * Cleared at the start of each prompt() invocation.
-   */
-  private _externallyCancelled = false;
-  /** Volatile Claude Code session ID (acpxSessionId) — updated on reconnect. */
-  readonly id?: string;
-  /** Stable record ID (acpxRecordId) — assigned at creation, never changes. */
-  readonly recordId?: string;
-
-  constructor(opts: {
-    agentName: string;
-    sessionName: string;
-    cwd: string;
-    model: string;
-    modelLabel?: string;
-    timeoutSeconds: number;
-    promptRetries: number;
-    permissionMode: string;
-    env: Record<string, string | undefined>;
-    onPidSpawned?: (pid: number) => void;
-    onPidExited?: (pid: number) => void;
-    id?: string;
-    recordId?: string;
-    onStreamActivity?: (event: AgentStreamEvent) => void;
-    onActiveCall?: (callId: string, cancel: () => Promise<void>) => void;
-    runId?: string;
-    storyId?: string;
-    stage?: import("../../config/permissions").PipelineStage;
-  }) {
-    this.agentName = opts.agentName;
-    this.sessionName = opts.sessionName;
-    this.cwd = opts.cwd;
-    this.model = opts.model;
-    this.modelLabel = opts.modelLabel ?? opts.model;
-    this.timeoutSeconds = opts.timeoutSeconds;
-    this.promptRetries = opts.promptRetries;
-    this.permissionMode = opts.permissionMode;
-    this.env = opts.env;
-    this.onPidSpawned = opts.onPidSpawned;
-    this.onPidExited = opts.onPidExited;
-    this.onStreamActivity = opts.onStreamActivity;
-    this.onActiveCall = opts.onActiveCall;
-    this.runId = opts.runId ?? "";
-    this.storyId = opts.storyId;
-    this.stage = opts.stage;
-    this.id = opts.id;
-    this.recordId = opts.recordId;
-  }
-
-  async prompt(text: string): Promise<AcpSessionResponse> {
-    const callId = randomUUID();
-    const emit = this.onStreamActivity;
-    const now = () => Date.now();
-    // Each prompt() starts with a fresh cancellation state — a stale flag from
-    // a prior cancelled prompt must not leak into the next call.
-    this._externallyCancelled = false;
-    const baseEvent = {
-      callId,
-      runId: this.runId,
-      agentName: this.agentName,
-      sessionName: this.sessionName,
-      storyId: this.storyId,
-      stage: this.stage,
-    } as const;
-
-    const cmd = [
-      "acpx",
-      "--cwd",
-      this.cwd,
-      "--format",
-      "json",
-      ...(this.permissionMode === "approve-all" ? ["--approve-all"] : []),
-      "--model",
-      this.model,
-      "--timeout",
-      String(this.timeoutSeconds),
-      ...(this.promptRetries > 0 ? ["--prompt-retries", String(this.promptRetries)] : []),
-      this.agentName,
-      "prompt",
-      "-s",
-      this.sessionName,
-      "--file",
-      "-",
-    ];
-
-    getSafeLogger()?.info("acp-adapter", "Sending prompt", {
-      session: this.sessionName,
-      permission: this.permissionMode,
-      cmd: cmd.join(" "),
-    });
-    getSafeLogger()?.debug("acp-adapter", `Sending prompt to session: ${this.sessionName}`);
-
-    let proc: ReturnType<typeof _spawnClientDeps.spawn>;
-    try {
-      proc = _spawnClientDeps.spawn(cmd, {
-        cwd: this.cwd,
-        stdin: "pipe",
-        stdout: "pipe",
-        stderr: "pipe",
-        env: this.env,
-        // ORPHAN-1: real process-group leader — close()/cancelActivePrompt() can
-        // killProcessTree() the whole group instead of leaking descendants.
-        detached: true,
-      });
-    } catch (spawnErr) {
-      // Spawn threw before a PID was obtained — AC9: emit call_ended without a prior call_started
-      emit?.({ ...baseEvent, kind: "agent.call_ended", status: "error", timestamp: now() });
-      throw spawnErr;
-    }
-
-    this.activeProc = proc;
-    const processPid = proc.pid;
-    this.onPidSpawned?.(processPid);
-
-    // Register the watchdog cancel function only after spawn succeeds and we have a live PID.
-    // Registering before spawn would leave a stale registry entry if spawn throws (#2).
-    this.onActiveCall?.(callId, () => this.cancelActivePrompt());
-
-    // AC5/AC6: Emit call_started after spawn succeeds (PID obtained), before process_update
-    emit?.({
-      ...baseEvent,
-      kind: "agent.call_started",
-      model: this.modelLabel,
-      timeoutSeconds: this.timeoutSeconds,
-      timestamp: now(),
-    });
-
-    // AC6: Emit process_update(spawned) AFTER PID registration
-    emit?.({
-      ...baseEvent,
-      kind: "agent.process_update",
-      status: "spawned",
-      pid: processPid,
-      timestamp: now(),
-    });
-
-    let exitNotified = false;
-    const notifyExit = (): void => {
-      if (exitNotified) return;
-      exitNotified = true;
-      try {
-        this.onPidExited?.(processPid);
-      } catch {
-        // unregister is best-effort — never let it surface from prompt()
-      }
-    };
-
-    // AC8: Guard to ensure call_ended is emitted exactly once across all terminal paths
-    let callEndedEmitted = false;
-
-    try {
-      try {
-        proc.stdin?.write(text);
-        proc.stdin?.end();
-      } catch {
-        // acpx exited before nax could write the prompt (EPIPE / broken pipe).
-        // This is expected when the subprocess crashes on startup.
-        // Do not rethrow — let proc.exited report the real exit code and stderr.
-        getSafeLogger()?.warn("acp-adapter", "Failed to write prompt to acpx stdin (subprocess exited early)", {
-          session: this.sessionName,
-        });
-      }
-
-      // Line-reader: parse stdout incrementally as lines arrive instead of buffering
-      // the full NDJSON output. Only extracted fields (strings + numbers) are held in
-      // memory — raw bytes are discarded immediately after each line is processed.
-      // .catch(() => {}) guards against stream errors (e.g. acpx crash mid-run).
-      // AC7: Emit activity events during stdout reading.
-      const parseState = createParseState();
-      const onActivity = emit
-        ? (activity: AcpLineActivity) => {
-            if (activity.kind === "message_update") {
-              emit({ ...baseEvent, kind: "agent.message_update", deltaBytes: activity.deltaBytes, timestamp: now() });
-            } else if (activity.kind === "thinking_update") {
-              emit({ ...baseEvent, kind: "agent.thinking_update", deltaBytes: activity.deltaBytes, timestamp: now() });
-            } else if (activity.kind === "usage_update") {
-              emit({
-                ...baseEvent,
-                kind: "agent.usage_update",
-                inputTokens: activity.inputTokens,
-                outputTokens: activity.outputTokens,
-                costUsd: activity.costUsd,
-                timestamp: now(),
-              });
-            } else if (activity.kind === "tool_call_update") {
-              emit({
-                ...baseEvent,
-                kind: "agent.tool_call_update",
-                toolName: activity.toolName,
-                timestamp: now(),
-              });
-            }
-          }
-        : undefined;
-      const parseHandle = readAndParseLines(proc.stdout, parseState, onActivity);
-      const parsePromise = parseHandle.promise.catch(() => {});
-      // MEM-1: cap stderr to a 64KB rolling tail instead of buffering the full stream.
-      const stderrPromise = readStreamTail(proc.stderr).catch(() => "");
-
-      const exitCode = await proc.exited;
-
-      // Bun bug: piped streams may not close after kill (e.g. cancelActivePrompt SIGTERM).
-      // Race each stream against its own cancellable drain timer so prompt() always resolves
-      // instead of hanging. Timers are cancelled as soon as the stream resolves to avoid
-      // keeping uncancellable timers alive across multi-turn sessions.
-      const makeDrain = (ms: number): { promise: Promise<string>; cancel: () => void } => {
-        let id: ReturnType<typeof setTimeout> | undefined;
-        const promise = new Promise<string>((resolve) => {
-          id = setTimeout(() => resolve(""), ms);
-        });
-        // Promise executor runs synchronously — id is set before return.
-        return { promise, cancel: () => clearTimeout(id) };
-      };
-      const drainA = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
-      const drainB = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
-      const stdoutRaceResult = Promise.race([
-        parsePromise.then(() => "parsed" as const),
-        drainA.promise.then(() => "drain" as const),
-      ]).finally(() => drainA.cancel());
-      const [stdoutWinner, stderr] = await Promise.all([
-        stdoutRaceResult,
-        Promise.race([stderrPromise, drainB.promise]).finally(() => drainB.cancel()),
-      ]);
-      // Drain timeout won the race: cancel the stdout reader so its pending read()
-      // settles and the reader/lock isn't held for the rest of the process (BUG-46).
-      if (stdoutWinner === "drain") parseHandle.cancel();
-
-      // Emit process_update(exited) after exit code is known
-      emit?.({ ...baseEvent, kind: "agent.process_update", status: "exited", exitCode, timestamp: now() });
-
-      if (exitCode !== 0) {
-        // Prefer parsed stdout error (JSON-RPC error response from acpx) over raw stderr.
-        // stderr at this point is typically the acpx session banner ("agent needs reconnect")
-        // which describes connection state, not the actual failure reason.
-        const parsedOnError = finalizeParseState(parseState);
-        // Prefer the parsed JSON-RPC error from stdout over raw stderr.
-        // Do NOT fall back to parsedOnError.text — it may be partial streaming content
-        // accumulated before the crash and would mislead error classification callers.
-        const errorContent = parsedOnError.error || stderr || `Exit code ${exitCode}`;
-        getSafeLogger()?.warn("acp-adapter", `Session prompt exited with code ${exitCode}`, {
-          exitCode,
-          error: errorContent.slice(0, 500),
-          ...(stderr && stderr !== errorContent ? { banner: stderr.trim().slice(0, 200) } : {}),
-        });
-        // AC8: Emit call_ended on non-zero exit path
-        callEndedEmitted = true;
-        emit?.({ ...baseEvent, kind: "agent.call_ended", status: "error", exitCode, timestamp: now() });
-        const errResponse: AcpSessionResponse = {
-          messages: [{ role: "assistant", content: errorContent }],
-          stopReason: "error",
-          retryable: parsedOnError.retryable,
-          exitCode,
-        };
-        if (this._externallyCancelled) errResponse.cancelled = true;
-        return errResponse;
-      }
-
-      try {
-        const parsed = finalizeParseState(parseState);
-        // AC8/BUG-2: an exit-0 turn that was externally cancelled (agent exited
-        // cleanly on cancelActivePrompt()'s SIGTERM) is not a clean success.
-        callEndedEmitted = true;
-        const cancelled = this._externallyCancelled;
-        emit?.({ ...baseEvent, kind: "agent.call_ended", status: cancelled ? "error" : "success", timestamp: now() });
-        // BUG-1: carry parsed.error/retryable through even on the success path —
-        // finalizeParseState can capture a JSON-RPC error envelope on an exit-0 turn.
-        const successResponse: AcpSessionResponse = {
-          messages: [{ role: "assistant", content: parsed.text || "" }],
-          stopReason: cancelled ? "error" : (parsed.stopReason ?? "end_turn"),
-          cumulative_token_usage: parsed.tokenUsage,
-          exactCostUsd: parsed.exactCostUsd,
-          error: parsed.error,
-          retryable: parsed.retryable,
-        };
-        if (cancelled) successResponse.cancelled = true;
-        return successResponse;
-      } catch (err) {
-        getSafeLogger()?.warn("acp-adapter", "Failed to parse session prompt response", {
-          stderr: stderr.slice(0, 200),
-        });
-        throw err;
-      }
-    } catch (err) {
-      // AC8: Emit call_ended exactly once for all thrown paths (stream errors, parse failure, etc.)
-      if (!callEndedEmitted) {
-        callEndedEmitted = true;
-        emit?.({ ...baseEvent, kind: "agent.call_ended", status: "error", timestamp: now() });
-      }
-      throw err;
-    } finally {
-      this.activeProc = null;
-      notifyExit();
-    }
-  }
-
-  /**
-   * Spawn an acpx command. Drains stdout/stderr concurrently to avoid pipe-buffer
-   * deadlock. PERF-1: bounded by a hard deadline — see runTrackedSpawn's doc comment.
-   */
-  private async trackedSpawn(
-    cmd: string[],
-    opts?: Parameters<typeof _spawnClientDeps.spawn>[1],
-    signal?: AbortSignal,
-  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-    return runTrackedSpawn(_spawnClientDeps, cmd, opts, this.onPidSpawned, this.onPidExited, signal);
-  }
-
-  /** ORPHAN-1: terminate the in-flight prompt's process tree — see killProcessTree's doc comment. */
-  private killActiveProcTree(): void {
-    if (!this.activeProc) return;
-    // BUG-6: pass `exited` so killProcessTree skips SIGKILL if already exited.
-    killProcessTree(this.activeProc.pid, _spawnClientDeps.killTreeGraceMs, this.activeProc.exited);
-  }
-
-  async close(options?: { forceTerminate?: boolean; signal?: AbortSignal }): Promise<void> {
-    // Kill in-flight prompt process tree first (if any)
-    if (this.activeProc) {
-      this.killActiveProcTree();
-      this.activeProc = null;
-    }
-
-    const cmd = ["acpx", "--cwd", this.cwd, this.agentName, "sessions", "close", this.sessionName];
-    getSafeLogger()?.debug("acp-adapter", `Closing session: ${this.sessionName}`);
-
-    const { exitCode, stderr } = await this.trackedSpawn(cmd, undefined, options?.signal);
-
-    if (exitCode !== 0) {
-      getSafeLogger()?.warn("acp-adapter", "Failed to close session", {
-        sessionName: this.sessionName,
-        stderr: stderr.slice(0, 200),
-      });
-    }
-
-    if (options?.forceTerminate) {
-      try {
-        await this.trackedSpawn(["acpx", this.agentName, "stop"], undefined, options?.signal);
-      } catch (err) {
-        getSafeLogger()?.debug("acp-adapter", "acpx stop failed (swallowed)", { cause: String(err) });
-      }
-    }
-  }
-
-  async cancelActivePrompt(): Promise<void> {
-    // Mark the in-flight prompt as externally cancelled so the resulting
-    // AcpSessionResponse is stamped with `cancelled: true`. The wiring layer
-    // above the adapter classifies _why_ (e.g. fail-stale when the watchdog
-    // triggered the cancel).
-    this._externallyCancelled = true;
-
-    // Kill in-flight prompt process tree directly (faster than acpx cancel)
-    if (this.activeProc) {
-      this.killActiveProcTree();
-      this.activeProc = null; // LOW: null out after kill, matching close()
-    }
-
-    const cmd = ["acpx", this.agentName, "cancel"];
-    getSafeLogger()?.debug("acp-adapter", `Cancelling active prompt: ${this.sessionName}`);
-
-    await this.trackedSpawn(cmd);
-  }
-}
+export { _spawnClientDeps } from "./spawn-client-deps";
+export { SpawnAcpSession } from "./spawn-client-session";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // SpawnAcpClient
@@ -503,6 +61,10 @@ export class SpawnAcpClient implements AcpClient {
   private readonly runId?: string;
   private readonly storyId?: string;
   private readonly stage?: import("../../config/permissions").PipelineStage;
+  /** Resolved teardown deadline (ms), forwarded to sessions this client creates (#1583). */
+  private readonly trackedSpawnDeadlineMs: number;
+  /** Resolved startup deadline (ms) — used by this client's own trackedSpawn (createSession/loadSession/applyReasoningEffort) (#1583). */
+  private readonly trackedSpawnStartupDeadlineMs: number;
 
   constructor(
     cmdStr: string,
@@ -540,18 +102,37 @@ export class SpawnAcpClient implements AcpClient {
     this.runId = opts?.runId;
     this.storyId = opts?.storyId;
     this.stage = opts?.stage;
+    this.trackedSpawnDeadlineMs = opts?.trackedSpawnDeadlineMs ?? _spawnClientDeps.trackedSpawnDeadlineMs;
+    this.trackedSpawnStartupDeadlineMs =
+      opts?.trackedSpawnStartupDeadlineMs ?? _spawnClientDeps.trackedSpawnStartupDeadlineMs;
   }
 
   async start(): Promise<void> {
     // No-op — spawn-based client doesn't need upfront initialization
   }
 
-  /** Spawn an acpx command. PERF-1: bounded by the same deadline as SpawnAcpSession.trackedSpawn. */
+  /**
+   * Spawn an acpx command. Issue #1583: most callers of this client's
+   * trackedSpawn — createSession/loadSession/applyReasoningEffort — are
+   * startup ops (`sessions ensure`), so it defaults to the startup deadline,
+   * NOT SpawnAcpSession's teardown deadline. `sessions ensure` measured a
+   * real-world median of 8.15s. `closeSession` (a teardown op that goes
+   * through this client rather than a live SpawnAcpSession) passes the
+   * teardown deadline explicitly via `deadlineMsOverride`.
+   */
   private async trackedSpawn(
     cmd: string[],
     signal?: AbortSignal,
+    deadlineMsOverride?: number,
   ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-    return runTrackedSpawn(_spawnClientDeps, cmd, undefined, this.onPidSpawned, this.onPidExited, signal);
+    return runTrackedSpawn(
+      { ..._spawnClientDeps, trackedSpawnDeadlineMs: deadlineMsOverride ?? this.trackedSpawnStartupDeadlineMs },
+      cmd,
+      undefined,
+      this.onPidSpawned,
+      this.onPidExited,
+      signal,
+    );
   }
 
   async createSession(opts: {
@@ -611,6 +192,7 @@ export class SpawnAcpClient implements AcpClient {
       stage: this.stage,
       id: sessionId,
       recordId,
+      trackedSpawnDeadlineMs: this.trackedSpawnDeadlineMs,
     });
   }
 
@@ -623,7 +205,20 @@ export class SpawnAcpClient implements AcpClient {
     const { exitCode, stdout } = await this.trackedSpawn(cmd);
 
     if (exitCode !== 0) {
-      return null; // Session doesn't exist or can't be resumed
+      // Issue #1583: exitCode -1 means runTrackedSpawn hit its deadline (or an
+      // external abort) and killed the process — a DIFFERENT situation from a
+      // genuine "no session exists" miss (non-zero exit from acpx itself). Both
+      // fall back to a context-less createSession below, but the timeout case
+      // silently degraded reviewer/session context with no visible signal.
+      // Surface it so it's distinguishable from a normal miss.
+      if (exitCode === -1) {
+        getSafeLogger()?.warn(
+          "acp-adapter",
+          "sessions ensure hit its trackedSpawn deadline — falling back to a context-less session",
+          { sessionName, agentName },
+        );
+      }
+      return null; // Session doesn't exist, can't be resumed, or the ensure call timed out
     }
 
     const { sessionId, recordId } = parseSessionIds(stdout);
@@ -654,12 +249,14 @@ export class SpawnAcpClient implements AcpClient {
       stage: this.stage,
       id: sessionId,
       recordId,
+      trackedSpawnDeadlineMs: this.trackedSpawnDeadlineMs,
     });
   }
 
   async closeSession(sessionName: string, agentName: string, signal?: AbortSignal): Promise<void> {
     const cmd = ["acpx", "--cwd", this.cwd, agentName, "sessions", "close", sessionName];
-    const { exitCode, stderr } = await this.trackedSpawn(cmd, signal);
+    // Teardown op — use the teardown deadline, not the (longer) startup default.
+    const { exitCode, stderr } = await this.trackedSpawn(cmd, signal, this.trackedSpawnDeadlineMs);
     if (exitCode !== 0) {
       getSafeLogger()?.debug("acp-adapter", "Session close failed (ignored)", {
         sessionName,

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -6,6 +6,7 @@
  */
 
 import { EventEmitter } from "node:events";
+import { trackedSpawnDeadlines } from "@/config";
 import type { AgentManagerConfig } from "@/config/selectors";
 import { resolvePermissions } from "../config/permissions";
 import type { AdapterFailure } from "../context/engine";
@@ -16,16 +17,10 @@ import { getSafeLogger } from "../logger";
 // src/runtime/index.ts → internal/agent-manager-factory → agents/factory → agents/manager → runtime/index.ts
 import { MiddlewareChain } from "../runtime/agent-middleware";
 import type { MiddlewareContext } from "../runtime/agent-middleware";
-import type {
-  CompleteDispatchEvent,
-  DispatchErrorEvent,
-  IDispatchEventBus,
-  SessionTurnDispatchEvent,
-} from "../runtime/dispatch-events";
+import type { IDispatchEventBus } from "../runtime/dispatch-events";
 import { DispatchEventBus } from "../runtime/dispatch-events";
 import { formatSessionName } from "../runtime/session-name";
 import { cancellableDelay } from "../utils/bun-deps";
-import { errorMessage } from "../utils/errors";
 import { classifyCompleteException } from "./complete-exception-classifier";
 import { buildCompleteEvent, buildDispatchErrorEvent, buildSessionTurnEvent } from "./manager-dispatch";
 import type {
@@ -720,8 +715,12 @@ export class AgentManager implements IAgentManager {
   async completeAs(agentName: string, prompt: string, options: CompleteOptions): Promise<CompleteResult> {
     const stage = options.pipelineStage ?? "complete";
     const resolvedPermissions = resolvePermissions(this._config, stage);
-    const promptRetries = this._config.agent?.acp?.promptRetries;
-    const augmented: ResolvedCompleteOptions = { ...options, resolvedPermissions, promptRetries };
+    const augmented: ResolvedCompleteOptions = {
+      ...options,
+      resolvedPermissions,
+      promptRetries: this._config.agent?.acp?.promptRetries,
+      ...trackedSpawnDeadlines(this._config),
+    };
     const sessionName =
       options.sessionName ??
       formatSessionName({

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -205,14 +205,19 @@ export interface AgentCapabilities {
   readonly features: ReadonlySet<"tdd" | "review" | "refactor" | "batch">;
 }
 
+/** trackedSpawn hard deadlines (ms) — teardown vs startup, resolved from config.agent.acp (#1583). */
+export interface TrackedSpawnDeadlineOptions {
+  trackedSpawnDeadlineMs?: number;
+  trackedSpawnStartupDeadlineMs?: number;
+}
+
 /**
- * Options for one-shot LLM completion calls.
- *
- * Callers pass this to `AgentManager.completeAs()` — the manager fills in
- * `resolvedPermissions`, `promptRetries`, `onPidSpawned`, and `onPidExited`
- * before handing the augmented `ResolvedCompleteOptions` to the adapter.
+ * Options for one-shot LLM completion calls. Callers pass this to
+ * `AgentManager.completeAs()` — the manager fills in `resolvedPermissions`,
+ * `promptRetries`, `onPidSpawned`, and `onPidExited` before handing the
+ * augmented `ResolvedCompleteOptions` to the adapter.
  */
-export interface CompleteOptions {
+export interface CompleteOptions extends TrackedSpawnDeadlineOptions {
   /** Maximum tokens for the response */
   maxTokens?: number;
   /** Request JSON-formatted output (adds --output-format json) */
@@ -246,12 +251,10 @@ export interface CompleteOptions {
    */
   timeoutMs?: number;
   /**
-   * Number of prompt retries for ACP sessions, and trackedSpawn teardown/startup
-   * deadlines (ms) — all pre-resolved by AgentManager.completeAs from config.agent.acp (#1583).
+   * Number of prompt retries for ACP sessions.
+   * Pre-resolved by AgentManager.completeAs from config.agent.acp.promptRetries.
    */
   promptRetries?: number;
-  trackedSpawnDeadlineMs?: number;
-  trackedSpawnStartupDeadlineMs?: number;
   /**
    * Named session to use for this completion call.
    * If omitted, a timestamp-based ephemeral session name is generated.
@@ -388,7 +391,7 @@ export interface SessionHandle {
 }
 
 /** Options for openSession() — protocol-agnostic surface + ACP-specific pass-throughs. */
-export interface OpenSessionOpts {
+export interface OpenSessionOpts extends TrackedSpawnDeadlineOptions {
   agentName: string;
   workdir: string;
   /** Pre-resolved permissions from AgentManager. */
@@ -399,10 +402,8 @@ export interface OpenSessionOpts {
   modelTier?: ModelTier;
   /** ACP: maximum session duration in seconds. */
   timeoutSeconds: number;
-  /** ACP: acpx --prompt-retries value (default 0 — opt-in). Deadlines below resolved from config.agent.acp (#1583). */
+  /** ACP: acpx --prompt-retries value (default 0 — opt-in). */
   promptRetries?: number;
-  trackedSpawnDeadlineMs?: number;
-  trackedSpawnStartupDeadlineMs?: number;
   /** Fired once the session is physically established, before the first prompt. */
   onSessionEstablished?: (protocolIds: ProtocolIds, sessionName: string) => void;
   /** PID registration callback for crash-recovery bookkeeping. */

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -246,10 +246,12 @@ export interface CompleteOptions {
    */
   timeoutMs?: number;
   /**
-   * Number of prompt retries for ACP sessions.
-   * Pre-resolved by AgentManager.completeAs from config.agent.acp.promptRetries.
+   * Number of prompt retries for ACP sessions, and trackedSpawn teardown/startup
+   * deadlines (ms) — all pre-resolved by AgentManager.completeAs from config.agent.acp (#1583).
    */
   promptRetries?: number;
+  trackedSpawnDeadlineMs?: number;
+  trackedSpawnStartupDeadlineMs?: number;
   /**
    * Named session to use for this completion call.
    * If omitted, a timestamp-based ephemeral session name is generated.
@@ -397,8 +399,10 @@ export interface OpenSessionOpts {
   modelTier?: ModelTier;
   /** ACP: maximum session duration in seconds. */
   timeoutSeconds: number;
-  /** ACP: acpx --prompt-retries value (default 0 — opt-in). */
+  /** ACP: acpx --prompt-retries value (default 0 — opt-in). Deadlines below resolved from config.agent.acp (#1583). */
   promptRetries?: number;
+  trackedSpawnDeadlineMs?: number;
+  trackedSpawnStartupDeadlineMs?: number;
   /** Fired once the session is physically established, before the first prompt. */
   onSessionEstablished?: (protocolIds: ProtocolIds, sessionName: string) => void;
   /** PID registration callback for crash-recovery bookkeeping. */

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -105,8 +105,8 @@ export {
   mutationCheckConfigSelector,
   executionGatesConfigSelector,
   finishConfigSelector,
-  trackedSpawnDeadlines,
 } from "./selectors";
+export { trackedSpawnDeadlines } from "./tracked-spawn-deadlines";
 export { createConfigLoader } from "./loader-runtime";
 export type { ConfigLoader } from "./loader-runtime";
 export {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -105,6 +105,7 @@ export {
   mutationCheckConfigSelector,
   executionGatesConfigSelector,
   finishConfigSelector,
+  trackedSpawnDeadlines,
 } from "./selectors";
 export { createConfigLoader } from "./loader-runtime";
 export type { ConfigLoader } from "./loader-runtime";

--- a/src/config/runtime-types-agent.ts
+++ b/src/config/runtime-types-agent.ts
@@ -62,6 +62,16 @@ export interface IdleWatchdogConfig {
 export interface AgentAcpConfig {
   /** Retries for transient prompt failures via acpx --prompt-retries (default: 0 — opt-in) */
   promptRetries?: number;
+  /**
+   * trackedSpawn hard deadline (ms) for teardown ops — sessions close/stop/cancel
+   * (default: 10000). #1583.
+   */
+  trackedSpawnDeadlineMs?: number;
+  /**
+   * trackedSpawn hard deadline (ms) for startup ops — sessions ensure
+   * (createSession/loadSession/applyReasoningEffort) (default: 30000). #1583.
+   */
+  trackedSpawnStartupDeadlineMs?: number;
 }
 
 /** Bounded same-agent retry after a wall-clock timeout (US-002) */

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -241,6 +241,21 @@ const AgentIdleWatchdogConfigSchema = z
 
 const AgentAcpConfigSchema = z.object({
   promptRetries: z.number().int().min(0).max(5).default(0),
+  /**
+   * trackedSpawn hard deadline (ms) for teardown ops — `sessions close`,
+   * `acpx stop`, `cancel`. Bounds a wedged acpx subprocess so run teardown
+   * can't hang indefinitely (PERF-1). Issue #1583: keep this tight — it must
+   * NOT be reused for startup ops (see trackedSpawnStartupDeadlineMs).
+   */
+  trackedSpawnDeadlineMs: z.number().int().positive().default(10_000),
+  /**
+   * trackedSpawn hard deadline (ms) for startup ops — `sessions ensure`
+   * (createSession/loadSession) and applyReasoningEffort. Issue #1583:
+   * `sessions ensure` measured a real-world median of 8.15s, so this needs
+   * real headroom over that under concurrency — do not lower toward the
+   * teardown deadline.
+   */
+  trackedSpawnStartupDeadlineMs: z.number().int().positive().default(30_000),
 });
 
 // Bounded same-agent retry after a wall-clock timeout (US-002). `budgetMultiplier`
@@ -270,7 +285,11 @@ export const AgentConfigSchema = z.object({
     onQualityFailure: false,
     rebuildContext: true,
   }),
-  acp: AgentAcpConfigSchema.default({ promptRetries: 0 }),
+  acp: AgentAcpConfigSchema.default({
+    promptRetries: 0,
+    trackedSpawnDeadlineMs: 10_000,
+    trackedSpawnStartupDeadlineMs: 30_000,
+  }),
   idleWatchdog: AgentIdleWatchdogConfigSchema.default(DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG),
   timeoutRetry: AgentTimeoutRetryConfigSchema.default(DEFAULT_AGENT_TIMEOUT_RETRY_CONFIG),
 });

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -329,7 +329,7 @@ export const NaxConfigSchema = z
       maxInteractionTurns: 20,
       promptAudit: { enabled: false },
       fallback: { enabled: false, map: {}, maxHopsPerStory: 2, onQualityFailure: false, rebuildContext: true },
-      acp: { promptRetries: 0 },
+      acp: { promptRetries: 0, trackedSpawnDeadlineMs: 10_000, trackedSpawnStartupDeadlineMs: 30_000 },
       idleWatchdog: DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG,
       timeoutRetry: DEFAULT_AGENT_TIMEOUT_RETRY_CONFIG,
     }),

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -163,3 +163,19 @@ export type AutofixConfig = ReturnType<typeof autofixConfigSelector.select>;
 export type ExecutionGatesConfig = ReturnType<typeof executionGatesConfigSelector.select>;
 export type NonBlockingFixConfig = NonNullable<z.infer<typeof AdversarialReviewConfigSchema>["nonBlockingFix"]>;
 export type FinishConfig = ReturnType<typeof finishConfigSelector.select>;
+
+/**
+ * trackedSpawn teardown/startup deadlines (ms), resolved from config.agent.acp.
+ * Shared by AgentManager.completeAs and SessionManager.openSession so both
+ * wiring layers stay consistent (#1583).
+ */
+export function trackedSpawnDeadlines(config: Pick<NaxConfig, "agent"> | undefined): {
+  trackedSpawnDeadlineMs?: number;
+  trackedSpawnStartupDeadlineMs?: number;
+} {
+  const acp = config?.agent?.acp;
+  return {
+    trackedSpawnDeadlineMs: acp?.trackedSpawnDeadlineMs,
+    trackedSpawnStartupDeadlineMs: acp?.trackedSpawnStartupDeadlineMs,
+  };
+}

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -163,19 +163,3 @@ export type AutofixConfig = ReturnType<typeof autofixConfigSelector.select>;
 export type ExecutionGatesConfig = ReturnType<typeof executionGatesConfigSelector.select>;
 export type NonBlockingFixConfig = NonNullable<z.infer<typeof AdversarialReviewConfigSchema>["nonBlockingFix"]>;
 export type FinishConfig = ReturnType<typeof finishConfigSelector.select>;
-
-/**
- * trackedSpawn teardown/startup deadlines (ms), resolved from config.agent.acp.
- * Shared by AgentManager.completeAs and SessionManager.openSession so both
- * wiring layers stay consistent (#1583).
- */
-export function trackedSpawnDeadlines(config: Pick<NaxConfig, "agent"> | undefined): {
-  trackedSpawnDeadlineMs?: number;
-  trackedSpawnStartupDeadlineMs?: number;
-} {
-  const acp = config?.agent?.acp;
-  return {
-    trackedSpawnDeadlineMs: acp?.trackedSpawnDeadlineMs,
-    trackedSpawnStartupDeadlineMs: acp?.trackedSpawnStartupDeadlineMs,
-  };
-}

--- a/src/config/tracked-spawn-deadlines.ts
+++ b/src/config/tracked-spawn-deadlines.ts
@@ -1,0 +1,25 @@
+/**
+ * trackedSpawn teardown/startup deadline resolution (#1583).
+ *
+ * Not a ConfigSelector (see ./selectors.ts) — its callers hold a config slice
+ * (AgentManagerConfig) or a possibly-undefined NaxConfig, neither of which
+ * satisfies ConfigSelector.select()'s `(config: NaxConfig) => C` shape.
+ */
+
+import type { NaxConfig } from "./types";
+
+/**
+ * trackedSpawn teardown/startup deadlines (ms), resolved from config.agent.acp.
+ * Shared by AgentManager.completeAs and SessionManager.openSession so both
+ * wiring layers stay consistent.
+ */
+export function trackedSpawnDeadlines(config: Pick<NaxConfig, "agent"> | undefined): {
+  trackedSpawnDeadlineMs?: number;
+  trackedSpawnStartupDeadlineMs?: number;
+} {
+  const acp = config?.agent?.acp;
+  return {
+    trackedSpawnDeadlineMs: acp?.trackedSpawnDeadlineMs,
+    trackedSpawnStartupDeadlineMs: acp?.trackedSpawnStartupDeadlineMs,
+  };
+}

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -9,7 +9,7 @@
 
 import type { AgentAdapter, AgentResult, SessionHandle, TurnResult } from "../agents/types";
 import { SessionFailureError, SessionTurnError } from "../agents/types";
-import type { NaxConfig } from "../config";
+import { type NaxConfig, trackedSpawnDeadlines } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import { NaxError } from "../errors";
 import type { PidRegistry } from "../execution/pid-registry";
@@ -427,9 +427,8 @@ export class SessionManager implements ISessionManager {
       if (!liveDesc || (liveDesc.state !== "COMPLETED" && liveDesc.state !== "FAILED")) {
         return liveHandle;
       }
-      // Stale handle: keepOpen left it in _liveHandles but runTrackedSession
-      // already transitioned the descriptor to a terminal state. Remove the
-      // stale entry so the full open path runs and resets the descriptor.
+      // Stale handle: keepOpen left it in _liveHandles but runTrackedSession already
+      // transitioned the descriptor to a terminal state. Remove it so the full open path runs.
       this._liveHandles.delete(name);
     }
 
@@ -459,6 +458,7 @@ export class SessionManager implements ISessionManager {
       resume,
       onActiveCall: this._buildOnActiveCall(name),
       onStreamActivity: this._onStreamActivity,
+      ...trackedSpawnDeadlines(this._config), // #1583
     });
     this._liveHandles.set(name, handle);
 

--- a/test/unit/agents/acp/_spawn-client-test-helpers.ts
+++ b/test/unit/agents/acp/_spawn-client-test-helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared low-level spawn-result stubs for spawn-client*.test.ts files.
+ * Local (underscore-prefixed) helper, not test/helpers/ — these mock the raw
+ * Bun.spawn() result shape used only by the ACP spawn-client test suite, not
+ * one of the domain types (IAgentManager, NaxConfig, ...) test/helpers/ covers.
+ */
+
+import { afterEach, beforeEach } from "bun:test";
+import type { _spawnClientDeps } from "@/agents/acp";
+
+/**
+ * SAFETY: cancelActivePrompt()/close() call killProcessGroup, which hits the
+ * REAL process.kill(-pid, signal) unless stubbed. Several tests in this suite
+ * exercise these paths with fake PIDs — without this stub, any test lacking
+ * its own local override can send a real signal to the host. Stub
+ * process.kill for every test in the calling file, unconditionally, and
+ * restore the true original after each test.
+ */
+export function stubProcessKill(): void {
+  let original: typeof process.kill;
+
+  beforeEach(() => {
+    original = process.kill;
+    process.kill = ((_pid: number | string, _signal?: NodeJS.Signals | number) => true) as typeof process.kill;
+  });
+
+  afterEach(() => {
+    process.kill = original;
+  });
+}
+
+export function makeSpawnResult(exitCode: number, stdout = ""): ReturnType<typeof _spawnClientDeps.spawn> {
+  const enc = new TextEncoder();
+  const makeStream = (content: string) =>
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        if (content) c.enqueue(enc.encode(content));
+        c.close();
+      },
+    });
+
+  return {
+    stdout: makeStream(stdout),
+    stderr: makeStream(""),
+    stdin: { write: () => 0, end: () => {}, flush: () => {} },
+    exited: Promise.resolve(exitCode),
+    pid: 99999999,
+    kill: () => {},
+  };
+}
+
+/** Spawn mock that never exits — simulates a wedged/slow acpx subprocess. */
+export function makeWedgedSpawnResult(): ReturnType<typeof _spawnClientDeps.spawn> {
+  return {
+    stdout: new ReadableStream<Uint8Array>({ start() {} }),
+    stderr: new ReadableStream<Uint8Array>({ start() {} }),
+    stdin: { write: () => 0, end: () => {}, flush: () => {} },
+    exited: new Promise<number>(() => {}),
+    pid: 99999999,
+    kill: () => {},
+  };
+}

--- a/test/unit/agents/acp/spawn-client-tracked-spawn-deadlines.test.ts
+++ b/test/unit/agents/acp/spawn-client-tracked-spawn-deadlines.test.ts
@@ -5,52 +5,12 @@
  * the test-file-size ratchet.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { SpawnAcpClient, _spawnClientDeps } from "@/agents/acp";
 import { withDepsRestore } from "@test/helpers";
+import { makeSpawnResult, makeWedgedSpawnResult, stubProcessKill } from "./_spawn-client-test-helpers";
 
-// SAFETY: file-scope process.kill stub — see spawn-client.test.ts for rationale.
-let _originalProcessKill: typeof process.kill;
-
-beforeEach(() => {
-  _originalProcessKill = process.kill;
-  process.kill = ((_pid: number | string, _signal?: NodeJS.Signals | number) => true) as typeof process.kill;
-});
-
-afterEach(() => {
-  process.kill = _originalProcessKill;
-});
-
-function makeSpawnResult(exitCode: number, stdout = ""): ReturnType<typeof _spawnClientDeps.spawn> {
-  const enc = new TextEncoder();
-  const makeStream = (content: string) =>
-    new ReadableStream<Uint8Array>({
-      start(c) {
-        if (content) c.enqueue(enc.encode(content));
-        c.close();
-      },
-    });
-
-  return {
-    stdout: makeStream(stdout),
-    stderr: makeStream(""),
-    stdin: { write: () => 0, end: () => {}, flush: () => {} },
-    exited: Promise.resolve(exitCode),
-    pid: 99999999,
-    kill: () => {},
-  };
-}
-
-function makeWedgedSpawnResult(): ReturnType<typeof _spawnClientDeps.spawn> {
-  return {
-    stdout: new ReadableStream<Uint8Array>({ start() {} }),
-    stderr: new ReadableStream<Uint8Array>({ start() {} }),
-    stdin: { write: () => 0, end: () => {}, flush: () => {} },
-    exited: new Promise<number>(() => {}), // never resolves — simulates a wedged/slow acpx
-    pid: 99999999,
-    kill: () => {},
-  };
-}
+stubProcessKill();
 
 describe("SpawnAcpClient — startup vs teardown trackedSpawn deadlines (#1583)", () => {
   withDepsRestore(_spawnClientDeps, [

--- a/test/unit/agents/acp/spawn-client-tracked-spawn-deadlines.test.ts
+++ b/test/unit/agents/acp/spawn-client-tracked-spawn-deadlines.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for spawn-client.ts — Issue #1583: startup ops (sessions ensure) must
+ * use trackedSpawnStartupDeadlineMs, never the (shorter) teardown deadline
+ * used for close/stop/cancel. Split out of spawn-client.test.ts to stay under
+ * the test-file-size ratchet.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { SpawnAcpClient, _spawnClientDeps } from "@/agents/acp";
+import { withDepsRestore } from "@test/helpers";
+
+// SAFETY: file-scope process.kill stub — see spawn-client.test.ts for rationale.
+let _originalProcessKill: typeof process.kill;
+
+beforeEach(() => {
+  _originalProcessKill = process.kill;
+  process.kill = ((_pid: number | string, _signal?: NodeJS.Signals | number) => true) as typeof process.kill;
+});
+
+afterEach(() => {
+  process.kill = _originalProcessKill;
+});
+
+function makeSpawnResult(exitCode: number, stdout = ""): ReturnType<typeof _spawnClientDeps.spawn> {
+  const enc = new TextEncoder();
+  const makeStream = (content: string) =>
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        if (content) c.enqueue(enc.encode(content));
+        c.close();
+      },
+    });
+
+  return {
+    stdout: makeStream(stdout),
+    stderr: makeStream(""),
+    stdin: { write: () => 0, end: () => {}, flush: () => {} },
+    exited: Promise.resolve(exitCode),
+    pid: 99999999,
+    kill: () => {},
+  };
+}
+
+function makeWedgedSpawnResult(): ReturnType<typeof _spawnClientDeps.spawn> {
+  return {
+    stdout: new ReadableStream<Uint8Array>({ start() {} }),
+    stderr: new ReadableStream<Uint8Array>({ start() {} }),
+    stdin: { write: () => 0, end: () => {}, flush: () => {} },
+    exited: new Promise<number>(() => {}), // never resolves — simulates a wedged/slow acpx
+    pid: 99999999,
+    kill: () => {},
+  };
+}
+
+describe("SpawnAcpClient — startup vs teardown trackedSpawn deadlines (#1583)", () => {
+  withDepsRestore(_spawnClientDeps, [
+    "spawn",
+    "trackedSpawnDeadlineMs",
+    "trackedSpawnStartupDeadlineMs",
+    "killTreeGraceMs",
+  ]);
+
+  test("loadSession (a startup op) waits out the startup deadline, not the shorter teardown deadline", async () => {
+    _spawnClientDeps.trackedSpawnDeadlineMs = 20; // teardown — deliberately too short to matter here
+    _spawnClientDeps.trackedSpawnStartupDeadlineMs = 150;
+    _spawnClientDeps.killTreeGraceMs = 1;
+    _spawnClientDeps.spawn = () => makeWedgedSpawnResult();
+
+    const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
+    const start = Date.now();
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    const elapsed = Date.now() - start;
+
+    // Regression guard for #1583: before the fix, loadSession shared the 10s
+    // teardown deadline and would have returned near trackedSpawnDeadlineMs (20ms).
+    expect(elapsed).toBeGreaterThanOrEqual(100);
+    expect(session).toBeNull();
+  });
+
+  test("createSession (a startup op) waits out the startup deadline, not the shorter teardown deadline", async () => {
+    _spawnClientDeps.trackedSpawnDeadlineMs = 20;
+    _spawnClientDeps.trackedSpawnStartupDeadlineMs = 150;
+    _spawnClientDeps.killTreeGraceMs = 1;
+    _spawnClientDeps.spawn = () => makeWedgedSpawnResult();
+
+    const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
+    const start = Date.now();
+    await expect(
+      client.createSession({ agentName: "claude", permissionMode: "approve-reads", sessionName: "test-session" }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(100);
+  });
+
+  test("closeSession (a teardown op reached through the client) is bounded by the teardown deadline, not the longer startup deadline", async () => {
+    _spawnClientDeps.trackedSpawnDeadlineMs = 20;
+    _spawnClientDeps.trackedSpawnStartupDeadlineMs = 5000; // deliberately too long to matter here
+    _spawnClientDeps.killTreeGraceMs = 1;
+    _spawnClientDeps.spawn = () => makeWedgedSpawnResult();
+
+    const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
+
+    const MARGIN_MS = 500;
+    const timed = Symbol("timed");
+    const result = await Promise.race([
+      client.closeSession("test-session", "claude"),
+      new Promise<typeof timed>((resolve) => setTimeout(() => resolve(timed), MARGIN_MS)),
+    ]);
+
+    // Regression guard: if closeSession fell back to the 5000ms startup
+    // deadline, it would still be pending when the 500ms race window elapses.
+    expect(result).not.toBe(timed);
+  });
+
+  test("a live session's close() uses its resolved teardown deadline even when the startup deadline is much longer", async () => {
+    _spawnClientDeps.trackedSpawnDeadlineMs = 20;
+    _spawnClientDeps.trackedSpawnStartupDeadlineMs = 5000;
+    _spawnClientDeps.killTreeGraceMs = 1;
+
+    let callCount = 0;
+    _spawnClientDeps.spawn = () => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0); // ensure session succeeds immediately
+      return makeWedgedSpawnResult(); // session-close spawn: wedged
+    };
+
+    const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    expect(session).not.toBeNull();
+
+    const MARGIN_MS = 500;
+    const timed = Symbol("timed");
+    const result = await Promise.race([
+      session?.close(),
+      new Promise<typeof timed>((resolve) => setTimeout(() => resolve(timed), MARGIN_MS)),
+    ]);
+
+    expect(result).not.toBe(timed);
+  });
+
+  test("constructor opts override the module-level defaults for both deadlines", async () => {
+    // Module defaults left at their normal (larger) values — the explicit opts
+    // passed to the constructor must win.
+    _spawnClientDeps.spawn = () => makeWedgedSpawnResult();
+    _spawnClientDeps.killTreeGraceMs = 1;
+
+    const client = new SpawnAcpClient(
+      "acpx --model claude-sonnet-4-5 claude",
+      "/tmp",
+      undefined,
+      undefined,
+      0,
+      undefined,
+      {
+        trackedSpawnStartupDeadlineMs: 60,
+      },
+    );
+
+    const start = Date.now();
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    const elapsed = Date.now() - start;
+
+    expect(session).toBeNull();
+    // Bounded by the injected 60ms override, not the (much larger) module default.
+    expect(elapsed).toBeLessThan(2000);
+  });
+});

--- a/test/unit/agents/acp/spawn-client.test.ts
+++ b/test/unit/agents/acp/spawn-client.test.ts
@@ -5,10 +5,11 @@
  *        It must use the client's stored permissionMode ("approve-reads" by default).
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { SpawnAcpClient, _spawnClientDeps } from "@/agents/acp";
 import type { SpawnOptions } from "@/utils/bun-deps";
 import { waitForCondition, withDepsRestore, withTimerSpy } from "@test/helpers";
+import { makeSpawnResult, stubProcessKill } from "./_spawn-client-test-helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // SAFETY: file-scope process.kill stub
@@ -25,40 +26,7 @@ import { waitForCondition, withDepsRestore, withTimerSpy } from "@test/helpers";
 // tests either.
 // ─────────────────────────────────────────────────────────────────────────────
 
-let _originalProcessKill: typeof process.kill;
-
-beforeEach(() => {
-  _originalProcessKill = process.kill;
-  process.kill = ((_pid: number | string, _signal?: NodeJS.Signals | number) => true) as typeof process.kill;
-});
-
-afterEach(() => {
-  process.kill = _originalProcessKill;
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Spawn mock helper
-// ─────────────────────────────────────────────────────────────────────────────
-
-function makeSpawnResult(exitCode: number, stdout = ""): ReturnType<typeof _spawnClientDeps.spawn> {
-  const enc = new TextEncoder();
-  const makeStream = (content: string) =>
-    new ReadableStream<Uint8Array>({
-      start(c) {
-        if (content) c.enqueue(enc.encode(content));
-        c.close();
-      },
-    });
-
-  return {
-    stdout: makeStream(stdout),
-    stderr: makeStream(""),
-    stdin: { write: () => 0, end: () => {}, flush: () => {} },
-    exited: Promise.resolve(exitCode),
-    pid: 99999999,
-    kill: () => {},
-  };
-}
+stubProcessKill();
 
 /**
  * Spawn mock where process exit resolves only after stdout starts being consumed.


### PR DESCRIPTION
## Summary

Fixes #1583. `TRACKED_SPAWN_DEADLINE_MS` (10s), added by #1574 (PERF-1) to bound `trackedSpawn`'s teardown wait, was shared by every `trackedSpawn` call — including `sessions ensure` (a **startup** op via `createSession`/`loadSession`/`applyReasoningEffort`), which measured a real-world median of 8.15s. Under concurrency this left too little margin, and nax was SIGTERMing healthy acpx processes and silently falling back to context-less sessions.

- Split the deadline into `trackedSpawnDeadlineMs` (teardown — `sessions close`/`acpx stop`/`cancel`, default 10s) and `trackedSpawnStartupDeadlineMs` (startup — `sessions ensure`, default 30s), threaded through `SpawnAcpClient`/`SpawnAcpSession` → the ACP adapter → `AgentManager.completeAs` / `SessionManager.openSession`.
- Both are now configurable via `config.agent.acp.trackedSpawnDeadlineMs` / `trackedSpawnStartupDeadlineMs` (Zod schema in `schemas-infra.ts`, resolved from config at the wiring layer via a shared `trackedSpawnDeadlines()` helper).
- `loadSession` now logs a warning when the context-less fallback was caused by hitting the trackedSpawn deadline (`exitCode === -1`) rather than a genuine "no session exists" miss, so the degradation is no longer silent.
- Split `spawn-client.ts` (`SpawnAcpSession` → `spawn-client-session.ts`, shared deps → `spawn-client-deps.ts`) and `adapter.ts` (`closePhysicalSession` → `adapter-close-physical.ts`) to stay under the 600-line file-size ratchet everywhere touched.
- Self-review follow-ups: shared `TrackedSpawnDeadlineOptions` interface instead of duplicating field docs; moved `trackedSpawnDeadlines()` out of `config/selectors.ts` into its own file (it isn't a `ConfigSelector`); deduped test spawn-result stubs into `test/unit/agents/acp/_spawn-client-test-helpers.ts`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (biome + all check: scripts, incl. `check:file-sizes`, `check:alias-internals`) — clean
- [x] `bun run check:test-typecheck` / `check:test-as-unknown-as` — at baseline, no regressions
- [x] New regression tests in `spawn-client-tracked-spawn-deadlines.test.ts` proving startup ops (`loadSession`/`createSession`) wait out the startup deadline while teardown ops (`closeSession`, session `close()`) stay bounded by the shorter teardown deadline, and that constructor-level overrides win over module defaults
- [x] Full suite: 13201 unit + 1104 integration + 25 UI tests, 0 failures