### PR TITLE
test(queue-handler): pre-create log file to fix flaky chmod race

### DIFF
--- a/test/unit/execution/queue-handler.test.ts
+++ b/test/unit/execution/queue-handler.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { clearQueueFile, readQueueFile } from "@/execution";
 import { getLogger, initLogger, resetLogger } from "@/logger";
@@ -32,6 +33,7 @@ describe("readQueueFile", () => {
     workdir = makeTempDir("nax-queue-handler-");
     logFile = join(workdir, "audit.jsonl");
     initLogger({ level: "silent", filePath: logFile });
+    writeFileSync(logFile, "");
   });
 
   afterEach(() => {
@@ -106,6 +108,7 @@ describe("clearQueueFile", () => {
     workdir = makeTempDir("nax-queue-handler-clear-");
     logFile = join(workdir, "audit.jsonl");
     initLogger({ level: "silent", filePath: logFile });
+    writeFileSync(logFile, "");
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Fix the flaky `readQueueFile > a rename failure logs a specific rename-failure warn` test that intermittently failed on `bun run test:coverage`.
- The test chmod'd the workdir to `0o555`, then the logger's `appendFile` microtask ran before the test's `finally { chmod 0o755 }`, so it tried to create the log file in a read-only directory and dropped the warn line.
- Pre-create the log file in `beforeEach` so the file already exists when chmod is applied. Opening an existing file in a `0o555` directory only requires read+execute on the parent, so `appendFile` succeeds deterministically regardless of microtask ordering.

## Root cause

The race:
1. `chmodSync(workdir, 0o555)` — directory is now read-only.
2. `await readQueueFile(workdir)` → rename fails → `logger.warn(...)` is called.
3. `logger.warn` synchronously pushes to `pendingLines` and chains `writeQueueTail = writeQueueTail.then(...)`.
4. The chained `.then()` microtask runs **before** the test's `await readQueueFile` continuation resumes.
5. Inside the microtask: `await appendFile(filePath, batch)` opens the (non-existent) log file in the `0o555` workdir → `EACCES: permission denied, open`.
6. The error is swallowed by `.catch()`, the warn is lost, `flush()` returns, `Bun.file(logFile).exists()` is `false`, `readWarnLines` returns `[]`.
7. Only then does the test's `finally` block chmod the workdir back to `0o755` — too late.

Verified reproduction: ran the test in isolation 50x — 3 failed with the exact same `EACCES: permission denied, open` from the logger's `process.stderr.write("[logger] Failed to write to log file: …")`.

## Fix

`test/unit/execution/queue-handler.test.ts` — add `writeFileSync(logFile, "")` in both `beforeEach` blocks. The file now exists with default `0644` perms before the chmod. Opening it from a `0o555` parent succeeds because directory write permission is only needed to **create** directory entries, not to open existing ones.

## Verification

- 10/10 isolated test runs of `bun test test/unit/execution/queue-handler.test.ts -t "a rename failure"`
- 10/10 full `bun run test:coverage` runs (was failing ~50% of runs before)
- `bun run typecheck` ✓
- `bun run lint` ✓

## Test Plan

- [ ] `bun test test/unit/execution/queue-handler.test.ts` — all 8 tests pass
- [ ] `bun run test:coverage` — runs cleanly without the `EACCES: permission denied, open` stderr line
- [ ] `bun run typecheck` and `bun run lint` — clean