### PR TITLE
fix(llm-json): stop stripTrailingCommas corrupting string values

### DIFF
--- a/docs/20260814-review-current.md
+++ b/docs/20260814-review-current.md
@@ -520,7 +520,9 @@ BUG-03 (bake-off crashes on every invocation; `_contestantDeps` has zero install
 
 ### Batch 7 — P3. Cleanup (still pending)
 
-L1…L38. This batch originally pulled **L5**, **L8**, and **L13** forward as having live failure modes. Resolved 2026-08-16: **L5 and L8 refuted, L13 confirmed and fixed** — see the "Status update" section near the top of this doc for the evidence. The remaining L-items are hygiene and are still pending.
+L1…L38. This batch originally pulled **L5**, **L8**, and **L13** forward as having live failure modes. Resolved 2026-08-16: **L5 and L8 refuted, L13 confirmed and fixed** — see the "Status update" section near the top of this doc for the evidence.
+
+⚠️ **The "hygiene" label on the remainder was wrong.** A re-triage on 2026-08-16 promoted four items to real defects — **L11** (silent string corruption on the PRD path, since fixed), **L10** (`markStoryFailed` never clears `passes`, so a re-failed story is skipped), **L33** (`execution.permissions` parses but is never read), **L16** (one truncated JSONL line blanks `nax runs`). See **`docs/20260816-batch7-retriage.md`** for per-item verdicts, verification depth, and a recommended order. Severity labels in *this* document have now proven unreliable in both directions — use the re-triage instead.
 
 ## Verified Clean (no findings)
 

--- a/docs/20260816-batch7-retriage.md
+++ b/docs/20260816-batch7-retriage.md
@@ -1,0 +1,67 @@
+# Batch 7 Re-triage (L1…L38)
+
+**Date:** 2026-08-16
+**Source doc:** `docs/20260814-review-current.md`
+**Reason:** that doc's Batch 7 triage proved unreliable in *both* directions. It promoted three items as having "live failure modes" — two of which were wrong (L5 described code that does not exist; L8 assumed pipe semantics `Bun.spawn` does not have) — while filing the remainder as "hygiene". At least four of those "hygiene" items are real defects, one of them silent data corruption on the PRD path.
+
+This pass re-verifies every L-item against current source and re-assigns severity.
+
+## Verification depth
+
+Each item is tagged with how far it was actually checked. Do not treat these as equivalent.
+
+| Tag | Meaning |
+|:---|:---|
+| `[probe]` | Empirically reproduced with a runnable script |
+| `[read]` | Confirmed by reading the cited code and its consumers |
+| `[shallow]` | Pattern spotted at the cited site; consumers not traced |
+
+## Re-assigned severities
+
+### Promoted — real defects, not hygiene
+
+| ID | Severity | Status | Finding |
+|:---|:---|:---|:---|
+| **L11** | HIGH | ✅ **Fixed** | `[probe]` `stripTrailingCommas` was regex-only and string-blind, so `,}` / `,]` inside string *values* were deleted. The rewrite still parsed, so the corruption was silent. `prd/schema.ts:523` and `acceptance/refinement.ts:28,62` call it **unconditionally** before any parse, so AC text quoting code was mangled into `prd.json`. |
+| **L10** | HIGH | Open | `[read]` `markStoryPassed` sets **both** `passes = true` and `status`; `markStoryFailed` sets **only** `status = "failed"` and never clears `passes`. A story that passed then failed keeps `passes: true`, and `story-selector.ts:163` / `story-context.ts:232` treat `passes` as "complete" — so it is skipped on re-run. The asymmetry between the two sibling functions is the tell. |
+| **L33** | MEDIUM | Open | `[read]` Two distinct defects. `skipPermissions` has **zero readers** outside `permissions.ts` (only `.mode` is consumed, in `acp/adapter.ts` and `middleware/audit.ts`) — dead output that `CLAUDE.md` still advertises as the destructuring pattern. Worse: the `execution.permissions` schema block has **zero readers** — it parses and silently does nothing, so a user configuring it gets no error and no effect. |
+| **L16** | MEDIUM | Open | `[read]` `parseRunLog` does `lines.map(line => JSON.parse(line))` inside one try/catch returning `[]`. A single truncated final line — exactly what a crashed run leaves — blanks the entire log for `nax runs list/show`, defeating the diagnostic tool precisely when it is needed. Should skip bad lines, not the file. |
+
+### Confirmed, correctly rated as low
+
+| ID | Severity | Finding |
+|:---|:---|:---|
+| L2 | LOW-MED | `[read]` Uncancellable `await Bun.sleep(iterationDelayMs)` at `unified-executor.ts:554,647`. Violates the repo's own forbidden-patterns rule; `cancellableDelay` exists in `utils/bun-deps`. Ctrl+C will not interrupt the delay. |
+| L9 | LOW-MED | `[read]` `matchesAllowedPath` builds `new RegExp` from glob patterns. A `(`, `+`, or `[` in a scope pattern throws or matches wrongly. The `nosemgrep` note calls patterns "not user input", but PRD scope config is LLM-authored. |
+| L15 | LOW-MED | `[read]` `promptForConfirmation` registers only a `data` listener — no `end`/`error`, so stdin EOF on a TTY hangs forever with raw mode still set. Raw mode *is* restored on the normal and Ctrl+C paths, so that half of the original claim is weaker than filed. Both callers are interactive (`bin/nax.ts:493,647`). |
+| L12 | LOW | `[read]` `parseCommandToArgv` applies `~` expansion via `.map()` *after* quote parsing, so `"~/x"` expands inside quotes; `if (current.length > 0)` drops a legitimately empty `""` argument. |
+| L21 | LOW | `[read]` `sink({ ...entry })` is a shallow clone, so nested `entry.data` is shared across sinks — the isolation the doc comment claims is not provided. |
+| L1 | LOW | `[read]` `Bun.spawnSync` git call on the main thread at `run-setup.ts:322`. One-time and fast; cosmetic in practice. |
+| L3 | LOW | `[read]` `filePath.includes("../")` traversal check. `..//` *is* caught (it contains `../`); the real gap is absolute paths. Inputs are internal. |
+| L7 | LOW | `[shallow]` Feature name flows unvalidated into `runDir` path construction at `subscribers/registry.ts:53`. Overlaps L17. |
+| L14 | LOW | `[shallow]` `followLogs` re-reads the whole file per poll; stalls on rotation, crashes on deletion. |
+
+### Downgraded or refuted
+
+| ID | Verdict | Basis |
+|:---|:---|:---|
+| **L5** | ❌ **Refuted** | `[read]` `pipeline/runner.ts` already reads `if (result.cost) stageCostAccum += result.cost;` — since PR #304. That guard is falsy for `undefined`, `0`, **and `NaN`**. The unguarded `+=` the finding described does not exist. |
+| **L8** | ❌ **Refuted** | `[probe]` The pattern (awaiting `proc.exited` before draining `proc.stdout`) is real at four sites, but the deadlock assumes POSIX 64KB pipe-buffer semantics `Bun.spawn` does not have — it buffers child stdout internally. Measured on Bun 1.3.13: this repo's own `git ls-files` (132KB) and a synthetic **64MB** stream both complete with every byte recovered. |
+| **L13** | ✅ **Fixed (PR #1595)** | Confirmed and *worse* than filed — six sites, no SSOT, and `execution/lock.ts` more dangerous than the cited `unlock.ts`. |
+| **L20** | ⚠️ Partially refuted | `[read]` `registeredRequestIds` is **not** simply unbounded — there is a `.delete()` at `webhook.ts:290` and a `.clear()` at `:237`. Growth is limited to requests that never reach the delete path. Re-scope or close. |
+
+### Not re-verified in this pass
+
+L4, L6, L17, L18, L19, L22–L32, L34–L38 were left at their original severity. They are predominantly type-safety nits, dead surfaces, and documentation drift, and nothing in the promoted set suggests a systematic under-rating in that group. **They still carry a single verification pass** — read the cited line before acting, and record it in the commit if the code no longer matches.
+
+## Recommended order
+
+1. **L10** — silent story-state corruption that changes which stories run. Small fix (clear `passes` in `markStoryFailed`), needs a test asserting a passed→failed story is re-selected.
+2. **L16** — per-line tolerant parse; one-line fix, restores the crash-diagnosis path.
+3. **L33** — decide per half: delete the dead `skipPermissions` field, and either wire `execution.permissions` or reject it at parse time so it cannot silently no-op.
+4. **L2, L9, L15** — one small batch.
+5. Everything else — hygiene, genuinely.
+
+## Method note
+
+Two of the three items the source doc ranked highest were wrong, and four it dismissed were real. Severity labels in that document carry no signal in either direction; the only reliable input is the cited `file:line`, and even those drift. Reproduce before fixing — a ten-line script settled L8 and L11 in one shot each.

--- a/src/utils/llm-json.ts
+++ b/src/utils/llm-json.ts
@@ -32,9 +32,57 @@ export function extractJsonFromMarkdown(text: string): string {
  * e.g. `{"a":1,}` → `{"a":1}`
  *
  * Common LLM quirk especially in truncated or partial responses.
+ *
+ * Only *structural* commas are removed. The scan tracks JSON string literals
+ * (honouring backslash escapes) and leaves their contents byte-for-byte
+ * intact: a trailing comma is syntax, but the same characters inside a string
+ * value are data — an acceptance criterion quoting `{a: 1,}`, a review finding
+ * quoting an array literal. A plain `/,\s*([}\]])/g` replace cannot tell the
+ * two apart, and because its rewrite still parses, the corruption is silent.
  */
 export function stripTrailingCommas(text: string): string {
-  return text.replace(/,\s*([}\]])/g, "$1");
+  const insideString = markStringLiteralSpans(text);
+
+  // The `\s*` between the comma and the closer cannot contain a quote, so a
+  // structural-looking match can only be spurious if the COMMA itself sits
+  // inside a string — one mask lookup is enough to decide.
+  return text.replace(/,\s*([}\]])/g, (match, closer: string, offset: number) =>
+    insideString[offset] ? match : closer,
+  );
+}
+
+/**
+ * One linear pass marking every index that falls inside a JSON string literal
+ * (quotes themselves excluded), honouring backslash escapes.
+ */
+function markStringLiteralSpans(text: string): Uint8Array {
+  const mask = new Uint8Array(text.length);
+  let inString = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charCodeAt(i);
+
+    if (inString) {
+      if (ch === 0x5c /* \ */) {
+        // Skip the escaped character so an escaped quote or an escaped
+        // backslash cannot be mistaken for the string terminator.
+        mask[i] = 1;
+        if (i + 1 < text.length) mask[i + 1] = 1;
+        i++;
+        continue;
+      }
+      if (ch === 0x22 /* " */) {
+        inString = false;
+        continue;
+      }
+      mask[i] = 1;
+      continue;
+    }
+
+    if (ch === 0x22 /* " */) inString = true;
+  }
+
+  return mask;
 }
 
 /**

--- a/test/unit/utils/llm-json.test.ts
+++ b/test/unit/utils/llm-json.test.ts
@@ -85,6 +85,30 @@ describe("stripTrailingCommas", () => {
   test("leaves valid JSON unchanged", () => {
     expect(stripTrailingCommas(JSON_FIXTURE)).toBe(JSON_FIXTURE);
   });
+
+  // A trailing comma is JSON *syntax*. The same characters inside a string
+  // VALUE are data — an acceptance criterion quoting `{a: 1,}`, a review
+  // finding quoting an array literal. Rewriting those silently corrupts the
+  // payload, and because the result still parses, nothing ever errors.
+  test.each<string>([
+    '{"note":"use {a: 1,} not {a: 1}"}',
+    '{"arr":"x,] y"}',
+    '{"spaced":"trailing ,   } inside"}',
+    '{"escaped":"quote \\" then ,] here"}',
+  ])("preserves comma sequences inside string values: %s", (input) => {
+    expect(stripTrailingCommas(input)).toBe(input);
+    expect(JSON.parse(stripTrailingCommas(input))).toEqual(JSON.parse(input));
+  });
+
+  test("still strips real trailing commas that sit next to string values", () => {
+    expect(stripTrailingCommas('{"a":"x,]",}')).toBe('{"a":"x,]"}');
+    expect(stripTrailingCommas('["a,}","b,]",]')).toBe('["a,}","b,]"]');
+  });
+
+  test("does not treat an escaped backslash as escaping the closing quote", () => {
+    // "path\\" is a complete string; the following `,]` is real syntax.
+    expect(stripTrailingCommas('["path\\\\",]')).toBe('["path\\\\"]');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`stripTrailingCommas` was a single regex — `text.replace(/,\s*([}\]])/g, "$1")` — which cannot tell a structural trailing comma from the same characters inside a string *value*:

```
in:  {"note":"use {a: 1,} not {a: 1}","arr":"x,] y"}
out: {"note":"use {a: 1} not {a: 1}","arr":"x] y"}
```

The rewrite still parses, so nothing ever errored. The corruption was silent.

On `parseLLMJson` the blast radius is limited — a bare `JSON.parse` is attempted first and the strip is only reached as a fallback. But **`src/prd/schema.ts:523` and `src/acceptance/refinement.ts:28,62` call it unconditionally, before any parse attempt.** `schema.ts` is the PRD path, so an acceptance criterion quoting a code snippet or object literal was mangled into `prd.json`.

## How

Keeps the regex for finding candidates and adds one linear pass marking string-literal spans (honouring backslash escapes). A match is rewritten only when the comma itself falls outside a string — the `\s*` between comma and closer cannot contain a quote, so that single lookup is sufficient.

Measured on a 370KB payload: **0.50ms** vs 0.10ms for the bare regex. A char-by-char scan was 1.84ms, which is why this uses a mask rather than rebuilding the string.

## Provenance and a caveat about the source review

This is `L11` from the 2026-08-14 deep review, where it was filed under **Batch 7 — "P3. Cleanup"**.

That label was wrong, and not only for this item. After `L5` and `L8` were both refuted last week (`#1595`), this PR also adds `docs/20260816-batch7-retriage.md`, a re-verification of the whole L1–L38 set with per-item verification depth recorded. It promotes four items out of "hygiene":

| ID | New severity | Finding |
|:---|:---|:---|
| L11 | HIGH | this PR |
| L10 | HIGH | `markStoryPassed` sets both `passes` and `status`; `markStoryFailed` sets only `status`. A passed→failed story keeps `passes: true` and is then treated as complete by `story-selector.ts:163`, so it is skipped on re-run. |
| L33 | MEDIUM | `skipPermissions` has zero readers (only `.mode` is consumed); `execution.permissions` parses but is never read — a config block that silently no-ops. |
| L16 | MEDIUM | `parseRunLog` maps `JSON.parse` over every line inside one try/catch. One truncated final line — what a crashed run leaves — blanks the whole log for `nax runs list/show`. |

`L20` is partially refuted (the Set does have a `.delete()` and a `.clear()`). Severity labels in the source review have now proven unreliable in both directions; the re-triage doc says so explicitly and records which items were probed, which were read, and which were only spot-checked.

## Testing

- 5 new cases pinning that comma sequences inside string values survive untouched, including an escaped-quote case and an escaped-backslash case (where the following `,]` *is* real syntax).
- 2 cases asserting real trailing commas adjacent to string values are still stripped.
- The pre-existing `stripTrailingCommas` cases are unchanged and still pass.
- Full suite green (unit + integration + ui); all 22 static gates green, no ratchet baselines moved.