### PR TITLE
fix: recurrence-key progress detection and pause-reason persistence (#1581, #1582)

### DIFF
--- a/src/execution/escalation/index.ts
+++ b/src/execution/escalation/index.ts
@@ -4,6 +4,7 @@
 
 export { escalateTier, getTierConfig, calculateMaxIterations } from "./escalation";
 export { runBatchPreChecks, type BatchPreCheckOptions, type BatchPreCheckResult } from "./batch-pre-check";
+export { verifyEscalationQuotes } from "./quote-integrity";
 export {
   resolveMaxAttemptsOutcome,
   preIterationTierCheck,
@@ -16,3 +17,4 @@ export {
   type EscalationHandlerContext,
   type EscalationHandlerResult,
 } from "./tier-escalation";
+export { handleNoTierAvailable, handleMaxAttemptsReached } from "./tier-outcome";

--- a/src/execution/escalation/tier-outcome.ts
+++ b/src/execution/escalation/tier-outcome.ts
@@ -27,7 +27,8 @@ export async function handleNoTierAvailable(
   const outcome = resolveMaxAttemptsOutcome(failureCategory);
 
   if (outcome === "pause") {
-    const pauseReason = `Execution stopped (${failureCategory ?? "unknown"} requires human review)`;
+    const pipelineDetail = ctx.pipelineResult.reason ? `: ${ctx.pipelineResult.reason}` : "";
+    const pauseReason = `Execution stopped (${failureCategory ?? "unknown"} requires human review)${pipelineDetail}`;
     const pausedPrd = { ...ctx.prd };
     markStoryPaused(pausedPrd, ctx.story.id, await verifyEscalationQuotes(pauseReason, ctx.workdir, ctx.story.id));
     await savePRD(pausedPrd, ctx.prdPath);
@@ -92,7 +93,8 @@ export async function handleMaxAttemptsReached(
   const outcome = resolveMaxAttemptsOutcome(failureCategory);
 
   if (outcome === "pause") {
-    const pauseReason = `Max attempts reached (${failureCategory ?? "unknown"} requires human review)`;
+    const pipelineDetail = ctx.pipelineResult.reason ? `: ${ctx.pipelineResult.reason}` : "";
+    const pauseReason = `Max attempts reached (${failureCategory ?? "unknown"} requires human review)${pipelineDetail}`;
     const pausedPrd = { ...ctx.prd };
     markStoryPaused(pausedPrd, ctx.story.id, await verifyEscalationQuotes(pauseReason, ctx.workdir, ctx.story.id));
     await savePRD(pausedPrd, ctx.prdPath);

--- a/src/execution/escalation/tier-outcome.ts
+++ b/src/execution/escalation/tier-outcome.ts
@@ -12,6 +12,7 @@ import { getSafeLogger } from "../../logger";
 import { markStoryFailed, markStoryPaused, savePRD } from "../../prd";
 import type { FailureCategory } from "../../tdd/types";
 import { appendProgress } from "../progress";
+import { verifyEscalationQuotes } from "./quote-integrity";
 import type { EscalationHandlerContext, EscalationHandlerResult } from "./tier-escalation";
 import { resolveMaxAttemptsOutcome } from "./tier-escalation";
 
@@ -26,8 +27,9 @@ export async function handleNoTierAvailable(
   const outcome = resolveMaxAttemptsOutcome(failureCategory);
 
   if (outcome === "pause") {
+    const pauseReason = `Execution stopped (${failureCategory ?? "unknown"} requires human review)`;
     const pausedPrd = { ...ctx.prd };
-    markStoryPaused(pausedPrd, ctx.story.id);
+    markStoryPaused(pausedPrd, ctx.story.id, await verifyEscalationQuotes(pauseReason, ctx.workdir, ctx.story.id));
     await savePRD(pausedPrd, ctx.prdPath);
 
     logger?.warn("execution", "Story paused - no tier available (needs human review)", {
@@ -47,7 +49,7 @@ export async function handleNoTierAvailable(
     pipelineEventBus.emit({
       type: "story:paused",
       storyId: ctx.story.id,
-      reason: `Execution stopped (${failureCategory ?? "unknown"} requires human review)`,
+      reason: pauseReason,
       cost: ctx.runtime?.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
     });
 
@@ -90,8 +92,9 @@ export async function handleMaxAttemptsReached(
   const outcome = resolveMaxAttemptsOutcome(failureCategory);
 
   if (outcome === "pause") {
+    const pauseReason = `Max attempts reached (${failureCategory ?? "unknown"} requires human review)`;
     const pausedPrd = { ...ctx.prd };
-    markStoryPaused(pausedPrd, ctx.story.id);
+    markStoryPaused(pausedPrd, ctx.story.id, await verifyEscalationQuotes(pauseReason, ctx.workdir, ctx.story.id));
     await savePRD(pausedPrd, ctx.prdPath);
 
     logger?.warn("execution", "Story paused - max attempts reached (needs human review)", {
@@ -111,7 +114,7 @@ export async function handleMaxAttemptsReached(
     pipelineEventBus.emit({
       type: "story:paused",
       storyId: ctx.story.id,
-      reason: `Max attempts reached (${failureCategory ?? "unknown"} requires human review)`,
+      reason: pauseReason,
       cost: ctx.runtime?.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
     });
 

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -23,7 +23,7 @@ import type { DispatchContext } from "../runtime/dispatch-context";
 import { spawn } from "../utils/bun-deps";
 import { captureDiffSummary, captureOutputFiles } from "../utils/git";
 import { MergeEngine, WorktreeManager } from "../worktree";
-import { handleTierEscalation } from "./escalation";
+import { handleTierEscalation, verifyEscalationQuotes } from "./escalation";
 import { appendProgress } from "./progress";
 
 /** Injectable deps for testability */
@@ -321,8 +321,15 @@ export async function handlePipelineFailure(
   const costDelta = (pipelineResult.context.agentResult?.estimatedCostUsd ?? 0) + (pipelineResult.stageCost ?? 0);
 
   switch (pipelineResult.finalAction) {
-    case "pause":
-      markStoryPaused(prd, ctx.story.id);
+    case "pause": {
+      // nax#1582: persist the blocking reason so the resume prompt and the
+      // resumed agent's context aren't left with "no reason recorded".
+      // Quote-scrub first — the reason can carry LLM-sourced text.
+      const rawPauseReason = pipelineResult.reason ?? "";
+      const pauseReason = rawPauseReason
+        ? await verifyEscalationQuotes(rawPauseReason, ctx.workdir, ctx.story.id)
+        : rawPauseReason;
+      markStoryPaused(prd, ctx.story.id, pauseReason || undefined);
       await savePRD(prd, ctx.prdPath);
       prdDirty = true;
       logger?.warn("pipeline", "Story paused", { storyId: ctx.story.id, reason: pipelineResult.reason });
@@ -337,6 +344,7 @@ export async function handlePipelineFailure(
         cost: ctx.runtime.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
       });
       break;
+    }
 
     case "skip":
       logger?.warn("pipeline", "Story skipped", { storyId: ctx.story.id, reason: pipelineResult.reason });

--- a/src/execution/story-orchestrator/no-progress-bail.ts
+++ b/src/execution/story-orchestrator/no-progress-bail.ts
@@ -1,10 +1,13 @@
-import { findingKey, isNaxBailWrapper, markNaxBailWrapper } from "@/findings";
+import { findingRecurrenceKey, isNaxBailWrapper, markNaxBailWrapper } from "@/findings";
 import type { Finding, FixStrategy, Iteration } from "@/findings";
 
+// Uses the coarse recurrence key (not findingKey) so an LLM reviewer rewording
+// the same finding at the same file:line:rule still reads as "no progress"
+// instead of minting a new identity every iteration (nax#1581).
 function madeNoProgress(iteration: Iteration<Finding>): boolean {
   if (iteration.findingsBefore.length === 0) return false;
-  const after = new Set(iteration.findingsAfter.map(findingKey));
-  return iteration.findingsBefore.every((finding) => after.has(findingKey(finding)));
+  const after = new Set(iteration.findingsAfter.map(findingRecurrenceKey));
+  return iteration.findingsBefore.every((finding) => after.has(findingRecurrenceKey(finding)));
 }
 
 export function withNoProgressBail(

--- a/src/findings/cycle-iteration-log.ts
+++ b/src/findings/cycle-iteration-log.ts
@@ -17,7 +17,7 @@
 import type { Logger } from "@/logger";
 import type { FixApplied, FixCycle, Iteration, IterationOutcome } from "./cycle-types";
 import type { Finding } from "./types";
-import { findingKey } from "./types";
+import { findingKey, findingRecurrenceKey } from "./types";
 
 export interface RecordIterationInput<F extends Finding> {
   findingsBefore: F[];
@@ -45,6 +45,8 @@ export function recordIteration<F extends Finding>(
   const findingsAfterCount = input.findingsAfter.length;
   const findingKeysBefore = input.findingsBefore.map(findingKey);
   const findingKeysAfter = input.findingsAfter.map(findingKey);
+  const findingRecurrenceKeysBefore = input.findingsBefore.map(findingRecurrenceKey);
+  const findingRecurrenceKeysAfter = input.findingsAfter.map(findingRecurrenceKey);
   const costUsd = input.fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
   const seenTargetFiles = new Set<string>();
   const fixTargetFiles: string[] = [];
@@ -67,6 +69,8 @@ export function recordIteration<F extends Finding>(
     finishedAt: input.finishedAt,
     findingKeysBefore,
     findingKeysAfter,
+    findingRecurrenceKeysBefore,
+    findingRecurrenceKeysAfter,
     ...(hasFixes ? { fixTargetFiles, fixSummaries } : {}),
     ...(costUsd > 0 ? { costUsd } : {}),
   };
@@ -83,6 +87,8 @@ export function recordIteration<F extends Finding>(
     findingsAfter: findingsAfterCount,
     findingKeysBefore,
     findingKeysAfter,
+    findingRecurrenceKeysBefore,
+    findingRecurrenceKeysAfter,
     ...(hasFixes ? { fixTargetFiles, fixSummaries } : {}),
     ...(costUsd > 0 ? { costUsd } : {}),
   });

--- a/src/findings/cycle-types.ts
+++ b/src/findings/cycle-types.ts
@@ -50,15 +50,26 @@ export interface Iteration<F extends Finding = Finding> {
   /** Findings observed after the iteration ran. */
   findingsAfter: F[];
   /**
-   * Exact `findingKey(f)` per entry in the pre-iteration findings, in array
-   * order. Set by `recordIteration`; omitted on carry-forward iterations
-   * recorded by review orchestrators (which retain the array form above).
-   * Identities match `classifyOutcome` so the iteration record can answer
-   * "same defect or different?" without re-deriving the keys.
+   * Exact `findingKey(f)` (message included) per entry in the pre-iteration
+   * findings, in array order. Set by `recordIteration`; omitted on
+   * carry-forward iterations recorded by review orchestrators (which retain
+   * the array form above). This is the strict identity — for the coarser
+   * identity `classifyOutcome` actually classifies by, see
+   * `findingRecurrenceKeysBefore`/`After` (nax#1581).
    */
   findingKeysBefore?: string[];
   /** Mirror of `findingKeysBefore` for the post-iteration findings. */
   findingKeysAfter?: string[];
+  /**
+   * `findingRecurrenceKey(f)` per entry in the pre-iteration findings, in
+   * array order — the coarse (message-excluded) identity `classifyOutcome`
+   * uses to compute `outcome`. Logged alongside the strict `findingKeys*`
+   * fields so a reader can tell why two `message`-differing findings were
+   * classified as the same defect (nax#1581).
+   */
+  findingRecurrenceKeysBefore?: string[];
+  /** Mirror of `findingRecurrenceKeysBefore` for the post-iteration findings. */
+  findingRecurrenceKeysAfter?: string[];
   /**
    * De-duplicated union of `fixesApplied[].targetFiles` in first-seen order.
    * Omitted when `fixesApplied` is empty so carry-forward iterations don't

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -26,7 +26,7 @@ import type {
   ValidateResult,
 } from "./cycle-types";
 import type { Finding } from "./types";
-import { findingKey } from "./types";
+import { findingRecurrenceKey } from "./types";
 
 // ─── Injectable deps (for testing) ───────────────────────────────────────────
 
@@ -43,13 +43,10 @@ function normalizeValidateResult<F extends Finding>(r: F[] | ValidateResult<F>):
 
 // ─── classifyOutcome ─────────────────────────────────────────────────────────
 
-/**
- * Classify the outcome of a single iteration for one finding source.
- * Uses findingKey for stable identity.
- */
+/** Classify the outcome of a single iteration for one finding source. Uses findingRecurrenceKey (excludes message) so a reworded finding doesn't read as a spurious regression (nax#1581). */
 function classifySingleSource<F extends Finding>(before: F[], after: F[]): IterationOutcome {
-  const beforeKeys = new Set(before.map(findingKey));
-  const afterKeys = new Set(after.map(findingKey));
+  const beforeKeys = new Set(before.map(findingRecurrenceKey));
+  const afterKeys = new Set(after.map(findingRecurrenceKey));
 
   if (afterKeys.size === 0 && beforeKeys.size === 0) return "resolved";
   if (afterKeys.size === 0) return "resolved";

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -18,7 +18,7 @@ export type {
   FixTarget,
 } from "./types";
 
-export { SEVERITY_ORDER, compareSeverity, findingKey } from "./types";
+export { SEVERITY_ORDER, compareSeverity, findingKey, findingRecurrenceKey } from "./types";
 
 export {
   acceptanceDiagnoseRawArrayToFindings,

--- a/src/findings/types.ts
+++ b/src/findings/types.ts
@@ -245,3 +245,25 @@ export function compareSeverity(a: FindingSeverity, b: FindingSeverity): number 
 export function findingKey(f: Finding): string {
   return JSON.stringify([f.source, f.file ?? null, f.line ?? null, f.rule ?? null, f.message]);
 }
+
+/**
+ * Coarse identity for a Finding, excluding `message` — used wherever the
+ * question is "is this substantively the same finding?" rather than "is this
+ * byte-identical?" (nax#1581).
+ *
+ * `findingKey` including `message` defeats progress detection: an LLM
+ * reviewer (semantic/adversarial) rewording the same finding at the same
+ * `file:line:rule` mints a new key every iteration, so consumers that diff
+ * `before`/`after` by `findingKey` — `madeNoProgress` in
+ * `no-progress-bail.ts`, and `classifySingleSource`'s new/resolved diff in
+ * `cycle.ts` — never see the finding as unchanged. Deterministic sources
+ * (lint, typecheck) have stable messages and are unaffected either way.
+ *
+ * Falls back to `findingKey` (message included) when a finding carries none
+ * of `file`/`line`/`rule` — with no locator at all, dropping `message` would
+ * conflate genuinely distinct findings from the same source into one key.
+ */
+export function findingRecurrenceKey(f: Finding): string {
+  if (f.file == null && f.line == null && f.rule == null) return findingKey(f);
+  return JSON.stringify([f.source, f.file ?? null, f.line ?? null, f.rule ?? null]);
+}

--- a/src/findings/types.ts
+++ b/src/findings/types.ts
@@ -228,18 +228,16 @@ export function compareSeverity(a: FindingSeverity, b: FindingSeverity): number 
 // ─── Stable identity ─────────────────────────────────────────────────────────
 
 /**
- * Stable string identity for a Finding — used by ADR-022's `classifyOutcome`
- * to detect whether two iterations produced equivalent finding sets ("did
- * the fix change anything?"). Also usable for deduplication and persistence.
+ * Stable string identity for a Finding — used for deduplication, persistence,
+ * and (historically) by `classifyOutcome` to detect whether two iterations
+ * produced equivalent finding sets. As of nax#1581, `classifyOutcome`'s
+ * new/resolved diff and the no-progress bail use the coarser
+ * `findingRecurrenceKey` below instead — see that function's docblock for
+ * why. `findingKey` remains the strict identity for callers that genuinely
+ * want byte-identical matching (e.g. the cycle-retirement decline ledger,
+ * structured log fields).
  *
  * Key composition: `(source, file, line, rule, message)` JSON-serialised.
- * Including `message` makes the key strict — LLM rephrasing of the same
- * underlying issue produces a different key. This is the safe direction:
- * over-counting "different findings" is fine because it conservatively
- * classifies the iteration as "changed" rather than "unchanged"; the
- * falsified-hypothesis detection only fires on truly identical output,
- * which validator-emitted (deterministic tool) findings reliably produce.
- *
  * JSON.stringify is used to handle pipe-character collisions in messages.
  */
 export function findingKey(f: Finding): string {
@@ -259,11 +257,21 @@ export function findingKey(f: Finding): string {
  * `cycle.ts` — never see the finding as unchanged. Deterministic sources
  * (lint, typecheck) have stable messages and are unaffected either way.
  *
- * Falls back to `findingKey` (message included) when a finding carries none
- * of `file`/`line`/`rule` — with no locator at all, dropping `message` would
- * conflate genuinely distinct findings from the same source into one key.
+ * Consequence: `classifySingleSource` now reads a same-location LLM reword as
+ * `"unchanged"`, which `prior-iterations-builder.ts` surfaces to the next fix
+ * attempt as "the prior hypothesis is FALSIFIED". That is the intended read —
+ * a reworded finding at the same location means the fix did not actually
+ * address the underlying defect, which is exactly what "falsified" should
+ * mean here.
+ *
+ * Falls back to `findingKey` (message included) whenever a finding lacks
+ * both `line` and `rule` — `file` alone does not discriminate between
+ * multiple distinct findings in the same file, so dropping `message` in that
+ * case would conflate genuinely different defects into one key. This is
+ * deliberately more conservative than requiring all three locators to be
+ * absent: LLM findings commonly carry `file` without `line`/`rule`.
  */
 export function findingRecurrenceKey(f: Finding): string {
-  if (f.file == null && f.line == null && f.rule == null) return findingKey(f);
+  if (f.line == null && f.rule == null) return findingKey(f);
   return JSON.stringify([f.source, f.file ?? null, f.line ?? null, f.rule ?? null]);
 }

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -407,12 +407,22 @@ export function setStoryPriority(prd: PRD, storyId: string, priority: number): v
   }
 }
 
-/** Mark a story as paused */
-export function markStoryPaused(prd: PRD, storyId: string): void {
+/**
+ * Mark a story as paused. `reason`, when supplied, is appended to
+ * `priorErrors` (mirroring the `BLOCKED:` convention below) so the resume
+ * prompt and the resumed agent's context carry the blocking reason instead
+ * of falling back to "no reason recorded" (nax#1582). Callers are
+ * responsible for scrubbing any agent-sourced text (e.g. via
+ * `verifyEscalationQuotes`) before passing it in.
+ */
+export function markStoryPaused(prd: PRD, storyId: string, reason?: string): void {
   const story = prd.userStories.find((s) => s.id === storyId);
   if (story) {
     story.status = "paused";
     story.attempts = (story.attempts ?? 0) + 1;
+    if (reason) {
+      story.priorErrors = [...(story.priorErrors || []), `PAUSED: ${reason}`];
+    }
   }
 }
 export { validatePlanOutput } from "./schema";

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -421,7 +421,12 @@ export function markStoryPaused(prd: PRD, storyId: string, reason?: string): voi
     story.status = "paused";
     story.attempts = (story.attempts ?? 0) + 1;
     if (reason) {
-      story.priorErrors = [...(story.priorErrors || []), `PAUSED: ${reason}`];
+      const entry = `PAUSED: ${reason}`;
+      const prior = story.priorErrors ?? [];
+      // Skip the append when unchanged so repeated pause/resume cycles on the
+      // same blocker don't grow priorErrors unboundedly — every entry is
+      // injected into the resumed agent's context (src/context/builder.ts).
+      if (prior.at(-1) !== entry) story.priorErrors = [...prior, entry];
     }
   }
 }

--- a/test/unit/execution/escalation/tier-outcome.test.ts
+++ b/test/unit/execution/escalation/tier-outcome.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tier Escalation Outcome Handlers — pause-reason persistence (nax#1582)
+ *
+ * Verifies the pause path appends a structured reason to `priorErrors`
+ * instead of leaving it empty (which surfaces as "no reason recorded" in
+ * the resume prompt).
+ */
+
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { handleMaxAttemptsReached, handleNoTierAvailable } from "@/execution/escalation";
+import type { EscalationHandlerContext } from "@/execution/escalation";
+import { cleanupTempDir, makePRD, makeStory, makeTempDir } from "@test/helpers";
+
+function makeCtx(overrides: Partial<EscalationHandlerContext> = {}, prdPath: string): EscalationHandlerContext {
+  const story = makeStory({ id: "US-001", status: "in-progress" });
+  const prd = makePRD({ userStories: [story] });
+  return {
+    story,
+    storiesToExecute: [story],
+    isBatchExecution: false,
+    routing: { modelTier: "fast", testStrategy: "test-after" },
+    pipelineResult: { reason: "Rectification exhausted", context: {} },
+    config: {} as EscalationHandlerContext["config"],
+    prd,
+    prdPath,
+    featureDir: undefined,
+    hooks: { hooks: {} } as EscalationHandlerContext["hooks"],
+    feature: "f",
+    totalCost: 0,
+    workdir: "/tmp",
+    ...overrides,
+  } as EscalationHandlerContext;
+}
+
+describe("handleNoTierAvailable — pause-reason persistence (nax#1582)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-tier-outcome-");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  test("appends the pause reason to priorErrors instead of leaving it empty", async () => {
+    const prdPath = join(tempDir, "prd.json");
+    const ctx = makeCtx({}, prdPath);
+
+    const result = await handleNoTierAvailable(ctx, "verifier-rejected");
+
+    expect(result.outcome).toBe("paused");
+    const pausedStory = result.prd.userStories.find((s) => s.id === "US-001");
+    expect(pausedStory?.priorErrors).toEqual([
+      "PAUSED: Execution stopped (verifier-rejected requires human review)",
+    ]);
+  });
+});
+
+describe("handleMaxAttemptsReached — pause-reason persistence (nax#1582)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-tier-outcome-");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  test("appends the pause reason to priorErrors instead of leaving it empty", async () => {
+    const prdPath = join(tempDir, "prd.json");
+    const ctx = makeCtx({}, prdPath);
+
+    const result = await handleMaxAttemptsReached(ctx, "runtime-crash");
+
+    expect(result.outcome).toBe("paused");
+    const pausedStory = result.prd.userStories.find((s) => s.id === "US-001");
+    expect(pausedStory?.priorErrors).toEqual(["PAUSED: Max attempts reached (runtime-crash requires human review)"]);
+  });
+});

--- a/test/unit/execution/escalation/tier-outcome.test.ts
+++ b/test/unit/execution/escalation/tier-outcome.test.ts
@@ -44,7 +44,7 @@ describe("handleNoTierAvailable — pause-reason persistence (nax#1582)", () => 
     cleanupTempDir(tempDir);
   });
 
-  test("appends the pause reason to priorErrors instead of leaving it empty", async () => {
+  test("appends the pause reason, including the pipeline diagnosis, to priorErrors instead of leaving it empty", async () => {
     const prdPath = join(tempDir, "prd.json");
     const ctx = makeCtx({}, prdPath);
 
@@ -53,8 +53,32 @@ describe("handleNoTierAvailable — pause-reason persistence (nax#1582)", () => 
     expect(result.outcome).toBe("paused");
     const pausedStory = result.prd.userStories.find((s) => s.id === "US-001");
     expect(pausedStory?.priorErrors).toEqual([
-      "PAUSED: Execution stopped (verifier-rejected requires human review)",
+      "PAUSED: Execution stopped (verifier-rejected requires human review): Rectification exhausted",
     ]);
+  });
+
+  test("omits the trailing colon when the pipeline result carries no reason", async () => {
+    const prdPath = join(tempDir, "prd.json");
+    const ctx = makeCtx({ pipelineResult: { reason: undefined, context: {} } }, prdPath);
+
+    const result = await handleNoTierAvailable(ctx, "verifier-rejected");
+
+    const pausedStory = result.prd.userStories.find((s) => s.id === "US-001");
+    expect(pausedStory?.priorErrors).toEqual(["PAUSED: Execution stopped (verifier-rejected requires human review)"]);
+  });
+
+  test("scrubs a fabricated quote in the pipeline reason before persisting (nax#930 convention)", async () => {
+    const prdPath = join(tempDir, "prd.json");
+    const ctx = makeCtx(
+      { pipelineResult: { reason: 'src/does-not-exist.ts:1 says `this quote is fabricated`', context: {} } },
+      prdPath,
+    );
+
+    const result = await handleNoTierAvailable(ctx, "verifier-rejected");
+
+    const pausedStory = result.prd.userStories.find((s) => s.id === "US-001");
+    expect(pausedStory?.priorErrors?.[0]).toContain("<UNVERIFIED_QUOTE>");
+    expect(pausedStory?.priorErrors?.[0]).not.toContain("this quote is fabricated");
   });
 });
 
@@ -69,7 +93,7 @@ describe("handleMaxAttemptsReached — pause-reason persistence (nax#1582)", () 
     cleanupTempDir(tempDir);
   });
 
-  test("appends the pause reason to priorErrors instead of leaving it empty", async () => {
+  test("appends the pause reason, including the pipeline diagnosis, to priorErrors instead of leaving it empty", async () => {
     const prdPath = join(tempDir, "prd.json");
     const ctx = makeCtx({}, prdPath);
 
@@ -77,6 +101,8 @@ describe("handleMaxAttemptsReached — pause-reason persistence (nax#1582)", () 
 
     expect(result.outcome).toBe("paused");
     const pausedStory = result.prd.userStories.find((s) => s.id === "US-001");
-    expect(pausedStory?.priorErrors).toEqual(["PAUSED: Max attempts reached (runtime-crash requires human review)"]);
+    expect(pausedStory?.priorErrors).toEqual([
+      "PAUSED: Max attempts reached (runtime-crash requires human review): Rectification exhausted",
+    ]);
   });
 });

--- a/test/unit/execution/pipeline-result-handler-pause-reason.test.ts
+++ b/test/unit/execution/pipeline-result-handler-pause-reason.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for pipeline-result-handler.ts — pause-reason persistence (nax#1582)
+ *
+ * Split out of pipeline-result-handler.test.ts to stay under the 800-line test
+ * file cap (.claude/rules/project-conventions.md).
+ */
+
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "@/config";
+import { handlePipelineFailure, type PipelineHandlerContext } from "@/execution";
+import type { PipelineRunResult } from "@/pipeline";
+import { PluginRegistry } from "@/plugins";
+import { loadPRD } from "@/prd";
+import type { UserStory } from "@/prd/types";
+import { cleanupTempDir, makeMockRuntime, makePRD, makeStory, makeTempDir } from "@test/helpers";
+
+function makeCtx(story: UserStory, overrides: Partial<PipelineHandlerContext> = {}): PipelineHandlerContext {
+  const prd = makePRD({ userStories: [story] });
+  return {
+    config: DEFAULT_CONFIG,
+    prd,
+    prdPath: "/tmp/prd.json",
+    workdir: "/tmp/repo",
+    hooks: { hooks: [] } as unknown as PipelineHandlerContext["hooks"], // test-ratchet-allow: as-unknown-as
+    feature: "test-feature",
+    totalCost: 0,
+    startTime: Date.now(),
+    runId: "run-001",
+    pluginRegistry: new PluginRegistry([]),
+    story,
+    storiesToExecute: [story],
+    routing: { complexity: "simple", modelTier: "standard", testStrategy: "test-after", reasoning: "" },
+    isBatchExecution: false,
+    allStoryMetrics: [],
+    storyGitRef: "abc123",
+    runtime: makeMockRuntime(),
+    ...overrides,
+  } as PipelineHandlerContext;
+}
+
+describe("handlePipelineFailure — pause-reason persistence (nax#1582)", () => {
+  let tempDir: string;
+  let prdPath: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-pause-reason-");
+    prdPath = join(tempDir, "prd.json");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  test("appends the pipeline reason to priorErrors instead of leaving it empty", async () => {
+    const story = makeStory({ id: "US-001", status: "in-progress", passes: false, attempts: 1 });
+    const ctx = makeCtx(story, { prdPath });
+
+    const pauseResult: PipelineRunResult = {
+      success: false,
+      finalAction: "pause",
+      reason: "Semantic review failed: 1 findings",
+      context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
+    };
+
+    await handlePipelineFailure(ctx, pauseResult);
+
+    const onDisk = await loadPRD(prdPath);
+    const pausedStory = onDisk.userStories.find((s) => s.id === "US-001");
+    expect(pausedStory?.status).toBe("paused");
+    expect(pausedStory?.priorErrors).toEqual(["PAUSED: Semantic review failed: 1 findings"]);
+  });
+
+  test("leaves priorErrors empty when the pipeline result carries no reason", async () => {
+    const story = makeStory({ id: "US-002", status: "in-progress", passes: false, attempts: 1 });
+    const ctx = makeCtx(story, { prdPath });
+
+    const pauseResult: PipelineRunResult = {
+      success: false,
+      finalAction: "pause",
+      context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
+    };
+
+    await handlePipelineFailure(ctx, pauseResult);
+
+    const onDisk = await loadPRD(prdPath);
+    const pausedStory = onDisk.userStories.find((s) => s.id === "US-002");
+    expect(pausedStory?.status).toBe("paused");
+    expect(pausedStory?.priorErrors ?? []).toHaveLength(0);
+  });
+
+  test("scrubs a fabricated quote in the pipeline reason before persisting (nax#930 convention)", async () => {
+    const story = makeStory({ id: "US-003", status: "in-progress", passes: false, attempts: 1 });
+    const ctx = makeCtx(story, { prdPath });
+
+    const pauseResult: PipelineRunResult = {
+      success: false,
+      finalAction: "pause",
+      reason: 'src/does-not-exist.ts:1 says `this quote is fabricated`',
+      context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
+    };
+
+    await handlePipelineFailure(ctx, pauseResult);
+
+    const onDisk = await loadPRD(prdPath);
+    const pausedStory = onDisk.userStories.find((s) => s.id === "US-003");
+    expect(pausedStory?.priorErrors?.[0]).toContain("<UNVERIFIED_QUOTE>");
+    expect(pausedStory?.priorErrors?.[0]).not.toContain("this quote is fabricated");
+  });
+});

--- a/test/unit/execution/pipeline-result-handler.test.ts
+++ b/test/unit/execution/pipeline-result-handler.test.ts
@@ -377,59 +377,9 @@ describe("handlePipelineFailure — worktree mode (EXEC-002)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// nax#1582 — pause path persists the blocking reason
+// nax#1582 — pause path persists the blocking reason: see
+// pipeline-result-handler-pause-reason.test.ts (split out for the 800-line cap)
 // ---------------------------------------------------------------------------
-
-describe("handlePipelineFailure — pause-reason persistence (nax#1582)", () => {
-  let tempDir: string;
-  let prdPath: string;
-
-  beforeEach(() => {
-    tempDir = makeTempDir("nax-pause-reason-");
-    prdPath = join(tempDir, "prd.json");
-  });
-
-  afterEach(() => {
-    cleanupTempDir(tempDir);
-  });
-
-  test("appends the pipeline reason to priorErrors instead of leaving it empty", async () => {
-    const story = makeStory("US-001", { status: "in-progress", passes: false, attempts: 1 });
-    const ctx = makeCtx(story, { prdPath });
-
-    const pauseResult: PipelineRunResult = {
-      success: false,
-      finalAction: "pause",
-      reason: "Semantic review failed: 1 findings",
-      context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
-    };
-
-    await handlePipelineFailure(ctx, pauseResult);
-
-    const onDisk = await loadPRD(prdPath);
-    const pausedStory = onDisk.userStories.find((s) => s.id === "US-001");
-    expect(pausedStory?.status).toBe("paused");
-    expect(pausedStory?.priorErrors).toEqual(["PAUSED: Semantic review failed: 1 findings"]);
-  });
-
-  test("leaves priorErrors empty when the pipeline result carries no reason", async () => {
-    const story = makeStory("US-002", { status: "in-progress", passes: false, attempts: 1 });
-    const ctx = makeCtx(story, { prdPath });
-
-    const pauseResult: PipelineRunResult = {
-      success: false,
-      finalAction: "pause",
-      context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
-    };
-
-    await handlePipelineFailure(ctx, pauseResult);
-
-    const onDisk = await loadPRD(prdPath);
-    const pausedStory = onDisk.userStories.find((s) => s.id === "US-002");
-    expect(pausedStory?.status).toBe("paused");
-    expect(pausedStory?.priorErrors ?? []).toHaveLength(0);
-  });
-});
 
 // ---------------------------------------------------------------------------
 // story:skipped event emission

--- a/test/unit/execution/pipeline-result-handler.test.ts
+++ b/test/unit/execution/pipeline-result-handler.test.ts
@@ -377,6 +377,61 @@ describe("handlePipelineFailure — worktree mode (EXEC-002)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// nax#1582 — pause path persists the blocking reason
+// ---------------------------------------------------------------------------
+
+describe("handlePipelineFailure — pause-reason persistence (nax#1582)", () => {
+  let tempDir: string;
+  let prdPath: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-pause-reason-");
+    prdPath = join(tempDir, "prd.json");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  test("appends the pipeline reason to priorErrors instead of leaving it empty", async () => {
+    const story = makeStory("US-001", { status: "in-progress", passes: false, attempts: 1 });
+    const ctx = makeCtx(story, { prdPath });
+
+    const pauseResult: PipelineRunResult = {
+      success: false,
+      finalAction: "pause",
+      reason: "Semantic review failed: 1 findings",
+      context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
+    };
+
+    await handlePipelineFailure(ctx, pauseResult);
+
+    const onDisk = await loadPRD(prdPath);
+    const pausedStory = onDisk.userStories.find((s) => s.id === "US-001");
+    expect(pausedStory?.status).toBe("paused");
+    expect(pausedStory?.priorErrors).toEqual(["PAUSED: Semantic review failed: 1 findings"]);
+  });
+
+  test("leaves priorErrors empty when the pipeline result carries no reason", async () => {
+    const story = makeStory("US-002", { status: "in-progress", passes: false, attempts: 1 });
+    const ctx = makeCtx(story, { prdPath });
+
+    const pauseResult: PipelineRunResult = {
+      success: false,
+      finalAction: "pause",
+      context: { agentResult: { estimatedCostUsd: 0 } } as unknown as PipelineRunResult["context"], // test-ratchet-allow: as-unknown-as
+    };
+
+    await handlePipelineFailure(ctx, pauseResult);
+
+    const onDisk = await loadPRD(prdPath);
+    const pausedStory = onDisk.userStories.find((s) => s.id === "US-002");
+    expect(pausedStory?.status).toBe("paused");
+    expect(pausedStory?.priorErrors ?? []).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // story:skipped event emission
 // ---------------------------------------------------------------------------
 

--- a/test/unit/execution/story-orchestrator-no-progress-bail.test.ts
+++ b/test/unit/execution/story-orchestrator-no-progress-bail.test.ts
@@ -137,7 +137,10 @@ describe("withNoProgressBail — US-002", () => {
       iteration([reworded("same defect", index)], [reworded("same defect", index + 1)], index + 1),
     );
     const bail = bailWhen(withNoProgressBail([strategy()], true, 3));
-    expect(bail(iterations)).not.toBeNull();
+    const reason = bail(iterations);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain("3 consecutive iteration(s)");
+    expect(reason).toContain("1 finding(s) persisted");
   });
 
   test("US-002 AC15: no-progress reason outranks count-increase", () => {

--- a/test/unit/execution/story-orchestrator-no-progress-bail.test.ts
+++ b/test/unit/execution/story-orchestrator-no-progress-bail.test.ts
@@ -10,6 +10,19 @@ function finding(message: string): Finding {
   return { severity: "error", category: "test", source: "tdd-verifier", message };
 }
 
+/** Same source/file/line/rule as `finding(base)`, but a reworded message — simulates an LLM reviewer paraphrasing the same defect. */
+function reworded(base: string, variant: number): Finding {
+  return {
+    severity: "error",
+    category: "test",
+    source: "semantic-review",
+    file: "src/a.ts",
+    line: 10,
+    rule: "AC-2",
+    message: `${base} (variant ${variant})`,
+  };
+}
+
 function iteration(before: Finding[], after: Finding[], iterationNum: number): Iteration<Finding> {
   return {
     iterationNum,
@@ -117,6 +130,14 @@ describe("withNoProgressBail — US-002", () => {
   test("US-002 AC11: reason reports two persisted findings", () => {
     const bail = bailWhen(withNoProgressBail([strategy()], true, 3));
     expect(bail(stalledIterations([finding("one"), finding("two")], 3))).toContain("2 finding(s) persisted");
+  });
+
+  test("nax#1581: bails on an LLM finding reworded every iteration at the same file:line:rule", () => {
+    const iterations = Array.from({ length: 3 }, (_, index) =>
+      iteration([reworded("same defect", index)], [reworded("same defect", index + 1)], index + 1),
+    );
+    const bail = bailWhen(withNoProgressBail([strategy()], true, 3));
+    expect(bail(iterations)).not.toBeNull();
   });
 
   test("US-002 AC15: no-progress reason outranks count-increase", () => {

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -37,6 +37,16 @@ describe("classifyOutcome", () => {
   ])("classifyOutcome($before, $after) → $expected", (before, after, expected) => {
     expect(classifyOutcome(before, after)).toBe(expected);
   });
+
+  test("nax#1581: a reworded LLM finding at the same file:line:rule reads as unchanged, not regressed", () => {
+    const before = [
+      makeFinding({ source: "semantic-review", message: "cannot return X on failure path", file: "src/a.ts", line: 10, rule: "AC-2" }),
+    ];
+    const after = [
+      makeFinding({ source: "semantic-review", message: "violates AC-2, cannot return X", file: "src/a.ts", line: 10, rule: "AC-2" }),
+    ];
+    expect(classifyOutcome(before, after)).toBe("unchanged");
+  });
 });
 
 // ─── runFixCycle — bail: no-strategy ──────────────────────────────────────────

--- a/test/unit/findings/types.test.ts
+++ b/test/unit/findings/types.test.ts
@@ -1,35 +1,38 @@
 import { describe, expect, test } from "bun:test";
 import { findingKey, findingRecurrenceKey } from "@/findings";
-import type { Finding } from "@/findings";
-
-function finding(overrides: Partial<Finding> & Pick<Finding, "source" | "message">): Finding {
-  return { severity: "error", category: "test", ...overrides };
-}
+import { makeFinding } from "./_cycle-fixtures";
 
 describe("findingKey", () => {
   test("differs when only the message differs", () => {
-    const a = finding({ source: "lint", message: "unused var", file: "src/a.ts", line: 1 });
-    const b = finding({ source: "lint", message: "different wording", file: "src/a.ts", line: 1 });
+    const a = makeFinding({ source: "lint", message: "unused var", file: "src/a.ts", line: 1 });
+    const b = makeFinding({ source: "lint", message: "different wording", file: "src/a.ts", line: 1 });
     expect(findingKey(a)).not.toBe(findingKey(b));
   });
 });
 
 describe("findingRecurrenceKey — nax#1581", () => {
   test("matches when file/line/rule are identical but message differs", () => {
-    const a = finding({ source: "semantic-review", message: "cannot return X", file: "src/a.ts", line: 10, rule: "AC-2" });
-    const b = finding({ source: "semantic-review", message: "violates AC-2", file: "src/a.ts", line: 10, rule: "AC-2" });
+    const a = makeFinding({ source: "semantic-review", message: "cannot return X", file: "src/a.ts", line: 10, rule: "AC-2" });
+    const b = makeFinding({ source: "semantic-review", message: "violates AC-2", file: "src/a.ts", line: 10, rule: "AC-2" });
     expect(findingRecurrenceKey(a)).toBe(findingRecurrenceKey(b));
   });
 
   test("differs when line differs, even with the same message", () => {
-    const a = finding({ source: "semantic-review", message: "same", file: "src/a.ts", line: 10, rule: "AC-2" });
-    const b = finding({ source: "semantic-review", message: "same", file: "src/a.ts", line: 20, rule: "AC-2" });
+    const a = makeFinding({ source: "semantic-review", message: "same", file: "src/a.ts", line: 10, rule: "AC-2" });
+    const b = makeFinding({ source: "semantic-review", message: "same", file: "src/a.ts", line: 20, rule: "AC-2" });
     expect(findingRecurrenceKey(a)).not.toBe(findingRecurrenceKey(b));
   });
 
   test("falls back to findingKey (message included) when file/line/rule are all absent", () => {
-    const a = finding({ source: "tdd-verifier", message: "finding-a" });
-    const b = finding({ source: "tdd-verifier", message: "finding-b" });
+    const a = makeFinding({ source: "tdd-verifier", message: "finding-a" });
+    const b = makeFinding({ source: "tdd-verifier", message: "finding-b" });
+    expect(findingRecurrenceKey(a)).not.toBe(findingRecurrenceKey(b));
+    expect(findingRecurrenceKey(a)).toBe(findingKey(a));
+  });
+
+  test("falls back to findingKey when file is present but line and rule are both absent — file alone doesn't discriminate distinct findings in the same file", () => {
+    const a = makeFinding({ source: "semantic-review", message: "issue A in this file", file: "src/a.ts" });
+    const b = makeFinding({ source: "semantic-review", message: "issue B in this file", file: "src/a.ts" });
     expect(findingRecurrenceKey(a)).not.toBe(findingRecurrenceKey(b));
     expect(findingRecurrenceKey(a)).toBe(findingKey(a));
   });

--- a/test/unit/findings/types.test.ts
+++ b/test/unit/findings/types.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { findingKey, findingRecurrenceKey } from "@/findings";
+import type { Finding } from "@/findings";
+
+function finding(overrides: Partial<Finding> & Pick<Finding, "source" | "message">): Finding {
+  return { severity: "error", category: "test", ...overrides };
+}
+
+describe("findingKey", () => {
+  test("differs when only the message differs", () => {
+    const a = finding({ source: "lint", message: "unused var", file: "src/a.ts", line: 1 });
+    const b = finding({ source: "lint", message: "different wording", file: "src/a.ts", line: 1 });
+    expect(findingKey(a)).not.toBe(findingKey(b));
+  });
+});
+
+describe("findingRecurrenceKey — nax#1581", () => {
+  test("matches when file/line/rule are identical but message differs", () => {
+    const a = finding({ source: "semantic-review", message: "cannot return X", file: "src/a.ts", line: 10, rule: "AC-2" });
+    const b = finding({ source: "semantic-review", message: "violates AC-2", file: "src/a.ts", line: 10, rule: "AC-2" });
+    expect(findingRecurrenceKey(a)).toBe(findingRecurrenceKey(b));
+  });
+
+  test("differs when line differs, even with the same message", () => {
+    const a = finding({ source: "semantic-review", message: "same", file: "src/a.ts", line: 10, rule: "AC-2" });
+    const b = finding({ source: "semantic-review", message: "same", file: "src/a.ts", line: 20, rule: "AC-2" });
+    expect(findingRecurrenceKey(a)).not.toBe(findingRecurrenceKey(b));
+  });
+
+  test("falls back to findingKey (message included) when file/line/rule are all absent", () => {
+    const a = finding({ source: "tdd-verifier", message: "finding-a" });
+    const b = finding({ source: "tdd-verifier", message: "finding-b" });
+    expect(findingRecurrenceKey(a)).not.toBe(findingRecurrenceKey(b));
+    expect(findingRecurrenceKey(a)).toBe(findingKey(a));
+  });
+});

--- a/test/unit/prd/prd-failure-category.test.ts
+++ b/test/unit/prd/prd-failure-category.test.ts
@@ -165,3 +165,29 @@ describe("markStoryPaused and markStoryPassed — failureCategory not affected",
     expect(prd.userStories[0].failureCategory).toBeUndefined();
   });
 });
+
+// ── nax#1582: markStoryPaused persists the blocking reason ───────────────────
+
+describe("markStoryPaused — reason persistence (nax#1582)", () => {
+  test("appends a PAUSED: entry to priorErrors when reason is given", () => {
+    const prd = makePrd([makeStory("US-001")]);
+    markStoryPaused(prd, "US-001", "Semantic review failed: 1 findings");
+    expect(prd.userStories[0].priorErrors).toEqual(["PAUSED: Semantic review failed: 1 findings"]);
+  });
+
+  test("leaves priorErrors untouched when no reason is given", () => {
+    const prd = makePrd([makeStory("US-001")]);
+    markStoryPaused(prd, "US-001");
+    expect(prd.userStories[0].priorErrors ?? []).toHaveLength(0);
+  });
+
+  test("appends to existing priorErrors rather than replacing them", () => {
+    const prd = makePrd([makeStory("US-001")]);
+    prd.userStories[0].priorErrors = ["Attempt 1 failed with model tier: fast"];
+    markStoryPaused(prd, "US-001", "Rectification exhausted");
+    expect(prd.userStories[0].priorErrors).toEqual([
+      "Attempt 1 failed with model tier: fast",
+      "PAUSED: Rectification exhausted",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two related harness bugs found in rectification/pause telemetry:

**#1581 — no-progress bail is inert against LLM findings.** `findingKey()` includes the free-text `message`, so an LLM reviewer (semantic/adversarial) rewording the same finding at the same `file:line:rule` mints a new key every iteration. This defeated `withNoProgressBail` entirely and made `classifyOutcome` report `"regressed"` when nothing had regressed.

- Adds `findingRecurrenceKey()` — same identity minus `message` — used by `madeNoProgress` and `classifySingleSource`.
- Falls back to the strict `findingKey` whenever a finding has neither `line` nor `rule`, since `file` alone doesn't discriminate between distinct findings in the same file.
- Logs `findingRecurrenceKeysBefore/After` alongside the existing strict key fields so iteration telemetry stays self-consistent with the `outcome` it produced.
- Documents that `classifySingleSource`'s coarse-key `"unchanged"` outcome is the intended input to `prior-iterations-builder`'s "hypothesis FALSIFIED" prompt — a reworded finding at the same location means the fix didn't address the underlying defect.

**#1582 — paused stories persist no blocking reason.** `markStoryPaused(prd, storyId)` never recorded why a story paused, so `prd.json`'s `priorErrors` stayed empty and the resume prompt showed "no reason recorded" while the resumed agent's context carried no memory of the blocker.

- `markStoryPaused` now accepts an optional `reason`, appended as `PAUSED: ${reason}` to `priorErrors` (skips the append if identical to the last entry, so repeated pause/resume cycles don't grow the list unboundedly).
- Threaded from all three pause call sites: `pipeline-result-handler.ts` and `tier-outcome.ts` (`handleNoTierAvailable` + `handleMaxAttemptsReached`).
- `tier-outcome.ts` folds `ctx.pipelineResult.reason` into the persisted reason rather than a bare `failureCategory` label — the resume prompt reads only the *last* `priorErrors` entry, so a category-only string was displacing the more informative detail escalation had already written.
- Each site scrubs the reason via the existing `verifyEscalationQuotes()` before persisting, matching the convention already used on the escalation path for agent-sourced text (with regression tests for the fabricated-quote case).

## Test plan

- [x] New/updated unit tests: `findings/types.test.ts`, `findings/cycle.test.ts`, `execution/story-orchestrator-no-progress-bail.test.ts`, `execution/escalation/tier-outcome.test.ts`, `execution/pipeline-result-handler-pause-reason.test.ts`, `prd/prd-failure-category.test.ts`
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (incl. file-size, deep-relatives, inline-mock, ratchet checks)
- [x] `bun run test` — full suite green (13218 unit + 1104 integration + 25 ui, 0 failures)
- [x] Independent code review pass (code-reviewer agent) run against the diff; all findings addressed