### PR TITLE
fix(context): let the query_feature_context pull tool reach fragments

### DIFF
--- a/src/context/engine/handlers/query-feature-context.ts
+++ b/src/context/engine/handlers/query-feature-context.ts
@@ -46,6 +46,10 @@ function filterByKeyword(content: string, keyword: string): string {
  * @param repoRoot         - Working directory for feature-context resolution
  * @param budget           - Budget tracker for this session
  * @param maxTokensPerCall - Per-call token ceiling (chars = tokens × 4)
+ * @param featureId        - Feature under assembly, from the ContextBundle.
+ *                           Required for dependency-fragment reads: the
+ *                           provider early-returns without it, so omitting it
+ *                           silently limits this tool to context.md entries.
  */
 export async function handleQueryFeatureContext(
   input: { filter?: string },
@@ -54,6 +58,7 @@ export async function handleQueryFeatureContext(
   repoRoot: string,
   budget: PullToolBudget,
   maxTokensPerCall: number = DEFAULT_MAX_TOKENS_PER_CALL,
+  featureId?: string,
 ): Promise<string> {
   budget.consume();
 
@@ -65,6 +70,7 @@ export async function handleQueryFeatureContext(
     stage: "pull-tool",
     role: "reviewer",
     budgetTokens: maxTokensPerCall,
+    ...(featureId !== undefined && { featureId }),
   };
   const result = await provider.fetch(request);
 

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -453,6 +453,9 @@ export class ContextOrchestrator {
       chunks: packed.map(toContextChunk),
       // Propagate agentId when the caller specifies a target agent (Phase 7+).
       ...(request.agentId !== undefined && { agentId: request.agentId }),
+      // Propagate featureId so pull-tool handlers can rebuild an equivalent
+      // request (fragment reads early-return without it).
+      ...(request.featureId !== undefined && { featureId: request.featureId }),
     };
   }
 

--- a/src/context/engine/rebuild.ts
+++ b/src/context/engine/rebuild.ts
@@ -246,5 +246,8 @@ export function rebuild(
     manifest,
     chunks: rebuiltChunks,
     agentId: targetAgentId,
+    // Carry the feature forward: a rebuild that dropped it would leave every
+    // post-swap hop's pull tools unable to reach dependency fragments.
+    ...(prior.featureId !== undefined && { featureId: prior.featureId }),
   };
 }

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -146,6 +146,9 @@ export function createContextToolRuntime(options: {
             repoRoot,
             getBudget(tool),
             tool.maxTokensPerCall,
+            // Without the bundle's feature the provider cannot reach this
+            // story's dependency fragments (it early-returns on a missing id).
+            bundle.featureId,
           );
         case "query_scratch":
           return handleQueryScratch(

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -161,6 +161,18 @@ export interface ContextBundle {
    * rebuildForAgent(). Used by renderForAgent() to pick the correct framing.
    */
   agentId?: string;
+  /**
+   * Feature the bundle was assembled for. Carried so the pull-tool runtime can
+   * rebuild an equivalent ContextRequest: `query_feature_context` constructs
+   * its own request, and without a featureId the fragment read path early-
+   * returns, leaving the pull tool blind to dependency fragments the push path
+   * delivers. The bundle is already threaded to the runtime, so riding along
+   * here avoids plumbing a new argument through build-hop-callback.
+   *
+   * Preserved across rebuild() — dropping it there would silently disable
+   * fragments for every post-swap hop.
+   */
+  featureId?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/context/engine/query-feature-context-fragments.test.ts
+++ b/test/unit/context/engine/query-feature-context-fragments.test.ts
@@ -1,0 +1,118 @@
+/**
+ * query_feature_context pull tool — fragment reachability.
+ *
+ * The push path derives `featureId` from `ctx.featureDir` and sets it on the
+ * ContextRequest; the pull path built its own request without one, and
+ * `collectFragmentChunks` early-returns on `!request.featureId`. So the pull
+ * tool was fragment-blind even after the read path's store lookup was fixed
+ * (#1601) — an agent that asked for its dependencies' context got the
+ * context.md entries and nothing else.
+ *
+ * `featureId` now rides on the ContextBundle (like `agentId`), which is
+ * already threaded into the tool runtime, so no new plumbing crosses
+ * build-hop-callback.
+ *
+ * Real filesystem, real fragment store — the same reason as
+ * feature-context-fragments-realfs.test.ts: stubbing the store is what let
+ * the original path defect ship.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { PullToolBudget, createRunCallCounter, handleQueryFeatureContext } from "@/context/engine";
+import { _featureContextV2Deps } from "@/context/engine";
+import { renderFragmentBody, writeFragment } from "@/context/fragments";
+import type { ContextToolRuntimeConfig } from "@/config/selectors";
+import type { UserStory } from "@/prd";
+import { cleanupTempDir, makeTempDir, makePRD, makeStory } from "@test/helpers";
+
+const FEATURE_ID = "feat-pull";
+const FRAGMENT_MAX_TOKENS = 400;
+
+let repoRoot: string;
+
+type DepsShape = typeof _featureContextV2Deps;
+let origCreateV1Provider: DepsShape["createV1Provider"];
+
+beforeEach(() => {
+  repoRoot = makeTempDir();
+  origCreateV1Provider = _featureContextV2Deps.createV1Provider;
+  _featureContextV2Deps.createV1Provider = (() =>
+    ({
+      getContext: async () => null,
+    }) as ReturnType<DepsShape["createV1Provider"]>) as DepsShape["createV1Provider"];
+});
+
+afterEach(() => {
+  _featureContextV2Deps.createV1Provider = origCreateV1Provider;
+  cleanupTempDir(repoRoot);
+});
+
+function fragmentsConfig(): ContextToolRuntimeConfig {
+  return {
+    context: {
+      v2: {
+        fragments: { enabled: true, decay: 0.6, maxTokens: FRAGMENT_MAX_TOKENS, extractor: "deterministic" },
+      },
+    },
+  } as unknown as ContextToolRuntimeConfig;
+}
+
+function storyWith(id: string, dependencies: readonly string[] = []): UserStory {
+  return makeStory({ id, dependencies: [...dependencies] });
+}
+
+async function writePRD(stories: readonly UserStory[]): Promise<void> {
+  const dir = join(repoRoot, ".nax", "features", FEATURE_ID);
+  await mkdir(dir, { recursive: true });
+  const prd = makePRD({ feature: FEATURE_ID, userStories: stories as UserStory[] });
+  await writeFile(join(dir, "prd.json"), JSON.stringify(prd, null, 2), "utf-8");
+}
+
+async function seedFragment(storyId: string, filePath: string): Promise<void> {
+  await writeFragment(
+    repoRoot,
+    FEATURE_ID,
+    storyId,
+    renderFragmentBody(storyId, `story ${storyId}`, ["an acceptance criterion"], [filePath]),
+    FRAGMENT_MAX_TOKENS,
+  );
+}
+
+describe("handleQueryFeatureContext — fragments", () => {
+  test("returns a dependency's fragment when the feature is known", async () => {
+    await seedFragment("US-001", "src/target/module.ts");
+    await writePRD([storyWith("US-001"), storyWith("US-002", ["US-001"])]);
+
+    const output = await handleQueryFeatureContext(
+      {},
+      storyWith("US-002", ["US-001"]),
+      fragmentsConfig(),
+      repoRoot,
+      new PullToolBudget(10, 100, createRunCallCounter()),
+      2_000,
+      FEATURE_ID,
+    );
+
+    expect(output).toContain("src/target/module.ts");
+  });
+
+  test("returns no fragment content when the feature is unknown", async () => {
+    // Guards the early return rather than pretending it cannot happen: a
+    // caller with no featureId must degrade quietly, not throw.
+    await seedFragment("US-001", "src/target/module.ts");
+    await writePRD([storyWith("US-001"), storyWith("US-002", ["US-001"])]);
+
+    const output = await handleQueryFeatureContext(
+      {},
+      storyWith("US-002", ["US-001"]),
+      fragmentsConfig(),
+      repoRoot,
+      new PullToolBudget(10, 100, createRunCallCounter()),
+      2_000,
+    );
+
+    expect(output).not.toContain("src/target/module.ts");
+  });
+});

--- a/test/unit/context/engine/rebuild.test.ts
+++ b/test/unit/context/engine/rebuild.test.ts
@@ -648,3 +648,37 @@ describe("US-003 — repack to target ceiling", () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// featureId carrier — assemble() sets it, rebuild() must not drop it
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("featureId propagation", () => {
+  test("assemble() carries request.featureId onto the bundle", async () => {
+    const orch = new ContextOrchestrator([makeProvider("p1", makeChunkResult())]);
+
+    const bundle = await orch.assemble({ ...BASE_REQUEST, featureId: "feat-x" });
+
+    expect(bundle.featureId).toBe("feat-x");
+  });
+
+  test("rebuild() preserves featureId across an agent swap", async () => {
+    // A dropped featureId here would silently disable dependency-fragment
+    // reads for every post-swap hop's pull tools — invisible at runtime,
+    // since the provider's response to a missing id is an empty result.
+    const orch = new ContextOrchestrator([makeProvider("p1", makeChunkResult())]);
+    const prior = { ...(await orch.assemble({ ...BASE_REQUEST, featureId: "feat-x" })), agentId: "claude" };
+
+    const rebuilt = rebuild(prior, { newAgentId: "codex" });
+
+    expect(rebuilt.featureId).toBe("feat-x");
+  });
+
+  test("rebuild() omits featureId when the prior bundle had none", async () => {
+    const prior = await makePriorBundle();
+
+    const rebuilt = rebuild(prior, {});
+
+    expect(rebuilt.featureId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #1601. That PR fixed the fragment store lookup so the **push** path delivers dependency fragments; the `query_feature_context` **pull** tool was still blind to them. This closes that.

## Why it was blind

`handleQueryFeatureContext` constructs its own `ContextRequest`, and it set `storyId`, `repoRoot`, `packageDir`, `stage`, `role` and `budgetTokens` — but no `featureId`. `collectFragmentChunks` early-returns on `!request.featureId`, so the tool returned context.md entries and never a fragment. The push path works because `stages/context.ts` derives `featureId` from `ctx.featureDir` and sets it on the request.

## How

`featureId` now rides on `ContextBundle` alongside `agentId`:

- `assemble()` copies it from the request.
- `rebuild()` copies it from the prior bundle.
- `tool-runtime` passes `bundle.featureId` into the handler.
- The handler takes it as a trailing optional argument and includes it in the request it builds.

The bundle is the right carrier because it is **already** threaded into the tool runtime. `build-hop-callback` — which constructs the runtime once per hop — has no access to the feature at all, so the alternative was plumbing a new argument up through several layers that have no other use for it.

`rebuild()` copying it forward is not incidental. A rebuild that dropped the field would disable fragments for every post-swap hop, and the failure is invisible: an empty fragment set is exactly what a feature with no fragments looks like. There is a test pinning that specifically, plus one pinning the omit-when-absent case so the field does not materialise as `undefined` on bundles that never had it.

## Testing

- `query-feature-context-fragments.test.ts` — real temp dir, real `writeFragment`, real store, only `createV1Provider` stubbed. Same reasoning as #1601: stubbing the store is what let the original path defect ship.
- Three assertions added to `rebuild.test.ts` for the carrier (assemble sets it, rebuild preserves it across a swap, rebuild omits it when absent).
- **All three new behaviours fail against `main`** — verified by `git stash push -- src/` (reverting only the source, keeping the tests) and re-running: 3 fail, 25 pass.
- `bun run test` all phases pass; `typecheck` and `lint` exit 0.

## Not in this PR

Verifying end-to-end on a real run — that fragments now appear in an actual prompt — needs a `nax run` and is a separate, explicitly-approved step.
