### PR TITLE
fix: address 3 deferred LOW findings from the 2026-08-14 deep code review

### DIFF
--- a/src/commands/replay.ts
+++ b/src/commands/replay.ts
@@ -17,6 +17,7 @@ import type { Command } from "commander";
 import { NaxError } from "../errors";
 import type { NaxStatusFile } from "../execution/status-file";
 import type { LogEntry } from "../logger/types";
+import { MAX_RETAINED_RUNS } from "../metrics";
 import type { RunMetrics } from "../metrics/types";
 // Internal paths, not the `../replay` barrel: `../replay/index.ts` re-exports
 // `registerReplayCommand` from this file, so importing the barrel here would
@@ -134,6 +135,17 @@ export async function runReplay(
     eventsDir: discovered.meta.eventsDir,
   });
   const status = await deps.readStatus(discovered.meta.statusPath);
+
+  // GROWTH-1 follow-up: metrics.json retains only the last MAX_RETAINED_RUNS
+  // runs, so a discovered run (found via the central registry, independent
+  // of metrics.json) can legitimately have no metrics entry — cost, token,
+  // and per-story metric detail then silently disappear from the report with
+  // no indication why. Surface it explicitly instead of degrading quietly.
+  if (metrics === undefined) {
+    deps.stderr(
+      `Note: no run metrics found for ${discovered.meta.runId} — cost, token, and per-story metric detail will be unavailable in this report. This can happen if the run predates the retained metrics window (last ${MAX_RETAINED_RUNS} runs) or if metrics were never recorded for it.\n`,
+    );
+  }
 
   const timeline = deps.reconstructTimeline({
     entries,

--- a/src/interaction/plugins/webhook.ts
+++ b/src/interaction/plugins/webhook.ts
@@ -218,6 +218,23 @@ export class WebhookInteractionPlugin implements InteractionPlugin {
     return state.count <= maxRequests;
   }
 
+  /**
+   * Build a 429 response carrying a `Retry-After` header so a well-behaved
+   * caller knows when the current fixed window resets, instead of retrying
+   * blind. Must be called immediately after the `checkRateLimit` call that
+   * rejected the request, so `state.windowStart` reflects the active window.
+   */
+  private rateLimitedResponse(bucket: "pre" | "auth"): Response {
+    const windowMs = this.config.rateLimitWindowMs ?? DEFAULT_RATE_LIMIT_WINDOW_MS;
+    const state = this.rateLimitBuckets[bucket];
+    const now = _webhookPluginDeps.now();
+    const retryAfterSeconds = Math.max(1, Math.ceil((state.windowStart + windowMs - now) / 1000));
+    return new Response("Too Many Requests", {
+      status: 429,
+      headers: { "Retry-After": String(retryAfterSeconds) },
+    });
+  }
+
   async destroy(): Promise<void> {
     this.isDestroyed = true;
     this.resolvePendingReceivesOnDestroy();
@@ -491,7 +508,7 @@ export class WebhookInteractionPlugin implements InteractionPlugin {
     // volume. This alone must not be able to starve authenticated callers —
     // see the separate "auth" bucket check after signature verification below.
     if (!this.checkRateLimit("pre")) {
-      return new Response("Too Many Requests", { status: 429 });
+      return this.rateLimitedResponse("pre");
     }
 
     const maxBytes = this.config.maxPayloadBytes ?? 1024 * 1024;
@@ -527,7 +544,7 @@ export class WebhookInteractionPlugin implements InteractionPlugin {
       // actually required — with requireSecret: false there is no auth check
       // at all, so the single "pre" bucket is correct as-is for that case.
       if (this.config.requireSecret && !this.checkRateLimit("auth")) {
-        return new Response("Too Many Requests", { status: 429 });
+        return this.rateLimitedResponse("auth");
       }
     }
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -17,6 +17,7 @@ export {
   collectBatchMetrics,
   saveRunMetrics,
   loadRunMetrics,
+  MAX_RETAINED_RUNS,
 } from "./tracker";
 export { calculateAggregateMetrics, deriveRunFallbackAggregates, getLastRun } from "./aggregator";
 export {

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -25,6 +25,7 @@ import { TokenUsage } from "./types";
  * lifetime of a project. Oldest runs are dropped first on write; runs are
  * always appended chronologically so this keeps the most recent N.
  */
+/** Exported via the `src/metrics` barrel so replay/reporting consumers can reference the cap without hardcoding it. */
 export const MAX_RETAINED_RUNS = 200;
 
 /**

--- a/src/operations/mechanical-formatfix-strategy.ts
+++ b/src/operations/mechanical-formatfix-strategy.ts
@@ -4,6 +4,7 @@ import type { FixStrategy } from "../findings";
 import type { Finding } from "../findings/types";
 import type { QualityCommandOptions, QualityCommandResult } from "../quality/runner";
 import { runQualityCommand } from "../quality/runner";
+import { shellQuoteArg } from "../verification/shell-quote";
 import type { CallContext, DeterministicOperation } from "./types";
 
 export interface MechanicalFormatFixInput {
@@ -25,17 +26,13 @@ export const _mechanicalFormatFixDeps: MechanicalFormatFixDeps = {
   runQualityCommand,
 };
 
-function shellQuotePath(path: string): string {
-  return `'${path.replaceAll("'", `'\\''`)}'`;
-}
-
 function buildCommand(
   broad: string | undefined,
   scoped: string | undefined,
   scopeFiles?: readonly string[],
 ): string | null {
   if (scoped && scopeFiles && scopeFiles.length > 0) {
-    return scoped.replaceAll("{{files}}", scopeFiles.map(shellQuotePath).join(" "));
+    return scoped.replaceAll("{{files}}", scopeFiles.map(shellQuoteArg).join(" "));
   }
   if (broad) {
     return broad;

--- a/src/operations/mechanical-lintfix-strategy.ts
+++ b/src/operations/mechanical-lintfix-strategy.ts
@@ -4,6 +4,7 @@ import type { FixStrategy } from "../findings";
 import type { Finding } from "../findings/types";
 import type { QualityCommandOptions, QualityCommandResult } from "../quality/runner";
 import { runQualityCommand } from "../quality/runner";
+import { shellQuoteArg } from "../verification/shell-quote";
 import type { CallContext, DeterministicOperation } from "./types";
 
 export interface MechanicalLintFixInput {
@@ -25,17 +26,13 @@ export const _mechanicalLintFixDeps: MechanicalLintFixDeps = {
   runQualityCommand,
 };
 
-function shellQuotePath(path: string): string {
-  return `'${path.replaceAll("'", `'\\''`)}'`;
-}
-
 function buildCommand(
   broad: string | undefined,
   scoped: string | undefined,
   scopeFiles?: readonly string[],
 ): string | null {
   if (scoped && scopeFiles && scopeFiles.length > 0) {
-    return scoped.replaceAll("{{files}}", scopeFiles.map(shellQuotePath).join(" "));
+    return scoped.replaceAll("{{files}}", scopeFiles.map(shellQuoteArg).join(" "));
   }
   if (broad) {
     return broad;

--- a/src/review/scoped-lint.ts
+++ b/src/review/scoped-lint.ts
@@ -5,6 +5,7 @@ import { type UserStory, getContextFiles } from "../prd";
 import { type QualityCommandResult, runQualityCommand } from "../quality";
 import { findPackageDir } from "../test-runners/resolver";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
+import { shellQuoteArg } from "../verification/shell-quote";
 import { formatDiagnosticsOutput, parseLintOutput } from "./lint-parsing";
 import type { LintOutputFormat } from "./lint-parsing";
 import type { ReviewCheckResult, ReviewConfig } from "./types";
@@ -40,10 +41,6 @@ interface ScopeResult {
 
 const SCOPED_LINT_CHECK = "lint";
 
-function shellQuotePath(path: string): string {
-  return `'${path.replaceAll("'", "'\\''")}'`;
-}
-
 function normalizePath(path: string): string {
   return path.replaceAll("\\", "/").replace(/^\.\//, "");
 }
@@ -57,7 +54,7 @@ function isSupportedDerivedScopedCommand(command: string): boolean {
 }
 
 function appendFilesToCommand(command: string, files: readonly string[]): string {
-  const fileArgs = files.map(shellQuotePath).join(" ");
+  const fileArgs = files.map(shellQuoteArg).join(" ");
   return `${command} ${fileArgs}`;
 }
 
@@ -275,7 +272,7 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
   }
 
   if (scopedTemplate) {
-    const scopedCommand = scopedTemplate.replaceAll("{{files}}", scope.files.map(shellQuotePath).join(" "));
+    const scopedCommand = scopedTemplate.replaceAll("{{files}}", scope.files.map(shellQuoteArg).join(" "));
     const scopedResult = await _scopedLintDeps.runLintCommand(
       args.workdir,
       args.storyId,

--- a/src/verification/flake-probe.ts
+++ b/src/verification/flake-probe.ts
@@ -17,6 +17,7 @@ import { getSafeLogger } from "../logger";
 import type { Framework } from "../test-runners/detector";
 import type { TestFailure } from "../test-runners/types";
 import { executeWithTimeout } from "./executor";
+import { shellQuoteArg } from "./shell-quote";
 import type { TestExecutionResult } from "./types";
 
 // Frameworks that exit 0 for "zero tests matched the isolation filter" (primarily `go
@@ -32,8 +33,8 @@ function probeRanNoTests(output: string | undefined): boolean {
 }
 
 export type FlakeProbeVerdict =
-  | { verdict: "flaky"; probeRuns: number; probePasses: number }
-  | { verdict: "consistent-failure"; probeRuns: number }
+  | { verdict: "flaky"; probeRuns: number; probePasses: number; attributableRuns: number }
+  | { verdict: "consistent-failure"; probeRuns: number; attributableRuns: number }
   | { verdict: "unprobeable"; reason: string };
 
 export interface FlakeProbeInput {
@@ -75,16 +76,6 @@ export function escapeRegex(input: string): string {
 }
 
 /**
- * Single-quote a value for safe interpolation into a shell command string
- * (executed via `[shell, "-c", command]` — see `executeWithTimeout`). Wraps in
- * single quotes and escapes any embedded `'` using the standard
- * close-quote/escaped-quote/reopen-quote trick: `'` -> `'\''`.
- */
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
-/**
  * Build an isolation command for the failing test, scoped to its framework.
  *
  * - bun / jest / vitest: `<base> <quoted file> -t '<escaped name>'`
@@ -93,7 +84,7 @@ function shellQuote(value: string): string {
  * - go: `<base> -run '^<escaped name>$'` (cwd scoped to the failing package)
  *
  * Filter values — and, for bun/jest/vitest, the file path — are
- * single-quoted (`shellQuote`) because the command is ultimately executed
+ * single-quoted (`shellQuoteArg`) because the command is ultimately executed
  * through a shell (`[shell, "-c", command]`) — an unquoted test name or file
  * path containing whitespace (or shell metacharacters, since both originate
  * from parsed output of an arbitrary target repo) would be word-split or
@@ -111,13 +102,13 @@ export function buildIsolationCommand(baseCommand: string, failure: TestFailure,
 
   switch (framework) {
     case "pytest":
-      return `${baseCommand} ${shellQuote(`${file}::${name}`)}`;
+      return `${baseCommand} ${shellQuoteArg(`${file}::${name}`)}`;
     case "go":
-      return `${baseCommand} -run ${shellQuote(`^${escapeRegex(name)}$`)}`;
+      return `${baseCommand} -run ${shellQuoteArg(`^${escapeRegex(name)}$`)}`;
     case "bun":
     case "jest":
     case "vitest":
-      return `${baseCommand} ${shellQuote(file)} -t ${shellQuote(escapeRegex(name))}`;
+      return `${baseCommand} ${shellQuoteArg(file)} -t ${shellQuoteArg(escapeRegex(name))}`;
     default:
       throw new NaxError(
         `[flake-probe] unsupported framework: ${framework as string}`,
@@ -214,7 +205,7 @@ export async function runFlakeProbe(input: FlakeProbeInput): Promise<FlakeProbeV
   }
 
   if (probePasses > 0) {
-    return { verdict: "flaky", probeRuns, probePasses };
+    return { verdict: "flaky", probeRuns, probePasses, attributableRuns };
   }
-  return { verdict: "consistent-failure", probeRuns };
+  return { verdict: "consistent-failure", probeRuns, attributableRuns };
 }

--- a/src/verification/flake-triage.ts
+++ b/src/verification/flake-triage.ts
@@ -114,9 +114,13 @@ export const _flakeTriageDeps = {
 
 /**
  * Classify each `failed-test` finding in `input.findings`. Confirmed flakes
- * are relabeled to `category: "flaky-test"` with `meta: { probeRuns, probePasses }`
- * and recorded in the returned quarantine report. All other findings pass
- * through unchanged. Non-`failed-test` findings pass through untouched.
+ * are relabeled to `category: "flaky-test"` with
+ * `meta: { probeRuns, probePasses, attributableRuns }` — `probeRuns` is the
+ * raw number of probe attempts made, `attributableRuns` is the subset that
+ * actually produced a clean pass or genuine fail (excludes timeouts,
+ * executor crashes, and zero-matched runs) — and recorded in the returned
+ * quarantine report. All other findings pass through unchanged.
+ * Non-`failed-test` findings pass through untouched.
  *
  * Returns a new findings array; the input is not mutated.
  */
@@ -217,7 +221,12 @@ export async function triageFlakyFindings(input: FlakeTriageInput): Promise<Flak
 
     if (verdict.verdict === "flaky") {
       copy.category = "flaky-test";
-      copy.meta = { ...(copy.meta ?? {}), probeRuns: verdict.probeRuns, probePasses: verdict.probePasses };
+      copy.meta = {
+        ...(copy.meta ?? {}),
+        probeRuns: verdict.probeRuns,
+        probePasses: verdict.probePasses,
+        attributableRuns: verdict.attributableRuns,
+      };
       quarantineMemo.add(key);
       keys.push(key);
       reasons.push(`quarantined: ${key}`);

--- a/src/verification/runners.ts
+++ b/src/verification/runners.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { analyzeTestExitCode } from "../test-runners";
 import { sleep } from "../utils/bun-deps";
 import { buildTestCommand, executeWithTimeout, normalizeEnvironment } from "./executor";
+import { shellQuoteArg } from "./shell-quote";
 import type { AssetVerificationResult, VerificationGateOptions, VerificationResult } from "./types";
 
 /** Verify all expected files exist before running tests. */
@@ -124,19 +125,11 @@ export async function fullSuite(options: VerificationGateOptions): Promise<Verif
   return runVerificationCore(options);
 }
 
-/**
- * Single-quote a path for safe shell interpolation.
- * Escapes any single quotes within the path so metacharacters can't break out.
- */
-function shellQuotePath(p: string): string {
-  return `'${p.replace(/'/g, "'\\''")}'`;
-}
-
 /** Run tests scoped to modified files. */
 export async function scoped(options: VerificationGateOptions): Promise<VerificationResult> {
   let scopedCommand = options.command;
   if (options.scopedTestPaths && options.scopedTestPaths.length > 0) {
-    const quotedPaths = options.scopedTestPaths.map(shellQuotePath).join(" ");
+    const quotedPaths = options.scopedTestPaths.map(shellQuoteArg).join(" ");
     scopedCommand = `${options.command} ${quotedPaths}`;
   }
   return runVerificationCore({ ...options, command: scopedCommand });

--- a/test/unit/commands/replay.test.ts
+++ b/test/unit/commands/replay.test.ts
@@ -32,6 +32,7 @@ import { NaxError } from "@/errors";
 import { registerReplayCommand } from "@/replay";
 import type { MetaJson } from "@/pipeline/subscribers/registry";
 import type { LogEntry } from "@/logger/types";
+import type { RunMetrics } from "@/metrics";
 import type { RunTimeline } from "@/replay";
 import { cleanupTempDir, makeTempDir } from "@test/helpers";
 
@@ -472,6 +473,60 @@ describe("runReplay — AC10: crashed-run end-to-end", () => {
     expect(reportArg.status).toBe("crashed");
     expect(reportArg.runId).toBe("run-crash-x");
     expect(stdoutWrites.join("")).toContain("CRASHED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metrics-retention follow-up: missing metrics is surfaced, not silent.
+// ---------------------------------------------------------------------------
+
+describe("runReplay — missing metrics is surfaced on stderr, not silent", () => {
+  let runsDir: string;
+  let stdoutWrites: string[];
+  let stderrWrites: string[];
+  let deps: ReplayCommandDeps;
+
+  beforeEach(() => {
+    runsDir = makeTempDir("nax-replay-cmd-test-");
+    stdoutWrites = [];
+    stderrWrites = [];
+    deps = makeBaseDeps(runsDir, stdoutWrites, stderrWrites);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(runsDir);
+  });
+
+  test("readMetrics resolving undefined writes an explanatory note to stderr naming the run", async () => {
+    const exit = await runReplay("run-known", {}, deps);
+
+    expect(exit).toBe(0);
+    const stderr = stderrWrites.join("");
+    expect(stderr).toContain("run-known");
+    expect(stderr).toContain("no run metrics found");
+  });
+
+  test("readMetrics resolving a value writes no stderr note", async () => {
+    const runMetrics: RunMetrics = {
+      runId: "run-known",
+      feature: "feat-known",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:10:00.000Z",
+      totalCost: 0,
+      totalStories: 0,
+      storiesCompleted: 0,
+      totalDurationMs: 600_000,
+      stories: [],
+      storiesFailed: 0,
+    };
+    deps = makeBaseDeps(runsDir, stdoutWrites, stderrWrites, {
+      readMetrics: mock(async () => runMetrics),
+    });
+
+    const exit = await runReplay("run-known", {}, deps);
+
+    expect(exit).toBe(0);
+    expect(stderrWrites.join("")).toBe("");
   });
 });
 

--- a/test/unit/execution/story-orchestrator/flake-triage-seam.test.ts
+++ b/test/unit/execution/story-orchestrator/flake-triage-seam.test.ts
@@ -102,7 +102,7 @@ describe("productionTriageSeam", () => {
     let probeCalled = false;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalled = true;
-      return { verdict: "flaky", probeRuns: 2, probePasses: 1 };
+      return { verdict: "flaky", probeRuns: 2, probePasses: 1, attributableRuns: 2 };
     };
 
     const config = makeNaxConfig({
@@ -129,7 +129,7 @@ describe("productionTriageSeam", () => {
     let probeCalled = false;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalled = true;
-      return { verdict: "flaky", probeRuns: 2, probePasses: 1 };
+      return { verdict: "flaky", probeRuns: 2, probePasses: 1, attributableRuns: 2 };
     };
 
     const config = makeNaxConfig({

--- a/test/unit/interaction/interaction-plugins.test.ts
+++ b/test/unit/interaction/interaction-plugins.test.ts
@@ -238,6 +238,41 @@ describe("WebhookInteractionPlugin - rate limiting (SEC-8)", () => {
     }
   });
 
+  test("429 responses carry a Retry-After header naming seconds until the window resets", async () => {
+    fakeNowMs = 1_700_000_000_000;
+    _webhookPluginDeps.now = () => fakeNowMs;
+
+    const plugin = new WebhookInteractionPlugin();
+    await plugin.init({
+      url: "http://localhost/unused",
+      requireSecret: false,
+      callbackPort: 0,
+      rateLimitMaxRequests: 1,
+      rateLimitWindowMs: 10_000,
+    });
+
+    void plugin.receive("sec8-retry-after-1", 4000);
+    void plugin.receive("sec8-retry-after-2", 4000);
+    await Promise.resolve();
+    await Promise.resolve();
+    const port = plugin.callbackServerPort!;
+
+    try {
+      const under = await postCallback(port, "sec8-retry-after-1");
+      expect(under.status).toBe(200);
+      expect(under.headers.get("Retry-After")).toBeNull();
+
+      const over = await postCallback(port, "sec8-retry-after-2");
+      expect(over.status).toBe(429);
+      const retryAfter = over.headers.get("Retry-After");
+      expect(retryAfter).not.toBeNull();
+      expect(Number.parseInt(retryAfter ?? "", 10)).toBeGreaterThan(0);
+      expect(Number.parseInt(retryAfter ?? "", 10)).toBeLessThanOrEqual(10);
+    } finally {
+      await plugin.destroy();
+    }
+  });
+
   test("rate limit window resets after the configured window elapses", async () => {
     fakeNowMs = 1_700_000_000_000;
     _webhookPluginDeps.now = () => fakeNowMs;

--- a/test/unit/verification/flake-probe.test.ts
+++ b/test/unit/verification/flake-probe.test.ts
@@ -193,6 +193,7 @@ describe("runFlakeProbe — verdict logic", () => {
     if (result.verdict === "flaky") {
       expect(result.probeRuns).toBe(2);
       expect(result.probePasses).toBe(1);
+      expect(result.attributableRuns).toBe(2);
     }
     expect(fake).toHaveBeenCalledTimes(2);
   });
@@ -212,6 +213,7 @@ describe("runFlakeProbe — verdict logic", () => {
     expect(result.verdict).toBe("consistent-failure");
     if (result.verdict === "consistent-failure") {
       expect(result.probeRuns).toBe(3);
+      expect(result.attributableRuns).toBe(3);
     }
     expect(fake).toHaveBeenCalledTimes(3);
   });
@@ -270,6 +272,10 @@ describe("runFlakeProbe — verdict logic", () => {
     if (result.verdict === "flaky") {
       expect(result.probeRuns).toBe(2);
       expect(result.probePasses).toBe(1);
+      // Only 1 of the 2 raw attempts was attributable (the other was an
+      // environmental timeout) — attributableRuns must reflect that, distinct
+      // from the raw probeRuns count.
+      expect(result.attributableRuns).toBe(1);
     }
     expect(fake).toHaveBeenCalledTimes(2);
   });
@@ -373,6 +379,9 @@ describe("runFlakeProbe — verdict logic", () => {
     expect(result.verdict).toBe("consistent-failure");
     if (result.verdict === "consistent-failure") {
       expect(result.probeRuns).toBe(3);
+      // Only the one genuine fail is attributable — the two env failures
+      // consumed a probe slot but confirmed nothing.
+      expect(result.attributableRuns).toBe(1);
     }
     expect(fake).toHaveBeenCalledTimes(3);
   });

--- a/test/unit/verification/flake-triage.test.ts
+++ b/test/unit/verification/flake-triage.test.ts
@@ -72,7 +72,7 @@ describe("triageFlakyFindings — empty findings (AC1)", () => {
     const orig = _flakeTriageDeps.runFlakeProbe;
     _flakeTriageDeps.runFlakeProbe = async () => {
       calls += 1;
-      return { verdict: "consistent-failure", probeRuns: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 } satisfies FlakeProbeVerdict;
     };
     try {
       await triageFlakyFindings(makeInput());
@@ -89,14 +89,14 @@ describe("triageFlakyFindings — empty findings (AC1)", () => {
 
 describe("triageFlakyFindings — pre-existing test probing (AC2)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC2 — invokes probe exactly once with file, testName, and resolved config", async () => {
     const calls: Array<{ file: string; testName: string; cfg: FlakeDetectionConfig }> = [];
     _flakeTriageDeps.runFlakeProbe = async ({ failure, config }) => {
       calls.push({ file: failure.file, testName: failure.testName, cfg: config });
-      return { verdict: "consistent-failure", probeRuns: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 } satisfies FlakeProbeVerdict;
     };
 
     const finding = makeFinding({ file: "test/unit/foo.test.ts", rule: "should work" });
@@ -122,14 +122,14 @@ describe("triageFlakyFindings — pre-existing test probing (AC2)", () => {
 
 describe("triageFlakyFindings — test file in diff (AC3)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC3 — skips probe when test file is in changedTestFiles", async () => {
     let probeCalls = 0;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalls += 1;
-      return { verdict: "consistent-failure", probeRuns: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 } satisfies FlakeProbeVerdict;
     };
 
     const finding = makeFinding({ file: "test/unit/foo.test.ts", rule: "should work" });
@@ -151,14 +151,14 @@ describe("triageFlakyFindings — test file in diff (AC3)", () => {
 
 describe("triageFlakyFindings — test file mapped from changed source (AC4)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC4 — skips probe when test file is in mappedTestFiles", async () => {
     let probeCalls = 0;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalls += 1;
-      return { verdict: "consistent-failure", probeRuns: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 } satisfies FlakeProbeVerdict;
     };
 
     const finding = makeFinding({ file: "test/unit/foo.test.ts", rule: "should work" });
@@ -183,12 +183,12 @@ describe("triageFlakyFindings — test file mapped from changed source (AC4)", (
 
 describe("triageFlakyFindings — verdict flaky (AC5)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
-  test("AC5 — relabels to flaky-test with meta.probeRuns and meta.probePasses", async () => {
+  test("AC5 — relabels to flaky-test with meta.probeRuns, meta.probePasses, and meta.attributableRuns", async () => {
     _flakeTriageDeps.runFlakeProbe = async () =>
-      ({ verdict: "flaky", probeRuns: 3, probePasses: 2 }) satisfies FlakeProbeVerdict;
+      ({ verdict: "flaky", probeRuns: 3, probePasses: 2, attributableRuns: 2 }) satisfies FlakeProbeVerdict;
 
     const finding = makeFinding({ file: "test/unit/foo.test.ts", rule: "should work" });
     const result = await triageFlakyFindings(makeInput({ findings: [finding] }));
@@ -196,6 +196,7 @@ describe("triageFlakyFindings — verdict flaky (AC5)", () => {
     expect(result.findings[0]?.category).toBe("flaky-test");
     expect(result.findings[0]?.meta?.probeRuns).toBe(3);
     expect(result.findings[0]?.meta?.probePasses).toBe(2);
+    expect(result.findings[0]?.meta?.attributableRuns).toBe(2);
   });
 });
 
@@ -205,12 +206,12 @@ describe("triageFlakyFindings — verdict flaky (AC5)", () => {
 
 describe("triageFlakyFindings — verdict consistent-failure (AC6)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC6 — keeps category failed-test on consistent-failure verdict", async () => {
     _flakeTriageDeps.runFlakeProbe = async () =>
-      ({ verdict: "consistent-failure", probeRuns: 2 }) satisfies FlakeProbeVerdict;
+      ({ verdict: "consistent-failure", probeRuns: 2, attributableRuns: 2 }) satisfies FlakeProbeVerdict;
 
     const finding = makeFinding({ file: "test/unit/foo.test.ts", rule: "should work" });
     const result = await triageFlakyFindings(makeInput({ findings: [finding] }));
@@ -225,14 +226,14 @@ describe("triageFlakyFindings — verdict consistent-failure (AC6)", () => {
 
 describe("triageFlakyFindings — run-scoped quarantine memo (AC7)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC7 — relabels to flaky-test and does NOT invoke probe again", async () => {
     let probeCalls = 0;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalls += 1;
-      return { verdict: "consistent-failure", probeRuns: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 } satisfies FlakeProbeVerdict;
     };
 
     const memo = new Map<string, true>();
@@ -255,7 +256,7 @@ describe("triageFlakyFindings — run-scoped quarantine memo (AC7)", () => {
     let probeCalls = 0;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalls += 1;
-      return { verdict: "consistent-failure", probeRuns: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 } satisfies FlakeProbeVerdict;
     };
 
     const memo = new Map<string, true>();
@@ -291,14 +292,14 @@ describe("triageFlakyFindings — run-scoped quarantine memo (AC7)", () => {
 
 describe("triageFlakyFindings — maxProbesPerGate cap (AC8)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC8 — skips all probes and records the skip reason when over budget", async () => {
     let probeCalls = 0;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalls += 1;
-      return { verdict: "consistent-failure", probeRuns: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 } satisfies FlakeProbeVerdict;
     };
 
     // 6 distinct probe candidates, maxProbesPerGate=2 → over budget.
@@ -328,14 +329,14 @@ describe("triageFlakyFindings — maxProbesPerGate cap (AC8)", () => {
 
 describe("triageFlakyFindings — disabled (AC9)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC9 — never invokes probe and returns findings unchanged when disabled", async () => {
     let probeCalls = 0;
     _flakeTriageDeps.runFlakeProbe = async () => {
       probeCalls += 1;
-      return { verdict: "flaky", probeRuns: 2, probePasses: 1 } satisfies FlakeProbeVerdict;
+      return { verdict: "flaky", probeRuns: 2, probePasses: 1, attributableRuns: 2 } satisfies FlakeProbeVerdict;
     };
 
     const finding = makeFinding({ file: "test/unit/foo.test.ts", rule: "should work" });
@@ -354,7 +355,7 @@ describe("triageFlakyFindings — disabled (AC9)", () => {
 
 describe("triageFlakyFindings — probe dependency throws (AC10)", () => {
   afterEach(() => {
-    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1 });
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
   });
 
   test("AC10 — swallows probe exception and keeps failed-test category", async () => {


### PR DESCRIPTION
## Summary

Follow-up on `docs/reviews/2026-08-14-work-order-fix-review.md`, which shipped every HIGH/MEDIUM finding but explicitly deferred three LOW items as out of scope. This PR closes all three, verified against current `main` before implementing (none had been fixed since).

- **flake-probe confidence reporting**: `runFlakeProbe`'s `"flaky"`/`"consistent-failure"` verdicts reported `probeRuns` as the raw attempt count, conflating it with the number of runs that actually produced an attributable pass/fail (excluding timeouts, executor crashes, zero-matched runs). Existing tests bake in the raw-count semantics for `probeRuns`, so rather than change that field's meaning, a new `attributableRuns` field is added alongside it and persisted into `finding.meta` by `flake-triage`.
- **`nax replay` silent metrics gap**: a run discovered via the central registry can have no `metrics.json` entry once it falls outside the GROWTH-1 retention window (`MAX_RETAINED_RUNS = 200`) — cost/token/per-story detail then silently disappears from the report with no indication why. `runReplay` now writes an explanatory stderr note naming the run and the retention window.
- **Webhook 429s / duplicated shellQuote**: rate-limited webhook responses now carry a `Retry-After` header computed from the active fixed window. Also consolidated 5 independent `shellQuote`/`shellQuotePath` reimplementations (`flake-probe.ts`, `mechanical-formatfix-strategy.ts`, `mechanical-lintfix-strategy.ts`, `verification/runners.ts`, `review/scoped-lint.ts`) onto the existing canonical `shellQuoteArg` in `src/verification/shell-quote.ts` — behaviorally identical, just SSOT drift.

A self-review pass found one LOW item (`webhook.ts`'s `rateLimitedResponse` relies on a documented-but-type-unenforced call-order invariant with `checkRateLimit`) — left as-is since the two calls are synchronous and back-to-back today; not worth the added complexity to guard a non-reachable race.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (all static checks, including `check:test-typecheck` and `check:test-as-unknown-as` ratchets — both at or below baseline)
- [x] `bun run test:bail` — 13,299 unit + 1,120 integration + 25 UI tests, 0 fail
- [x] New/updated tests cover: `attributableRuns` in both flaky and consistent-failure verdicts (including mixed attributable/environmental cases), stderr note on missing replay metrics (present/absent), `Retry-After` header value bounds on 429 responses