### PR TITLE
fix(context): make fragment read-back resolve the real store path

### DIFF
--- a/src/context/engine/providers/feature-context.ts
+++ b/src/context/engine/providers/feature-context.ts
@@ -92,6 +92,16 @@ export const _featureContextV2Deps = {
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Share of a stage's token budget that dependency fragments may occupy.
+ *
+ * Fragments are floor-kind, so this is the only thing bounding them — see the
+ * rationale at the call site in `collectFragmentChunks`. The effective bound is
+ * never below one fragment's write-time ceiling (`fragments.maxTokens`), so a
+ * small stage budget degrades to "nearest fragment only" rather than to none.
+ */
+const FRAGMENT_BUDGET_SHARE = 0.2;
+
 function contentHash8(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 8);
 }
@@ -104,14 +114,22 @@ function renderEntryContent(section: string, text: string): string {
   return section ? `### ${section}\n\n${text}` : text;
 }
 
-/** Resolve on-disk projectDir for the feature (i.e. the `.nax` dir under repoRoot). */
-function projectDirFor(repoRoot: string): string {
-  // The fragment store and the feature PRD both live under repoRoot/.nax/.
+/**
+ * Resolve the `.nax` directory under repoRoot.
+ *
+ * NOTE: this is NOT the fragment store's `projectDir`. The store owns the
+ * `.nax` segment itself (`fragmentPath` -> `featureDir` -> `featuresDir`), so
+ * its `projectDir` argument is the REPO ROOT. Passing this helper's result
+ * there resolves to `<repoRoot>/.nax/.nax/...` and silently finds nothing —
+ * which is exactly the defect this comment exists to prevent recurring.
+ */
+function naxDirFor(repoRoot: string): string {
   return `${repoRoot}/.nax`;
 }
 
 function featurePrdPath(repoRoot: string, featureId: string): string {
-  return `${projectDirFor(repoRoot)}/features/${featureId}/prd.json`;
+  // Appends its own `/features/...`, so it takes the `.nax` dir, not the root.
+  return `${naxDirFor(repoRoot)}/features/${featureId}/prd.json`;
 }
 
 /**
@@ -310,7 +328,9 @@ export class FeatureContextProviderV2 implements IContextProvider {
     const featureId = request.featureId;
     if (!featureId) return [];
 
-    const projectDir = projectDirFor(request.repoRoot);
+    // The store owns the `.nax` segment — its `projectDir` is the repo root,
+    // matching what `completionStage` passes to `writeFragment` on capture.
+    const projectDir = request.repoRoot;
 
     // Fast path — empty fragment set means nothing to traverse (AC1 / AC10).
     const availableFragments = await _featureContextV2Deps.listFragmentStoryIds(projectDir, featureId);
@@ -328,6 +348,20 @@ export class FeatureContextProviderV2 implements IContextProvider {
     const decay = fragmentsConfig.decay;
     const out: RawChunk[] = [];
 
+    // Fragments are emitted as `kind: "feature"`, which is a FLOOR kind — they
+    // bypass the stage budget entirely and are force-included even when they
+    // score below the minimum. `decay ** distance` therefore only ORDERS them;
+    // it cannot exclude one. Without a bound here, a story late in a large
+    // feature pulls every transitive dependency's fragment into a 4k-token
+    // stage unmetered, starving the non-floor providers. BFS order makes this
+    // a nearest-first cut, which is the behaviour decay was meant to express.
+    const fragmentBudget = Math.max(
+      fragmentsConfig.maxTokens,
+      Math.floor(request.budgetTokens * FRAGMENT_BUDGET_SHARE),
+    );
+    let usedTokens = 0;
+    let droppedForBudget = 0;
+
     for (const [storyId, distance] of reached) {
       // AC8 / AC9: a reached story without a fragment contributes nothing.
       // The dep walk already terminated for cycles; listFragmentStoryIds
@@ -337,14 +371,36 @@ export class FeatureContextProviderV2 implements IContextProvider {
       const body = await _featureContextV2Deps.readFragment(projectDir, featureId, storyId);
       if (body === null) continue;
 
+      const bodyTokens = estimateTokens(body);
+      if (usedTokens + bodyTokens > fragmentBudget) {
+        droppedForBudget++;
+        continue;
+      }
+      usedTokens += bodyTokens;
+
       out.push({
         id: `feature-fragment:${storyId}`,
         kind: "feature",
         scope: "feature",
         role: ["implementer", "reviewer", "tdd"],
         content: body,
-        tokens: estimateTokens(body),
+        tokens: bodyTokens,
         rawScore: decay ** distance,
+      });
+    }
+
+    if (droppedForBudget > 0) {
+      // Warn, not debug: a silently truncated fragment set is the same class
+      // of invisible failure as the empty one this bound replaced.
+      // Note: the loop keeps scanning after a skip, so a small distant
+      // fragment may still fit once a larger nearer one has been dropped.
+      logger.warn("feature-context-v2", "Fragment budget reached — some dependency fragments were dropped", {
+        storyId: request.storyId,
+        featureId,
+        kept: out.length,
+        dropped: droppedForBudget,
+        fragmentBudget,
+        usedTokens,
       });
     }
 

--- a/test/unit/context/engine/providers/feature-context-fragments-realfs.test.ts
+++ b/test/unit/context/engine/providers/feature-context-fragments-realfs.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Fragment read-back — real-filesystem behaviour.
+ *
+ * The sibling `feature-context-fragments.test.ts` stubs `readFragment` and
+ * `listFragmentStoryIds`, and its stubs ignore the `projectDir` argument
+ * entirely. That is why the read path could ship broken: the provider passed
+ * `${repoRoot}/.nax` as the store's `projectDir`, but the store owns the
+ * `.nax` segment itself (`fragmentPath` -> `featureDir` -> `featuresDir`), so
+ * every read resolved to `<repoRoot>/.nax/.nax/features/...` and found
+ * nothing. Capture and read were tested on opposite sides of a stub, so the
+ * path contract between them was untested by construction.
+ *
+ * These tests therefore write fragments with the REAL `writeFragment` and read
+ * them back through the REAL provider against a REAL temp directory. Only
+ * `createV1Provider` is stubbed, to keep the legacy context.md path out of the
+ * assertions. Do not stub the fragment store here — that would reintroduce the
+ * blind spot this file exists to cover.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { FeatureContextProviderV2, _featureContextV2Deps } from "@/context/engine";
+import type { ContextRequest, RawChunk } from "@/context/engine/types";
+import { renderFragmentBody, writeFragment } from "@/context/fragments";
+import type { NaxConfig } from "@/config/types";
+import type { UserStory } from "@/prd";
+import { cleanupTempDir, makeTempDir, makePRD, makeStory } from "@test/helpers";
+
+const FEATURE_ID = "feat-readback";
+const FRAGMENT_MAX_TOKENS = 400;
+
+let repoRoot: string;
+
+type DepsShape = typeof _featureContextV2Deps;
+let origCreateV1Provider: DepsShape["createV1Provider"];
+
+beforeEach(() => {
+  repoRoot = makeTempDir();
+  origCreateV1Provider = _featureContextV2Deps.createV1Provider;
+  // The legacy context.md path is irrelevant here and would otherwise touch
+  // disk; every assertion below filters on the `feature-fragment:` prefix.
+  _featureContextV2Deps.createV1Provider = (() =>
+    ({
+      getContext: async () => null,
+    }) as ReturnType<DepsShape["createV1Provider"]>) as DepsShape["createV1Provider"];
+});
+
+afterEach(() => {
+  _featureContextV2Deps.createV1Provider = origCreateV1Provider;
+  cleanupTempDir(repoRoot);
+});
+
+function makeFragmentsConfig(overrides: { decay?: number; enabled?: boolean } = {}): NaxConfig {
+  return {
+    context: {
+      v2: {
+        fragments: {
+          enabled: overrides.enabled ?? true,
+          decay: overrides.decay ?? 0.6,
+          maxTokens: FRAGMENT_MAX_TOKENS,
+          extractor: "deterministic",
+        },
+      },
+    },
+  } as unknown as NaxConfig;
+}
+
+function storyWith(id: string, dependencies: readonly string[] = []): UserStory {
+  return makeStory({ id, dependencies: [...dependencies] });
+}
+
+/** Write a real prd.json where the provider's `featurePrdPath` expects it. */
+async function writePRD(stories: readonly UserStory[]): Promise<void> {
+  const dir = join(repoRoot, ".nax", "features", FEATURE_ID);
+  await mkdir(dir, { recursive: true });
+  const prd = makePRD({ feature: FEATURE_ID, userStories: stories as UserStory[] });
+  await writeFile(join(dir, "prd.json"), JSON.stringify(prd, null, 2), "utf-8");
+}
+
+function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
+  return {
+    storyId: "US-002",
+    featureId: FEATURE_ID,
+    repoRoot,
+    packageDir: repoRoot,
+    stage: "execution",
+    role: "implementer",
+    budgetTokens: 8_000,
+    ...overrides,
+  };
+}
+
+function fragmentChunks(chunks: RawChunk[]): RawChunk[] {
+  return chunks.filter((c) => c.id.startsWith("feature-fragment:"));
+}
+
+describe("FeatureContextProviderV2 fragment read-back (real fs)", () => {
+  test("reads back a fragment written by the real capture path", async () => {
+    // Capture exactly as completionStage does: projectDir is the repo root,
+    // and the store appends the `.nax/features/<id>/fragments` segments.
+    const body = renderFragmentBody(
+      "US-001",
+      "Resolve profile contestants",
+      ["Given a profile name, when resolved, then the overlay is merged"],
+      ["src/bakeoff/preflight.ts"],
+    );
+    await writeFragment(repoRoot, FEATURE_ID, "US-001", body, FRAGMENT_MAX_TOKENS);
+    await writePRD([storyWith("US-001"), storyWith("US-002", ["US-001"])]);
+
+    const provider = new FeatureContextProviderV2(storyWith("US-002", ["US-001"]), makeFragmentsConfig());
+    const result = await provider.fetch(makeRequest());
+
+    const fragments = fragmentChunks(result.chunks);
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0]?.id).toBe("feature-fragment:US-001");
+    expect(fragments[0]?.content).toContain("src/bakeoff/preflight.ts");
+  });
+
+  test("scores a transitive dependency by distance", async () => {
+    for (const id of ["US-001", "US-002"]) {
+      await writeFragment(
+        repoRoot,
+        FEATURE_ID,
+        id,
+        renderFragmentBody(id, `story ${id}`, ["ac"], [`src/${id}.ts`]),
+        FRAGMENT_MAX_TOKENS,
+      );
+    }
+    await writePRD([storyWith("US-001"), storyWith("US-002", ["US-001"]), storyWith("US-003", ["US-002"])]);
+
+    const provider = new FeatureContextProviderV2(
+      storyWith("US-003", ["US-002"]),
+      makeFragmentsConfig({ decay: 0.5 }),
+    );
+    const result = await provider.fetch(makeRequest({ storyId: "US-003" }));
+
+    const byId = new Map(fragmentChunks(result.chunks).map((c) => [c.id, c]));
+    expect(byId.get("feature-fragment:US-002")?.rawScore).toBeCloseTo(0.5, 10);
+    expect(byId.get("feature-fragment:US-001")?.rawScore).toBeCloseTo(0.25, 10);
+  });
+
+  test("bounds the fragment set by token budget, keeping the nearest dependencies", async () => {
+    // Fragments are floor-kind, so nothing downstream can drop them; the
+    // provider's own bound is the only thing between a long dependency chain
+    // and an unmetered injection. A 2_000-token stage yields a 400-token
+    // fragment budget, so only the two nearest of four ~143-token fragments
+    // survive (2 x 143 = 286 fits; a third would reach 429).
+    const filler = "src/some/module/with/a/reasonably/long/path.ts";
+    const chain = ["US-001", "US-002", "US-003", "US-004"];
+    for (const id of chain) {
+      await writeFragment(
+        repoRoot,
+        FEATURE_ID,
+        id,
+        renderFragmentBody(id, `story ${id}`, [`ac for ${id}`], Array.from({ length: 10 }, () => filler)),
+        FRAGMENT_MAX_TOKENS,
+      );
+    }
+    await writePRD([
+      storyWith("US-001"),
+      storyWith("US-002", ["US-001"]),
+      storyWith("US-003", ["US-002"]),
+      storyWith("US-004", ["US-003"]),
+      storyWith("US-005", ["US-004"]),
+    ]);
+
+    const provider = new FeatureContextProviderV2(storyWith("US-005", ["US-004"]), makeFragmentsConfig());
+    const result = await provider.fetch(makeRequest({ storyId: "US-005", budgetTokens: 2_000 }));
+
+    const fragments = fragmentChunks(result.chunks);
+    const totalTokens = fragments.reduce((sum, c) => sum + c.tokens, 0);
+
+    expect(fragments.map((c) => c.id)).toEqual(["feature-fragment:US-004", "feature-fragment:US-003"]);
+    expect(totalTokens).toBeLessThanOrEqual(400);
+  });
+
+  test("never drops the nearest fragment, even when the stage budget is tiny", async () => {
+    // Guards the `Math.max(maxTokens, share)` floor: a small budget must
+    // degrade to "nearest only", never to silently nothing.
+    await writeFragment(
+      repoRoot,
+      FEATURE_ID,
+      "US-001",
+      renderFragmentBody("US-001", "story US-001", ["ac"], ["src/a.ts"]),
+      FRAGMENT_MAX_TOKENS,
+    );
+    await writePRD([storyWith("US-001"), storyWith("US-002", ["US-001"])]);
+
+    const provider = new FeatureContextProviderV2(storyWith("US-002", ["US-001"]), makeFragmentsConfig());
+    const result = await provider.fetch(makeRequest({ budgetTokens: 10 }));
+
+    expect(fragmentChunks(result.chunks).map((c) => c.id)).toEqual(["feature-fragment:US-001"]);
+  });
+
+  test("emits nothing when the feature has no fragments on disk", async () => {
+    await writePRD([storyWith("US-001"), storyWith("US-002", ["US-001"])]);
+
+    const provider = new FeatureContextProviderV2(storyWith("US-002", ["US-001"]), makeFragmentsConfig());
+    const result = await provider.fetch(makeRequest());
+
+    expect(fragmentChunks(result.chunks)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Fragment read-back has never worked. `FeatureContextProviderV2` resolved the fragment store to `<repoRoot>/.nax/.nax/features/...`, so `listFragmentStoryIds` always returned `[]` and `collectFragmentChunks` early-returned before touching anything else. This fixes the path and bounds the fragment set that now actually flows.

## Evidence it never worked

`## Files touched` (the fragment body's own header) appears **0 times across 116 prompt-audit files** — all 58 from `bakeoff-compare-profiles` and all 58 from `context-providers-22`, both of which captured 5 real fragments each.

The path arithmetic, using the real exported function:

```
capture writes : /repo/.nax/features/my-feature/fragments/US-001.md
read looks at  : /repo/.nax/.nax/features/my-feature/fragments/US-001.md
```

Capture is correct — `completionStage` passes `ctx.projectDir` (the repo root) and the store appends `.nax/features/<id>/fragments` via `fragmentPath` -> `featureDir` -> `featuresDir`. The provider pre-appended `.nax` on top of that.

## Why #1592 didn't catch it

#1592 fixed this exact compensation — its commit message describes the mechanism precisely — but in the CLI (`src/cli/context-fragments.ts`) and the store. It never touched this file: `git show 92851b98 -- src/context/engine/providers/feature-context.ts` is empty. There are two files named `feature-context.ts`; the one #1592 fixed (`src/context/providers/`) has zero fragment references. `git log -S` dates the offending line to #1567, unmodified since.

## The fix, and the one it isn't

Passing `request.repoRoot` at the store call sites. **Not** changing the shared helper to return `repoRoot`: its other caller, `featurePrdPath`, appends its own `/features/<id>/prd.json` and is already correct. Changing the helper breaks the PRD load, `collectFragmentChunks` returns `[]` again, and the symptom is byte-identical to the bug. The helper is renamed `naxDirFor` and carries a comment saying exactly this.

## Why a bound ships in the same PR

Fragments are emitted as `kind: "feature"` — a **floor kind** (`FLOOR_KINDS = ["static", "feature", "test-coverage"]`). Floor chunks bypass the stage budget and are included even when below min score, so `decay ** distance` only *orders* fragments; it cannot exclude one. Unbounded, a late story in a long dependency chain pulls every transitive fragment into a stage budgeted as low as 4,000 tokens, and `remainingBudget = max(0, budget - usedTokens)` then starves code-neighbor / git-history / session-scratch.

Capped at 20% of the stage budget, never below one fragment's write-time ceiling (so a small budget degrades to "nearest only", never to silently nothing), with a `warn` when the cap sheds any — an unexplained truncation would be the same invisible failure this PR removes.

Deliberately **not** dropping `"feature"` from `FLOOR_KINDS`: the base feature-context chunk (`feature-context:<hash>`, the story/feature description) shares that kind, so it would become budget-eligible and droppable from every prompt.

## Testing

- New `feature-context-fragments-realfs.test.ts` — real temp dir, real `writeFragment`, real store. Only `createV1Provider` is stubbed. **4 of its 5 tests fail against the unfixed provider** (verified by stashing the source and re-running); the fifth is the negative case, which passes either way.
- The existing `feature-context-fragments.test.ts` stubs `readFragment`/`listFragmentStoryIds` with stubs that ignore the `projectDir` argument — that is why this shipped green, and why the new tests do not use dep injection.
- `bun run test`: all phases pass. `bun run typecheck` exit 0, `bun run lint` exit 0.

## Known gap, not fixed here

`handleQueryFeatureContext` builds its own `ContextRequest` without `featureId`, and `collectFragmentChunks` early-returns on `!request.featureId` — so the `query_feature_context` pull tool stays fragment-blind even after this. Separate one-field fix, kept out of a packing-adjacent change.
