### PR TITLE
fix(process): treat EPERM as alive in PID liveness probes

### DIFF
--- a/docs/20260814-review-current.md
+++ b/docs/20260814-review-current.md
@@ -40,7 +40,13 @@ rev 2 put **BUG-03 in P0**. It is a feature that crashes 100% of the time, so no
 
 **BUG-03 caveat:** the crash is contained (a bad `worktreeManager`/`pipeline` dependency now yields a per-contestant `dnf-crashed` result instead of crashing the whole CLI), but `_contestantDeps` is still unwired to a real worktree-scoped pipeline implementation anywhere in `src/`/`bin/`. `nax run --compare` will still report every contestant as `dnf-crashed`. Making bake-off actually functional is a feature-completion task (worktree-scoped pipeline execution, per-contestant PRD/config, result aggregation), not a bug fix, and remains open.
 
-**Batch 7 (L1…L38 cleanup): still pending.** Not attempted in either PR — see the batch's own note for which items (L5, L8, L13) have live failure modes worth pulling forward.
+**Batch 7 (L1…L38 cleanup): the three pulled-forward items are resolved; L1…L38 hygiene otherwise still pending.** This doc named L5, L8, and L13 as having live failure modes. On re-verification against source (2026-08-16), **two of the three were wrong**:
+
+- **L5 — refuted.** `src/pipeline/runner.ts` reads `if (result.cost) stageCostAccum += result.cost;`. The guard has been there since PR #304 and is falsy for `undefined`, `0`, *and* `NaN`, so a missing `cost` cannot poison the accumulator. The finding described an unguarded `+=` that does not exist.
+- **L8 — refuted.** The pattern is real (`await proc.exited` before draining `proc.stdout`, in `review/runner.ts`, `test-runners/detect/file-scan.ts`, `test-runners/detect/directory-scan.ts`, `agents/shared/version-detection.ts`), but the *deadlock* is not: it assumes POSIX 64KB pipe-buffer semantics that `Bun.spawn` does not have. Bun buffers the child's stdout internally. Measured on Bun 1.3.13: this repo's own `git ls-files` (132KB) and a synthetic **64MB** stream both complete through the exact pattern with the full byte count recovered. `gitLsFiles` already runs against this 132KB repo on every detection pass, which is why no hang was ever observed.
+- **L13 — confirmed, and worse than described.** Fixed in `fix(process): treat EPERM as alive in PID liveness probes`. The bare `catch { return false }` was not one site but **six** (`commands/unlock.ts`, `execution/lock.ts`, `precheck/checks-config.ts`, `agents/acp/spawn-client-process.ts`, `utils/queue-file-lock.ts`, `cli/status-features.ts`) with no SSOT — a violation of `monorepo-awareness.md` §C. `execution/lock.ts` is the more dangerous site than the cited `unlock.ts`: misreading a live holder as stale lets a **second run start on top of the first**. `unlock.ts`'s TOCTOU guard does not mitigate it, since the on-disk PID is unchanged. All six now route through `src/utils/process-alive.ts`, where only `ESRCH` proves absence.
+
+**Method note for whoever drains the rest of L1…L38:** two of the three items this doc flagged as highest-value were incorrect — one described code that never existed, the other assumed non-Bun runtime semantics. Reproduce before fixing, and prefer an empirical check over reasoning about buffer sizes.
 
 ---
 
@@ -514,7 +520,7 @@ BUG-03 (bake-off crashes on every invocation; `_contestantDeps` has zero install
 
 ### Batch 7 — P3. Cleanup (still pending)
 
-L1…L38. Pull **L5** (NaN cost accumulator), **L8** (pipe deadlock on >64KB diff output), and **L13** (`nax unlock` removing a live run's lock) forward into Batch 6 — they have live failure modes; the rest are hygiene.
+L1…L38. This batch originally pulled **L5**, **L8**, and **L13** forward as having live failure modes. Resolved 2026-08-16: **L5 and L8 refuted, L13 confirmed and fixed** — see the "Status update" section near the top of this doc for the evidence. The remaining L-items are hygiene and are still pending.
 
 ## Verified Clean (no findings)
 

--- a/src/agents/acp/spawn-client-process.ts
+++ b/src/agents/acp/spawn-client-process.ts
@@ -13,6 +13,7 @@
 
 import { getSafeLogger } from "@/logger";
 import { type SpawnOptions, type SpawnResult, cancellableDelay } from "@/utils/bun-deps";
+import { isProcessAlive } from "@/utils/process-alive";
 import { killProcessGroup } from "@/utils/process-kill";
 
 export interface TrackedSpawnDeps {
@@ -40,14 +41,6 @@ const activeKillTimers = new Map<number, KillTreeHandle>();
  * SIGKILL so a reused/unrelated pid (the original process already reaped)
  * isn't signalled — mirrors verification/executor.ts's exitedDuringGrace guard.
  */
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Terminate a process tree by group PID: SIGTERM immediately, SIGKILL

--- a/src/cli/status-features.ts
+++ b/src/cli/status-features.ts
@@ -12,6 +12,7 @@ import { loadConfig } from "../config";
 import type { NaxStatusFile } from "../execution/status-file";
 import { countStories, loadPRD } from "../prd";
 import { projectOutputDir } from "../runtime";
+import { isProcessAlive } from "../utils/process-alive";
 
 /** Injectable deps for status-features (enables test isolation of output dir derivation) */
 export const _statusFeaturesDeps = {
@@ -51,23 +52,15 @@ interface FeatureSummary {
 }
 
 /**
- * Check if a process is alive via POSIX signal 0 (portable, no subprocess).
- *
- * Known limitation: PIDs are recycled by the OS, so a long-dead run's PID can
- * be reassigned to an unrelated live process, producing a false "⚡ Running"
- * report. There is no cheap secondary signal available here — status.json
- * carries no process-start-time or lock-token alongside the PID — so this is
- * a best-effort liveness check, not a guarantee. Cross-checking against a
- * lock/start-time token would require a status.json schema change.
+ * Known limitation of the liveness report below: PIDs are recycled by the OS,
+ * so a long-dead run's PID can be reassigned to an unrelated live process,
+ * producing a false "⚡ Running" report. There is no cheap secondary signal
+ * available here — status.json carries no process-start-time or lock-token
+ * alongside the PID — so this is a best-effort liveness check, not a
+ * guarantee. Cross-checking against a lock/start-time token would require a
+ * status.json schema change.
  */
-function isPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
+const isPidAlive = isProcessAlive;
 
 /** Load status.json for a feature (if it exists) */
 async function loadStatusFile(featureDir: string): Promise<NaxStatusFile | null> {

--- a/src/cli/status-features.ts
+++ b/src/cli/status-features.ts
@@ -12,7 +12,7 @@ import { loadConfig } from "../config";
 import type { NaxStatusFile } from "../execution/status-file";
 import { countStories, loadPRD } from "../prd";
 import { projectOutputDir } from "../runtime";
-import { isProcessAlive } from "../utils/process-alive";
+import { isProcessAlive as isPidAlive } from "../utils/process-alive";
 
 /** Injectable deps for status-features (enables test isolation of output dir derivation) */
 export const _statusFeaturesDeps = {
@@ -51,16 +51,15 @@ interface FeatureSummary {
   costLimitStopped?: boolean;
 }
 
-/**
- * Known limitation of the liveness report below: PIDs are recycled by the OS,
- * so a long-dead run's PID can be reassigned to an unrelated live process,
+/*
+ * Known limitation of the `isPidAlive` reports below: PIDs are recycled by the
+ * OS, so a long-dead run's PID can be reassigned to an unrelated live process,
  * producing a false "⚡ Running" report. There is no cheap secondary signal
  * available here — status.json carries no process-start-time or lock-token
  * alongside the PID — so this is a best-effort liveness check, not a
  * guarantee. Cross-checking against a lock/start-time token would require a
  * status.json schema change.
  */
-const isPidAlive = isProcessAlive;
 
 /** Load status.json for a feature (if it exists) */
 async function loadStatusFile(featureDir: string): Promise<NaxStatusFile | null> {

--- a/src/commands/unlock.ts
+++ b/src/commands/unlock.ts
@@ -7,6 +7,7 @@
 
 import { unlink } from "node:fs/promises";
 import { join } from "node:path";
+import { isProcessAlive } from "@/utils/process-alive";
 import chalk from "chalk";
 
 /**
@@ -17,19 +18,6 @@ export interface UnlockOptions {
   dir?: string;
   /** Force unlock without liveness check (from --force flag) */
   force?: boolean;
-}
-
-/**
- * Check if a process with given PID is still alive
- */
-function isProcessAlive(pid: number): boolean {
-  try {
-    // kill(pid, 0) checks if process exists without actually sending a signal
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/src/execution/lock.ts
+++ b/src/execution/lock.ts
@@ -7,6 +7,7 @@
 
 import { rename, unlink } from "node:fs/promises";
 import path from "node:path";
+import { isProcessAlive } from "@/utils/process-alive";
 import { getLogger } from "../logger";
 
 /** Safely get logger instance, returns null if not initialized */
@@ -34,17 +35,6 @@ async function tryExclusiveCreate(targetPath: string, content: string): Promise<
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
     throw error;
-  }
-}
-
-/** Check if a process with given PID is still alive */
-function isProcessAlive(pid: number): boolean {
-  try {
-    // kill(pid, 0) checks if process exists without actually sending a signal
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
   }
 }
 

--- a/src/precheck/checks-config.ts
+++ b/src/precheck/checks-config.ts
@@ -3,18 +3,9 @@
  */
 
 import { existsSync, statSync } from "node:fs";
+import { isProcessAlive } from "@/utils/process-alive";
 import type { PRD } from "../prd/types";
 import type { Check } from "./types";
-
-/** Check if a process with the given PID is still alive. */
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /** Check if nax.lock is older than 2 hours. */
 export async function checkStaleLock(workdir: string): Promise<Check> {

--- a/src/utils/process-alive.ts
+++ b/src/utils/process-alive.ts
@@ -13,12 +13,12 @@
  * existence checks the kernel would run for a real signal, then throws on
  * failure. Interpreting that throw is the whole subtlety:
  *
- * | errno   | Meaning                                          | Alive? |
- * |:--------|:-------------------------------------------------|:-------|
- * | (none)  | Probe succeeded                                   | yes    |
- * | `ESRCH` | No such process                                   | no     |
- * | `EPERM` | Process EXISTS, caller may not signal it          | yes    |
- * | other   | Probe inconclusive                                | yes    |
+ * | Outcome        | Meaning                                    | Alive? |
+ * |:---------------|:-------------------------------------------|:-------|
+ * | no throw       | Probe succeeded                            | yes    |
+ * | `ESRCH`        | No such process                            | no     |
+ * | `EPERM`        | Process EXISTS, caller may not signal it   | yes    |
+ * | any other/none | Probe inconclusive                         | yes    |
  *
  * Only `ESRCH` proves absence. A bare `catch { return false }` — the shape this
  * helper replaces — misreads `EPERM` as "dead", so a live run owned by another
@@ -47,10 +47,10 @@ export function isProcessAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ESRCH") return false;
-    // EPERM and other errnos mean the process was not proven absent. Without an
-    // errno at all there is nothing to interpret, so treat it as dead.
-    return code !== undefined;
+    // Only ESRCH proves absence. EPERM, any other errno, and a throw carrying
+    // no errno at all all mean the same thing — the process was not proven
+    // gone — so they report alive. Reclaiming callers (lock steal, unlock
+    // delete) must never act on an inconclusive probe.
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
   }
 }

--- a/src/utils/process-alive.ts
+++ b/src/utils/process-alive.ts
@@ -1,0 +1,56 @@
+/**
+ * Process Liveness Probe — SSOT
+ *
+ * Answers "is this PID still running?" for lock holders, queue holders, and
+ * spawned children. This is the only place in the codebase that interprets a
+ * `process.kill(pid, 0)` probe.
+ */
+
+/**
+ * Check whether a process with the given PID is still alive.
+ *
+ * `process.kill(pid, 0)` sends no signal — it only performs the permission and
+ * existence checks the kernel would run for a real signal, then throws on
+ * failure. Interpreting that throw is the whole subtlety:
+ *
+ * | errno   | Meaning                                          | Alive? |
+ * |:--------|:-------------------------------------------------|:-------|
+ * | (none)  | Probe succeeded                                   | yes    |
+ * | `ESRCH` | No such process                                   | no     |
+ * | `EPERM` | Process EXISTS, caller may not signal it          | yes    |
+ * | other   | Probe inconclusive                                | yes    |
+ *
+ * Only `ESRCH` proves absence. A bare `catch { return false }` — the shape this
+ * helper replaces — misreads `EPERM` as "dead", so a live run owned by another
+ * user or another privilege level looks stale. That is a correctness bug for
+ * every caller that then reclaims the resource: `nax unlock` deletes a running
+ * process's lock, and lock acquisition lets a second run start on top of the
+ * first. Inconclusive errors therefore fail **safe** (report alive) rather than
+ * fail convenient.
+ *
+ * @param pid - Process ID to probe. Non-positive and non-finite values are
+ *   never valid process IDs and report dead without probing — passing a
+ *   negative PID to `process.kill` would address a process *group*.
+ * @returns true if the process exists (or its existence cannot be ruled out)
+ *
+ * @example
+ * ```ts
+ * if (isProcessAlive(lockPid)) {
+ *   throw new Error(`nax is already running (PID ${lockPid})`);
+ * }
+ * ```
+ */
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    // EPERM and other errnos mean the process was not proven absent. Without an
+    // errno at all there is nothing to interpret, so treat it as dead.
+    return code !== undefined;
+  }
+}

--- a/src/utils/queue-file-lock.ts
+++ b/src/utils/queue-file-lock.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { open, readdir, stat, unlink } from "node:fs/promises";
 import { basename, dirname } from "node:path";
+import { isProcessAlive } from "./process-alive";
 
 const LOCK_RETRY_MS = 10;
 const LOCK_TIMEOUT_MS = 5_000;
@@ -14,14 +15,7 @@ export const _queueLockDeps = {
   randomUUID,
   now: () => Date.now(),
   sleep: (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
-  isPidAlive: (pid: number) => {
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch {
-      return false;
-    }
-  },
+  isPidAlive: isProcessAlive,
 };
 
 function buildCandidatePath(queuePath: string): string {

--- a/test/unit/execution/helpers.test.ts
+++ b/test/unit/execution/helpers.test.ts
@@ -226,6 +226,35 @@ describe("acquireLock and releaseLock", () => {
     await releaseLock(testDir);
   });
 
+  test("refuses to steal a lock whose holder cannot be probed (EPERM)", async () => {
+    // A lock held by a process this user may not signal — e.g. another user's
+    // run, or one at a different privilege level. process.kill(pid, 0) throws
+    // EPERM there, which means the holder EXISTS. Reading that as "dead" would
+    // let this run start on top of a live one.
+    const foreignPid = 4242;
+    await Bun.write(lockPath, JSON.stringify({ pid: foreignPid, timestamp: Date.now() - 60000 }));
+
+    const originalKill = process.kill;
+    process.kill = ((pid: number | string, _signal?: string | number) => {
+      if (pid === foreignPid) {
+        const err = new Error("EPERM") as NodeJS.ErrnoException;
+        err.code = "EPERM";
+        throw err;
+      }
+      return true;
+    }) as typeof process.kill;
+
+    try {
+      expect(await acquireLock(testDir)).toBe(false);
+
+      // The holder's lock must still be on disk, untouched.
+      const lockData = JSON.parse(await Bun.file(lockPath).text());
+      expect(lockData.pid).toBe(foreignPid);
+    } finally {
+      process.kill = originalKill;
+    }
+  });
+
   test("detects stale lock from OOM-killed process", async () => {
     // Spawn a short-lived child process
     const proc = spawn({

--- a/test/unit/utils/process-alive.test.ts
+++ b/test/unit/utils/process-alive.test.ts
@@ -54,12 +54,12 @@ describe("isProcessAlive", () => {
     expect(isProcessAlive(4321)).toBe(true);
   });
 
-  test("reports dead for a non-errno throw (no code to interpret)", () => {
+  test("reports alive for a throw carrying no errno — an inconclusive probe must not read as absence", () => {
     process.kill = (() => {
       throw new Error("boom");
     }) as typeof process.kill;
 
-    expect(isProcessAlive(4321)).toBe(false);
+    expect(isProcessAlive(4321)).toBe(true);
   });
 
   test("treats a non-positive pid as dead without probing", () => {

--- a/test/unit/utils/process-alive.test.ts
+++ b/test/unit/utils/process-alive.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { isProcessAlive } from "@/utils/process-alive";
+
+/** Build an errno-carrying error the way node's process.kill throws one. */
+function errnoError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe("isProcessAlive", () => {
+  let originalKill: typeof process.kill;
+
+  beforeEach(() => {
+    originalKill = process.kill;
+  });
+
+  afterEach(() => {
+    process.kill = originalKill;
+  });
+
+  test("probes with signal 0 so no signal is actually delivered", () => {
+    const calls: Array<{ pid: number | string; signal?: string | number }> = [];
+    process.kill = ((pid, signal) => {
+      calls.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    expect(isProcessAlive(4321)).toBe(true);
+    expect(calls).toEqual([{ pid: 4321, signal: 0 }]);
+  });
+
+  test("reports dead when the process does not exist (ESRCH)", () => {
+    process.kill = (() => {
+      throw errnoError("ESRCH");
+    }) as typeof process.kill;
+
+    expect(isProcessAlive(4321)).toBe(false);
+  });
+
+  test("reports ALIVE when the probe is denied (EPERM) — the process exists, we just cannot signal it", () => {
+    process.kill = (() => {
+      throw errnoError("EPERM");
+    }) as typeof process.kill;
+
+    expect(isProcessAlive(4321)).toBe(true);
+  });
+
+  test("reports alive for any other errno — only ESRCH proves absence", () => {
+    process.kill = (() => {
+      throw errnoError("EINVAL");
+    }) as typeof process.kill;
+
+    expect(isProcessAlive(4321)).toBe(true);
+  });
+
+  test("reports dead for a non-errno throw (no code to interpret)", () => {
+    process.kill = (() => {
+      throw new Error("boom");
+    }) as typeof process.kill;
+
+    expect(isProcessAlive(4321)).toBe(false);
+  });
+
+  test("treats a non-positive pid as dead without probing", () => {
+    let probed = false;
+    process.kill = (() => {
+      probed = true;
+      return true;
+    }) as typeof process.kill;
+
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-1)).toBe(false);
+    expect(isProcessAlive(Number.NaN)).toBe(false);
+    expect(probed).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`process.kill(pid, 0)` throws `ESRCH` when a process is gone, but `EPERM` when it **exists** and the caller merely lacks permission to signal it. Six independent copies of this probe each ended in a bare `catch { return false }`, so all six misread a live process owned by another user or privilege level as dead — and every caller then reclaimed the resource.

The two that matter:

- **`src/execution/lock.ts`** — a live lock holder is judged stale, so a second run starts on top of the first.
- **`src/commands/unlock.ts`** — `nax unlock` deletes a running process's lock. Its TOCTOU guard does not help here: the on-disk PID is unchanged, so the guard passes and the live lock is removed.

The other four (`precheck/checks-config.ts`, `agents/acp/spawn-client-process.ts`, `utils/queue-file-lock.ts`, `cli/status-features.ts`) had the same bug with milder consequences.

## How

Adds `src/utils/process-alive.ts` as the single probe and routes all six sites through it — there was no SSOT for this concept, which is what let the bug propagate.

The rule is now uniform: **only `ESRCH` proves absence.** `EPERM`, any other errno, and a throw carrying no errno at all report *alive*, because a reclaiming caller must never act on an inconclusive probe. Non-positive and non-integer PIDs report dead without probing, since a negative PID would address a process *group*.

The two `_deps`-injected sites keep their injection seams intact.

## Provenance

`L13` in the 2026-08-14 deep review. That doc also flagged `L5` and `L8` as having live failure modes; both were re-verified against source and **refuted**, with the evidence recorded in `docs/20260814-review-current.md`:

- **L5** — `pipeline/runner.ts` already reads `if (result.cost) stageCostAccum += result.cost;`, and that guard is falsy for `undefined`, `0`, *and* `NaN`. The unguarded `+=` it described does not exist.
- **L8** — the pattern (awaiting `proc.exited` before draining `proc.stdout`) is real at four sites, but the deadlock assumes POSIX 64KB pipe-buffer semantics `Bun.spawn` does not have. Measured on Bun 1.3.13: this repo's own `git ls-files` (132KB) and a synthetic 64MB stream both complete through the exact pattern with every byte recovered.

## Testing

- 6 unit tests for the probe, covering `ESRCH` / `EPERM` / other-errno / no-errno / non-positive PID, and asserting the probe uses signal `0`.
- One test at the site that motivated the change: `acquireLock` must refuse to steal a lock whose holder throws `EPERM`. **Verified to fail against the previous bare-catch behavior**, so it pins the bug rather than just the fix.
- Full suite green (unit + integration + ui); all 22 static gates green, no ratchet baselines moved.