### PR TITLE
fix: drain the promoted batch-7 findings (L10, L16, L33)

### DIFF
--- a/.nax/context.md
+++ b/.nax/context.md
@@ -124,7 +124,7 @@ All agent permission decisions go through `resolvePermissions(config, stage)` in
 ```typescript
 // ✅ Correct
 import { resolvePermissions } from "../config/permissions";
-const { skipPermissions, mode } = resolvePermissions(config, "run");
+const { mode } = resolvePermissions(config, "run");
 
 // ❌ Wrong — local fallback
 const skip = config?.execution?.dangerouslySkipPermissions ?? true;
@@ -133,7 +133,12 @@ const skip = config?.execution?.dangerouslySkipPermissions ?? true;
 args.push("--dangerously-skip-permissions");
 ```
 
+`mode` is the only resolved value. The old `skipPermissions` field belonged to
+the CLI adapter, which no longer exists, and was removed — do not reintroduce it.
+
 **Profiles:** `unrestricted` (approve-all), `safe` (approve-reads), `scoped` (Phase 2).
+`scoped` and the per-stage `execution.permissions` block are both rejected at
+config load until GitHub #374 lands — neither is wired to anything.
 **Full spec:** `docs/architecture/agent-adapters.md` §14.
 
 ## Workflow Protocol

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ These instructions apply to all AI coding agents in this project.
 
 **Key dependencies:** @types/react, react, zod, @types/bun, react-devtools-core, typescript
 
+**Commands:** test: `bun run test` | lint: `bun run lint:json` | typecheck: `bun run typecheck`
+
 ---
 # nax — AI Coding Agent Orchestrator
 
@@ -144,7 +146,7 @@ All agent permission decisions go through `resolvePermissions(config, stage)` in
 ```typescript
 // ✅ Correct
 import { resolvePermissions } from "../config/permissions";
-const { skipPermissions, mode } = resolvePermissions(config, "run");
+const { mode } = resolvePermissions(config, "run");
 
 // ❌ Wrong — local fallback
 const skip = config?.execution?.dangerouslySkipPermissions ?? true;
@@ -153,7 +155,12 @@ const skip = config?.execution?.dangerouslySkipPermissions ?? true;
 args.push("--dangerously-skip-permissions");
 ```
 
+`mode` is the only resolved value. The old `skipPermissions` field belonged to
+the CLI adapter, which no longer exists, and was removed — do not reintroduce it.
+
 **Profiles:** `unrestricted` (approve-all), `safe` (approve-reads), `scoped` (Phase 2).
+`scoped` and the per-stage `execution.permissions` block are both rejected at
+config load until GitHub #374 lands — neither is wired to anything.
 **Full spec:** `docs/architecture/agent-adapters.md` §14.
 
 ## Workflow Protocol

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ DO NOT EDIT MANUALLY — run `nax generate` to regenerate.
 
 **Key dependencies:** @types/react, react, zod, @types/bun, react-devtools-core, typescript
 
+**Commands:** test: `bun run test` | lint: `bun run lint:json` | typecheck: `bun run typecheck`
+
 ---
 # nax — AI Coding Agent Orchestrator
 
@@ -142,7 +144,7 @@ All agent permission decisions go through `resolvePermissions(config, stage)` in
 ```typescript
 // ✅ Correct
 import { resolvePermissions } from "../config/permissions";
-const { skipPermissions, mode } = resolvePermissions(config, "run");
+const { mode } = resolvePermissions(config, "run");
 
 // ❌ Wrong — local fallback
 const skip = config?.execution?.dangerouslySkipPermissions ?? true;
@@ -151,7 +153,12 @@ const skip = config?.execution?.dangerouslySkipPermissions ?? true;
 args.push("--dangerously-skip-permissions");
 ```
 
+`mode` is the only resolved value. The old `skipPermissions` field belonged to
+the CLI adapter, which no longer exists, and was removed — do not reintroduce it.
+
 **Profiles:** `unrestricted` (approve-all), `safe` (approve-reads), `scoped` (Phase 2).
+`scoped` and the per-stage `execution.permissions` block are both rejected at
+config load until GitHub #374 lands — neither is wired to anything.
 **Full spec:** `docs/architecture/agent-adapters.md` §14.
 
 ## Workflow Protocol

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,6 +15,8 @@ DO NOT EDIT MANUALLY — run `nax generate` to regenerate.
 
 **Key dependencies:** @types/react, react, zod, @types/bun, react-devtools-core, typescript
 
+**Commands:** test: `bun run test` | lint: `bun run lint:json` | typecheck: `bun run typecheck`
+
 ---
 # nax — AI Coding Agent Orchestrator
 
@@ -142,7 +144,7 @@ All agent permission decisions go through `resolvePermissions(config, stage)` in
 ```typescript
 // ✅ Correct
 import { resolvePermissions } from "../config/permissions";
-const { skipPermissions, mode } = resolvePermissions(config, "run");
+const { mode } = resolvePermissions(config, "run");
 
 // ❌ Wrong — local fallback
 const skip = config?.execution?.dangerouslySkipPermissions ?? true;
@@ -151,7 +153,12 @@ const skip = config?.execution?.dangerouslySkipPermissions ?? true;
 args.push("--dangerously-skip-permissions");
 ```
 
+`mode` is the only resolved value. The old `skipPermissions` field belonged to
+the CLI adapter, which no longer exists, and was removed — do not reintroduce it.
+
 **Profiles:** `unrestricted` (approve-all), `safe` (approve-reads), `scoped` (Phase 2).
+`scoped` and the per-stage `execution.permissions` block are both rejected at
+config load until GitHub #374 lands — neither is wired to anything.
 **Full spec:** `docs/architecture/agent-adapters.md` §14.
 
 ## Workflow Protocol

--- a/codex.md
+++ b/codex.md
@@ -15,6 +15,8 @@ DO NOT EDIT MANUALLY — run `nax generate` to regenerate.
 
 **Key dependencies:** @types/react, react, zod, @types/bun, react-devtools-core, typescript
 
+**Commands:** test: `bun run test` | lint: `bun run lint:json` | typecheck: `bun run typecheck`
+
 ---
 # nax — AI Coding Agent Orchestrator
 
@@ -142,7 +144,7 @@ All agent permission decisions go through `resolvePermissions(config, stage)` in
 ```typescript
 // ✅ Correct
 import { resolvePermissions } from "../config/permissions";
-const { skipPermissions, mode } = resolvePermissions(config, "run");
+const { mode } = resolvePermissions(config, "run");
 
 // ❌ Wrong — local fallback
 const skip = config?.execution?.dangerouslySkipPermissions ?? true;
@@ -151,7 +153,12 @@ const skip = config?.execution?.dangerouslySkipPermissions ?? true;
 args.push("--dangerously-skip-permissions");
 ```
 
+`mode` is the only resolved value. The old `skipPermissions` field belonged to
+the CLI adapter, which no longer exists, and was removed — do not reintroduce it.
+
 **Profiles:** `unrestricted` (approve-all), `safe` (approve-reads), `scoped` (Phase 2).
+`scoped` and the per-stage `execution.permissions` block are both rejected at
+config load until GitHub #374 lands — neither is wired to anything.
 **Full spec:** `docs/architecture/agent-adapters.md` §14.
 
 ## Workflow Protocol

--- a/docs/20260816-batch7-retriage.md
+++ b/docs/20260816-batch7-retriage.md
@@ -23,9 +23,9 @@ Each item is tagged with how far it was actually checked. Do not treat these as 
 | ID | Severity | Status | Finding |
 |:---|:---|:---|:---|
 | **L11** | HIGH | ✅ **Fixed** | `[probe]` `stripTrailingCommas` was regex-only and string-blind, so `,}` / `,]` inside string *values* were deleted. The rewrite still parsed, so the corruption was silent. `prd/schema.ts:523` and `acceptance/refinement.ts:28,62` call it **unconditionally** before any parse, so AC text quoting code was mangled into `prd.json`. |
-| **L10** | HIGH | Open | `[read]` `markStoryPassed` sets **both** `passes = true` and `status`; `markStoryFailed` sets **only** `status = "failed"` and never clears `passes`. A story that passed then failed keeps `passes: true`, and `story-selector.ts:163` / `story-context.ts:232` treat `passes` as "complete" — so it is skipped on re-run. The asymmetry between the two sibling functions is the tell. |
-| **L33** | MEDIUM | Open | `[read]` Two distinct defects. `skipPermissions` has **zero readers** outside `permissions.ts` (only `.mode` is consumed, in `acp/adapter.ts` and `middleware/audit.ts`) — dead output that `CLAUDE.md` still advertises as the destructuring pattern. Worse: the `execution.permissions` schema block has **zero readers** — it parses and silently does nothing, so a user configuring it gets no error and no effect. |
-| **L16** | MEDIUM | Open | `[read]` `parseRunLog` does `lines.map(line => JSON.parse(line))` inside one try/catch returning `[]`. A single truncated final line — exactly what a crashed run leaves — blanks the entire log for `nax runs list/show`, defeating the diagnostic tool precisely when it is needed. Should skip bad lines, not the file. |
+| **L10** | HIGH | ✅ **Fixed** | `[read]` `markStoryPassed` sets **both** `passes = true` and `status`; `markStoryFailed` set **only** `status = "failed"` and never cleared `passes`. The asymmetry between the two sibling functions is the tell. **Correction to an earlier draft of this row:** the consequence is *not* that the story is skipped — both selectors exclude `status === "failed"` independently, so the story itself is handled correctly. The damage is one level out, in **dependency** resolution: `story-selector.ts:174` reads `dep.passes \|\| dep.status === "passed"` and `story-context.ts:232` builds `completedIds` from `s.passes`, so a dependency that went passed → failed still reads as satisfied and its **dependents unblock and run**. `unified-executor.ts:719` marks a story failed on merge conflict after its pipeline passed, so the work never reached the base branch. |
+| **L33** | MEDIUM | ✅ **Fixed** | `[read]` Two distinct defects. `skipPermissions` has **zero readers** outside `permissions.ts` (only `.mode` is consumed, in `acp/adapter.ts` and `middleware/audit.ts`) — dead output that `CLAUDE.md` still advertises as the destructuring pattern. Worse: the `execution.permissions` schema block has **zero readers** — it parses and silently does nothing, so a user configuring it gets no error and no effect. |
+| **L16** | MEDIUM | ✅ **Fixed** | `[read]` `parseRunLog` does `lines.map(line => JSON.parse(line))` inside one try/catch returning `[]`. A single truncated final line — exactly what a crashed run leaves — blanks the entire log for `nax runs list/show`, defeating the diagnostic tool precisely when it is needed. Should skip bad lines, not the file. |
 
 ### Confirmed, correctly rated as low
 
@@ -56,11 +56,16 @@ L4, L6, L17, L18, L19, L22–L32, L34–L38 were left at their original severity
 
 ## Recommended order
 
-1. **L10** — silent story-state corruption that changes which stories run. Small fix (clear `passes` in `markStoryFailed`), needs a test asserting a passed→failed story is re-selected.
-2. **L16** — per-line tolerant parse; one-line fix, restores the crash-diagnosis path.
-3. **L33** — decide per half: delete the dead `skipPermissions` field, and either wire `execution.permissions` or reject it at parse time so it cannot silently no-op.
-4. **L2, L9, L15** — one small batch.
-5. Everything else — hygiene, genuinely.
+1. ~~**L11**~~ — done.
+2. ~~**L10**~~ — done. `markStoryFailed` now clears `passes`.
+3. ~~**L16**~~ — done. Per-line tolerant parse; malformed lines are skipped and counted in a warning.
+4. ~~**L33**~~ — done, both halves. `skipPermissions` and the unused `allowedTools` are gone from `ResolvedPermissions`; `execution.permissions` is now rejected at config load by `rejectUnimplementedPermissionsBlock`, alongside the `"scoped"` profile it belongs to, and its schema and `runtime-types.ts` entries were removed.
+5. **L2, L9, L15** — the remaining confirmed set; one small batch.
+6. Everything else — hygiene, genuinely.
+
+### Why L33 was rejected rather than implemented
+
+Per-stage permissions are **frozen, not merely unfinished**: acpx's own permission support is not mature enough to build on, which is also why SEC-01 was discarded. So the config surface for a frozen feature had to stop accepting input rather than grow an implementation. Rejecting at load mirrors `rejectUnimplementedScopedProfile` and is safe in practice — neither the global `~/.nax/config.json` nor this repo's `.nax/config.json` carried the key.
 
 ## Method note
 

--- a/src/cli/runs.ts
+++ b/src/cli/runs.ts
@@ -48,19 +48,39 @@ export interface RunsShowOptions {
 /**
  * Parse JSONL log file and extract run events.
  *
+ * Malformed lines are skipped individually rather than discarding the file. A
+ * crashed or SIGKILLed run leaves a half-written final line, and an
+ * all-or-nothing parse threw on it and returned `[]` — losing every valid
+ * entry before it, exactly when the log is most needed for diagnosis.
+ *
  * @param logPath - Path to .jsonl log file
  * @returns Array of log entries
  */
 async function parseRunLog(logPath: string): Promise<LogEntry[]> {
   const logger = getLogger();
+  let content: string;
   try {
-    const content = await Bun.file(logPath).text();
-    const lines = content.trim().split("\n").filter(Boolean);
-    return lines.map((line) => JSON.parse(line) as LogEntry);
+    content = await Bun.file(logPath).text();
   } catch (err) {
-    logger.warn("cli", "Failed to parse run log", { logPath, error: (err as Error).message });
+    logger.warn("cli", "Failed to read run log", { logPath, error: (err as Error).message });
     return [];
   }
+
+  const entries: LogEntry[] = [];
+  let skipped = 0;
+  for (const line of content.trim().split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      entries.push(JSON.parse(line) as LogEntry);
+    } catch {
+      skipped++;
+    }
+  }
+
+  if (skipped > 0) {
+    logger.warn("cli", "Skipped malformed run log lines", { logPath, skipped, parsed: entries.length });
+  }
+  return entries;
 }
 
 /**

--- a/src/config/config-guards.ts
+++ b/src/config/config-guards.ts
@@ -292,3 +292,31 @@ export function rejectUnimplementedScopedProfile(conf: Record<string, unknown>):
   ].join("\n");
   throw new NaxError(message, "CONFIG_SCOPED_PROFILE_UNIMPLEMENTED", { stage: "config" });
 }
+
+/**
+ * @internal Reject the `execution.permissions` policy block until Phase 2 lands.
+ *
+ * The block is the per-stage counterpart to `permissionProfile: "scoped"` and
+ * belongs to the same unimplemented feature (GitHub #374). Zod accepted and
+ * validated its whole shape while nothing in `src/` ever read it, so a user
+ * could write a per-stage permission policy, get no error, and get no
+ * enforcement — believing their agents were constrained while every stage ran
+ * under the resolved profile. Silently ignoring a stated security intent is
+ * worse than not offering the key, so this fails fast for the same reason the
+ * `"scoped"` profile above does.
+ *
+ * Remove this guard when scoped permissions are implemented (GitHub #374).
+ */
+export function rejectUnimplementedPermissionsBlock(conf: Record<string, unknown>): void {
+  const execution = conf.execution as Record<string, unknown> | undefined;
+  if (execution === null || typeof execution !== "object") return;
+  if (!("permissions" in execution)) return;
+
+  const message = [
+    "Invalid configuration — execution.permissions is not yet implemented.",
+    "Per-stage permission policy is tracked by GitHub #374. The block is currently",
+    "read by nothing, so leaving it in place would silently give you no enforcement.",
+    "Remove it and use execution.permissionProfile for now.",
+  ].join("\n");
+  throw new NaxError(message, "CONFIG_PERMISSIONS_BLOCK_UNIMPLEMENTED", { stage: "config" });
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -19,6 +19,7 @@ import {
   rejectDeadQualityFlags,
   rejectLegacyAgentKeys,
   rejectLegacyRectificationKeys,
+  rejectUnimplementedPermissionsBlock,
   rejectUnimplementedScopedProfile,
   stripRemovedNoOpKeys,
 } from "./config-guards";
@@ -222,6 +223,9 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   // Fail fast on the not-yet-implemented scoped permission profile (GitHub #374)
   // rather than letting it silently degrade to "safe".
   rejectUnimplementedScopedProfile(rawConfig);
+  // Same feature, same treatment: the per-stage policy block is read by nothing,
+  // so accepting it would silently provide no enforcement.
+  rejectUnimplementedPermissionsBlock(rawConfig);
   // Strip the four inert no-op keys (warn-and-strip, not throw — see
   // config-guards.ts for the divergence rationale). Runs AFTER the reject guards
   // and BEFORE safeParse, so the removed key is gone before the schema sees it.

--- a/src/config/permissions.ts
+++ b/src/config/permissions.ts
@@ -24,12 +24,11 @@ export type PipelineStage =
   | "complete";
 
 export interface ResolvedPermissions {
-  /** ACP permission mode string */
+  /**
+   * ACP permission mode string — the only resolved value anything consumes
+   * (`agents/acp/adapter.ts`, `runtime/middleware/audit.ts`).
+   */
   mode: "approve-all" | "approve-reads" | "default";
-  /** CLI adapter: whether to pass --dangerously-skip-permissions */
-  skipPermissions: boolean;
-  /** Future: scoped tool allowlist (Phase 2) */
-  allowedTools?: string[];
 }
 
 /**
@@ -41,13 +40,13 @@ export function resolvePermissions(config: AgentManagerConfig | undefined, _stag
 
   switch (profile) {
     case "unrestricted":
-      return { mode: "approve-all", skipPermissions: true };
+      return { mode: "approve-all" };
     case "safe":
-      return { mode: "approve-reads", skipPermissions: false };
+      return { mode: "approve-reads" };
     case "scoped":
       return resolveScopedPermissions(config, _stage);
     default:
-      return { mode: "approve-reads", skipPermissions: false };
+      return { mode: "approve-reads" };
   }
 }
 
@@ -62,5 +61,5 @@ export function resolvePermissions(config: AgentManagerConfig | undefined, _stag
  * the loader guard.
  */
 function resolveScopedPermissions(_config: AgentManagerConfig | undefined, _stage: PipelineStage): ResolvedPermissions {
-  return { mode: "approve-reads", skipPermissions: false };
+  return { mode: "approve-reads" };
 }

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -125,15 +125,8 @@ export interface ExecutionConfig {
   typecheckCommand?: string | null;
   /** Permission profile for the agent (default: "unrestricted") */
   permissionProfile?: "unrestricted" | "safe" | "scoped";
-  /** Per-stage permission overrides — only read when permissionProfile = "scoped" (Phase 2) */
-  permissions?: Record<
-    string,
-    {
-      mode: "approve-all" | "approve-reads" | "scoped";
-      allowedTools?: string[];
-      inherit?: string;
-    }
-  >;
+  // NOTE: the Phase 2 per-stage `permissions` block is intentionally absent —
+  // it is rejected at config load until GitHub #374 lands. See schemas-execution.ts.
   /** Enable smart test runner to scope test runs to changed files (default: true).
    * Accepts boolean for backward compat or a SmartTestRunnerConfig object. */
   smartTestRunner?: boolean | SmartTestRunnerConfig;

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -186,17 +186,11 @@ export const ExecutionConfigSchema = z.object({
   lintCommand: z.string().nullable().optional(),
   typecheckCommand: z.string().nullable().optional(),
   permissionProfile: z.enum(["unrestricted", "safe", "scoped"]).default("unrestricted"),
-  // Phase 2: per-stage permission overrides (only read when profile = "scoped")
-  permissions: z
-    .record(
-      z.string(),
-      z.object({
-        mode: z.enum(["approve-all", "approve-reads", "scoped"]),
-        allowedTools: z.array(z.string()).optional(),
-        inherit: z.string().optional(),
-      }),
-    )
-    .optional(),
+  // NOTE: the Phase 2 `permissions` block (per-stage overrides) deliberately has
+  // no schema entry. It was accepted and validated here while nothing in src/
+  // read it, so a user could state a permission policy and get no enforcement.
+  // `rejectUnimplementedPermissionsBlock` now fails the load instead. Re-add
+  // this alongside the resolver when GitHub #374 lands.
   smartTestRunner: smartTestRunnerFieldSchema,
   worktreeDependencies: WorktreeDependenciesConfigSchema.default({
     mode: "off",

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -264,6 +264,12 @@ export function markStoryFailed(
       statusWriter?.resetPostRunStatus();
     }
     story.status = "failed";
+    // `passes` is what dependency resolution reads (story-selector.ts,
+    // story-context.ts), not `status`. A story can genuinely go passed ->
+    // failed — unified-executor.ts marks one failed on merge conflict after
+    // its pipeline passed — and leaving `passes` true there would let
+    // dependents unblock against work that never reached the base branch.
+    story.passes = false;
     story.attempts += 1;
     if (failureCategory !== undefined) {
       story.failureCategory = failureCategory;

--- a/test/integration/acceptance/audit-naming.test.ts
+++ b/test/integration/acceptance/audit-naming.test.ts
@@ -19,7 +19,7 @@ import { attachAuditSubscriber } from "../../../src/runtime/middleware/audit";
 import { PromptAuditor } from "../../../src/runtime/prompt-auditor";
 import { withTempDir } from "../../helpers/temp";
 
-const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+const PERMS = { mode: "approve-reads" as const };
 
 function makeAcceptanceGenEvent(): CompleteDispatchEvent {
   return {

--- a/test/integration/agents/fail-stale-watchdog.test.ts
+++ b/test/integration/agents/fail-stale-watchdog.test.ts
@@ -62,7 +62,7 @@ function makeCompleteOptions(
   timeoutMs = 5000,
 ) {
   return {
-    resolvedPermissions: { mode: "approve-reads" as const, skipPermissions: false },
+    resolvedPermissions: { mode: "approve-reads" as const },
     modelDef: { provider: "anthropic" as const, model: "claude-haiku-4-5" as const },
     workdir: "/tmp/test",
     timeoutMs,

--- a/test/integration/tdd/audit-naming.test.ts
+++ b/test/integration/tdd/audit-naming.test.ts
@@ -26,7 +26,7 @@ import { PromptAuditor } from "../../../src/runtime/prompt-auditor";
 import type { SessionRole } from "../../../src/runtime/session-role";
 import { withTempDir } from "../../helpers/temp";
 
-const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+const PERMS = { mode: "approve-reads" as const };
 
 function makeTddTurnEvent(role: SessionRole, turn = 1): SessionTurnDispatchEvent {
   const sessionName = `nax-abcd1234-tdd-calc-US-001-${role}`;

--- a/test/unit/agents/acp/adapter-phase-a.test.ts
+++ b/test/unit/agents/acp/adapter-phase-a.test.ts
@@ -11,7 +11,7 @@ function makeOpenSessionOpts(overrides: Partial<OpenSessionOpts> = {}): OpenSess
   return {
     agentName: "claude",
     workdir: ACP_WORKDIR,
-    resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    resolvedPermissions: { mode: "approve-reads" },
     modelDef: { provider: "anthropic", model: "claude-sonnet-4-5", env: {} },
     timeoutSeconds: 30,
     ...overrides,

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -87,7 +87,7 @@ function makeCompleteOptions(overrides: Record<string, unknown> = {}): import(".
   return {
     modelDef: { provider: "anthropic", model: "claude-sonnet-4-5", env: {} },
     workdir: ACP_WORKDIR,
-    resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const },
+    resolvedPermissions: { mode: "approve-reads" as const },
     ...overrides,
   } as import("../../../../src/agents/types").ResolvedCompleteOptions;
 }
@@ -487,7 +487,7 @@ describe("complete() — modelDef primitive consumption", () => {
     });
 
     await new AcpAgentAdapter("claude").complete("test", makeCompleteOptions({
-      resolvedPermissions: { skipPermissions: true, mode: "approve-all" as const },
+      resolvedPermissions: { mode: "approve-all" as const },
     }));
     expect(capturedPermissionMode).toBe("approve-all");
   });

--- a/test/unit/agents/manager-complete-empty-output.test.ts
+++ b/test/unit/agents/manager-complete-empty-output.test.ts
@@ -6,7 +6,7 @@ import { makeNaxConfig } from "../../helpers";
 const baseOptions = {
   modelDef: { provider: "anthropic" as const, model: "claude-sonnet-4-6", env: {} as Record<string, string> },
   workdir: "/tmp/test",
-  resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const },
+  resolvedPermissions: { mode: "approve-reads" as const },
 };
 
 /** Build a NaxConfig slice for watchdog + fallback tuning used by these tests. */

--- a/test/unit/agents/manager-complete.test.ts
+++ b/test/unit/agents/manager-complete.test.ts
@@ -71,7 +71,7 @@ describe("AgentManager PID lifecycle — configureRuntime", () => {
 
     m.configureRuntime({ pidRegistry: patchedRegistry });
 
-    await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const } });
+    await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { mode: "approve-reads" as const } });
 
     expect(capturedOptions?.onPidSpawned).toBeDefined();
     expect(capturedOptions?.onPidExited).toBeDefined();
@@ -95,7 +95,7 @@ describe("AgentManager PID lifecycle — configureRuntime", () => {
     } as unknown as AgentRegistry;
 
     const m = new AgentManager(makeNaxConfig(), registry);
-    await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const } });
+    await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { mode: "approve-reads" as const } });
 
     expect(capturedOptions?.onPidSpawned).toBeUndefined();
     expect(capturedOptions?.onPidExited).toBeUndefined();
@@ -105,7 +105,7 @@ describe("AgentManager PID lifecycle — configureRuntime", () => {
 describe("AgentManager.completeWithFallback (#567)", () => {
   test("returns output on success", async () => {
     const m = new AgentManager(makeConfig(), makeRegistry({ claude: { output: "hello" } }));
-    const outcome = await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const } });
+    const outcome = await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { mode: "approve-reads" as const } });
     expect(outcome.result.output).toBe("hello");
     expect(outcome.fallbacks).toHaveLength(0);
   });
@@ -116,7 +116,7 @@ describe("AgentManager.completeWithFallback (#567)", () => {
       codex: { output: "from codex" },
     });
     const m = new AgentManager(makeConfig(), registry);
-    const outcome = await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const } });
+    const outcome = await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { mode: "approve-reads" as const } });
     expect(outcome.result.output).toBe("from codex");
     expect(outcome.fallbacks).toHaveLength(1);
     expect(outcome.fallbacks[0].priorAgent).toBe("claude");
@@ -138,7 +138,7 @@ describe("AgentManager.completeWithFallback (#567)", () => {
       config,
       makeRegistry({ claude: { output: "", failure: availFailure } }),
     );
-    const outcome = await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const } });
+    const outcome = await m.completeWithFallback("prompt", { modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} }, workdir: "/tmp/test", resolvedPermissions: { mode: "approve-reads" as const } });
     expect(outcome.result.adapterFailure?.outcome).toBe("fail-auth");
   });
 });
@@ -153,7 +153,7 @@ describe("AgentManager.completeWithFallback — hard-exception classification (B
     const outcome = await m.completeWithFallback("prompt", {
       modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} },
       workdir: "/tmp/test",
-      resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const },
+      resolvedPermissions: { mode: "approve-reads" as const },
     });
     expect(outcome.result.output).toBe("from codex");
     expect(outcome.fallbacks).toHaveLength(1);
@@ -175,7 +175,7 @@ describe("AgentManager.completeWithFallback — hard-exception classification (B
     await m.completeWithFallback("prompt", {
       modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} },
       workdir: "/tmp/test",
-      resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const },
+      resolvedPermissions: { mode: "approve-reads" as const },
     });
 
     expect(m.isUnavailable("claude")).toBe(true);
@@ -191,7 +191,7 @@ describe("AgentManager.completeWithFallback — hard-exception classification (B
     const outcome = await m.completeWithFallback("prompt", {
       modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} },
       workdir: "/tmp/test",
-      resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const },
+      resolvedPermissions: { mode: "approve-reads" as const },
     });
     expect(outcome.result.adapterFailure).toEqual({
       category: "quality",

--- a/test/unit/cli/runs.test.ts
+++ b/test/unit/cli/runs.test.ts
@@ -125,6 +125,21 @@ describe("nax runs — event lookup", () => {
     expect(row?.data?.status).toBe("completed");
   });
 
+  // A crashed or SIGKILLed run leaves a half-written final line. Parsing the file
+  // all-or-nothing threw on that line and blanked every valid entry before it —
+  // losing the log exactly when it is most needed for diagnosis.
+  test("a truncated final line does not blank the entries before it", async () => {
+    await seedRunLog(outputDir, { complete: true });
+    const logPath = join(outputDir, "features", "demo", "runs", `${RUN_ID}.jsonl`);
+    await writeFile(logPath, `${await Bun.file(logPath).text()}{"timestamp":"2026-08-11T12:00:04.000Z","st`);
+
+    const { entries } = captureLogger();
+    await runsShowCommand({ runId: RUN_ID, feature: "demo", workdir, outputDir });
+
+    expect(entries.some((e) => e.message === `Run: ${RUN_ID}`)).toBe(true);
+    expect(entries.find((e) => e.message === `Run: ${RUN_ID}`)?.data?.status).toBe("completed");
+  });
+
   // The completion phase emits multiple `run.complete` entries. Matching the stage
   // alone takes the FIRST — a purge notice with no summary payload — which reports a
   // completed run with zeroed totals. The summary is identified by its payload.

--- a/test/unit/config/permissions.test.ts
+++ b/test/unit/config/permissions.test.ts
@@ -43,10 +43,9 @@ const REPRESENTATIVE_STAGES: PipelineStage[] = ["plan", "run", "rectification", 
 describe("resolvePermissions — unrestricted profile", () => {
   const config = makeConfig({ permissionProfile: "unrestricted" });
 
-  test.each(REPRESENTATIVE_STAGES)("stage=%s → approve-all + skipPermissions=true", (stage) => {
+  test.each(REPRESENTATIVE_STAGES)("stage=%s → approve-all", (stage) => {
     const result = resolvePermissions(config, stage);
     expect(result.mode).toBe("approve-all");
-    expect(result.skipPermissions).toBe(true);
   });
 });
 
@@ -57,10 +56,9 @@ describe("resolvePermissions — unrestricted profile", () => {
 describe("resolvePermissions — safe profile", () => {
   const config = makeConfig({ permissionProfile: "safe" });
 
-  test.each(REPRESENTATIVE_STAGES)("stage=%s → approve-reads + skipPermissions=false", (stage) => {
+  test.each(REPRESENTATIVE_STAGES)("stage=%s → approve-reads", (stage) => {
     const result = resolvePermissions(config, stage);
     expect(result.mode).toBe("approve-reads");
-    expect(result.skipPermissions).toBe(false);
   });
 });
 
@@ -71,10 +69,9 @@ describe("resolvePermissions — safe profile", () => {
 describe("resolvePermissions — scoped profile (Phase 2 stub)", () => {
   const config = makeConfig({ permissionProfile: "scoped" });
 
-  test.each(REPRESENTATIVE_STAGES)("stage=%s → safe defaults (approve-reads, skipPermissions=false)", (stage) => {
+  test.each(REPRESENTATIVE_STAGES)("stage=%s → safe defaults (approve-reads)", (stage) => {
     const result = resolvePermissions(config, stage);
     expect(result.mode).toBe("approve-reads");
-    expect(result.skipPermissions).toBe(false);
   });
 });
 
@@ -87,13 +84,11 @@ describe("resolvePermissions — default behaviour", () => {
     const config = makeConfig();
     const result = resolvePermissions(config, "run");
     expect(result.mode).toBe("approve-all");
-    expect(result.skipPermissions).toBe(true);
   });
 
   test("no config → unrestricted (approve-all)", () => {
     const result = resolvePermissions(undefined, "run");
     expect(result.mode).toBe("approve-all");
-    expect(result.skipPermissions).toBe(true);
   });
 });
 

--- a/test/unit/config/scoped-profile-guard.test.ts
+++ b/test/unit/config/scoped-profile-guard.test.ts
@@ -67,4 +67,35 @@ describe("scoped permission profile — unimplemented guard (#374)", () => {
     const config = await loadConfig(root);
     expect(config.execution.permissionProfile).toBe("safe");
   });
+
+  // `execution.permissions` is the per-stage policy block belonging to the same
+  // unimplemented feature. The schema accepted and validated it while nothing in
+  // src/ ever read it, so a user could write a permission policy, see no error,
+  // and get no enforcement. Same treatment as the profile value it belongs to.
+  test("rejects the execution.permissions policy block with a pointer to #374", async () => {
+    const root = await writeProjectConfig({
+      execution: { permissions: { run: { mode: "approve-reads", allowedTools: ["read"] } } },
+    });
+    try {
+      await loadConfig(root);
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      const e = err as NaxError;
+      expect(e.code).toBe("CONFIG_PERMISSIONS_BLOCK_UNIMPLEMENTED");
+      expect(e.message).toContain("#374");
+      expect(e.message).toContain("execution.permissions");
+    }
+  });
+
+  test("an empty execution.permissions block is still rejected", async () => {
+    const root = await writeProjectConfig({ execution: { permissions: {} } });
+    await expect(loadConfig(root)).rejects.toThrow(/execution\.permissions/);
+  });
+
+  test("a config with no permissions block loads normally", async () => {
+    const root = await writeProjectConfig({ execution: { permissionProfile: "unrestricted" } });
+    const config = await loadConfig(root);
+    expect(config.execution.permissionProfile).toBe("unrestricted");
+  });
 });

--- a/test/unit/execution/story-selector.test.ts
+++ b/test/unit/execution/story-selector.test.ts
@@ -8,6 +8,7 @@ import { describe, test, expect } from "bun:test";
 import { selectIndependentBatch, groupStoriesByDependencies, selectNextStories } from "../../../src/execution/story-selector";
 import type { UserStory } from "../../../src/prd/types";
 import type { StoryBatch } from "../../../src/execution/batching";
+import { markStoryFailed, markStoryPassed } from "@/prd";
 import { makePRD, makeStory } from "../../helpers/mock-story";
 import { DEFAULT_CONFIG } from "../../../src/config";
 
@@ -44,6 +45,25 @@ describe("selectIndependentBatch", () => {
   test("returns an empty array when stories is empty", () => {
     const result = selectIndependentBatch([], 10);
     expect(result).toEqual([]);
+  });
+
+  test("does not unblock a dependent whose dependency went passed -> failed", () => {
+    // A story can pass its pipeline and still be marked failed afterwards —
+    // unified-executor.ts does exactly that on a merge conflict, so the work
+    // never reached the base branch. Driven through the real mark* functions
+    // rather than hand-built state, because the defect being pinned is that
+    // markStoryFailed left `passes` true while dependency resolution below
+    // reads `dep.passes`.
+    const dependency = createStory("US-001", []);
+    const dependent = createStory("US-002", ["US-001"]);
+    const prd = makePRD({ userStories: [dependency, dependent] });
+
+    markStoryPassed(prd, "US-001");
+    markStoryFailed(prd, "US-001", "tests-failing");
+
+    const result = selectIndependentBatch(prd.userStories, 10);
+
+    expect(result.map((s) => s.id)).not.toContain("US-002");
   });
 
   test("returns a single-element array when exactly one story has no unmet dependencies", () => {

--- a/test/unit/prd/prd-failure-category.test.ts
+++ b/test/unit/prd/prd-failure-category.test.ts
@@ -124,6 +124,22 @@ describe("markStoryFailed()", () => {
     expect(prd.userStories[0].status).toBe("pending");
   });
 
+  // `passes` is a separate field from `status`, and dependency resolution reads
+  // `passes` (story-selector.ts / story-context.ts) rather than `status`. A
+  // story can genuinely go passed -> failed: unified-executor.ts marks a story
+  // failed on merge conflict after its pipeline passed. If `passes` is left
+  // true, dependents treat the failure as satisfied and run anyway.
+  test("clears passes when a previously-passed story fails", () => {
+    const prd = makePrd([makeStory("US-001")]);
+    markStoryPassed(prd, "US-001");
+    expect(prd.userStories[0].passes).toBe(true);
+
+    markStoryFailed(prd, "US-001", "tests-failing");
+
+    expect(prd.userStories[0].status).toBe("failed");
+    expect(prd.userStories[0].passes).toBe(false);
+  });
+
   test("does not affect other stories", () => {
     const prd = makePrd([makeStory("US-001"), makeStory("US-002")]);
     markStoryFailed(prd, "US-001", "tests-failing");

--- a/test/unit/runtime/agent-middleware.test.ts
+++ b/test/unit/runtime/agent-middleware.test.ts
@@ -9,7 +9,7 @@ function makeCtx(overrides: Partial<MiddlewareContext> = {}): MiddlewareContext 
     kind: "run",
     request: null,
     config: DEFAULT_CONFIG,
-    resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    resolvedPermissions: { mode: "approve-reads" },
     ...overrides,
   };
 }

--- a/test/unit/runtime/dispatch-events.test.ts
+++ b/test/unit/runtime/dispatch-events.test.ts
@@ -9,7 +9,7 @@ import {
   type SessionTurnDispatchEvent,
 } from "../../../src/runtime/dispatch-events";
 
-const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+const PERMS = { mode: "approve-reads" as const };
 
 function makeSessionTurnEvent(overrides: Partial<SessionTurnDispatchEvent> = {}): SessionTurnDispatchEvent {
   return {

--- a/test/unit/runtime/middleware/audit.test.ts
+++ b/test/unit/runtime/middleware/audit.test.ts
@@ -8,7 +8,7 @@ import {
   type PromptAuditErrorEntry,
 } from "../../../../src/runtime/prompt-auditor";
 
-const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+const PERMS = { mode: "approve-reads" as const };
 
 function makeSessionTurnEvent(overrides: Partial<SessionTurnDispatchEvent> = {}): SessionTurnDispatchEvent {
   return {

--- a/test/unit/runtime/middleware/cancellation.test.ts
+++ b/test/unit/runtime/middleware/cancellation.test.ts
@@ -10,7 +10,7 @@ function makeCtx(aborted = false): MiddlewareContext {
     runId: "r-001", agentName: "claude", kind: "run",
     request: null, prompt: null, config: DEFAULT_CONFIG,
     signal: ctrl.signal,
-    resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    resolvedPermissions: { mode: "approve-reads" },
   };
 }
 
@@ -30,7 +30,7 @@ describe("cancellationMiddleware", () => {
     const ctx: MiddlewareContext = {
       runId: "r-001", agentName: "claude", kind: "run",
       request: null, prompt: null, config: DEFAULT_CONFIG,
-      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+      resolvedPermissions: { mode: "approve-reads" },
     };
     await expect(mw.before!(ctx)).resolves.toBeUndefined();
   });
@@ -43,7 +43,7 @@ describe("cancellationMiddleware", () => {
       runId: "r-001", agentName: "claude", kind: "complete",
       request: null, prompt: "test", config: DEFAULT_CONFIG,
       signal: ctrl.signal,
-      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+      resolvedPermissions: { mode: "approve-reads" },
     };
     await expect(mw.before!(ctx)).rejects.toThrow("Agent call cancelled");
   });

--- a/test/unit/runtime/middleware/cost.test.ts
+++ b/test/unit/runtime/middleware/cost.test.ts
@@ -4,7 +4,7 @@ import type { CompleteDispatchEvent, DispatchErrorEvent, SessionTurnDispatchEven
 import { COST_ROW_SCHEMA_VERSION, attachCostSubscriber } from "../../../../src/runtime/middleware/cost";
 import { createNoOpCostAggregator, type CostEvent, type CostErrorEvent } from "../../../../src/runtime/cost-aggregator";
 
-const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+const PERMS = { mode: "approve-reads" as const };
 
 function makeSessionTurnEvent(overrides: Partial<SessionTurnDispatchEvent> = {}): SessionTurnDispatchEvent {
   return {

--- a/test/unit/runtime/middleware/logging.test.ts
+++ b/test/unit/runtime/middleware/logging.test.ts
@@ -7,7 +7,7 @@ import type { CompleteDispatchEvent, DispatchErrorEvent, SessionTurnDispatchEven
 import { attachLoggingSubscriber } from "../../../../src/runtime/middleware/logging";
 import { cleanupTempDir, makeTempDir } from "../../../helpers";
 
-const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+const PERMS = { mode: "approve-reads" as const };
 
 function makeSessionTurnEvent(overrides: Partial<SessionTurnDispatchEvent> = {}): SessionTurnDispatchEvent {
   return {

--- a/test/unit/runtime/middleware/review-audit.test.ts
+++ b/test/unit/runtime/middleware/review-audit.test.ts
@@ -4,7 +4,7 @@ import { DispatchEventBus } from "../../../../src/runtime/dispatch-events";
 import type { ReviewDecisionEvent, SessionTurnDispatchEvent } from "../../../../src/runtime/dispatch-events";
 import { attachReviewAuditSubscriber } from "../../../../src/runtime/middleware/review-audit";
 
-const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+const PERMS = { mode: "approve-reads" as const };
 
 function makeSessionTurnEvent(overrides: Partial<SessionTurnDispatchEvent> = {}): SessionTurnDispatchEvent {
   return {

--- a/test/unit/session/manager-phase-b-session.test.ts
+++ b/test/unit/session/manager-phase-b-session.test.ts
@@ -119,7 +119,6 @@ describe("openSession()", () => {
 
     expect(capturedOpts).toHaveLength(1);
     expect(capturedOpts[0].resolvedPermissions.mode).toBe("approve-reads");
-    expect(capturedOpts[0].resolvedPermissions.skipPermissions).toBe(false);
   });
 
   test("passes resume=false when no descriptor exists", async () => {


### PR DESCRIPTION
Three of the four findings the batch-7 re-triage promoted out of "hygiene". L11 shipped in #1596; this drains the rest.

## L10 — a failed dependency still reads as satisfied

`markStoryPassed` sets **both** `passes = true` and `status = "passed"`. `markStoryFailed` set **only** `status`. The asymmetry between two sibling functions is the tell.

The damage is not to the story itself — both selectors exclude `status === "failed"` independently. It is one level out, in dependency resolution:

```ts
// story-selector.ts:174
return dep.passes || dep.status === "passed";
```

A dependency that went passed → failed has `passes: true` **and** `status: "failed"`, so that returns true and **dependents unblock and run**. `story-context.ts:232` builds `completedIds` from `s.passes` the same way.

The transition is real, not theoretical: `unified-executor.ts:719` marks a story failed on **merge conflict**, after its pipeline passed — so the work never reached the base branch, and dependents then built on top of it.

## L16 — a truncated line blanks the whole run log

`parseRunLog` mapped `JSON.parse` over every line inside one try/catch returning `[]`. A crashed or SIGKILLed run leaves a half-written final record, so `nax runs list` / `nax runs show` lost the entire log for exactly the runs worth diagnosing — reported as `Run log missing run.start event`, which points at the wrong problem. Bad lines are now skipped individually and counted in one warning.

## L33 — the dead permission surface

Two halves of one problem: the config and result surface for per-stage permissions was live while nothing behind it was.

- **`ResolvedPermissions.skipPermissions`** had zero readers; only `.mode` is consumed. Its own comment gave the reason — "CLI adapter: whether to pass `--dangerously-skip-permissions`" — and the CLI adapter was removed when ACP became the only protocol. It survived because tests asserted the field *existed* rather than that anything used it, and `.nax/context.md` taught destructuring it as the canonical pattern. Removed, with the equally unread `allowedTools`.
- **`execution.permissions`** was worse. Zod validated the entire per-stage policy shape and no code read it, so a user could write a permission policy, get no error, and get no enforcement — believing agents were constrained while every stage ran under the resolved profile.

Now rejected at load by `rejectUnimplementedPermissionsBlock`, mirroring `rejectUnimplementedScopedProfile` for the `"scoped"` profile it belongs to. The schema entry and its hand-synced `runtime-types.ts` twin are gone.

**Rejecting rather than implementing is deliberate.** Per-stage permissions are frozen pending acpx permission support, not merely unfinished — the same reason SEC-01 was discarded. The config surface for a frozen feature should stop accepting input, not grow an implementation.

## Testing

- L10 is driven through the real `markStoryPassed`/`markStoryFailed` rather than hand-built state, and asserts the **dependent** is not selected. Verified to fail before the fix (`Received: [ "US-002" ]`).
- L16 seeds a real run log, appends a truncated final line, and asserts the earlier entries survive. Verified to fail before the fix.
- L33 adds three guard cases (populated block, empty block, no block).
- Smoke-tested that the real global `~/.nax/config.json` and this repo's `.nax/config.json` still load — neither carries the rejected key, so the hard-reject breaks nothing in practice.
- Agent context regenerated with `nax generate`; canonical rules lint clean before and after (9 pre-existing warnings, unchanged).
- Full suite green; all 22 static gates green, no ratchet baselines moved.

## Also

Corrects the re-triage doc's L10 row, which described the wrong mechanism (it said the story would be skipped; the real defect is dependents unblocking), and marks L10/L16/L33 done. Remaining confirmed set is L2, L9, L15.