### PR TITLE
fix: drain the last confirmed batch-7 findings (L2, L9, L15)

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -50,6 +50,7 @@ import {
   planCommand,
   planDecomposeCommand,
   pluginsListCommand,
+  promptForConfirmation,
   promptsCommand,
   promptsInitCommand,
   resolveRunProfileOverride,
@@ -122,52 +123,6 @@ function warnIfPlanDegraded(result: PlanResult): void {
   console.log(chalk.yellow("\n[WARN] PRD recovered after a plan failure — this is a degraded result"));
   console.log(chalk.dim(`   Cause: ${result.degraded.reason}`));
   console.log(chalk.dim("   Deterministic spec->PRD repairs were re-applied, but review the PRD before running."));
-}
-
-/**
- * Prompt user for a yes/no confirmation via stdin.
- * In tests or non-TTY environments, defaults to true.
- *
- * @param question - Confirmation question to display
- * @returns true if user answers Y/y, false if N/n, true by default for non-TTY
- */
-async function promptForConfirmation(question: string): Promise<boolean> {
-  // In non-TTY mode (tests, pipes), default to true
-  if (!process.stdin.isTTY) {
-    return true;
-  }
-
-  return new Promise((resolve) => {
-    process.stdout.write(chalk.bold(`${question} [Y/n] `));
-
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding("utf8");
-
-    const handler = (char: string) => {
-      process.stdin.setRawMode(false);
-      process.stdin.pause();
-      process.stdin.removeListener("data", handler);
-
-      process.stdout.write("\n");
-
-      if (char === "\u0003") {
-        // Ctrl+C — treat as cancellation, not confirmation
-        resolve(false);
-        process.exit(130);
-      }
-
-      const answer = char.toLowerCase();
-      if (answer === "n") {
-        resolve(false);
-      } else {
-        // Default to yes for Y, Enter, or any other input
-        resolve(true);
-      }
-    };
-
-    process.stdin.on("data", handler);
-  });
 }
 
 // ── init ─────────────────────────────────────────────

--- a/docs/20260816-batch7-retriage.md
+++ b/docs/20260816-batch7-retriage.md
@@ -27,19 +27,19 @@ Each item is tagged with how far it was actually checked. Do not treat these as 
 | **L33** | MEDIUM | ✅ **Fixed** | `[read]` Two distinct defects. `skipPermissions` has **zero readers** outside `permissions.ts` (only `.mode` is consumed, in `acp/adapter.ts` and `middleware/audit.ts`) — dead output that `CLAUDE.md` still advertises as the destructuring pattern. Worse: the `execution.permissions` schema block has **zero readers** — it parses and silently does nothing, so a user configuring it gets no error and no effect. |
 | **L16** | MEDIUM | ✅ **Fixed** | `[read]` `parseRunLog` does `lines.map(line => JSON.parse(line))` inside one try/catch returning `[]`. A single truncated final line — exactly what a crashed run leaves — blanks the entire log for `nax runs list/show`, defeating the diagnostic tool precisely when it is needed. Should skip bad lines, not the file. |
 
-### Confirmed, correctly rated as low
+### Confirmed (originally rated low)
 
-| ID | Severity | Finding |
-|:---|:---|:---|
-| L2 | LOW-MED | `[read]` Uncancellable `await Bun.sleep(iterationDelayMs)` at `unified-executor.ts:554,647`. Violates the repo's own forbidden-patterns rule; `cancellableDelay` exists in `utils/bun-deps`. Ctrl+C will not interrupt the delay. |
-| L9 | LOW-MED | `[read]` `matchesAllowedPath` builds `new RegExp` from glob patterns. A `(`, `+`, or `[` in a scope pattern throws or matches wrongly. The `nosemgrep` note calls patterns "not user input", but PRD scope config is LLM-authored. |
-| L15 | LOW-MED | `[read]` `promptForConfirmation` registers only a `data` listener — no `end`/`error`, so stdin EOF on a TTY hangs forever with raw mode still set. Raw mode *is* restored on the normal and Ctrl+C paths, so that half of the original claim is weaker than filed. Both callers are interactive (`bin/nax.ts:493,647`). |
-| L12 | LOW | `[read]` `parseCommandToArgv` applies `~` expansion via `.map()` *after* quote parsing, so `"~/x"` expands inside quotes; `if (current.length > 0)` drops a legitimately empty `""` argument. |
-| L21 | LOW | `[read]` `sink({ ...entry })` is a shallow clone, so nested `entry.data` is shared across sinks — the isolation the doc comment claims is not provided. |
-| L1 | LOW | `[read]` `Bun.spawnSync` git call on the main thread at `run-setup.ts:322`. One-time and fast; cosmetic in practice. |
-| L3 | LOW | `[read]` `filePath.includes("../")` traversal check. `..//` *is* caught (it contains `../`); the real gap is absolute paths. Inputs are internal. |
-| L7 | LOW | `[shallow]` Feature name flows unvalidated into `runDir` path construction at `subscribers/registry.ts:53`. Overlaps L17. |
-| L14 | LOW | `[shallow]` `followLogs` re-reads the whole file per poll; stalls on rotation, crashes on deletion. |
+| ID | Severity | Status | Finding |
+|:---|:---|:---|:---|
+| L2 | LOW-MED | ✅ **Fixed** | `[read]` Uncancellable `await Bun.sleep(iterationDelayMs)` at `unified-executor.ts`. Now `cancellableDelay(..., ctx.runtime.signal)`. The `> 0` guard was dropped deliberately: with it, a run configured with no iteration delay never reached a cancellation point here at all. |
+| L9 | **MEDIUM** | ✅ **Fixed** | `[probe]` Worse than filed — **four** failure modes, not one. The chained replaces rewrote each other: `*` -> `[^/]*` ran after `**` -> `.*` and rewrote the `*` **inside** it, so the **shipped default** `src/**/index.ts` compiled to `src/.[^/]*/index.ts` and matched exactly one directory level. Plus `.` stayed a wildcard (`src/a.ts` allowed `src/axts.ts` — widening the allowlist), `[id]`/`a+b`/`app(1)` matched nothing, and an unbalanced `(` threw. Replaced with a single escaping scan. |
+| L15 | LOW-MED | ✅ **Fixed** | `[probe]` The filed "EOF hang" is real but hard to reach. The reachable defect is different: raw mode does no EOF processing, so **Ctrl+D arrived as ordinary data and fell into the "any other input" branch — confirming the run**. Extracted to `src/cli/confirm.ts` (testable), Ctrl+D now cancels, `end`/`error` are handled, and the terminal is restored exactly once on every path. |
+| L12 | LOW | Open | `[read]` `parseCommandToArgv` applies `~` expansion via `.map()` *after* quote parsing, so `"~/x"` expands inside quotes; `if (current.length > 0)` drops a legitimately empty `""` argument. |
+| L21 | LOW | Open | `[read]` `sink({ ...entry })` is a shallow clone, so nested `entry.data` is shared across sinks — the isolation the doc comment claims is not provided. |
+| L1 | LOW | Open | `[read]` `Bun.spawnSync` git call on the main thread at `run-setup.ts:322`. One-time and fast; cosmetic in practice. |
+| L3 | LOW | Open | `[read]` `filePath.includes("../")` traversal check. `..//` *is* caught (it contains `../`); the real gap is absolute paths. Inputs are internal. |
+| L7 | LOW | Open | `[shallow]` Feature name flows unvalidated into `runDir` path construction at `subscribers/registry.ts:53`. Overlaps L17. |
+| L14 | LOW | Open | `[shallow]` `followLogs` re-reads the whole file per poll; stalls on rotation, crashes on deletion. |
 
 ### Downgraded or refuted
 
@@ -60,8 +60,8 @@ L4, L6, L17, L18, L19, L22–L32, L34–L38 were left at their original severity
 2. ~~**L10**~~ — done. `markStoryFailed` now clears `passes`.
 3. ~~**L16**~~ — done. Per-line tolerant parse; malformed lines are skipped and counted in a warning.
 4. ~~**L33**~~ — done, both halves. `skipPermissions` and the unused `allowedTools` are gone from `ResolvedPermissions`; `execution.permissions` is now rejected at config load by `rejectUnimplementedPermissionsBlock`, alongside the `"scoped"` profile it belongs to, and its schema and `runtime-types.ts` entries were removed.
-5. **L2, L9, L15** — the remaining confirmed set; one small batch.
-6. Everything else — hygiene, genuinely.
+5. ~~**L2, L9, L15**~~ — done. L9 turned out to be MEDIUM, not LOW: it silently broke the shipped default allow pattern.
+6. Remaining: L1, L3, L7, L12, L14, L21 (confirmed but genuinely low), plus the never-re-verified group below.
 
 ### Why L33 was rejected rather than implemented
 

--- a/src/cli/confirm.ts
+++ b/src/cli/confirm.ts
@@ -1,0 +1,105 @@
+/**
+ * Interactive yes/no confirmation prompt.
+ *
+ * Extracted from bin/nax.ts so the terminal-state handling below is reachable
+ * from tests — the entry point is not importable without running commander.
+ */
+
+import chalk from "chalk";
+
+/** Ctrl+C — cancel and exit with the conventional 128+SIGINT status. */
+const ETX = "\u0003";
+/** Ctrl+D — end of transmission. Conventionally "cancel", never "confirm". */
+const EOT = "\u0004";
+/** Exit status for a SIGINT-initiated cancellation. */
+const SIGINT_EXIT_CODE = 130;
+
+/** The slice of `process.stdin` this prompt drives. Injected so tests can stand one up. */
+export interface ConfirmStdin {
+  isTTY?: boolean;
+  setRawMode(mode: boolean): unknown;
+  resume(): unknown;
+  pause(): unknown;
+  setEncoding(encoding: string): unknown;
+  on(event: string, listener: (chunk: string) => void): unknown;
+  once(event: string, listener: () => void): unknown;
+  removeListener(event: string, listener: (...args: never[]) => void): unknown;
+}
+
+export const _confirmDeps = {
+  stdin: process.stdin as unknown as ConfirmStdin,
+  write: (text: string) => process.stdout.write(text),
+  exit: (code: number) => process.exit(code),
+};
+
+/**
+ * Prompt for a yes/no confirmation on a single keypress.
+ *
+ * Non-TTY (tests, pipes, CI) resolves `true` without touching the terminal.
+ *
+ * Terminal state is restored exactly once, on every exit path — keypress,
+ * stream end, or stream error. The previous version registered only a `data`
+ * listener, which left two gaps:
+ *
+ *   - `end`/`error` had no listener at all, so a stream that closed without
+ *     delivering a byte left the promise pending forever with the terminal
+ *     still in raw mode.
+ *   - Ctrl+D fell through to the "any other input" branch and resolved
+ *     **true**. Raw mode performs no EOF processing, so the byte arrives as
+ *     ordinary data; a keystroke that universally means "cancel" was
+ *     confirming the action instead.
+ *
+ * @param question - Confirmation question to display
+ * @returns true for Y/Enter/other keys, false for N, Ctrl+D, or a closed stream
+ */
+export async function promptForConfirmation(question: string): Promise<boolean> {
+  const { stdin } = _confirmDeps;
+
+  // In non-TTY mode (tests, pipes), default to true
+  if (!stdin.isTTY) {
+    return true;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    _confirmDeps.write(chalk.bold(`${question} [Y/n] `));
+
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    let settled = false;
+    /** Restore the terminal and detach every listener, exactly once. */
+    const finish = (answer: boolean): void => {
+      if (settled) return;
+      settled = true;
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener("data", onData);
+      stdin.removeListener("end", onClosed);
+      stdin.removeListener("error", onClosed);
+      _confirmDeps.write("\n");
+      resolve(answer);
+    };
+
+    const onData = (char: string): void => {
+      if (char === ETX) {
+        finish(false);
+        _confirmDeps.exit(SIGINT_EXIT_CODE);
+        return;
+      }
+      if (char === EOT) {
+        finish(false);
+        return;
+      }
+      // Default to yes for Y, Enter, or any other input
+      finish(char.toLowerCase() !== "n");
+    };
+
+    // A stream that ends or errors before a keypress must not hang the CLI.
+    const onClosed = (): void => finish(false);
+
+    stdin.on("data", onData);
+    stdin.once("end", onClosed);
+    stdin.once("error", onClosed);
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,6 +48,7 @@ export { writeSetupConfig, _writeSetupDeps, type WriteSetupConfigResult } from "
 export { pluginsListCommand } from "./plugins";
 export { generateCommand, type GenerateCommandOptions } from "./generate";
 export { configCommand, type ConfigCommandOptions } from "./config";
+export { promptForConfirmation, _confirmDeps, type ConfirmStdin } from "./confirm";
 export { agentsListCommand } from "./agents";
 export { contextInspectCommand, type ContextInspectOptions } from "./context";
 export {

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -14,6 +14,7 @@ import { wireReporters } from "../pipeline/subscribers/reporters";
 import type { PipelineContext } from "../pipeline/types";
 import { countStories, isComplete, isStalled, loadPRD, markStoryFailed, markStoryPassed, savePRD } from "../prd";
 import type { PRD } from "../prd/types";
+import { cancellableDelay } from "../utils/bun-deps";
 import { buildNaxIgnoreIndex } from "../utils/path-filters";
 import { precomputeBatchPlan } from "./batching";
 import { maybeSendCostWarning } from "./cost-warning";
@@ -551,7 +552,7 @@ export async function executeUnified(
             pipelineEventBus.emit({ type: "run:paused", reason: "All remaining stories blocked", cost: totalCost });
             return buildResult("stalled");
           }
-          if (ctx.config.execution.iterationDelayMs > 0) await Bun.sleep(ctx.config.execution.iterationDelayMs);
+          await cancellableDelay(ctx.config.execution.iterationDelayMs, ctx.runtime.signal);
           continue;
         }
         // batch.length === 0: fall through to sequential single-story path
@@ -644,7 +645,7 @@ export async function executeUnified(
         pipelineEventBus.emit({ type: "run:paused", reason: "All remaining stories blocked", cost: totalCost });
         return buildResult("stalled");
       }
-      if (ctx.config.execution.iterationDelayMs > 0) await Bun.sleep(ctx.config.execution.iterationDelayMs);
+      await cancellableDelay(ctx.config.execution.iterationDelayMs, ctx.runtime.signal);
     }
 
     // Post-run pipeline (acceptance tests) — only when acceptance is configured

--- a/src/tdd/isolation.ts
+++ b/src/tdd/isolation.ts
@@ -118,14 +118,54 @@ export async function getAddedLinesPerFile(workdir: string, fromRef = "HEAD"): P
   return result;
 }
 
+/** Regex metacharacters that must be matched literally inside an allow pattern. */
+const REGEX_METACHARACTERS = ".+?^${}()|[]\\/";
+
+/**
+ * Translate a glob-style allow pattern into a fully-anchored RegExp.
+ *
+ * `**` matches across directory separators, `*` matches within one segment,
+ * and every other character is matched literally.
+ *
+ * Built as a single left-to-right scan rather than chained `.replace()` calls,
+ * which had four separate failure modes:
+ *   - `*` -> `[^/]*` ran after `**` -> `.*` and rewrote the `*` **inside** the
+ *     `.*` it had just produced, so the shipped default `src/**\/index.ts`
+ *     compiled to `src/.[^/]*\/index.ts` and matched exactly one directory
+ *     level — `src/a/b/index.ts` was reported as a hard violation.
+ *   - `.` stayed a wildcard, so `src/a.ts` also allowed `src/axts.ts`, widening
+ *     the allowlist and downgrading a real violation to soft.
+ *   - `[id]`, `a+b`, `app(1)` — ordinary directory names — silently matched
+ *     nothing, so allowed files were reported as violations.
+ *   - an unbalanced `(` threw out of the whole isolation check.
+ *
+ * Anchored `^...$` against the repo-relative path. This is deliberately
+ * stricter than the suffix-matching `globToRegex` in the context engine and
+ * `utils/path-filters`: those decide which rules apply, whereas widening this
+ * allowlist silently permits a source write the TDD session should not make.
+ */
+function allowPatternToRegex(pattern: string): RegExp {
+  let source = "";
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+    if (char === "*") {
+      if (pattern[i + 1] === "*") {
+        source += ".*";
+        i++;
+      } else {
+        source += "[^/]*";
+      }
+      continue;
+    }
+    source += REGEX_METACHARACTERS.includes(char) ? `\\${char}` : char;
+  }
+  // Every metacharacter is escaped above, so this can no longer throw.
+  return new RegExp(`^${source}$`); // nosemgrep: detect-non-literal-regexp — pattern is escaped, not interpolated raw
+}
+
 /** Check if a file path matches any of the allowed patterns (glob-like) */
 function matchesAllowedPath(filePath: string, allowedPaths: string[]): boolean {
-  return allowedPaths.some((pattern) => {
-    // Simple glob matching: ** = any directory, * = any filename segment
-    const regexPattern = pattern.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\//g, "\\/");
-    const regex = new RegExp(`^${regexPattern}$`); // nosemgrep: detect-non-literal-regexp — pattern from PRD scope config, not user input
-    return regex.test(filePath);
-  });
+  return allowedPaths.some((pattern) => allowPatternToRegex(pattern).test(filePath));
 }
 
 /**

--- a/test/unit/cli/confirm.test.ts
+++ b/test/unit/cli/confirm.test.ts
@@ -1,0 +1,153 @@
+// L15 (review 2026-08-14): the confirmation prompt registered only a `data`
+// listener. Two consequences, both covered here:
+//   - a stream that ended or errored before a keypress left the promise pending
+//     forever with the terminal still in raw mode
+//   - Ctrl+D fell into the "any other input" branch and resolved TRUE. Raw mode
+//     does no EOF processing, so the byte arrives as ordinary data, and a
+//     keystroke that universally means "cancel" was confirming the run.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type ConfirmStdin, _confirmDeps, promptForConfirmation } from "@/cli";
+
+const ETX = "\u0003";
+const EOT = "\u0004";
+
+/** Minimal EventEmitter-ish stdin double that records terminal-state calls. */
+function makeStdin(isTTY = true) {
+  const listeners = new Map<string, ((chunk: string) => void)[]>();
+  const rawModeCalls: boolean[] = [];
+  const stdin: ConfirmStdin = {
+    isTTY,
+    setRawMode: (mode: boolean) => rawModeCalls.push(mode),
+    resume: () => undefined,
+    pause: () => undefined,
+    setEncoding: () => undefined,
+    on: (event, listener) => listeners.set(event, [...(listeners.get(event) ?? []), listener]),
+    once: (event, listener) => listeners.set(event, [...(listeners.get(event) ?? []), listener as () => void]),
+    removeListener: (event, listener) =>
+      listeners.set(event, (listeners.get(event) ?? []).filter((l) => l !== (listener as unknown))),
+  };
+  return {
+    stdin,
+    rawModeCalls,
+    emit: (event: string, chunk = "") => {
+      for (const l of [...(listeners.get(event) ?? [])]) l(chunk);
+    },
+    listenerCount: (event: string) => (listeners.get(event) ?? []).length,
+  };
+}
+
+describe("promptForConfirmation", () => {
+  let original: typeof _confirmDeps.stdin;
+  let originalWrite: typeof _confirmDeps.write;
+  let originalExit: typeof _confirmDeps.exit;
+  let exitCodes: number[];
+
+  beforeEach(() => {
+    original = _confirmDeps.stdin;
+    originalWrite = _confirmDeps.write;
+    originalExit = _confirmDeps.exit;
+    exitCodes = [];
+    _confirmDeps.write = () => true;
+    _confirmDeps.exit = ((code: number) => {
+      exitCodes.push(code);
+      return undefined as never;
+    }) as typeof _confirmDeps.exit;
+  });
+
+  afterEach(() => {
+    _confirmDeps.stdin = original;
+    _confirmDeps.write = originalWrite;
+    _confirmDeps.exit = originalExit;
+  });
+
+  test("resolves true without touching the terminal when stdin is not a TTY", async () => {
+    const h = makeStdin(false);
+    _confirmDeps.stdin = h.stdin;
+
+    expect(await promptForConfirmation("go?")).toBe(true);
+    expect(h.rawModeCalls).toEqual([]);
+  });
+
+  test.each([
+    ["y", true],
+    ["Y", true],
+    ["\r", true],
+    ["n", false],
+    ["N", false],
+  ])("resolves %o as %o", async (key, expected) => {
+    const h = makeStdin();
+    _confirmDeps.stdin = h.stdin;
+
+    const pending = promptForConfirmation("go?");
+    h.emit("data", key);
+
+    expect(await pending).toBe(expected);
+    expect(h.rawModeCalls).toEqual([true, false]);
+  });
+
+  test("treats Ctrl+D as cancellation rather than confirmation", async () => {
+    const h = makeStdin();
+    _confirmDeps.stdin = h.stdin;
+
+    const pending = promptForConfirmation("go?");
+    h.emit("data", EOT);
+
+    expect(await pending).toBe(false);
+    expect(h.rawModeCalls).toEqual([true, false]);
+    // Ctrl+D is not Ctrl+C — it must not take the exit path.
+    expect(exitCodes).toEqual([]);
+  });
+
+  test("treats Ctrl+C as cancellation and exits 130", async () => {
+    const h = makeStdin();
+    _confirmDeps.stdin = h.stdin;
+
+    const pending = promptForConfirmation("go?");
+    h.emit("data", ETX);
+
+    expect(await pending).toBe(false);
+    expect(exitCodes).toEqual([130]);
+    expect(h.rawModeCalls).toEqual([true, false]);
+  });
+
+  test("resolves false and restores the terminal when stdin ends before a keypress", async () => {
+    const h = makeStdin();
+    _confirmDeps.stdin = h.stdin;
+
+    const pending = promptForConfirmation("go?");
+    h.emit("end");
+
+    expect(await pending).toBe(false);
+    expect(h.rawModeCalls).toEqual([true, false]);
+  });
+
+  test("resolves false and restores the terminal when stdin errors", async () => {
+    const h = makeStdin();
+    _confirmDeps.stdin = h.stdin;
+
+    const pending = promptForConfirmation("go?");
+    h.emit("error");
+
+    expect(await pending).toBe(false);
+    expect(h.rawModeCalls).toEqual([true, false]);
+  });
+
+  test("detaches every listener and restores raw mode exactly once", async () => {
+    const h = makeStdin();
+    _confirmDeps.stdin = h.stdin;
+
+    const pending = promptForConfirmation("go?");
+    h.emit("data", "y");
+    await pending;
+
+    // A late end/error after the answer must not re-enter the settle path.
+    h.emit("end");
+    h.emit("data", "n");
+
+    expect(h.rawModeCalls).toEqual([true, false]);
+    expect(h.listenerCount("data")).toBe(0);
+    expect(h.listenerCount("end")).toBe(0);
+    expect(h.listenerCount("error")).toBe(0);
+  });
+});

--- a/test/unit/tdd/isolation-allow-patterns.test.ts
+++ b/test/unit/tdd/isolation-allow-patterns.test.ts
@@ -1,0 +1,96 @@
+// Split from isolation.test.ts by concern (see test-architecture.md): that file
+// covers getChangedFiles, this one covers how allow patterns are matched.
+//
+// L9 (review 2026-08-14): allow patterns were interpolated straight into a
+// RegExp, so regex metacharacters in ordinary directory names changed meaning.
+// Three distinct failure modes, all reachable from real paths:
+//   - `.` matched any character, so the pattern `src/a.ts` also allowed
+//     `src/axts.ts` — WIDENING the allowlist, downgrading a hard violation to soft
+//   - `[id]`, `a+b`, `app(1)` matched nothing, so a genuinely-allowed file was
+//     reported as a hard violation
+//   - an unbalanced `(` threw out of the isolation check entirely
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { verifyTestWriterIsolation } from "@/tdd";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+}
+
+describe("verifyTestWriterIsolation — allow-pattern matching", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = makeTempDir("nax-isolation-allow-");
+    await Bun.write(`${dir}/seed.txt`, "seed");
+    await git(dir, ["init", "-q"]);
+    await git(dir, ["config", "user.email", "t@t"]);
+    await git(dir, ["config", "user.name", "t"]);
+    await git(dir, ["add", "."]);
+    await git(dir, ["commit", "-qm", "base"]);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(dir);
+  });
+
+  /**
+   * Write a source file and return the isolation result for the given allow patterns.
+   *
+   * `git add -- <file>` matters twice over: when an entire directory is
+   * untracked `git status --porcelain` collapses it to a single `?? src/`
+   * entry so the file never reaches the matcher, and the `--` stops git
+   * treating a name like `src/[id]/page.ts` as a pathspec glob.
+   */
+  async function checkWith(file: string, allowedPaths: string[]) {
+    await Bun.write(`${dir}/${file}`, "export const x = 1;\n");
+    await git(dir, ["add", "--", file]);
+    return verifyTestWriterIsolation(dir, "HEAD", allowedPaths);
+  }
+
+  test("treats `.` in a pattern literally instead of as a wildcard", async () => {
+    const result = await checkWith("src/axts.ts", ["src/a.ts"]);
+    expect(result.softViolations).not.toContain("src/axts.ts");
+    expect(result.violations).toContain("src/axts.ts");
+  });
+
+  test("matches a bracketed directory against its own literal pattern", async () => {
+    const result = await checkWith("src/[id]/page.ts", ["src/[id]/**"]);
+    expect(result.softViolations).toContain("src/[id]/page.ts");
+    expect(result.violations).not.toContain("src/[id]/page.ts");
+  });
+
+  test("matches a `+` directory against its own literal pattern", async () => {
+    const result = await checkWith("src/a+b/page.ts", ["src/a+b/**"]);
+    expect(result.softViolations).toContain("src/a+b/page.ts");
+    expect(result.violations).not.toContain("src/a+b/page.ts");
+  });
+
+  test("matches a parenthesised directory against its own literal pattern", async () => {
+    const result = await checkWith("src/app(1)/page.ts", ["src/app(1)/**"]);
+    expect(result.softViolations).toContain("src/app(1)/page.ts");
+    expect(result.violations).not.toContain("src/app(1)/page.ts");
+  });
+
+  test("does not throw on a pattern containing an unbalanced parenthesis", async () => {
+    const result = await checkWith("src/plain.ts", ["src/a(b/**"]);
+    expect(result.violations).toContain("src/plain.ts");
+  });
+
+  test("still honours ** across directories", async () => {
+    const result = await checkWith("src/a/b/index.ts", ["src/**/index.ts"]);
+    expect(result.softViolations).toContain("src/a/b/index.ts");
+  });
+
+  test("still honours * within a single segment", async () => {
+    const result = await checkWith("src/thing.ts", ["src/*.ts"]);
+    expect(result.softViolations).toContain("src/thing.ts");
+  });
+
+  test("* does not cross a directory separator", async () => {
+    const result = await checkWith("src/deep/thing.ts", ["src/*.ts"]);
+    expect(result.softViolations).not.toContain("src/deep/thing.ts");
+  });
+});


### PR DESCRIPTION
The remaining confirmed set from the batch-7 re-triage. Two of the three turned out to be worse than filed.

## L9 — allow patterns were raw regex (upgraded LOW → MEDIUM)

`matchesAllowedPath` interpolated the pattern straight into a `RegExp` after three chained `.replace()` calls. **Four** failure modes, not one:

| Input | Compiled to | Effect |
|:---|:---|:---|
| `src/**/index.ts` *(the shipped default)* | `src/.[^/]*/index.ts` | matches exactly **one** directory level — `src/a/b/index.ts` reported as a hard violation |
| `src/a.ts` | `src/a.ts` with `.` as wildcard | also allows `src/axts.ts` — **widens the allowlist** |
| `src/[id]/**`, `src/a+b/**`, `src/app(1)/**` | mangled classes/quantifiers | matched nothing; allowed files reported as violations |
| `src/a(b/**` | invalid | **threw** out of the isolation check |

The first is the one to note: the replaces rewrote each other. `*` → `[^/]*` ran *after* `**` → `.*` and rewrote the `*` inside the `.*` it had just produced, so the default allow pattern has silently only ever matched one level deep.

The `.`-as-wildcard case is the dangerous direction — a match downgrades a hard violation to a soft one, so the allowlist quietly widened.

Replaced with a single left-to-right scan that escapes every metacharacter and expands only `**` and `*`. Nothing is interpolated raw any more, so construction can no longer throw. Kept anchored `^…$` — deliberately stricter than the suffix-matching `globToRegex` in the context engine and `utils/path-filters`, because those decide which rules *apply* whereas widening this allowlist permits a write the TDD session should not make.

## L15 — Ctrl+D was confirming the run

The review filed this as "hangs on stdin EOF". That hang is real (the covering tests time out at 3s against the old code) but hard to reach. The reachable defect is different and worse: **raw mode performs no EOF processing**, so Ctrl+D arrives as an ordinary byte, fell through to the "any other input" branch, and resolved **true** — on the two prompts that gate a bake-off and an execution.

Moved to `src/cli/confirm.ts` with injectable deps, because `bin/nax.ts` cannot be imported without running commander and none of this was reachable from a test. Ctrl+D now cancels, `end`/`error` are handled, and the terminal is restored exactly once on every path.

## L2 — uncancellable iteration delay

`await Bun.sleep(...)` → `cancellableDelay(ms, ctx.runtime.signal)`. The repo's own forbidden-patterns rule bans the former precisely because Ctrl+C during the delay was ignored until it elapsed.

The `if (… > 0)` guard was dropped **deliberately, not for brevity**: with it, a run configured with no iteration delay never reached a cancellation point here at all. Without it every iteration observes the abort signal, and a zero delay costs one macrotask. An already-aborted signal now rejects, propagating through the existing try/catch like any other mid-run cancellation.

## Testing

Every fix is pinned by a test verified to fail against the previous behaviour:

- L9 — 8 cases covering all four modes plus `**`/`*` regression guards. Tests live in a sibling file split by concern (`isolation.test.ts` covers `getChangedFiles`); keeping both describes in one file produced cross-describe temp-dir pollution.
- L15 — 11 cases; the two stream-close cases time out at 3s against the old code, the Ctrl+D case returns `true`.
- L2 — covered by the existing execution suite; the change is a call-site swap.
- Full suite green; all 22 static gates green, no ratchet baselines moved. CLI `--help` and `bun run build` smoke-tested after the `bin/nax.ts` extraction.

## Also

Updates the re-triage doc: L2/L9/L15 marked done, L9 re-rated MEDIUM with the four modes recorded. Remaining open there are L1, L3, L7, L12, L14, L21 — confirmed but genuinely low — plus the group never re-verified in that pass.