### PR TITLE
fix: Batch 6 pending findings from the 2026-08-14 deep code review

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -71,6 +71,7 @@ import {
 } from "../src/cli/config-profile";
 import { resolveFeatureSpec } from "../src/cli/features-resolve";
 import { generateCommand } from "../src/cli/generate";
+import { resolveUseHeadless } from "../src/cli/run-mode";
 import { registerStatusCommand } from "../src/cli/status-dispatch";
 import { detectCommand } from "../src/commands/detect";
 import { logsCommand } from "../src/commands/logs";
@@ -679,15 +680,11 @@ program
     const runId = new Date().toISOString().replace(/:/g, "-").replace(/\..+/, "");
     const logFilePath = join(runsDir, `${runId}.jsonl`);
 
-    // Determine TUI vs headless mode
-    // TUI activates when:
-    // 1. stdout is a TTY, AND
-    // 2. --headless flag is NOT passed, AND
-    // 3. NAX_HEADLESS env var is NOT set
+    // Determine TUI vs headless mode — see resolveUseHeadless() for the rule.
     const isTTY = process.stdout.isTTY ?? false;
     const headlessFlag = options.headless ?? false;
     const headlessEnv = process.env.NAX_HEADLESS === "1";
-    const useHeadless = !isTTY || headlessFlag || headlessEnv;
+    const useHeadless = resolveUseHeadless({ isTTY, headlessFlag, headlessEnv, formatterMode });
 
     // Initialize logger with selected level, file path, and formatter mode
     initLogger({

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -757,6 +757,10 @@ program
     if (options.parallel !== undefined) {
       parallel = Number.parseInt(options.parallel, 10);
       if (Number.isNaN(parallel) || parallel < 0) {
+        // BUG-22: this validation runs after the TUI is already mounted
+        // (renderTui above) — without unmounting first, the error message
+        // printed over the still-live TUI frame instead of a clean error.
+        tuiInstance?.unmount();
         console.error(chalk.red("--parallel must be a non-negative integer"));
         process.exit(1);
       }
@@ -778,6 +782,10 @@ program
       });
       process.removeListener("SIGINT", onSigint);
       if (outcome === "cancelled") {
+        // BUG-22: unmount before exiting — the TUI is already mounted by
+        // this point, and exiting without unmounting left the cancellation
+        // message printed over the still-live TUI frame.
+        tuiInstance?.unmount();
         console.log(chalk.dim("\nScheduled run cancelled."));
         process.exit(0);
       }

--- a/docs/20260814-review-current.md
+++ b/docs/20260814-review-current.md
@@ -32,6 +32,18 @@ rev 2 put **BUG-03 in P0**. It is a feature that crashes 100% of the time, so no
 
 ---
 
+## Status update (2026-08-15)
+
+**Batches 1–5 (all P0/P1 security & reliability findings): ✅ Fixed.** Landed in PR #1588 (commit `fed3681a`, "P0 + P1") covering all of SEC-02/03/05/07/08, BUG-01/02/04/05/06/07/09/10/11/12/13/14/17/18/20/21/24/25/26/28/29, MED-02/03/04/05. **SEC-04 and BUG-08** are HIGH/MEDIUM findings not explicitly named in a batch below — neither was actually touched by #1588 despite being adjacent in severity to what it covered; both were fixed later, in PR #1591 (see next paragraph).
+
+**Batch 6 (dead/inert surfaces, 10 findings) + SEC-04, SEC-09, BUG-08: ✅ Fixed.** Landed in PR #1591 (branch `fix/deep-review-batch6-pending-findings`): SEC-04 (streamed body-size enforcement — closes the gap for real, not just the loopback-only narrowing the severity correction above describes), SEC-06, SEC-09, MED-01, BUG-03 (contained to `dnf-crashed`, **not** made functional — see note below), BUG-08, BUG-15, BUG-16, BUG-19, BUG-22, BUG-23, BUG-27. Went through a `code-reviewer` subagent pass plus an automated security review before merge; both caught real issues (a regression in the BUG-19 fix, a `forceStop` scoping gap, MED-01 pattern tuning) that were fixed in the same PR — see the PR description for the full review trail.
+
+**BUG-03 caveat:** the crash is contained (a bad `worktreeManager`/`pipeline` dependency now yields a per-contestant `dnf-crashed` result instead of crashing the whole CLI), but `_contestantDeps` is still unwired to a real worktree-scoped pipeline implementation anywhere in `src/`/`bin/`. `nax run --compare` will still report every contestant as `dnf-crashed`. Making bake-off actually functional is a feature-completion task (worktree-scoped pipeline execution, per-contestant PRD/config, result aggregation), not a bug fix, and remains open.
+
+**Batch 7 (L1…L38 cleanup): still pending.** Not attempted in either PR — see the batch's own note for which items (L5, L8, L13) have live failure modes worth pulling forward.
+
+---
+
 ## Overall Grade: B- (74/100)
 
 | Dimension | Score |
@@ -77,6 +89,8 @@ if (isAbsolute(file)) {
 **Fix:** Delete the `isAbsolute` fallback, or contain via `validateModulePath` against `repoRoot`/`workdir`.
 
 #### SEC-04: Webhook callback enforces payload size only *after* fully buffering the body
+
+**Status:** ✅ Fixed — PR #1591 (streamed body reads with an early abort once `maxPayloadBytes` is exceeded).
 **Severity:** HIGH | **Category:** Security
 **File:** `src/interaction/plugins/webhook.ts:483-502`
 **Proof (verified):** Content-Length pre-check (line 486) is bypassable (chunked transfer); the authoritative check runs on `await req.text()` (line 491) — the full body is already in memory. Rate limiter bounds request count (300/window), not size.
@@ -113,6 +127,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** Add `detached: true` to the spawn (mirroring `executeWithTimeout`).
 
 #### BUG-03: `nax run --compare` (bake-off) always crashes — production deps never wired
+
+**Status:** ⚠️ Partially fixed — PR #1591 contains the crash (per-contestant `dnf-crashed` instead of a whole-CLI crash), but `_contestantDeps` is still unwired. Bake-off is not functional; see the PR/status-update note above.
 **Severity:** HIGH | **Category:** Bug
 **File:** `src/bakeoff/contestant.ts:49-52,101`
 **Proof (verified):** `_contestantDeps` holds `undefined as unknown as ...` stubs; grep across src/ and bin/ finds no installation site ("Production wiring installs these via init steps" is false). `bin/nax.ts:793-807` calls `runContestant(agent, options)` (2 args) → line 101 `await deps.worktreeManager.create(...)` throws `TypeError` **outside** the try/catch (starts line 103).
@@ -150,6 +166,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 ### 🟡 MEDIUM
 
 #### SEC-06: Global monkey-patch of `Bun.serve` + `globalThis.fetch` as a module side effect
+
+**Status:** ✅ Fixed — PR #1591 (install deferred to first server start; port-reuse hardened).
 **Severity:** MEDIUM | **Category:** Security/Quality
 **File:** `src/interaction/plugins/webhook-serve-compat.ts:55-90` (installed at webhook.ts:15-17)
 **Proof (verified):** `installServePortZeroCompat` rewrites `Bun.serve` and `globalThis.fetch` process-wide. Scope note (rev 2): the patched fetch intercepts **only** ports registered in `inMemoryServers` (i.e. while a compat in-memory server is live — itself only created when `Bun.serve` genuinely fails), so unrelated-fetch misrouting requires an in-memory server to be active; the wrap hazard is real but narrower than originally worded.
@@ -170,6 +188,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** Validate `profileName` as a single path segment at all three entry points.
 
 #### SEC-09: No ANSI/escape-sequence sanitization on agent-controlled display strings
+
+**Status:** ✅ Fixed — PR #1591 (shared `stripControlChars()` applied to TUI panel rows and the headless log formatter).
 **Severity:** MEDIUM | **Category:** Security
 **File:** `src/tui/components/StoriesPanel.tsx:159-164`, `LiveActivityPanel.tsx:147-159`, `src/log-format/formatter.ts:278`
 **Proof (verified):** story failure reasons (`slice(0, 25)`), titles, agent/model names render raw into Ink `<Text>`; Ink does not sanitize ESC sequences.
@@ -177,6 +197,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** One shared ESC/OSC strip util applied in TUI row renderers and the log formatter.
 
 #### BUG-08: Escalation quote-verifier reads files outside the workdir (path traversal)
+
+**Status:** ✅ Fixed — PR #1591 (routed through the existing `validateModulePath` containment guard). Not touched by PR #1588 despite the "Re-verified and confirmed" list above naming other findings in that pass.
 **Severity:** MEDIUM | **Category:** Security
 **File:** `src/execution/escalation/quote-integrity.ts:46,80`
 **Proof (verified):** regex `[a-zA-Z0-9_./-]+` admits `..`; `absPath = \`${workdir}/${triple.file}\`` with no containment check; `deps.readFile(absPath)` reads it.
@@ -222,6 +244,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** Race each tracked promise against a settle deadline; drop + log on timeout.
 
 #### BUG-15: Per-model `env` overrides are silently dropped in the ACP-only adapter
+
+**Status:** ✅ Fixed — PR #1591 (`buildAllowedEnv`'s existing `modelEnv` option threaded through both `createClient` call sites).
 **Severity:** MEDIUM | **Category:** Bug
 **File:** `src/agents/acp/spawn-client.ts:94`, `src/config/schemas-model.ts:17`
 **Proof (verified):** `models.<agent>.<tier>.env` is a first-class schema field; `SpawnAcpClient` constructor calls `this.env = buildAllowedEnv()` with no options, and `AcpClientOptions` has no `env` field — no consumer of `modelDef.env` anywhere in src.
@@ -229,6 +253,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** Thread `modelDef.env` through `AcpClientOptions.env` → `buildAllowedEnv`.
 
 #### BUG-16: `closePhysicalSession({ force: true })` silently no-ops — errored sessions never hard-terminated
+
+**Status:** ✅ Fixed — PR #1591 (`forceStop` implemented on `SpawnAcpClient`, scoped to the client's worktree via `--cwd` after a review-round fix).
 **Severity:** MEDIUM | **Category:** Bug
 **File:** `src/agents/acp/adapter-close-physical.ts:23-28`
 **Proof (verified):** grep shows `forceStop` exists only at this cast site — no production class implements it; the `else if (client.loadSession)` fallback is dead because `SpawnAcpClient` always has `closeSession`. So `session-manager-runtime.ts:119`'s force close never terminates the acpx queue-owner.
@@ -248,6 +274,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** AbortController timeout on the fetch (default ~30s) and/or a deadline race in `sendTurn`'s context-tool path.
 
 #### BUG-19: Module-level `getInstalledAgents()`/`checkAgentHealth()` registry stubs return `[]` — multi-agent precheck is dead
+
+**Status:** ✅ Fixed — PR #1591. First pass had a real regression (collapsed "all known agents" and "installed agents" into the same set, so `installed` was always `true`, keeping the "available but not installed" precheck section dead for a different reason) — caught by code review and fixed via a new `getAllAgents()` before merge.
 **Severity:** MEDIUM | **Category:** Bug
 **File:** `src/agents/registry.ts:31-39`, `src/agents/shared/version-detection.ts:9,76-100`
 **Proof (verified):** `version-detection.ts:9` imports the module-level `getInstalledAgents` (stub `return []`), and `getAgentVersions` calls it twice (lines 77 and 82) — always returns `[]`, so `multi-agent-health` precheck always reports "No additional agents detected". The real implementation exists only inside `createAgentRegistry()`.
@@ -268,12 +296,16 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** Fold `process.env` into the base map, or document the throw and wrap in `NaxError` with profile name + key path.
 
 #### BUG-22: TUI exit paths leave the TUI mounted; `q`+confirm only hides the UI (run keeps executing)
+
+**Status:** ✅ Fixed — PR #1591 (remaining gaps: `--parallel`/schedule-cancel exits now unmount first; a Ctrl+<letter> combo no longer falls through to the matching bare-letter shortcut).
 **Severity:** MEDIUM | **Category:** Reliability
 **File:** `bin/nax.ts:743` vs :757-765, :783-786; `src/tui/App.tsx:149-156,191-209`; `src/tui/hooks/useKeyboard.ts:113-141`
 **Proof (verified, rev 2 refinement):** (a) `--parallel` validation `exit(1)` and schedule-cancel `exit(0)` fire **after** `renderTui` (bin/nax.ts:743) without `unmount()` — message prints over the TUI frame. (b) `q`+`y` calls `exit()` only (UI unmount) — the runner keeps executing with no visible UI; **a real abort exists but only via `a`+confirm** (writes `ABORT` queue command, App.tsx:198-200) — the original wording overstated "no way to stop"; the defect is that `q` misleads the user into thinking the run quit while spend continues, and Ctrl+C lands on `SHOW_COST` (useKeyboard case "c") instead of quit/abort.
 **Fix:** On quit-confirm, write `{ type: "ABORT" }` to the queue file in addition to `exit()`; explicit ctrl+c branch in `useKeyboard`; hoist `--parallel` validation before `renderTui`; unmount before schedule-cancel exit.
 
 #### BUG-23: `nax run --json` silently ignored when stdout is a TTY
+
+**Status:** ✅ Fixed — PR #1591 (`formatterMode === "json"` added as a fourth headless trigger; extracted to a testable `resolveUseHeadless()`).
 **Severity:** MEDIUM | **Category:** Bug
 **File:** `bin/nax.ts:532-540,688-690`
 **Proof (verified):** `useHeadless = !isTTY || headlessFlag || headlessEnv` — `formatterMode === "json"` not considered; on a TTY the TUI mounts and `formatterMode: undefined` is passed to `run()` (bin/nax.ts:697).
@@ -298,6 +330,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** Keyword-gate the downgrade (text actually explains absent tests) or drop the auto-downgrade.
 
 #### BUG-27: Dependency cycles not validated at plan time → `topologicalSort` throws and aborts the merge batch
+
+**Status:** ✅ Fixed — PR #1591 (`validatePlanOutput` now fails fast on a cycle; `mergeAll` also defensively catches `topologicalSort`'s throw for PRDs written outside the validated path).
 **Severity:** MEDIUM | **Category:** Reliability
 **File:** `src/worktree/merge.ts:174-176,272-284`, `src/prd/schema.ts:234-242`
 **Proof (verified):** `validateStory` checks unknown IDs only (no cycle check); `mergeAll` calls `topologicalSort` first thing — the `visiting.has(storyId)` cycle branch throws (merge.ts:282-284) with no try/catch in `mergeAll` or `runParallelBatch` (execution/parallel-batch.ts:282). Sequential mode silently ends with the two stories forever `pending`/`"running"`.
@@ -316,6 +350,8 @@ this._mutex = this._mutex.then(() => write).catch(() => write);
 **Fix:** `[...passedStories].reverse().slice(0, 5)` or sort by completion recency.
 
 #### MED-01: Secret-redaction gaps — PEM keys, JWTs, auth headers, short keys pass through
+
+**Status:** ✅ Fixed — PR #1591. Went through three tuning passes: the initial patterns over-redacted ordinary prose ("Basic authentication failed") and had a tight PEM bound that could miss large legitimate cert-chain bundles (caught by code review + an automated security review) — final version requires credential-shaped values and bounds the PEM gap at 64KB.
 **Severity:** MEDIUM | **Category:** Security
 **File:** `src/logger/redact.ts:21-30`
 **Proof (verified):** `SECRET_VALUE_PATTERNS` covers `sk-`, `ghp_`, `npm_`, `AKIA`, `xox*`, `KEY=value` only; `SECRET_KEY_PATTERN` inspects object keys only. PEM blocks, `eyJ...` JWTs, `Bearer`/`Basic` headers, and short keys in free text pass through into the JSONL and terminal.
@@ -472,11 +508,11 @@ These do not crash; they produce a wrong verdict. Every fix needs a test pinning
 
 ### Batch 6 — P2. Dead or inert surfaces (10 findings)
 
-Real defects, but no live user impact — schedule after Batches 1–5.
+**Status: ✅ Fixed — PR #1591** (see "Status update" near the top of this doc). Real defects, but no live user impact — schedule after Batches 1–5.
 
 BUG-03 (bake-off crashes on every invocation; `_contestantDeps` has zero installation sites in `src`/`bin` — also move `worktreeManager.create` inside the try so failure yields `dnf-crashed`), BUG-19 (registry stubs return `[]`), BUG-16 (`forceStop` implemented nowhere — implement or delete the branch), BUG-15 (per-model `env` never threaded), BUG-23 (`--json` ignored on a TTY), BUG-22 (TUI quit/exit paths), BUG-27 (dependency-cycle validation), SEC-06, SEC-09, MED-01.
 
-### Batch 7 — P3. Cleanup
+### Batch 7 — P3. Cleanup (still pending)
 
 L1…L38. Pull **L5** (NaN cost accumulator), **L8** (pipe deadlock on >64KB diff output), and **L13** (`nax unlock` removing a live run's lock) forward into Batch 6 — they have live failure modes; the rest are hygiene.
 

--- a/src/agents/acp/adapter-close-physical.ts
+++ b/src/agents/acp/adapter-close-physical.ts
@@ -21,7 +21,7 @@ export async function closePhysicalSession(
         await client.closeSession(handle, agentName, options?.signal);
         // AC-83: hard-terminate (acpx stop) when force=true, e.g. for errored sessions
         if (options?.force) {
-          await (client as { forceStop?: (agentName: string) => Promise<void> }).forceStop?.(agentName).catch(() => {});
+          await client.forceStop?.(agentName, options?.signal).catch(() => {});
         }
       } else if (client.loadSession) {
         const session = await client.loadSession(handle, agentName, "approve-reads");

--- a/src/agents/acp/adapter-session-types.ts
+++ b/src/agents/acp/adapter-session-types.ts
@@ -90,5 +90,13 @@ export interface AcpClient {
   loadSession?(sessionName: string, agentName: string, permissionMode: string): Promise<AcpSession | null>;
   /** Close a named session directly without first ensuring/loading it. */
   closeSession?(sessionName: string, agentName: string, signal?: AbortSignal): Promise<void>;
+  /**
+   * BUG-16: hard-terminate the acpx queue-owner process for `agentName`
+   * (`acpx <agentName> stop`), regardless of session state. Used by
+   * closePhysicalSession({ force: true }) for errored sessions where a
+   * graceful closeSession is not enough. Optional — clients without a
+   * hard-stop concept may omit it.
+   */
+  forceStop?(agentName: string, signal?: AbortSignal): Promise<void>;
   close(): Promise<void>;
 }

--- a/src/agents/acp/adapter-session-types.ts
+++ b/src/agents/acp/adapter-session-types.ts
@@ -79,6 +79,14 @@ export interface AcpClientOptions {
    * the spawn-client module default when omitted (#1583).
    */
   trackedSpawnStartupDeadlineMs?: number;
+  /**
+   * BUG-15: per-model env overrides from config.models.<agent>.<tier>.env.
+   * Merged over the process env baseline in buildAllowedEnv() so a model
+   * entry can supply its own API key / base URL without polluting other
+   * models' subprocess env. Previously accepted by the schema but never
+   * threaded anywhere — silently ignored.
+   */
+  env?: Record<string, string>;
 }
 
 export interface AcpClient {

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -143,6 +143,7 @@ export class AcpAgentAdapter implements AgentAdapter {
           onActiveCall: _options.onActiveCall,
           trackedSpawnDeadlineMs: _options.trackedSpawnDeadlineMs,
           trackedSpawnStartupDeadlineMs: _options.trackedSpawnStartupDeadlineMs,
+          env: _options.modelDef.env,
         },
       );
       await client.start();
@@ -326,6 +327,7 @@ export class AcpAgentAdapter implements AgentAdapter {
         onActiveCall: opts.onActiveCall,
         trackedSpawnDeadlineMs: opts.trackedSpawnDeadlineMs,
         trackedSpawnStartupDeadlineMs: opts.trackedSpawnStartupDeadlineMs,
+        env: modelDef.env,
       },
     );
     let session: import("./adapter-session-types").AcpSession | undefined;

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -91,7 +91,11 @@ export class SpawnAcpClient implements AcpClient {
     this.cwd = cwd;
     this.timeoutSeconds = timeoutSeconds || 1800;
     this.promptRetries = promptRetries ?? 0;
-    this.env = buildAllowedEnv();
+    // BUG-15: modelDef.env (config.models.<agent>.<tier>.env) was accepted by
+    // the schema but never threaded here — a per-model API key/base URL
+    // override was silently ignored, and the subprocess ran on ambient env
+    // only, surfacing as confusing auth errors instead of the configured key.
+    this.env = buildAllowedEnv({ modelEnv: opts?.env });
     this.onPidSpawned = onPidSpawned;
     this.onPidExited = onPidExited;
     this.onStreamActivity = opts?.onStreamActivity;

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -270,14 +270,21 @@ export class SpawnAcpClient implements AcpClient {
 
   /**
    * BUG-16: hard-terminate the acpx queue-owner process for `agentName` via
-   * `acpx <agentName> stop`. Mirrors the session-level hard-stop already
-   * used by SpawnAcpSession.close({ forceTerminate: true }) (spawn-client-session.ts).
+   * `acpx --cwd <cwd> <agentName> stop`. `--cwd` is required here — acpx
+   * scopes session/queue-owner lookups to the invoking cwd (mirrors
+   * `sessions close`'s "current cwd" semantics), and without it this would
+   * default to the spawned acpx process's own cwd rather than this client's
+   * worktree, risking a hit against — or a miss of — the wrong queue owner
+   * in a parallel/worktree run where multiple agent instances of the same
+   * `agentName` run concurrently in different directories.
+   * Mirrors the session-level hard-stop already used by
+   * SpawnAcpSession.close({ forceTerminate: true }) (spawn-client-session.ts).
    * Failures are logged and swallowed — the caller (closePhysicalSession)
    * already wraps this in a best-effort `.catch(() => {})`, but logging here
    * gives visibility into why a force-close didn't actually terminate.
    */
   async forceStop(agentName: string, signal?: AbortSignal): Promise<void> {
-    const cmd = ["acpx", agentName, "stop"];
+    const cmd = ["acpx", "--cwd", this.cwd, agentName, "stop"];
     const { exitCode, stderr } = await this.trackedSpawn(cmd, signal, this.trackedSpawnDeadlineMs);
     if (exitCode !== 0) {
       getSafeLogger()?.debug("acp-adapter", "forceStop failed (ignored)", {

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -264,6 +264,26 @@ export class SpawnAcpClient implements AcpClient {
     }
   }
 
+  /**
+   * BUG-16: hard-terminate the acpx queue-owner process for `agentName` via
+   * `acpx <agentName> stop`. Mirrors the session-level hard-stop already
+   * used by SpawnAcpSession.close({ forceTerminate: true }) (spawn-client-session.ts).
+   * Failures are logged and swallowed — the caller (closePhysicalSession)
+   * already wraps this in a best-effort `.catch(() => {})`, but logging here
+   * gives visibility into why a force-close didn't actually terminate.
+   */
+  async forceStop(agentName: string, signal?: AbortSignal): Promise<void> {
+    const cmd = ["acpx", agentName, "stop"];
+    const { exitCode, stderr } = await this.trackedSpawn(cmd, signal, this.trackedSpawnDeadlineMs);
+    if (exitCode !== 0) {
+      getSafeLogger()?.debug("acp-adapter", "forceStop failed (ignored)", {
+        agentName,
+        exitCode,
+        stderr: stderr.slice(0, 200),
+      });
+    }
+  }
+
   async close(): Promise<void> {
     // No-op — spawn-based client has no persistent connection
   }

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -39,6 +39,17 @@ function buildAdapterList(): AgentAdapter[] {
 }
 
 /**
+ * All known agent adapters, regardless of installed status — the full
+ * candidate set `getInstalledAgents()` filters down from. Exists separately
+ * so callers that need to report on *un*installed agents too (e.g.
+ * version-detection's "available but not installed" list) have a set to
+ * diff `getInstalledAgents()`'s result against.
+ */
+export function getAllAgents(): AgentAdapter[] {
+  return buildAdapterList();
+}
+
+/**
  * BUG-19: this used to unconditionally return `[]`, so `multi-agent-health`
  * precheck always reported "No additional agents detected" regardless of
  * what was actually installed. Mirrors createAgentRegistry().getInstalledAgents().

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -28,14 +28,39 @@ export function getAllAgentNames(): string[] {
   return KNOWN_AGENT_NAMES;
 }
 
-/** Get all installed agents on this machine */
-export async function getInstalledAgents(): Promise<AgentAdapter[]> {
-  return [];
+/**
+ * Build the module-level adapter list (test overrides + one AcpAgentAdapter
+ * per known agent name). Shared by the two config-less module-level
+ * functions below — createAgentRegistry() keeps its own cached version
+ * since it needs to reuse adapters across getAgent() calls too.
+ */
+function buildAdapterList(): AgentAdapter[] {
+  return [...Array.from(_registryTestAdapters.values()), ...KNOWN_AGENT_NAMES.map((name) => new AcpAgentAdapter(name))];
 }
 
-/** Check health of all agents */
+/**
+ * BUG-19: this used to unconditionally return `[]`, so `multi-agent-health`
+ * precheck always reported "No additional agents detected" regardless of
+ * what was actually installed. Mirrors createAgentRegistry().getInstalledAgents().
+ */
+export async function getInstalledAgents(): Promise<AgentAdapter[]> {
+  const allAdapters = buildAdapterList();
+  const results = await Promise.all(
+    allAdapters.map(async (agent) => ({ agent, installed: await agent.isInstalled() })),
+  );
+  return results.filter((r) => r.installed).map((r) => r.agent);
+}
+
+/** Check health of all agents. BUG-19: previously an unconditional `[]` stub. */
 export async function checkAgentHealth(): Promise<Array<{ name: string; displayName: string; installed: boolean }>> {
-  return [];
+  const allAdapters = buildAdapterList();
+  return Promise.all(
+    allAdapters.map(async (agent) => ({
+      name: agent.name,
+      displayName: agent.displayName,
+      installed: await agent.isInstalled(),
+    })),
+  );
 }
 
 /** Protocol-aware agent registry returned by createAgentRegistry() */

--- a/src/agents/shared/version-detection.ts
+++ b/src/agents/shared/version-detection.ts
@@ -6,7 +6,7 @@
  */
 
 import { typedSpawn } from "../../utils/bun-deps";
-import { getInstalledAgents } from "../registry";
+import { getAllAgents, getInstalledAgents } from "../registry";
 
 /**
  * Information about an installed agent including its version
@@ -28,6 +28,7 @@ export interface AgentVersionInfo {
 export const _versionDetectionDeps = {
   spawn: typedSpawn,
   getInstalledAgents,
+  getAllAgents,
 };
 
 /**
@@ -74,20 +75,26 @@ export async function getAgentVersion(binaryName: string): Promise<string | null
  * Returns list of agents with their installation status and version info.
  */
 export async function getAgentVersions(): Promise<AgentVersionInfo[]> {
-  // BUG-19: getInstalledAgents() was called twice here for no reason — both
-  // calls return the same result (module-level state, no arguments).
+  // BUG-19: previously called getInstalledAgents() twice and mapped over
+  // that result alone — collapsing "all known agents" and "installed
+  // agents" into the same set means `installed` is always true, silently
+  // dropping the "available but not installed" report (multi-agent-health
+  // precheck's second section). getAllAgents() is the full candidate set;
+  // getInstalledAgents() is the (possibly smaller) subset actually on PATH.
+  const allAgents = _versionDetectionDeps.getAllAgents();
   const installedAgents = await _versionDetectionDeps.getInstalledAgents();
   const installedByName = new Map(installedAgents.map((a) => [a.name, a]));
 
   const versions = await Promise.all(
-    installedAgents.map(async (agent): Promise<AgentVersionInfo> => {
-      const version = installedByName.has(agent.name) ? await getAgentVersion(agent.binary) : null;
+    allAgents.map(async (agent): Promise<AgentVersionInfo> => {
+      const installed = installedByName.has(agent.name);
+      const version = installed ? await getAgentVersion(agent.binary) : null;
 
       return {
         name: agent.name,
         displayName: agent.displayName,
         version,
-        installed: installedByName.has(agent.name),
+        installed,
       };
     }),
   );

--- a/src/agents/shared/version-detection.ts
+++ b/src/agents/shared/version-detection.ts
@@ -74,17 +74,13 @@ export async function getAgentVersion(binaryName: string): Promise<string | null
  * Returns list of agents with their installation status and version info.
  */
 export async function getAgentVersions(): Promise<AgentVersionInfo[]> {
+  // BUG-19: getInstalledAgents() was called twice here for no reason — both
+  // calls return the same result (module-level state, no arguments).
   const installedAgents = await _versionDetectionDeps.getInstalledAgents();
   const installedByName = new Map(installedAgents.map((a) => [a.name, a]));
 
-  // Use all installed agents directly — getInstalledAgents now returns AcpAgentAdapters
-  // that have the correct name, displayName, and binary fields
-  const allAgents = await _versionDetectionDeps.getInstalledAgents();
-  const agentsByName = new Map(allAgents.map((a) => [a.name, a]));
-
-  // Also include any installed agents
   const versions = await Promise.all(
-    Array.from(agentsByName.values()).map(async (agent): Promise<AgentVersionInfo> => {
+    installedAgents.map(async (agent): Promise<AgentVersionInfo> => {
       const version = installedByName.has(agent.name) ? await getAgentVersion(agent.binary) : null;
 
       return {

--- a/src/bakeoff/contestant.ts
+++ b/src/bakeoff/contestant.ts
@@ -98,9 +98,14 @@ export async function runContestant(
     },
   };
 
-  await deps.worktreeManager.create(options.projectRoot, storyId);
-
   try {
+    // BUG-03: worktreeManager.create() used to run before this try block —
+    // a failure there (including the deps being unwired, e.g. undefined in
+    // production before init wiring runs) threw uncaught out of
+    // runContestant entirely, crashing the whole bake-off CLI invocation
+    // instead of reporting this one contestant as "dnf-crashed" and letting
+    // the sequential coordinator continue with the rest.
+    await deps.worktreeManager.create(options.projectRoot, storyId);
     const result = await deps.pipeline(pinnedConfig);
 
     const totals = aggregateTotals(result.metrics);

--- a/src/cli/run-mode.ts
+++ b/src/cli/run-mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Headless-vs-TUI mode resolution for `nax run` (BUG-23).
+ *
+ * Extracted as a pure function so the decision is unit-testable — it
+ * previously lived inline in bin/nax.ts, an untested CLI entry point.
+ */
+
+export interface RunModeInput {
+  /** process.stdout.isTTY */
+  isTTY: boolean;
+  /** --headless flag */
+  headlessFlag: boolean;
+  /** NAX_HEADLESS=1 env var */
+  headlessEnv: boolean;
+  /** Resolved formatter mode from CLI flags (--json/--verbose/--quiet/--silent) */
+  formatterMode: "quiet" | "normal" | "verbose" | "json";
+}
+
+/**
+ * TUI mounts only when stdout is a TTY, none of --headless/NAX_HEADLESS
+ * force headless, and --json was not requested. --json output is
+ * machine-consumed; mounting the TUI over stdout on a TTY silently
+ * discarded --json's request for structured output (BUG-23).
+ */
+export function resolveUseHeadless(input: RunModeInput): boolean {
+  return !input.isTTY || input.headlessFlag || input.headlessEnv || input.formatterMode === "json";
+}

--- a/src/execution/escalation/quote-integrity.ts
+++ b/src/execution/escalation/quote-integrity.ts
@@ -13,8 +13,8 @@
  * described in Issue #930 Pattern B.
  */
 
+import { validateModulePath } from "@/utils/path-security";
 import { getSafeLogger } from "../../logger";
-import { validateModulePath } from "../../utils/path-security";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/execution/escalation/quote-integrity.ts
+++ b/src/execution/escalation/quote-integrity.ts
@@ -14,6 +14,7 @@
  */
 
 import { getSafeLogger } from "../../logger";
+import { validateModulePath } from "../../utils/path-security";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -77,8 +78,15 @@ export async function verifyQuoteTriple(
   workdir: string,
   deps = _quoteIntegrityDeps,
 ): Promise<boolean> {
-  const absPath = `${workdir}/${triple.file}`;
-  const content = await deps.readFile(absPath);
+  // BUG-08: triple.file is extracted from LLM-authored (agent-controlled)
+  // escalation text via a regex that admits ".." segments. Without
+  // containment, a citation like "../../.env:1 `SECRET=x`" would read
+  // outside workdir and could get "verified" — evidence from outside the
+  // repo influencing the next-tier agent's decision.
+  const validated = validateModulePath(triple.file, [workdir]);
+  if (!validated.valid || !validated.absolutePath) return false;
+
+  const content = await deps.readFile(validated.absolutePath);
   if (content === null) return false;
 
   const lines = content.split("\n");

--- a/src/interaction/plugins/webhook-body-limit.ts
+++ b/src/interaction/plugins/webhook-body-limit.ts
@@ -8,10 +8,12 @@
  * bytes exceed the cap, without draining the rest of the stream.
  */
 
+import { NaxError } from "@/errors";
+
 /** Thrown by {@link readBodyWithLimit} when the accumulated stream exceeds the configured cap. */
-export class PayloadTooLargeError extends Error {
+export class PayloadTooLargeError extends NaxError {
   constructor() {
-    super("Payload exceeds configured maxPayloadBytes");
+    super("Payload exceeds configured maxPayloadBytes", "WEBHOOK_PAYLOAD_TOO_LARGE", { stage: "interaction" });
   }
 }
 
@@ -27,6 +29,10 @@ export async function readBodyWithLimit(req: Request, maxBytes: number): Promise
       if (done) break;
       total += value.byteLength;
       if (total > maxBytes) {
+        // Actively abort the ingest rather than leaving the body half-read
+        // and merely unlocked — cancel() signals upstream that we're done
+        // consuming, instead of relying on backpressure alone.
+        await reader.cancel();
         throw new PayloadTooLargeError();
       }
       chunks.push(value);

--- a/src/interaction/plugins/webhook-body-limit.ts
+++ b/src/interaction/plugins/webhook-body-limit.ts
@@ -1,0 +1,45 @@
+/**
+ * SEC-04: bounded-memory request body reader for the webhook callback server.
+ *
+ * `req.text()` buffers the entire body into memory before any size check can
+ * run — a chunked-transfer request with no (or a lying) Content-Length
+ * header would be fully read regardless of the configured maxPayloadBytes.
+ * This reads the body via a stream reader and aborts the moment accumulated
+ * bytes exceed the cap, without draining the rest of the stream.
+ */
+
+/** Thrown by {@link readBodyWithLimit} when the accumulated stream exceeds the configured cap. */
+export class PayloadTooLargeError extends Error {
+  constructor() {
+    super("Payload exceeds configured maxPayloadBytes");
+  }
+}
+
+export async function readBodyWithLimit(req: Request, maxBytes: number): Promise<string> {
+  const reader = req.body?.getReader();
+  if (!reader) return "";
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        throw new PayloadTooLargeError();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(combined);
+}

--- a/src/interaction/plugins/webhook-serve-compat.ts
+++ b/src/interaction/plugins/webhook-serve-compat.ts
@@ -18,10 +18,22 @@ let servePortZeroCompatInstalled = false;
 let servePortZeroCounter = 0;
 const inMemoryServers = new Map<number, { fetch: (request: Request) => Response | Promise<Response> }>();
 
+/**
+ * SEC-06(b): the counter previously wrapped unconditionally after
+ * PORT_ZERO_COMPAT_SPAN cycles and could reassign a port still held by a
+ * live in-memory server (a long-running process with many webhook
+ * start/stop cycles). Skip forward past any port still in inMemoryServers
+ * instead of blindly overwriting it.
+ */
 function nextCompatPort(): number {
-  const port = PORT_ZERO_COMPAT_BASE + (servePortZeroCounter % PORT_ZERO_COMPAT_SPAN);
-  servePortZeroCounter += 1;
-  return port;
+  for (let i = 0; i < PORT_ZERO_COMPAT_SPAN; i++) {
+    const port = PORT_ZERO_COMPAT_BASE + (servePortZeroCounter % PORT_ZERO_COMPAT_SPAN);
+    servePortZeroCounter += 1;
+    if (!inMemoryServers.has(port)) return port;
+  }
+  // All compat ports are live (pathological) — fall back to the raw
+  // counter value rather than looping forever.
+  return PORT_ZERO_COMPAT_BASE + (servePortZeroCounter % PORT_ZERO_COMPAT_SPAN);
 }
 
 function createInMemoryServer(options: ServeCompatOptions, port: number): ServeCompatReturn {

--- a/src/interaction/plugins/webhook.ts
+++ b/src/interaction/plugins/webhook.ts
@@ -12,6 +12,7 @@ import { getSafeLogger } from "@/logger";
 import { sleep } from "@/utils/bun-deps";
 import { z } from "zod";
 import type { InteractionPlugin, InteractionRequest, InteractionResponse } from "../types";
+import { PayloadTooLargeError, readBodyWithLimit } from "./webhook-body-limit";
 import { installServePortZeroCompat } from "./webhook-serve-compat";
 
 installServePortZeroCompat();
@@ -519,17 +520,21 @@ export class WebhookInteractionPlugin implements InteractionPlugin {
       return new Response("Payload Too Large", { status: 413 });
     }
 
-    // Read body once, then enforce byte-accurate size limit in both branches
+    // SEC-04: read the body via a stream reader and abort as soon as the
+    // accumulated byte count crosses maxBytes, instead of buffering the
+    // full body with req.text() first. A chunked-transfer request with no
+    // (or a lying) Content-Length header would otherwise be fully read
+    // into memory before size was ever checked — the Content-Length guard
+    // above is bypassable and was the only enforcement that ran before the
+    // buffer existed.
     let body: string;
     try {
-      body = await req.text();
-    } catch {
+      body = await readBodyWithLimit(req, maxBytes);
+    } catch (err) {
+      if (err instanceof PayloadTooLargeError) {
+        return new Response("Payload Too Large", { status: 413 });
+      }
       return new Response("Bad Request", { status: 400 });
-    }
-
-    // Use TextEncoder for byte-accurate measurement (handles multibyte chars correctly)
-    if (new TextEncoder().encode(body).byteLength > maxBytes) {
-      return new Response("Payload Too Large", { status: 413 });
     }
 
     // Verify signature if secret is configured

--- a/src/interaction/plugins/webhook.ts
+++ b/src/interaction/plugins/webhook.ts
@@ -15,13 +15,7 @@ import type { InteractionPlugin, InteractionRequest, InteractionResponse } from 
 import { PayloadTooLargeError, readBodyWithLimit } from "./webhook-body-limit";
 import { installServePortZeroCompat } from "./webhook-serve-compat";
 
-installServePortZeroCompat();
-
-/**
- * Injectable sleep — kept for backward compat with existing tests that override it.
- * No longer used internally by receive() (replaced by event-driven delivery).
- * @internal
- */
+/** Injectable sleep — kept for backward compat with tests; unused by receive() (event-driven delivery). @internal */
 export const _webhookPluginDeps = {
   sleep,
   /**
@@ -453,6 +447,10 @@ export class WebhookInteractionPlugin implements InteractionPlugin {
       await this.serverStartPromise;
       return;
     }
+    // SEC-06: install the compat shim lazily on first actual server start,
+    // not as a module-import side effect (previously patched two
+    // process-wide globals merely by importing webhook.ts).
+    installServePortZeroCompat();
     this.serverStartPromise = (async () => {
       const port = this.config.callbackPort ?? 0;
       this.server = Bun.serve({

--- a/src/log-format/formatter.ts
+++ b/src/log-format/formatter.ts
@@ -15,6 +15,7 @@ import type { AdvisoryFindingSummaryEntry } from "../review/review-audit.js";
 // undefined selector (crash: "undefined is not an object (evaluating 'selector.name')").
 // severity.ts is a dependency-free leaf, so importing it directly breaks the cycle.
 import { SEVERITY_RANK } from "../review/severity.js";
+import { stripControlChars } from "../utils/strip-control-chars.js";
 import { EMOJI, type FormatterOptions, type RunSummary } from "./types.js";
 
 /**
@@ -160,8 +161,10 @@ function formatRunStart(entry: LogEntry, c: ChalkLike, timestamp: string, _mode:
  */
 function formatStoryStart(entry: LogEntry, c: ChalkLike, _timestamp: string, mode: string): FormattedEntry {
   const data = entry.data as Record<string, unknown>;
-  const storyId = String(data.storyId || entry.storyId || "unknown");
-  const title = String(data.storyTitle || data.title || "Untitled story");
+  // SEC-09: storyId/title are PRD-authored (planner output) — strip
+  // ANSI/control chars before interpolating into a chalk-colorized line.
+  const storyId = stripControlChars(String(data.storyId || entry.storyId || "unknown"));
+  const title = stripControlChars(String(data.storyTitle || data.title || "Untitled story"));
   const complexity = typeof data.complexity === "string" ? data.complexity : "unknown";
   const tier = typeof data.modelTier === "string" ? data.modelTier : "unknown";
   const attempt = typeof data.attempt === "number" ? data.attempt : 1;
@@ -205,7 +208,8 @@ function formatStoryStart(entry: LogEntry, c: ChalkLike, _timestamp: string, mod
  */
 function formatStoryComplete(entry: LogEntry, c: ChalkLike, _timestamp: string, mode: string): FormattedEntry {
   const data = entry.data as Record<string, unknown>;
-  const storyId = String(data.storyId || entry.storyId || "unknown");
+  // SEC-09: storyId is PRD-authored; reason (below) is agent-authored escalation text.
+  const storyId = stripControlChars(String(data.storyId || entry.storyId || "unknown"));
   const success = data.success ?? true;
   const cost =
     typeof data.cost === "number" ? data.cost : typeof data.estimatedCostUsd === "number" ? data.estimatedCostUsd : 0;
@@ -229,7 +233,7 @@ function formatStoryComplete(entry: LogEntry, c: ChalkLike, _timestamp: string, 
   }
 
   if (mode === "verbose" && data.reason) {
-    lines.push(`     ${c.gray(`Reason: ${data.reason}`)}`);
+    lines.push(`     ${c.gray(`Reason: ${stripControlChars(String(data.reason))}`)}`);
   }
 
   lines.push("");
@@ -266,8 +270,11 @@ function formatDefault(entry: LogEntry, c: ChalkLike, timestamp: string, mode: s
   const levelColor = entry.level === "error" ? c.red : entry.level === "warn" ? c.yellow : c.gray;
   const parts = [c.gray(`[${timestamp}]`), levelColor(`${levelEmoji} ${entry.stage}`)];
 
+  // SEC-09: storyId is PRD-authored; message routinely interpolates agent
+  // stderr/output and error text — neither is ANSI/control-char sanitized
+  // upstream (the logger's redaction only targets secret-shaped substrings).
   if (entry.storyId) {
-    parts.push(c.dim(`[${entry.storyId}]`));
+    parts.push(c.dim(`[${stripControlChars(entry.storyId)}]`));
   }
   // sessionRole is a first-class LogEntry field (stripped from data by the logger);
   // render it as a tag so per-line provenance is visible without a JSONL cross-reference.
@@ -275,7 +282,7 @@ function formatDefault(entry: LogEntry, c: ChalkLike, timestamp: string, mode: s
     parts.push(c.dim(`(${entry.sessionRole})`));
   }
 
-  parts.push(entry.message);
+  parts.push(stripControlChars(entry.message));
 
   let output = parts.join(" ");
 
@@ -351,7 +358,7 @@ function buildDefaultMeta(data: Record<string, unknown>, mode: string): string[]
   if (typeof data.durationMs === "number" && data.durationMs > 0)
     meta.push(`${EMOJI.duration} ${formatDuration(data.durationMs)}`);
   if (typeof data.action === "string") meta.push(`action: ${data.action}`);
-  if (typeof data.reason === "string" && mode !== "quiet") meta.push(data.reason);
+  if (typeof data.reason === "string" && mode !== "quiet") meta.push(stripControlChars(data.reason));
 
   return meta;
 }

--- a/src/logger/redact.ts
+++ b/src/logger/redact.ts
@@ -28,21 +28,24 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   // KEY=value assignments inside strings (e.g. "NPM_TOKEN=somevalue")
   /(?:SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)=[^\s"',]+/gi,
   // MED-01: PEM-encoded key/cert blocks (private keys, certificates, incl.
-  // PGP's " ... BLOCK" suffix). The gap between BEGIN/END is bounded
-  // (real PEM blocks are a few KB) — an unbounded [\s\S]*? re-scans to
-  // end-of-string for every unterminated "BEGIN" marker, which is
-  // quadratic on large agent stdout/stderr payloads on this synchronous
-  // logger write path.
-  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)(?: BLOCK)?-----[\s\S]{0,8192}?-----END [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)(?: BLOCK)?-----/g,
+  // PGP's " ... BLOCK" suffix). The gap between BEGIN/END is bounded to
+  // 64KB — generous enough for any realistic single key or bundled
+  // certificate chain, while still capping the rescan cost of an
+  // unterminated "BEGIN" marker in a pathologically large payload on this
+  // synchronous logger write path (a small bound like a few KB risks
+  // missing legitimate multi-cert chain bundles entirely).
+  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)(?: BLOCK)?-----[\s\S]{0,65536}?-----END [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)(?: BLOCK)?-----/g,
   // MED-01: JWTs (header.payload.signature, base64url segments).
   /eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}/g,
   // MED-01: Authorization header values (Bearer/Basic schemes). Requires a
-  // credential-shaped value (>=16 chars, at least one digit/symbol) so
+  // credential-shaped value (>=8 chars, at least one digit/symbol) so
   // ordinary prose like "Basic authentication failed" or "Bearer token
   // scheme" isn't swallowed — real bearer tokens and base64 basic creds
-  // always contain non-alphabetic characters at that length; English words
-  // essentially never do.
-  /\b(?:Bearer|Basic)\s+(?=[A-Za-z0-9\-._~+/]*[0-9+/_-])[A-Za-z0-9\-._~+/]{16,}={0,2}/gi,
+  // almost always contain a non-alphabetic character; English words
+  // essentially never do. Length floor kept at 8 (not raised to 16) so
+  // short-but-real base64 credentials (e.g. "user:pass" -> ~16 raw chars,
+  // shorter inputs shorter still) aren't under-redacted.
+  /\b(?:Bearer|Basic)\s+(?=[A-Za-z0-9\-._~+/]*[0-9+/_-])[A-Za-z0-9\-._~+/]{8,}={0,2}/gi,
   // MED-01: header-style key:value / key=value pairs for api-key headers
   // that SECRET_KEY_PATTERN's object-key check can't reach because the
   // key/value are both embedded in one free-text string (e.g. raw HTTP logs).

--- a/src/logger/redact.ts
+++ b/src/logger/redact.ts
@@ -27,12 +27,22 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   /xox[baprs]-[A-Za-z0-9-]{10,}/g,
   // KEY=value assignments inside strings (e.g. "NPM_TOKEN=somevalue")
   /(?:SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)=[^\s"',]+/gi,
-  // MED-01: PEM-encoded key/cert blocks (private keys, certificates).
-  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----[\s\S]*?-----END [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----/g,
+  // MED-01: PEM-encoded key/cert blocks (private keys, certificates, incl.
+  // PGP's " ... BLOCK" suffix). The gap between BEGIN/END is bounded
+  // (real PEM blocks are a few KB) — an unbounded [\s\S]*? re-scans to
+  // end-of-string for every unterminated "BEGIN" marker, which is
+  // quadratic on large agent stdout/stderr payloads on this synchronous
+  // logger write path.
+  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)(?: BLOCK)?-----[\s\S]{0,8192}?-----END [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)(?: BLOCK)?-----/g,
   // MED-01: JWTs (header.payload.signature, base64url segments).
   /eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}/g,
-  // MED-01: Authorization header values (Bearer/Basic schemes).
-  /\b(?:Bearer|Basic)\s+[A-Za-z0-9\-._~+/]{8,}=*/gi,
+  // MED-01: Authorization header values (Bearer/Basic schemes). Requires a
+  // credential-shaped value (>=16 chars, at least one digit/symbol) so
+  // ordinary prose like "Basic authentication failed" or "Bearer token
+  // scheme" isn't swallowed — real bearer tokens and base64 basic creds
+  // always contain non-alphabetic characters at that length; English words
+  // essentially never do.
+  /\b(?:Bearer|Basic)\s+(?=[A-Za-z0-9\-._~+/]*[0-9+/_-])[A-Za-z0-9\-._~+/]{16,}={0,2}/gi,
   // MED-01: header-style key:value / key=value pairs for api-key headers
   // that SECRET_KEY_PATTERN's object-key check can't reach because the
   // key/value are both embedded in one free-text string (e.g. raw HTTP logs).

--- a/src/logger/redact.ts
+++ b/src/logger/redact.ts
@@ -27,6 +27,16 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   /xox[baprs]-[A-Za-z0-9-]{10,}/g,
   // KEY=value assignments inside strings (e.g. "NPM_TOKEN=somevalue")
   /(?:SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)=[^\s"',]+/gi,
+  // MED-01: PEM-encoded key/cert blocks (private keys, certificates).
+  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----[\s\S]*?-----END [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----/g,
+  // MED-01: JWTs (header.payload.signature, base64url segments).
+  /eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}/g,
+  // MED-01: Authorization header values (Bearer/Basic schemes).
+  /\b(?:Bearer|Basic)\s+[A-Za-z0-9\-._~+/]{8,}=*/gi,
+  // MED-01: header-style key:value / key=value pairs for api-key headers
+  // that SECRET_KEY_PATTERN's object-key check can't reach because the
+  // key/value are both embedded in one free-text string (e.g. raw HTTP logs).
+  /(?:x-api-key|api[_-]?key)\s*[:=]\s*[^\s"',]+/gi,
 ];
 
 const REDACTED = "[REDACTED]";

--- a/src/prd/dependency-cycle.ts
+++ b/src/prd/dependency-cycle.ts
@@ -1,0 +1,57 @@
+/**
+ * Dependency-cycle detection for PRD user stories (BUG-27).
+ *
+ * Extracted from schema.ts to stay under the 600-line file limit.
+ */
+
+import { NaxError } from "../errors";
+import type { UserStory } from "./types";
+
+/**
+ * Depth-first cycle detection over the story dependency graph.
+ * Returns the cycle as an ordered array of story IDs (first ID repeated at
+ * the end) when found, or null when the graph is acyclic. Unknown
+ * dependency IDs are ignored here — schema validation already rejects those
+ * before this runs.
+ */
+export function detectDependencyCycle(stories: UserStory[]): string[] | null {
+  const depsById = new Map<string, string[]>(stories.map((s) => [s.id, s.dependencies ?? []]));
+  const visited = new Set<string>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+
+  function visit(id: string): string[] | null {
+    if (onStack.has(id)) {
+      const cycleStart = stack.indexOf(id);
+      return [...stack.slice(cycleStart), id];
+    }
+    if (visited.has(id)) return null;
+
+    visited.add(id);
+    onStack.add(id);
+    stack.push(id);
+    for (const dep of depsById.get(id) ?? []) {
+      const found = visit(dep);
+      if (found) return found;
+    }
+    stack.pop();
+    onStack.delete(id);
+    return null;
+  }
+
+  for (const story of stories) {
+    const found = visit(story.id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Throws a NaxError naming the cycle when one exists; no-op otherwise. */
+export function assertNoDependencyCycle(stories: UserStory[]): void {
+  const cycle = detectDependencyCycle(stories);
+  if (!cycle) return;
+  throw new NaxError(`[schema] Circular dependency detected: ${cycle.join(" -> ")}`, "SCHEMA_VALIDATION_FAILED", {
+    stage: "schema",
+    cycle,
+  });
+}

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -9,6 +9,7 @@ import { resolveTestStrategy } from "../config/test-strategy";
 import { NaxError } from "../errors";
 import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas } from "../utils/llm-json";
 export { extractJsonFromMarkdown };
+import { assertNoDependencyCycle } from "./dependency-cycle";
 import { normalizeOutOfScopeList } from "./out-of-scope";
 import type { ContextFileEntry, ModifiedFileEntry, PRD, UserStory } from "./types";
 import { validateStoryId } from "./validate";
@@ -576,6 +577,9 @@ export function validatePlanOutput(raw: unknown, feature: string, branch: string
   // contains every id up front, so it cannot be used to detect duplicates).
   const seenIds = new Set<string>();
   const userStories: UserStory[] = rawStories.map((story, index) => validateStory(story, index, allIds, seenIds));
+
+  // BUG-27: fail fast on a cycle instead of letting worktree/merge.ts discover it mid-run.
+  assertNoDependencyCycle(userStories);
 
   const now = new Date().toISOString();
   const featureOutOfScope = normalizeOutOfScopeList(obj.outOfScope);

--- a/src/tui/components/LiveActivityPanel.tsx
+++ b/src/tui/components/LiveActivityPanel.tsx
@@ -7,6 +7,7 @@
  * Shows recent escalation log entries.
  */
 
+import { stripControlChars } from "@/utils/strip-control-chars";
 import { Box, Text } from "ink";
 import type { ActiveCallState } from "../hooks/useAgentStreamEvents";
 import type { EscalationEntry, RunSummary } from "../hooks/usePipelineBusEvents";
@@ -69,9 +70,11 @@ export function LiveActivityPanel({
       </Box>
 
       {/* Error banner */}
+      {/* SEC-09: runErrored routinely embeds agent stderr / error text — strip
+          ANSI/control chars before Ink renders it. */}
       {hasError && (
         <Box paddingX={1} paddingY={1}>
-          <Text color="red">[FAIL] {runErrored}</Text>
+          <Text color="red">[FAIL] {stripControlChars(runErrored ?? "")}</Text>
         </Box>
       )}
 
@@ -143,16 +146,18 @@ function ActiveCallRow({ call, step, currentStage }: { call: ActiveCallState; st
   ) : currentStage ? (
     <Text dimColor>[{currentStage}]</Text>
   ) : null;
+  // SEC-09: storyId (PRD-controlled) and lastToolName (LLM tool_use output)
+  // are agent/PRD-controlled — strip ANSI/control chars before rendering.
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box flexDirection="row" gap={1}>
         <Text color="cyan">{call.agentName}</Text>
-        {call.storyId && <Text>{call.storyId}</Text>}
+        {call.storyId && <Text>{stripControlChars(call.storyId)}</Text>}
         {stageLabel}
       </Box>
       <Box flexDirection="row" gap={1}>
         {call.model && <Text dimColor>model:{call.model}</Text>}
-        {call.lastToolName && <Text dimColor>tool:{call.lastToolName}</Text>}
+        {call.lastToolName && <Text dimColor>tool:{stripControlChars(call.lastToolName)}</Text>}
         <Text dimColor>
           tools:{call.toolCallUpdates} msg:{call.messageUpdates}
         </Text>
@@ -180,7 +185,7 @@ function RunSummaryRow({ summary }: { summary: RunSummary }) {
 function EscalationRow({ entry }: { entry: EscalationEntry }) {
   return (
     <Box flexDirection="row" gap={1}>
-      <Text dimColor>{entry.storyId}</Text>
+      <Text dimColor>{stripControlChars(entry.storyId)}</Text>
       <Text color="yellow">{entry.fromTier}</Text>
       <Text dimColor>-&gt;</Text>
       <Text color="cyan">{entry.toTier}</Text>

--- a/src/tui/components/StoriesPanel.tsx
+++ b/src/tui/components/StoriesPanel.tsx
@@ -4,6 +4,7 @@
  * Supports scrolling for >15 stories and compact mode for single-column layout.
  */
 
+import { stripControlChars } from "@/utils/strip-control-chars";
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
 import { COMPACT_MAX_VISIBLE_STORIES, MAX_VISIBLE_STORIES } from "../hooks/useLayout";
@@ -138,7 +139,7 @@ export function StoriesPanel({
             return (
               <Box key={s.story.id}>
                 <Text>
-                  {icon} {s.story.id}
+                  {icon} {stripControlChars(s.story.id)}
                 </Text>
               </Box>
             );
@@ -154,14 +155,19 @@ export function StoriesPanel({
                 ? shortTier
                 : "";
           const showFailureLine = (s.status === "failed" || s.status === "paused") && s.failureReason;
+          // SEC-09: s.story.id and s.failureReason are PRD/agent-controlled
+          // (planner output, LLM error text) — strip ANSI/control chars
+          // before they reach Ink's <Text>, which does not sanitize.
+          const safeId = stripControlChars(s.story.id);
+          const safeFailureReason = showFailureLine ? stripControlChars((s.failureReason as string).slice(0, 25)) : "";
           return (
             <Box key={s.story.id} flexDirection="column">
               <Text>
-                {icon} {s.story.id}
+                {icon} {safeId}
                 <Text dimColor>{routing}</Text>
                 {tierSuffix ? <Text dimColor> {tierSuffix}</Text> : null}
               </Text>
-              {showFailureLine && <Text dimColor>{`  └ ${(s.failureReason as string).slice(0, 25)}`}</Text>}
+              {showFailureLine && <Text dimColor>{`  └ ${safeFailureReason}`}</Text>}
             </Box>
           );
         })}

--- a/src/tui/hooks/useKeyboard.ts
+++ b/src/tui/hooks/useKeyboard.ts
@@ -109,6 +109,16 @@ export function useKeyboard({ focus, currentStory, onAction, disabled = false }:
       return;
     }
 
+    // BUG-22: a Ctrl+<letter> combo shares its `input` character with the
+    // plain letter (e.g. Ctrl+C and "c" are both input === "c"), so without
+    // this guard Ctrl+C fell through to the "c" case below (SHOW_COST)
+    // instead of being left for Ink's own Ctrl+C exit handling. Ctrl+] is
+    // handled separately above (Agent-panel focus only); no other Ctrl
+    // combo has meaning here.
+    if (key.ctrl) {
+      return;
+    }
+
     // Character-based shortcuts
     switch (input.toLowerCase()) {
       case "p":

--- a/src/utils/strip-control-chars.ts
+++ b/src/utils/strip-control-chars.ts
@@ -1,0 +1,39 @@
+/**
+ * SEC-09: strip ANSI/escape sequences and other C0 control characters from
+ * agent-controlled or PRD-authored display strings before they reach a
+ * terminal renderer.
+ *
+ * Ink's <Text> does not sanitize its children, and the headless console
+ * formatter writes raw strings straight to stdout. A crafted prd.json field
+ * (story title, failure reason) or agent output containing ESC (\x1b)
+ * sequences can move the cursor, clear the screen, or (via OSC 52) write to
+ * the clipboard in a terminal showing the user's session — defense-in-depth
+ * against a prompt-injected repo or a malicious PRD, not a primary trust
+ * boundary (the LLM already writes code that runs).
+ */
+
+// C0 control range 0x00-0x1F and DEL (0x7F), excluding tab (\x09), newline
+// (\x0A), and carriage return (\x0D) — display strings are frequently
+// multi-line and stripping those would corrupt legitimate formatting for no
+// security benefit.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: this IS the control-character stripper
+const CONTROL_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+/**
+ * Removes ESC-initiated sequences (CSI, OSC, and other ANSI escape forms)
+ * and other C0 control characters, while leaving normal whitespace
+ * (tab, newline, carriage return) untouched.
+ */
+export function stripControlChars(input: string): string {
+  if (!input) return input;
+  // ESC-initiated sequences: OSC "\x1b]...BEL-or-ST", CSI "\x1b[...<final-byte>",
+  // and any other "\x1b" + single byte (short escapes like \x1bc, \x1b=).
+  const withoutEscapes = input
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: matching a real ESC/BEL/ST sequence to strip
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "") // OSC ... BEL | OSC ... ST
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: matching a real ESC (CSI) sequence to strip
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "") // CSI ... final byte
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: matching a real ESC sequence to strip
+    .replace(/\x1b[ -~]/g, ""); // other short two-byte escapes (ESC + one printable byte, e.g. ESC c, ESC =, ESC 7)
+  return withoutEscapes.replace(CONTROL_CHARS_RE, "");
+}

--- a/src/worktree/merge.ts
+++ b/src/worktree/merge.ts
@@ -172,8 +172,24 @@ export class MergeEngine {
    * On 2nd conflict: marks story as failed, continues with remaining stories
    */
   async mergeAll(projectRoot: string, storyIds: string[], dependencies: StoryDependencies): Promise<MergeResult[]> {
-    // Sort stories in topological order
-    const orderedStories = this.topologicalSort(storyIds, dependencies);
+    // BUG-27: topologicalSort() throws on a circular dependency. Schema
+    // validation now rejects cycles at plan time (src/prd/schema.ts), but
+    // this stays defensive — a PRD written or edited outside that path
+    // (manual edit, older artifact) must not crash the whole merge batch,
+    // leaving every story silently "pending"/"running" forever.
+    let orderedStories: string[];
+    try {
+      orderedStories = this.topologicalSort(storyIds, dependencies);
+    } catch (error) {
+      const message = errorMessage(error);
+      return storyIds.map((storyId) => ({
+        success: false,
+        storyId,
+        conflictFiles: [],
+        failureKind: "error",
+        error: `Merge batch aborted: ${message}`,
+      }));
+    }
     const results: MergeResult[] = [];
     const failedStories = new Set<string>();
 

--- a/test/integration/worktree/worktree-merge.test.ts
+++ b/test/integration/worktree/worktree-merge.test.ts
@@ -294,5 +294,27 @@ describe("MergeEngine", () => {
       expect(results[2].success).toBe(true);
       expect(results[2].storyId).toBe("story-3");
     });
+
+    // BUG-27: topologicalSort() throws on a circular dependency. Before the
+    // fix, that throw propagated out of mergeAll() uncaught, crashing the
+    // whole batch — every story (including any already merged in a
+    // sequential caller) was left with no result at all.
+    test("a circular dependency does not crash the whole batch — every story gets a failed result", async () => {
+      const storyIds = ["story-a", "story-b"];
+      const dependencies = {
+        "story-a": ["story-b"],
+        "story-b": ["story-a"],
+      };
+
+      await manager.create(projectRoot, "story-a");
+      await manager.create(projectRoot, "story-b");
+
+      const results = await engine.mergeAll(projectRoot, storyIds, dependencies);
+
+      expect(results.length).toBe(2);
+      expect(results.every((r) => r.success === false)).toBe(true);
+      expect(results.every((r) => r.failureKind === "error")).toBe(true);
+      expect(results.every((r) => r.error?.includes("Circular dependency"))).toBe(true);
+    });
   });
 });

--- a/test/ui/LiveActivityPanel.test.tsx
+++ b/test/ui/LiveActivityPanel.test.tsx
@@ -78,4 +78,44 @@ describe("LiveActivityPanel", () => {
     expect(frame).toContain("fast");
     expect(frame).toContain("balanced");
   });
+
+  // SEC-09: storyId, lastToolName, runErrored, and escalation storyId are
+  // agent/PRD-controlled — a crafted value containing an ESC sequence must
+  // not reach the terminal raw.
+  describe("SEC-09: ANSI/control-char stripping", () => {
+    test("strips a CSI sequence embedded in an active call's storyId", () => {
+      const calls = new Map([["call-1", makeCall({ storyId: "US-\x1b[2J001" })]]);
+      const { lastFrame } = render(React.createElement(LiveActivityPanel, { activeCalls: calls }));
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("\x1b[2J");
+      expect(frame).toContain("US-001");
+    });
+
+    test("strips a CSI sequence embedded in lastToolName", () => {
+      const calls = new Map([["call-1", makeCall({ lastToolName: "Write\x1b[31mEvil" })]]);
+      const { lastFrame } = render(React.createElement(LiveActivityPanel, { activeCalls: calls }));
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("\x1b[31m");
+      expect(frame).toContain("WriteEvil");
+    });
+
+    test("strips an OSC sequence embedded in runErrored", () => {
+      const { lastFrame } = render(
+        React.createElement(LiveActivityPanel, { runErrored: "config\x1b]52;c;evil\x07 load failed" }),
+      );
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("\x1b]52");
+      expect(frame).toContain("config load failed");
+    });
+
+    test("strips a CSI sequence embedded in an escalation entry's storyId", () => {
+      const escalationLog: EscalationEntry[] = [
+        { storyId: "US-\x1b[2J001", fromTier: "fast", toTier: "balanced", at: Date.now() },
+      ];
+      const { lastFrame } = render(React.createElement(LiveActivityPanel, { escalationLog }));
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("\x1b[2J");
+      expect(frame).toContain("US-001");
+    });
+  });
 });

--- a/test/ui/StoriesPanel.test.tsx
+++ b/test/ui/StoriesPanel.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+import React from "react";
+import { StoriesPanel } from "@/tui/components/StoriesPanel";
+import type { StoryDisplayState } from "@/tui";
+
+function makeStory(overrides: Partial<StoryDisplayState> = {}): StoryDisplayState {
+  return {
+    story: { id: "US-001", title: "Story", passes: false, workdir: ".", acceptanceCriteria: [] } as never,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("StoriesPanel", () => {
+  test("renders a story id in non-compact mode", () => {
+    const { lastFrame } = render(React.createElement(StoriesPanel, { stories: [makeStory()] }));
+    expect(lastFrame()).toContain("US-001");
+  });
+
+  test("renders a story id in compact mode", () => {
+    const { lastFrame } = render(React.createElement(StoriesPanel, { stories: [makeStory()], compact: true }));
+    expect(lastFrame()).toContain("US-001");
+  });
+
+  test("renders a failure reason for a failed story", () => {
+    const stories = [makeStory({ status: "failed", failureReason: "connection refused by remote host" })];
+    const { lastFrame } = render(React.createElement(StoriesPanel, { stories }));
+    expect(lastFrame()).toContain("connection refused");
+  });
+
+  // SEC-09: story.id (PRD-authored) and failureReason (agent/LLM-authored
+  // escalation text) are not sanitized upstream — a crafted value
+  // containing an ESC sequence must not reach the terminal raw.
+  describe("SEC-09: ANSI/control-char stripping", () => {
+    test("strips a CSI sequence embedded in the story id (non-compact mode)", () => {
+      const stories = [
+        makeStory({ story: { id: "US-\x1b[2J001", title: "t", passes: false, workdir: ".", acceptanceCriteria: [] } as never }),
+      ];
+      const { lastFrame } = render(React.createElement(StoriesPanel, { stories }));
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("\x1b[2J");
+      expect(frame).toContain("US-001");
+    });
+
+    test("strips a CSI sequence embedded in the story id (compact mode)", () => {
+      const stories = [
+        makeStory({ story: { id: "US-\x1b[2J001", title: "t", passes: false, workdir: ".", acceptanceCriteria: [] } as never }),
+      ];
+      const { lastFrame } = render(React.createElement(StoriesPanel, { stories, compact: true }));
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("\x1b[2J");
+      expect(frame).toContain("US-001");
+    });
+
+    test("strips a CSI sequence embedded in the failure reason", () => {
+      const stories = [makeStory({ status: "failed", failureReason: "crashed\x1b[31m badly here" })];
+      const { lastFrame } = render(React.createElement(StoriesPanel, { stories }));
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("\x1b[31m");
+      expect(frame).toContain("crashed");
+    });
+  });
+});

--- a/test/ui/tui-ctrl-key.test.tsx
+++ b/test/ui/tui-ctrl-key.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * BUG-22: a Ctrl+<letter> combo shares its `input` character with the plain
+ * letter (Ctrl+C and "c" are both input === "c" in Ink), so useKeyboard's
+ * character-shortcut switch previously matched Ctrl+C the same as a bare "c"
+ * keypress — opening the cost overlay (SHOW_COST) instead of leaving Ctrl+C
+ * for Ink's own exit handling.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+import React, { act } from "react";
+import { PipelineEventEmitter, pipelineEventBus } from "@/pipeline";
+import { App } from "@/tui/App";
+import type { StoryDisplayState } from "@/tui";
+
+function makeStory(id: string): StoryDisplayState {
+  return {
+    story: { id, title: `Story ${id}`, passes: false, workdir: ".", acceptanceCriteria: [] } as never,
+    status: "pending",
+  };
+}
+
+describe("TUI Ctrl+<letter> vs plain letter shortcuts", () => {
+  beforeEach(() => {
+    pipelineEventBus.clear();
+  });
+
+  afterEach(() => {
+    pipelineEventBus.clear();
+  });
+
+  test("plain 'c' opens the cost overlay", () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App feature="feat" stories={[makeStory("US-001")]} events={new PipelineEventEmitter()} />,
+    );
+
+    act(() => {
+      stdin.write("c");
+    });
+
+    expect(lastFrame()).toContain("Cost Breakdown");
+    unmount();
+  });
+
+  test("Ctrl+C does not open the cost overlay", () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App feature="feat" stories={[makeStory("US-001")]} events={new PipelineEventEmitter()} />,
+    );
+
+    act(() => {
+      // \x03 is ETX (Ctrl+C) — Ink reports this as input "c" with key.ctrl === true.
+      stdin.write("\x03");
+    });
+
+    expect(lastFrame()).not.toContain("Cost Breakdown");
+    unmount();
+  });
+});

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -327,6 +327,36 @@ describe("complete()", () => {
     expect(capturedOnPidSpawned).toBe(tracker);
   });
 
+  // BUG-15: modelDef.env (config.models.<agent>.<tier>.env) was accepted by
+  // the schema but never forwarded to createClient — a per-model API
+  // key/base URL override was silently dropped.
+  test("forwards modelDef.env to createClient's AcpClientOptions", async () => {
+    let capturedEnv: Record<string, string> | undefined;
+    const session = makeSession();
+    _acpAdapterDeps.createClient = mock(
+      (
+        _cmd: string,
+        _cwd: string,
+        _timeout?: number,
+        _onPidSpawned?: (pid: number) => void,
+        _promptRetries?: number,
+        _onPidExited?: (pid: number) => void,
+        opts?: { env?: Record<string, string> },
+      ) => {
+        capturedEnv = opts?.env;
+        return makeClient(session) as unknown as ReturnType<typeof _acpAdapterDeps.createClient>; // test-ratchet-allow: as-unknown-as
+      },
+    );
+
+    await new AcpAgentAdapter("claude").complete(
+      "model-env-test",
+      makeCompleteOptions({
+        modelDef: { provider: "anthropic", model: "claude-sonnet-4-5", env: { ANTHROPIC_BASE_URL: "https://custom" } },
+      }),
+    );
+    expect(capturedEnv).toEqual({ ANTHROPIC_BASE_URL: "https://custom" });
+  });
+
   test("force-terminates the session on successful completion (kills queue-owner)", async () => {
     let capturedCloseOpts: { forceTerminate?: boolean } | undefined;
     const session = makeSession({

--- a/test/unit/agents/acp/registry.test.ts
+++ b/test/unit/agents/acp/registry.test.ts
@@ -11,7 +11,12 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
-import { checkAgentHealth, createAgentRegistry, getInstalledAgents } from "../../../../src/agents/registry";
+import {
+  _registryTestAdapters,
+  checkAgentHealth,
+  createAgentRegistry,
+  getInstalledAgents,
+} from "../../../../src/agents/registry";
 import type { AgentConfig } from "../../../../src/config/schema";
 import type { NaxConfig } from "../../../../src/config/schema";
 import { logActiveProtocol } from "../../../../src/execution/lifecycle/run-initialization";
@@ -174,8 +179,16 @@ describe("createAgentRegistry — checkAgentHealth()", () => {
 describe("module-level getInstalledAgents() / checkAgentHealth() (BUG-19)", () => {
   const origWhich = _acpAdapterDeps.which;
 
+  beforeEach(() => {
+    // _registryTestAdapters is module-global state shared across test
+    // files in the same bun test process — a leaked entry from another
+    // file would make "returns empty when nothing is on PATH" flaky.
+    _registryTestAdapters.clear();
+  });
+
   afterEach(() => {
     _acpAdapterDeps.which = origWhich;
+    _registryTestAdapters.clear();
     mock.restore();
   });
 

--- a/test/unit/agents/acp/registry.test.ts
+++ b/test/unit/agents/acp/registry.test.ts
@@ -11,7 +11,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
-import { createAgentRegistry } from "../../../../src/agents/registry";
+import { checkAgentHealth, createAgentRegistry, getInstalledAgents } from "../../../../src/agents/registry";
 import type { AgentConfig } from "../../../../src/config/schema";
 import type { NaxConfig } from "../../../../src/config/schema";
 import { logActiveProtocol } from "../../../../src/execution/lifecycle/run-initialization";
@@ -160,6 +160,44 @@ describe("createAgentRegistry — checkAgentHealth()", () => {
     const claudeEntry = health.find((e) => e.name === "claude");
     expect(claudeEntry).toBeDefined();
     expect(claudeEntry?.installed).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module-level getInstalledAgents / checkAgentHealth (BUG-19)
+//
+// These used to unconditionally return [] regardless of what was actually
+// installed, so the "multi-agent-health" precheck always reported "No
+// additional agents detected" no matter what was really on PATH.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("module-level getInstalledAgents() / checkAgentHealth() (BUG-19)", () => {
+  const origWhich = _acpAdapterDeps.which;
+
+  afterEach(() => {
+    _acpAdapterDeps.which = origWhich;
+    mock.restore();
+  });
+
+  test("getInstalledAgents returns installed adapters instead of an unconditional []", async () => {
+    _acpAdapterDeps.which = mock((_name: string) => "/usr/local/bin/claude");
+    const installed = await getInstalledAgents();
+    expect(installed.length).toBeGreaterThan(0);
+    expect(installed.some((a) => a.name === "claude")).toBe(true);
+  });
+
+  test("getInstalledAgents returns empty when nothing is on PATH", async () => {
+    _acpAdapterDeps.which = mock((_name: string) => null);
+    const installed = await getInstalledAgents();
+    expect(installed).toEqual([]);
+  });
+
+  test("checkAgentHealth reflects real installed status instead of an unconditional []", async () => {
+    _acpAdapterDeps.which = mock((_name: string) => "/usr/local/bin/claude");
+    const health = await checkAgentHealth();
+    expect(health.length).toBeGreaterThan(0);
+    const claudeEntry = health.find((e) => e.name === "claude");
+    expect(claudeEntry?.installed).toBe(true);
   });
 });
 

--- a/test/unit/agents/acp/spawn-client.test.ts
+++ b/test/unit/agents/acp/spawn-client.test.ts
@@ -105,6 +105,30 @@ describe("SpawnAcpClient — onPidSpawned callback (#228)", () => {
 
     expect(pids).toHaveLength(1);
   });
+
+  // BUG-16: forceStop was declared on the AcpClient interface but never
+  // implemented anywhere — closePhysicalSession's { force: true } branch was
+  // a dead call site. SpawnAcpClient must actually run `acpx <agent> stop`.
+  test("forceStop spawns `acpx <agentName> stop`", async () => {
+    const spawnedCommands: string[][] = [];
+    _spawnClientDeps.spawn = (cmd, _opts) => {
+      spawnedCommands.push(cmd as string[]);
+      return makeSpawnResult(0);
+    };
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    await client.forceStop("claude");
+
+    expect(spawnedCommands).toHaveLength(1);
+    expect(spawnedCommands[0]).toEqual(["acpx", "claude", "stop"]);
+  });
+
+  test("forceStop does not throw when the stop command fails", async () => {
+    _spawnClientDeps.spawn = (_cmd, _opts) => makeSpawnResult(1);
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    await expect(client.forceStop("claude")).resolves.toBeUndefined();
+  });
 });
 
 describe("SpawnAcpClient — prompt EPIPE resilience", () => {

--- a/test/unit/agents/acp/spawn-client.test.ts
+++ b/test/unit/agents/acp/spawn-client.test.ts
@@ -108,19 +108,23 @@ describe("SpawnAcpClient — onPidSpawned callback (#228)", () => {
 
   // BUG-16: forceStop was declared on the AcpClient interface but never
   // implemented anywhere — closePhysicalSession's { force: true } branch was
-  // a dead call site. SpawnAcpClient must actually run `acpx <agent> stop`.
-  test("forceStop spawns `acpx <agentName> stop`", async () => {
+  // a dead call site. SpawnAcpClient must actually run `acpx --cwd <cwd>
+  // <agent> stop`. --cwd is required (matches every other acpx invocation
+  // in this client) — without it, the command scopes to the acpx process's
+  // own cwd instead of this client's worktree, risking the wrong queue
+  // owner in a parallel/worktree run with multiple instances of the same agent.
+  test("forceStop spawns `acpx --cwd <cwd> <agentName> stop`", async () => {
     const spawnedCommands: string[][] = [];
     _spawnClientDeps.spawn = (cmd, _opts) => {
       spawnedCommands.push(cmd as string[]);
       return makeSpawnResult(0);
     };
 
-    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const client = new SpawnAcpClient("acpx claude", "/tmp/my-worktree");
     await client.forceStop("claude");
 
     expect(spawnedCommands).toHaveLength(1);
-    expect(spawnedCommands[0]).toEqual(["acpx", "claude", "stop"]);
+    expect(spawnedCommands[0]).toEqual(["acpx", "--cwd", "/tmp/my-worktree", "claude", "stop"]);
   });
 
   test("forceStop does not throw when the stop command fails", async () => {

--- a/test/unit/agents/acp/spawn-client.test.ts
+++ b/test/unit/agents/acp/spawn-client.test.ts
@@ -129,6 +129,25 @@ describe("SpawnAcpClient — onPidSpawned callback (#228)", () => {
     const client = new SpawnAcpClient("acpx claude", "/tmp");
     await expect(client.forceStop("claude")).resolves.toBeUndefined();
   });
+
+  // BUG-15: opts.env (config.models.<agent>.<tier>.env) was accepted by the
+  // constructor's AcpClientOptions type but never passed into
+  // buildAllowedEnv() — a per-model API key/base URL override was silently
+  // dropped and the subprocess ran on ambient env only.
+  test("threads AcpClientOptions.env into the client's subprocess env as modelEnv", () => {
+    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, undefined, undefined, undefined, {
+      env: { ANTHROPIC_BASE_URL: "https://custom.example.com", ANTHROPIC_API_KEY: "from-model-def" },
+    });
+    const internals = client as unknown as { env: Record<string, string | undefined> }; // test-ratchet-allow: as-unknown-as
+    expect(internals.env.ANTHROPIC_BASE_URL).toBe("https://custom.example.com");
+    expect(internals.env.ANTHROPIC_API_KEY).toBe("from-model-def");
+  });
+
+  test("subprocess env is unaffected when no env override is passed", () => {
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const internals = client as unknown as { env: Record<string, string | undefined> }; // test-ratchet-allow: as-unknown-as
+    expect(internals.env.ANTHROPIC_BASE_URL).toBeUndefined();
+  });
 });
 
 describe("SpawnAcpClient — prompt EPIPE resilience", () => {

--- a/test/unit/agents/version-detection.test.ts
+++ b/test/unit/agents/version-detection.test.ts
@@ -42,15 +42,18 @@ function makeMockProc(stdout: string, exitCode: number) {
 
 let origSpawn: typeof _versionDetectionDeps.spawn;
 let origGetInstalledAgents: typeof _versionDetectionDeps.getInstalledAgents;
+let origGetAllAgents: typeof _versionDetectionDeps.getAllAgents;
 
 beforeEach(() => {
   origSpawn = _versionDetectionDeps.spawn;
   origGetInstalledAgents = _versionDetectionDeps.getInstalledAgents;
+  origGetAllAgents = _versionDetectionDeps.getAllAgents;
 });
 
 afterEach(() => {
   _versionDetectionDeps.spawn = origSpawn;
   _versionDetectionDeps.getInstalledAgents = origGetInstalledAgents;
+  _versionDetectionDeps.getAllAgents = origGetAllAgents;
 });
 
 // ---------------------------------------------------------------------------
@@ -147,13 +150,41 @@ describe("getAgentVersions", () => {
   });
 
   test("marks agent as not installed and version null when not in installed list", async () => {
-    // No agents installed — getAgentVersions returns an empty array
+    // No agents installed — every known agent from getAllAgents() should
+    // still be reported, each with installed: false and version: null.
     _versionDetectionDeps.getInstalledAgents = mock(async () => []);
     _versionDetectionDeps.spawn = mock(() => makeMockProc("", 1)) as typeof _versionDetectionDeps.spawn;
 
     const versions = await getAgentVersions();
-    // With no installed agents, agentsByName is empty so versions is empty
-    expect(Array.isArray(versions)).toBe(true);
-    expect(versions.length).toBe(0);
+    expect(versions.length).toBeGreaterThan(0);
+    for (const entry of versions) {
+      expect(entry.installed).toBe(false);
+      expect(entry.version).toBeNull();
+    }
+  });
+
+  // BUG-19 (regression, caught in code review): a version of the BUG-19 fix
+  // collapsed "all known agents" and "installed agents" into the same
+  // source array, making `installed` always true and silently dropping the
+  // "available but not installed" report (multi-agent-health precheck's
+  // second section). getAllAgents() (the full candidate set) must be kept
+  // distinct from getInstalledAgents() (the installed subset).
+  test("known-but-not-installed agents are still reported alongside installed ones", async () => {
+    const installedAgent = { name: "claude", displayName: "Claude Code", binary: "claude" } as AgentAdapter;
+    const notInstalledAgent = { name: "codex", displayName: "Codex", binary: "codex" } as AgentAdapter;
+
+    _versionDetectionDeps.getAllAgents = mock(() => [installedAgent, notInstalledAgent]);
+    _versionDetectionDeps.getInstalledAgents = mock(async () => [installedAgent]);
+    _versionDetectionDeps.spawn = mock(() => makeMockProc("claude v1.0.0\n", 0)) as typeof _versionDetectionDeps.spawn;
+
+    const versions = await getAgentVersions();
+    expect(versions).toHaveLength(2);
+
+    const claude = versions.find((v) => v.name === "claude");
+    const codex = versions.find((v) => v.name === "codex");
+    expect(claude?.installed).toBe(true);
+    expect(claude?.version).toBe("v1.0.0");
+    expect(codex?.installed).toBe(false);
+    expect(codex?.version).toBeNull();
   });
 });

--- a/test/unit/agents/version-detection.test.ts
+++ b/test/unit/agents/version-detection.test.ts
@@ -133,6 +133,19 @@ describe("getAgentVersions", () => {
     expect(entry?.version).toBe("v9.9.9");
   });
 
+  // BUG-19: getInstalledAgents() was called twice for no reason.
+  test("calls getInstalledAgents exactly once per getAgentVersions() call", async () => {
+    let calls = 0;
+    _versionDetectionDeps.getInstalledAgents = mock(async () => {
+      calls++;
+      return [];
+    });
+    _versionDetectionDeps.spawn = mock(() => makeMockProc("", 1)) as typeof _versionDetectionDeps.spawn;
+
+    await getAgentVersions();
+    expect(calls).toBe(1);
+  });
+
   test("marks agent as not installed and version null when not in installed list", async () => {
     // No agents installed — getAgentVersions returns an empty array
     _versionDetectionDeps.getInstalledAgents = mock(async () => []);

--- a/test/unit/bakeoff/contestant.test.ts
+++ b/test/unit/bakeoff/contestant.test.ts
@@ -334,6 +334,58 @@ describe("runContestant (AC-6: pipeline crash classification)", () => {
   });
 });
 
+// ── BUG-03: worktreeManager.create() failure (incl. unwired deps) must not
+// crash the whole bake-off CLI invocation — it used to run before the try
+// block, so a throw there propagated uncaught out of runContestant.
+describe("runContestant (BUG-03: worktreeManager.create failure classification)", () => {
+  it("does not throw when worktreeManager.create rejects — returns dnf-crashed instead", async () => {
+    const wt = makeWorktreeManager();
+    wt.create = mock(async () => {
+      throw new Error("worktree create failed");
+    });
+    const pipeline = makePipeline(async () => {
+      throw new Error("should never be called");
+    });
+
+    let didThrow = false;
+    let result: ContestantResult | unknown;
+    try {
+      result = await withDeps(
+        { worktreeManager: wt, pipeline: pipeline.fn as unknown as typeof _contestantDeps.pipeline }, // test-ratchet-allow: as-unknown-as
+        () => runContestant("claude", baseOptions()),
+      );
+    } catch (err) {
+      didThrow = true;
+      result = err;
+    }
+
+    expect(didThrow).toBe(false);
+    expect((result as ContestantResult).status).toBe("dnf-crashed");
+    expect(((result as ContestantResult).error as string)).toContain("worktree create failed");
+    expect(pipeline.fn).not.toHaveBeenCalled();
+  });
+
+  it("reproduces the reported crash: entirely unwired deps.worktreeManager (undefined) yields dnf-crashed, not a TypeError throw", async () => {
+    let didThrow = false;
+    let result: ContestantResult | unknown;
+    try {
+      result = await withDeps(
+        {
+          worktreeManager: undefined as unknown as typeof _contestantDeps.worktreeManager, // test-ratchet-allow: as-unknown-as
+          pipeline: undefined as unknown as typeof _contestantDeps.pipeline, // test-ratchet-allow: as-unknown-as
+        },
+        () => runContestant("claude", baseOptions()),
+      );
+    } catch (err) {
+      didThrow = true;
+      result = err;
+    }
+
+    expect(didThrow).toBe(false);
+    expect((result as ContestantResult).status).toBe("dnf-crashed");
+  });
+});
+
 // ── AC-7: Cost-limit abort → status 'cost-limit' ──────────────────────────────
 
 describe("runContestant (AC-7: cost-limit abort classification)", () => {

--- a/test/unit/cli/run-mode.test.ts
+++ b/test/unit/cli/run-mode.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { resolveUseHeadless } from "../../../src/cli/run-mode";
+
+describe("resolveUseHeadless (BUG-23)", () => {
+  test("TTY + normal formatter → TUI (not headless)", () => {
+    expect(
+      resolveUseHeadless({ isTTY: true, headlessFlag: false, headlessEnv: false, formatterMode: "normal" }),
+    ).toBe(false);
+  });
+
+  test("non-TTY → headless regardless of formatter", () => {
+    expect(
+      resolveUseHeadless({ isTTY: false, headlessFlag: false, headlessEnv: false, formatterMode: "normal" }),
+    ).toBe(true);
+  });
+
+  test("--headless flag forces headless on a TTY", () => {
+    expect(resolveUseHeadless({ isTTY: true, headlessFlag: true, headlessEnv: false, formatterMode: "normal" })).toBe(
+      true,
+    );
+  });
+
+  test("NAX_HEADLESS env forces headless on a TTY", () => {
+    expect(resolveUseHeadless({ isTTY: true, headlessFlag: false, headlessEnv: true, formatterMode: "normal" })).toBe(
+      true,
+    );
+  });
+
+  // BUG-23: --json on a TTY previously mounted the TUI and silently ignored --json.
+  test("--json on a TTY forces headless so JSON output is actually emitted", () => {
+    expect(resolveUseHeadless({ isTTY: true, headlessFlag: false, headlessEnv: false, formatterMode: "json" })).toBe(
+      true,
+    );
+  });
+
+  test("--json off a TTY is still headless (both reasons apply)", () => {
+    expect(resolveUseHeadless({ isTTY: false, headlessFlag: false, headlessEnv: false, formatterMode: "json" })).toBe(
+      true,
+    );
+  });
+
+  test("verbose/quiet formatter on a TTY does not force headless", () => {
+    expect(
+      resolveUseHeadless({ isTTY: true, headlessFlag: false, headlessEnv: false, formatterMode: "verbose" }),
+    ).toBe(false);
+    expect(
+      resolveUseHeadless({ isTTY: true, headlessFlag: false, headlessEnv: false, formatterMode: "quiet" }),
+    ).toBe(false);
+  });
+});

--- a/test/unit/execution/escalation/quote-integrity.test.ts
+++ b/test/unit/execution/escalation/quote-integrity.test.ts
@@ -97,6 +97,36 @@ describe("verifyQuoteTriple", () => {
     const triple = { file: "src/f.ts", line: 3, quote: "validateAcQuote  =  (finding)" };
     expect(await verifyQuoteTriple(triple, "/workdir", makeDeps(FILE_CONTENT))).toBe(true);
   });
+
+  // BUG-08: triple.file comes from LLM-authored escalation text and can
+  // contain ".." segments — must not be readable outside workdir even if a
+  // file happens to exist there (the readFile stub below would otherwise
+  // "verify" it).
+  test("path traversal outside workdir is rejected without ever calling readFile", async () => {
+    let called = false;
+    const deps = {
+      readFile: async (_path: string) => {
+        called = true;
+        return "SECRET=exfiltrated";
+      },
+    };
+    const triple = { file: "../../.env", line: 1, quote: "SECRET=exfiltrated" };
+    expect(await verifyQuoteTriple(triple, "/workdir/repo", deps)).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  test("absolute path outside workdir is rejected", async () => {
+    let called = false;
+    const deps = {
+      readFile: async (_path: string) => {
+        called = true;
+        return "root:x:0:0";
+      },
+    };
+    const triple = { file: "/etc/passwd", line: 1, quote: "root:x:0:0" };
+    expect(await verifyQuoteTriple(triple, "/workdir/repo", deps)).toBe(false);
+    expect(called).toBe(false);
+  });
 });
 
 // ─── verifyEscalationQuotes ───────────────────────────────────────────────────

--- a/test/unit/interaction/interaction-network-failures.test.ts
+++ b/test/unit/interaction/interaction-network-failures.test.ts
@@ -521,6 +521,43 @@ describe("WebhookInteractionPlugin - Payload Security", () => {
     await plugin.destroy();
   });
 
+  test("SEC-04: rejects an oversized chunked body with no Content-Length header, aborting before the full body is buffered", async () => {
+    const plugin = new WebhookInteractionPlugin();
+    await plugin.init({ url: "https://example.com/webhook", maxPayloadBytes: 100, requireSecret: false });
+
+    let bytesPulled = 0;
+    const totalChunks = 1000;
+    const chunkSize = 1024; // far more than maxPayloadBytes across the whole stream
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (bytesPulled >= totalChunks * chunkSize) {
+          controller.close();
+          return;
+        }
+        bytesPulled += chunkSize;
+        controller.enqueue(new TextEncoder().encode("x".repeat(chunkSize)));
+      },
+    });
+
+    // duplex: "half" is required by undici/Bun when a body is a stream.
+    const req = new Request("http://localhost:8765/nax/interact/test-id", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: stream,
+      duplex: "half",
+    } as RequestInit & { duplex: string });
+
+    const handleRequest = (plugin as unknown as { handleRequest: (req: Request) => Promise<Response> }) // test-ratchet-allow: as-unknown-as
+      .handleRequest;
+    const response = await handleRequest.call(plugin, req);
+
+    expect(response.status).toBe(413);
+    // The reader must have stopped well before draining the full (megabytes-sized) stream.
+    expect(bytesPulled).toBeLessThan(totalChunks * chunkSize);
+
+    await plugin.destroy();
+  });
+
   test("should reject malformed JSON with sanitized error", async () => {
     const plugin = new WebhookInteractionPlugin();
     await plugin.init({ url: "https://example.com/webhook", requireSecret: false });

--- a/test/unit/interaction/plugins/webhook-serve-compat.test.ts
+++ b/test/unit/interaction/plugins/webhook-serve-compat.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the Bun.serve port-0 compatibility shim (SEC-06).
+ *
+ * The shim previously installed unconditionally as a module-level side
+ * effect of importing webhook.ts, and its compat-port counter could wrap
+ * and silently overwrite a still-live in-memory server entry.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { installServePortZeroCompat } from "../../../../src/interaction/plugins/webhook-serve-compat";
+
+describe("installServePortZeroCompat (SEC-06)", () => {
+  const originalServe = Bun.serve;
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    (Bun as { serve: typeof Bun.serve }).serve = originalServe;
+    globalThis.fetch = originalFetch;
+  });
+
+  test("installing is idempotent and only patches globals once", () => {
+    installServePortZeroCompat();
+    const patchedServe = Bun.serve;
+    const patchedFetch = globalThis.fetch;
+
+    installServePortZeroCompat();
+    expect(Bun.serve).toBe(patchedServe);
+    expect(globalThis.fetch).toBe(patchedFetch);
+  });
+});
+
+describe("webhook.ts does not install the compat shim at module scope (SEC-06)", () => {
+  test("installServePortZeroCompat() is not called at the top level of webhook.ts", async () => {
+    // Regression guard: the shim used to run as a module-level side effect
+    // of importing webhook.ts (monkey-patching Bun.serve/fetch process-wide
+    // merely by being imported, e.g. via the plugin registry, even when the
+    // webhook plugin is never configured). It must now be called only from
+    // inside startServer(), not at module scope.
+    const source = await Bun.file(
+      new URL("../../../../src/interaction/plugins/webhook.ts", import.meta.url),
+    ).text();
+    const topLevelCall = /^installServePortZeroCompat\(\);\s*$/m;
+    expect(topLevelCall.test(source)).toBe(false);
+    expect(source).toContain("installServePortZeroCompat();");
+  });
+});

--- a/test/unit/log-format/formatter.test.ts
+++ b/test/unit/log-format/formatter.test.ts
@@ -265,3 +265,62 @@ describe("formatAdvisorySummary", () => {
     expect(output).toContain("US-001");
   });
 });
+
+// SEC-09: agent-controlled/PRD-authored fields (message, storyId, story
+// title, escalation reason) are not ANSI-sanitized upstream. A crafted
+// value containing ESC (\x1b) sequences could move the cursor, clear the
+// screen, or write to the clipboard (OSC 52) in the user's terminal.
+describe("formatLogEntry — ANSI/control-char sanitization (SEC-09)", () => {
+  test("strips a CSI sequence embedded in the message", () => {
+    const { output } = formatLogEntry(
+      entry({ stage: "execution", message: "before\x1b[2Jafter" }),
+      { mode: "normal", useColor: false },
+    );
+    expect(output).not.toContain("\x1b[2J");
+    expect(output).toContain("beforeafter");
+  });
+
+  test("strips an OSC 52 clipboard-write sequence embedded in storyId", () => {
+    const { output } = formatLogEntry(
+      entry({ stage: "execution", storyId: "US-\x1b]52;c;evil\x07001" }),
+      { mode: "normal", useColor: false },
+    );
+    expect(output).not.toContain("\x1b]52");
+    expect(output).toContain("US-001");
+  });
+
+  test("strips a CSI sequence embedded in the PRD-authored story title", () => {
+    const { output } = formatLogEntry(
+      entry({
+        stage: "story.start",
+        message: "irrelevant",
+        data: { storyId: "US-001", title: "Login\x1b[31m form" },
+      }),
+      { mode: "normal", useColor: false },
+    );
+    expect(output).not.toContain("\x1b[31m");
+    expect(output).toContain("Login form");
+  });
+
+  test("strips a CSI sequence embedded in the escalation reason", () => {
+    const { output } = formatLogEntry(
+      entry({
+        stage: "story.complete",
+        message: "irrelevant",
+        data: { storyId: "US-001", success: false, reason: "crashed\x1b[2K here" },
+      }),
+      { mode: "verbose", useColor: false },
+    );
+    expect(output).not.toContain("\x1b[2K");
+    expect(output).toContain("crashed here");
+  });
+
+  test("json mode is a raw passthrough — not sanitized (machine-consumed, not rendered)", () => {
+    const { output } = formatLogEntry(entry({ stage: "execution", message: "raw\x1b[2Jvalue" }), {
+      mode: "json",
+      useColor: false,
+    });
+    const parsed = JSON.parse(output);
+    expect(parsed.message).toBe("raw\x1b[2Jvalue");
+  });
+});

--- a/test/unit/logger/redact.test.ts
+++ b/test/unit/logger/redact.test.ts
@@ -47,6 +47,48 @@ describe("redactSecrets", () => {
     expect(out.accessToken).toBe("[REDACTED]");
   });
 
+  // MED-01: SECRET_VALUE_PATTERNS covered only sk-/ghp_/npm_/AKIA/xox* — PEM
+  // blocks, JWTs, and Authorization headers in free text passed through.
+  describe("MED-01 secret-shaped free-text patterns", () => {
+    test("redacts a PEM private key block", () => {
+      const pem = [
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "MIIEpAIBAAKCAQEA1c7+9z5Pad7OejecsQ0bu3aumnAxuNbaBcEAFy6mBAMzKZzk",
+        "-----END RSA PRIVATE KEY-----",
+      ].join("\n");
+      const out = redactSecrets({ output: `key:\n${pem}\ndone` }) as any;
+      expect(out.output).not.toContain("MIIEpAIBAAKCAQEA1c7");
+      expect(out.output).toContain("[REDACTED]");
+      expect(out.output).toContain("done");
+    });
+
+    test("redacts a JWT", () => {
+      const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+      const out = redactSecrets({ output: `auth: ${jwt}` }) as any;
+      expect(out.output).not.toContain(jwt);
+      expect(out.output).toContain("[REDACTED]");
+    });
+
+    test("redacts a Bearer authorization header value", () => {
+      const out = redactSecrets({ output: "Authorization: Bearer abc123def456ghi789" }) as any;
+      expect(out.output).not.toContain("abc123def456ghi789");
+      expect(out.output).toContain("[REDACTED]");
+    });
+
+    test("redacts a Basic authorization header value", () => {
+      const out = redactSecrets({ output: "Authorization: Basic dXNlcjpwYXNzd29yZA==" }) as any;
+      expect(out.output).not.toContain("dXNlcjpwYXNzd29yZA==");
+      expect(out.output).toContain("[REDACTED]");
+    });
+
+    test("redacts an x-api-key header captured in free text", () => {
+      const out = redactSecrets({ output: "x-api-key: abcd1234efgh5678" }) as any;
+      expect(out.output).not.toContain("abcd1234efgh5678");
+      expect(out.output).toContain("[REDACTED]");
+    });
+  });
+
   // MED-02: unguarded recursion threw RangeError (stack overflow) out of
   // every logger call whenever a data payload contained a circular reference.
   describe("circular references (MED-02)", () => {

--- a/test/unit/logger/redact.test.ts
+++ b/test/unit/logger/redact.test.ts
@@ -82,10 +82,32 @@ describe("redactSecrets", () => {
       expect(out.output).toContain("[REDACTED]");
     });
 
+    // Security-review follow-up: raising the length floor to 16 (an earlier
+    // revision of the over-redaction fix) would have under-redacted a short
+    // but real base64 basic-auth credential. The floor stays at 8 — only
+    // the "must look credential-shaped" requirement excludes prose.
+    test("still redacts a short (8-15 char) credential-shaped Basic value", () => {
+      const out = redactSecrets({ output: "Authorization: Basic Ym9iOjl4Mg==" }) as any; // base64("bob:9x2"), 12 chars
+      expect(out.output).not.toContain("Ym9iOjl4Mg==");
+      expect(out.output).toContain("[REDACTED]");
+    });
+
     test("redacts an x-api-key header captured in free text", () => {
       const out = redactSecrets({ output: "x-api-key: abcd1234efgh5678" }) as any;
       expect(out.output).not.toContain("abcd1234efgh5678");
       expect(out.output).toContain("[REDACTED]");
+    });
+
+    // Security-review follow-up: an earlier revision bounded the BEGIN/END
+    // gap to 8KB, which would silently miss a legitimate multi-cert chain
+    // bundle exceeding that size. The bound is now 64KB.
+    test("redacts a PEM block larger than 8KB (bundled certificate chain)", () => {
+      const bigBody = "A".repeat(20_000); // well past the old 8KB bound, within the new 64KB one
+      const pem = `-----BEGIN CERTIFICATE-----\n${bigBody}\n-----END CERTIFICATE-----`;
+      const out = redactSecrets({ output: `chain:\n${pem}\ndone` }) as any;
+      expect(out.output).not.toContain(bigBody);
+      expect(out.output).toContain("[REDACTED]");
+      expect(out.output).toContain("done");
     });
 
     test("redacts a PGP-style PEM block (' ... BLOCK' suffix)", () => {

--- a/test/unit/logger/redact.test.ts
+++ b/test/unit/logger/redact.test.ts
@@ -87,6 +87,39 @@ describe("redactSecrets", () => {
       expect(out.output).not.toContain("abcd1234efgh5678");
       expect(out.output).toContain("[REDACTED]");
     });
+
+    test("redacts a PGP-style PEM block (' ... BLOCK' suffix)", () => {
+      const pem = [
+        "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+        "lQOYBFtestKeyMaterialHerexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "-----END PGP PRIVATE KEY BLOCK-----",
+      ].join("\n");
+      const out = redactSecrets({ output: `key:\n${pem}\ndone` }) as any;
+      expect(out.output).not.toContain("lQOYBFtestKeyMaterialHere");
+      expect(out.output).toContain("[REDACTED]");
+    });
+
+    // Regression: the original Bearer/Basic pattern matched any 8+ char
+    // word-token after the literal word, swallowing ordinary log prose
+    // that just happens to use those English words.
+    test("does NOT redact ordinary prose containing the words Bearer/Basic", () => {
+      const out1 = redactSecrets({ output: "Basic authentication failed for user" }) as any;
+      expect(out1.output).toBe("Basic authentication failed for user");
+
+      const out2 = redactSecrets({ output: "use Bearer authentication scheme" }) as any;
+      expect(out2.output).toBe("use Bearer authentication scheme");
+    });
+
+    // The PEM pattern's BEGIN/END gap is bounded (not [\s\S]*?) so an
+    // unterminated "BEGIN" marker in a large payload (real agent
+    // stdout/stderr) can't force a full end-of-string re-scan per
+    // occurrence. Functional check: content just past the bound is left
+    // untouched rather than folded into a redaction that never finds an END.
+    test("does not redact past the bounded gap when no END marker follows", () => {
+      const beyondBound = "-".repeat(9000);
+      const out = redactSecrets({ output: `-----BEGIN RSA PRIVATE KEY-----${beyondBound}tail-marker` }) as any;
+      expect(out.output).toContain("tail-marker");
+    });
   });
 
   // MED-02: unguarded recursion threw RangeError (stack overflow) out of

--- a/test/unit/prd/dependency-cycle.test.ts
+++ b/test/unit/prd/dependency-cycle.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { assertNoDependencyCycle, detectDependencyCycle } from "../../../src/prd/dependency-cycle";
+import type { UserStory } from "../../../src/prd/types";
+
+function story(id: string, dependencies: string[] = []): UserStory {
+  return { id, dependencies } as UserStory;
+}
+
+describe("detectDependencyCycle (BUG-27)", () => {
+  test("returns null for an acyclic graph", () => {
+    expect(detectDependencyCycle([story("A"), story("B", ["A"]), story("C", ["B"])])).toBeNull();
+  });
+
+  test("detects a direct 2-node cycle", () => {
+    const cycle = detectDependencyCycle([story("A", ["B"]), story("B", ["A"])]);
+    expect(cycle).not.toBeNull();
+    expect(cycle).toContain("A");
+    expect(cycle).toContain("B");
+  });
+
+  test("detects a self-cycle", () => {
+    expect(detectDependencyCycle([story("A", ["A"])])).not.toBeNull();
+  });
+
+  test("detects a transitive cycle", () => {
+    expect(detectDependencyCycle([story("A", ["C"]), story("B", ["A"]), story("C", ["B"])])).not.toBeNull();
+  });
+
+  test("does not false-positive on a diamond DAG", () => {
+    expect(
+      detectDependencyCycle([story("A"), story("B", ["A"]), story("C", ["A"]), story("D", ["B", "C"])]),
+    ).toBeNull();
+  });
+});
+
+describe("assertNoDependencyCycle (BUG-27)", () => {
+  test("does not throw for an acyclic graph", () => {
+    expect(() => assertNoDependencyCycle([story("A"), story("B", ["A"])])).not.toThrow();
+  });
+
+  test("throws naming the cycle", () => {
+    expect(() => assertNoDependencyCycle([story("A", ["B"]), story("B", ["A"])])).toThrow(/Circular dependency/);
+  });
+});

--- a/test/unit/prd/schema.test.ts
+++ b/test/unit/prd/schema.test.ts
@@ -161,6 +161,57 @@ describe("validatePlanOutput — dependency validation", () => {
     );
     expect(prd.userStories[1]!.dependencies).toEqual(["ST-001"]);
   });
+
+  // BUG-27: a dependency cycle was never rejected at plan/validate time —
+  // only worktree/merge.ts's topologicalSort() discovered it, mid-run, by
+  // throwing and aborting the whole merge batch. Fail fast here instead.
+  test("BUG-27: throws on a direct 2-story circular dependency", () => {
+    expect(() =>
+      validatePlanOutput(
+        makeInput([
+          makeStory({ id: "ST-001", dependencies: ["ST-002"] }),
+          makeStory({ id: "ST-002", dependencies: ["ST-001"] }),
+        ]),
+        "feat",
+        "branch",
+      ),
+    ).toThrow(/Circular dependency/);
+  });
+
+  test("BUG-27: throws on a longer transitive cycle (A -> B -> C -> A)", () => {
+    expect(() =>
+      validatePlanOutput(
+        makeInput([
+          makeStory({ id: "ST-001", dependencies: ["ST-003"] }),
+          makeStory({ id: "ST-002", dependencies: ["ST-001"] }),
+          makeStory({ id: "ST-003", dependencies: ["ST-002"] }),
+        ]),
+        "feat",
+        "branch",
+      ),
+    ).toThrow(/Circular dependency/);
+  });
+
+  test("BUG-27: a story depending on itself throws", () => {
+    expect(() =>
+      validatePlanOutput(makeInput([makeStory({ id: "ST-001", dependencies: ["ST-001"] })]), "feat", "branch"),
+    ).toThrow(/Circular dependency/);
+  });
+
+  test("BUG-27: a DAG with shared dependencies (diamond shape) does not throw", () => {
+    expect(() =>
+      validatePlanOutput(
+        makeInput([
+          makeStory({ id: "ST-001", dependencies: [] }),
+          makeStory({ id: "ST-002", dependencies: ["ST-001"] }),
+          makeStory({ id: "ST-003", dependencies: ["ST-001"] }),
+          makeStory({ id: "ST-004", dependencies: ["ST-002", "ST-003"] }),
+        ]),
+        "feat",
+        "branch",
+      ),
+    ).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/precheck/checks-agents.test.ts
+++ b/test/unit/precheck/checks-agents.test.ts
@@ -59,6 +59,14 @@ describe("checkMultiAgentHealth", () => {
     expect(result).toBeTruthy();
     expect(typeof result.passed).toBe("boolean");
   });
+
+  // BUG-19 (regression, caught in code review): getAgentVersions() briefly
+  // marked every agent as installed, making this "available but not
+  // installed" section unreachable regardless of what MOCK_VERSIONS says.
+  test("lists agents with installed: false under 'Available but not installed'", () => {
+    expect(result.message).toContain("Available but not installed");
+    expect(result.message).toContain("Codex");
+  });
 });
 
 describe("checkMultiAgentHealth — no agents installed", () => {

--- a/test/unit/utils/strip-control-chars.test.ts
+++ b/test/unit/utils/strip-control-chars.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { stripControlChars } from "../../../src/utils/strip-control-chars";
+
+describe("stripControlChars (SEC-09)", () => {
+  test("strips a CSI cursor-move sequence", () => {
+    const out = stripControlChars("before\x1b[2Jafter");
+    expect(out).toBe("beforeafter");
+  });
+
+  test("strips a CSI color sequence", () => {
+    const out = stripControlChars("\x1b[31mred text\x1b[0m");
+    expect(out).toBe("red text");
+  });
+
+  test("strips an OSC 52 clipboard-write sequence terminated by BEL", () => {
+    const out = stripControlChars("evil\x1b]52;c;ZXZpbA==\x07safe");
+    expect(out).toBe("evilsafe");
+  });
+
+  test("strips an OSC sequence terminated by ST (ESC \\)", () => {
+    const out = stripControlChars("evil\x1b]0;title\x1b\\safe");
+    expect(out).toBe("evilsafe");
+  });
+
+  test("strips a short two-byte escape", () => {
+    const out = stripControlChars("before\x1bcafter");
+    expect(out).toBe("beforeafter");
+  });
+
+  test("strips stray control bytes not part of an escape sequence", () => {
+    const out = stripControlChars("a\x00b\x07c");
+    expect(out).toBe("abc");
+  });
+
+  test("preserves tabs, newlines, and carriage returns", () => {
+    const out = stripControlChars("line1\nline2\tindented\r\n");
+    expect(out).toBe("line1\nline2\tindented\r\n");
+  });
+
+  test("leaves ordinary text untouched", () => {
+    expect(stripControlChars("US-001: implement the login form")).toBe("US-001: implement the login form");
+  });
+
+  test("handles empty string", () => {
+    expect(stripControlChars("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the 12 remaining "Batch 6 — dead/inert surfaces" findings from `docs/20260814-review-current.md` and `docs/20260814-review-branch-latent-bugs.md`, left pending after the P0/P1 work in #1588. Also includes fixes from a code-reviewer pass and an automated security review run against this branch's own diff before opening this PR, and updates the review doc's fix-status tracking.

**Fixed:**
- **SEC-04** — webhook callback body was fully buffered via `req.text()` before any size check ran; now streams with an early abort once `maxPayloadBytes` is exceeded.
- **MED-01** — secret redaction added PEM/JWT/Bearer-Basic-header patterns; tuned after two review rounds to avoid both over-redacting ordinary log prose and under-redacting short real credentials or large cert-chain bundles.
- **BUG-08** — escalation quote-verifier read files via raw path concatenation with no containment check; now routes through the existing `validateModulePath` guard.
- **BUG-16** — `forceStop` was called on `AcpClient` via a loose cast but implemented nowhere; implemented on `SpawnAcpClient`, scoped to the client's worktree via `--cwd` (caught in review — the first pass missed this flag).
- **BUG-19** — module-level `getInstalledAgents`/`checkAgentHealth` always returned `[]`; now real. A follow-up review fix restores the "known vs. installed" distinction that a first pass had accidentally collapsed (was silently dropping the "available but not installed" precheck section).
- **BUG-15** — per-model `env` config was accepted by the schema but never threaded into the ACP client subprocess.
- **SEC-06** — `Bun.serve`/`fetch` were monkey-patched as a side effect of merely importing `webhook.ts`; now deferred to first actual server start.
- **SEC-09** — story failure reasons, titles, storyIds, escalation reasons, tool names, and agent stderr routinely reach Ink's `<Text>` and the headless console formatter unsanitized; added a shared `stripControlChars()` applied to the specific untrusted fields (not the final colorized output, which would also strip chalk's own legitimate ANSI codes).
- **BUG-23** — `nax run --json` on a TTY silently mounted the TUI instead of emitting JSON.
- **BUG-27** — dependency cycles in a PRD were never validated at plan time, only discovered mid-run by `topologicalSort()` throwing and aborting the whole merge batch.
- **BUG-22** — `--parallel` validation and schedule-cancel exits ran after the TUI was mounted without unmounting first; a Ctrl+<letter> combo (e.g. Ctrl+C) was misrouted to the same handler as the bare letter.
- **BUG-03** — `nax run --compare` (bake-off) crashed uncaught on every invocation. Contained to a per-contestant `dnf-crashed` result instead of crashing the whole CLI — **note: this does not make bake-off functional**, `_contestantDeps` is still unwired to a real pipeline/worktree implementation anywhere in `src/`/`bin/`. That's a feature-completion task, not a bug fix, and stays out of scope here.

**Docs:** `docs/20260814-review-current.md` never tracked fix status after being written — added a status-update summary plus a per-finding status line on all 12 Batch 6 findings (and SEC-04/BUG-08, which turned out not to have been touched by the earlier #1588 pass despite being adjacent findings).

## Review process

1. Implemented all 12 fixes with TDD (regression test per fix).
2. Ran a `code-reviewer` subagent against the full diff — found 1 real regression (BUG-19's known-vs-installed collapse) and 2 real bugs in new code (MED-01 over-redaction, `forceStop` missing `--cwd`), plus several LOW items (NaxError convention, `reader.cancel()`, test isolation) — all fixed.
3. An automated security review of the review-fix commit itself caught a further coverage/safety trade-off in the MED-01 tuning (length floor raised too far, PEM bound too tight) — fixed.
4. Caught during self-review (before requesting human review) that SEC-09 had been promised but not implemented — added it with the same TDD/mutation-verification rigor as the rest.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (biome + all repo-specific checks, including file-size and `as unknown as` ratchets)
- [x] `bun run test` — full suite green (13,338 unit + 1,159 integration + 37 UI tests, 0 fail)
- [x] Every fix has a regression test that fails without the fix (spot-verified via `git stash` for webhook body-limit, redaction perf/coverage, and SEC-09's TUI/log-formatter sanitization)