### PR TITLE
fix: drain HIGH and MEDIUM findings from 2026-08-16 deep review

### DIFF
--- a/docs/20260816-review-nax.md
+++ b/docs/20260816-review-nax.md
@@ -1,0 +1,669 @@
+# Deep Code Review: @nathapp/nax (Revision 2)
+
+**Date:** 2026-08-16 (rev 2 — every finding re-verified line-by-line against source)
+**Reviewer:** Subrina (AI)
+**Version:** 0.80.0-canary.4 (`3c02dbe9` — unchanged since rev 1; only `docs/20260816-review-nax.md` was added to the working tree)
+**Files:** 844 source files (~138,383 LOC src/bin/scripts) + 1,164 test files (~16,868 test/describe call sites)
+**Baseline:** `bun run test` full suite; `bun run lint` (Biome + 20+ custom check scripts) enforced in CI
+
+> **Revision note:** Rev 1's 14 top findings were re-verified directly; all 20+ agent-reported LOW/MEDIUM findings were individually re-read and confirmed against current source. Changes vs rev 1: **OTLP-1 downgraded HIGH→MEDIUM** (the normal run path exits naturally — `process.exit(0)` only occurs on bake-off cancel — so the event loop drains detached sends; data loss requires an explicit `process.exit`/kill mid-export), **CTX-8 downgraded MEDIUM→LOW** (string/number `__proto__` assignment is a silent no-op setter call, not global prototype pollution), **OTLP-2 and SEC-1 file paths corrected**, **VER-2 repro snippet corrected**, **BUG-1 annotated** as an in-code documented tradeoff. All other findings confirmed as originally reported.
+
+---
+
+## Overall Grade: B+ (82/100)
+
+| Dimension | Score | Notes |
+|:---|:---|:---|
+| Security | 17/20 | No command injection, HMAC-hardened webhook, extensive redaction — but 3 verified redaction gaps + global fetch patch |
+| Reliability | 14/20 | One command-corruption bug on the retry path, two Telegram timeout/hang bugs, checkpoint killed by a 75ms timer |
+| API Design | 17/20 | Consistent adapter pattern, discriminated unions, `_deps` DI everywhere |
+| Code Quality | 17/20 | Unusually defensive: BUG-* audit annotations, custom check scripts, 16k tests |
+| Best Practices | 17/20 | Config layering, permission resolver, structured JSONL logging all disciplined |
+
+No CRITICAL finding. Every spawn is an argv array (no shell interpolation except one documented `@design` trust boundary), the webhook is loopback-only with HMAC + timing-safe compare + body limits. The genuine problems cluster in three places: the **test-command retry path** (VER-1 corrupts commands), the **Telegram interaction plugin** (TEL-1/TEL-2 break it under realistic inputs), and the **context-engine glob/parse layer** (CTX-1 over-matches rule scopes). All findings carry exact file:line proof; each was verified by reading the file during this revision.
+
+---
+
+## Findings
+
+### 🔴 HIGH
+
+#### VER-1: `appendFlag` splits on `|`/`>` inside redirects and quoted strings — corrupts the command on every timeout-retry path
+**Severity:** HIGH | **Category:** Bug | **Verified:** ✅ lead review (rev 1 + rev 2)
+
+`src/verification/executor.ts:212-218`
+
+```typescript
+function appendFlag(command: string, flag: string): string {
+  const pipeIndex = command.search(/[|>]/);
+  if (pipeIndex > 0) {
+    return `${command.slice(0, pipeIndex).trimEnd()} ${flag} ${command.slice(pipeIndex)}`;
+  }
+  return `${command} ${flag}`;
+}
+```
+
+**What's wrong:** The split point is the *first* `|` or `>` anywhere in the string — no quote awareness, and `>` inside `2>&1` is a redirect target, not a start. Verified traces:
+
+```
+"bun test 2>&1 | tee out" + --forceExit  → "bun test 2 --forceExit >&1 | tee out"   ❌ (flag injected into redirect)
+"bun test -t 'a|b'"      + --forceExit  → "bun test -t 'a --forceExit |b'"         ❌ (unterminated quote)
+```
+
+`buildTestCommand` (`executor.ts:223-249`) runs this on **every timeout retry** (`timeoutRetryCount > 0`) or when `forceExit` is configured — and `2>&1 | tee` / `-t 'pattern'` are extremely common test-command shapes.
+**Risk:** The diagnostic retry path — the exact path meant to rescue a hung/failed run — executes a corrupted command: silent wrong behavior or loud shell errors, wasted rectification cycles, misleading findings. First-run commands are unaffected (injection only on retry), which is why this is not CRITICAL.
+**Fix:** Find the first `|`/`>` *outside* quotes and outside `2>&1`/`2>file` redirect tails; or append token-aligned (before first pipe token, else before first word-boundary `>`). Add unit tests for `2>&1 | tee`, `> log 2>&1`, `-t 'a|b'`.
+
+---
+
+#### TEL-1: Timeout-path fetch has no timeout — the Telegram `receive()` deadline is defeated by a hung network
+**Severity:** HIGH | **Category:** Bug | **Verified:** ✅ lead review
+
+`src/interaction/plugins/telegram.ts:292-295` + `531-556`
+
+```typescript
+private async expireReceiver(requestId: string): Promise<void> {
+    await this.sendTimeoutMessage(requestId);       // ← awaited before resolving
+    this.resolveReceiver(requestId, "skip", "timeout");
+}
+...
+private async sendTimeoutMessage(requestId: string): Promise<void> {
+    ...
+    await _telegramPluginDeps.fetch(`https://api.telegram.org/bot${this.botToken}/editMessageText`, {
+      method: "POST", ...                          // ← no AbortController / signal
+```
+
+**What's wrong:** Every other Telegram call uses `AbortController` + `CALLBACK_API_TIMEOUT_MS` (e.g. `getUpdates` at `telegram.ts:335-352`). `sendTimeoutMessage` is the only outbound fetch with no timeout — and it runs *on the timeout path itself*: when the 60s `receive()` timer fires, `expireReceiver` awaits the hung fetch before resolving the pending receiver. A stalled connection to `api.telegram.org` delays the interaction resolution — and thus the story's fallback action — far beyond the configured timeout.
+**Risk:** The run hangs on the timeout path exactly when the network is unhealthy; `cancel()` has the same structure.
+**Fix:** Reuse the AbortController + `CALLBACK_API_TIMEOUT_MS` pattern; resolve the receiver first, then best-effort the edit.
+
+---
+
+#### TEL-2: `buildHeader` bypasses Markdown sanitization — feature names with `_`/`*` break the entire send
+**Severity:** HIGH | **Category:** Bug | **Verified:** ✅ lead review (impact confirmed by in-code comment `telegram.ts:157`: send() has no fallback — "throwing here aborts the run")
+
+`src/interaction/plugins/telegram-format.ts:99-108` (vs `116-128`)
+
+```typescript
+export function buildHeader(request: InteractionRequest): string {
+  const emoji = getStageEmoji(request.stage);
+  let text = `${emoji} *${request.stage.toUpperCase()}*\n`;
+  text += `*Feature:* ${request.featureName}\n`;      // ← RAW, not sanitized
+  if (request.storyId) { text += `*Story:* ${request.storyId}\n`; }
+```
+
+**What's wrong:** `buildBody` deliberately runs `sanitizeMarkdown` on every variable field, and `send()` posts with `parse_mode: "Markdown"` (`telegram.ts:189`). The header interpolates `featureName`/`storyId` raw. Legacy Telegram Markdown rejects an unclosed `_` (italic) with a 400 — and feature names like `webhook_hmac` or `US-007_telegram` are routine.
+**Risk:** `send()` throws → no fallback on `send()` (in-code comment `telegram.ts:157`) → the story aborts. `plugins/builtin/nax-finish/telegram.ts:74-82` explicitly avoids `parse_mode` for exactly this reason — the two Telegram clients disagree.
+**Fix:** Run `featureName`/`storyId` through `sanitizeMarkdown()` in `buildHeader`, or drop `parse_mode` (plain text, as nax-finish does).
+
+---
+
+#### CTX-1: `globToRegex` eats the `/` before `**` — rule scopes over-match outside their declared glob
+**Severity:** HIGH | **Category:** Bug | **Verified:** ✅ lead review + executed (rev 1 + rev 2)
+
+`src/context/engine/providers/static-rules.ts:118-128`
+
+```typescript
+if (beforeSlash && afterSlash) {
+  regex = `${regex.slice(0, -1)}(?:.*\\/)?`;   // ← removes the accumulated "/" from "src/" and makes it optional
+  i += 3;
+}
+```
+
+**Proof (executed):** `globToRegex("src/**/*.ts")` → `(?:^|\/)src(?:.*\/)?[^/]*\.ts$`:
+
+```
+src/foo.ts   -> true  (correct)
+src/a/b.ts   -> true  (correct)
+srcfoo.ts    -> true  (WRONG — should not match)
+srcfoo/a.ts  -> true  (WRONG — should not match)
+```
+
+**Risk:** This backs the scope filters `ruleMatchesScopeFiles` (`appliesTo:`), `ruleMatchesPackage` (`paths:`), and `pathMatchesScope` (effectiveness annotator). A rule declared `paths: ["packages/api/**"]` silently applies to neighbouring packages; scope attribution mislabels chunk scope paths. `pathMatchesScope` has no `${rel}/` retest, so it disagrees with `ruleMatchesPackage` on the same glob.
+**Fix:** Keep the slash: `regex = `${regex}(?:.*\\/)?``. Add unit tests for `src/**/*.ts` vs `srcfoo.ts`.
+
+---
+
+### 🟡 MEDIUM
+
+#### LOG-1: Redaction misses `github_pat_` tokens, Telegram bot tokens, and pure-alphabetic Basic creds
+**Severity:** MEDIUM | **Category:** Security | **Verified:** ✅ lead review
+
+`src/logger/redact.ts:21-53`
+
+```typescript
+const SECRET_VALUE_PATTERNS: RegExp[] = [
+  /sk-[A-Za-z0-9_-]{16,}/g,
+  /gh[opsu]_[A-Za-z0-9]{16,}/g,                       // ← gho_/ghp_/ghs_/ghu_ only — NOT github_pat_
+  ...
+  /\b(?:Bearer|Basic)\s+(?=[A-Za-z0-9\-._~+/]*[0-9+/_-])[A-Za-z0-9\-._~+/]{8,}={0,2}/gi,  // lookahead requires digit/symbol
+```
+
+Three verified gaps:
+1. GitHub fine-grained PATs (`github_pat_<22>_<59>`): `gh[opsu]_` requires `gh`+`[opsu]`+`_` — `github_pat_` starts `gh`+`i`, never matches.
+2. Telegram bot tokens (`123456789:AAH...~35 chars`): no `\d+:[A-Za-z0-9_-]{30,}` pattern; tokens in free text leak.
+3. `Basic dXNlcjpwYXNz` (`user:pass` base64, pure alphabetic) fails the `[0-9+/_-]` lookahead and leaks verbatim.
+
+**Risk:** Secrets land in the JSONL file, the terminal, and — since redaction runs before OTLP dispatch — get exported to the telemetry collector.
+**Fix:** Add `/github_pat_[A-Za-z0-9_]{20,}/g`, `/\b\d{6,}:[A-Za-z0-9_-]{30,}\b/g`, and base64-validate Basic values instead of requiring a digit.
+
+---
+
+#### EXEC-1: Final run status written as `"running"` after the run has stopped
+**Severity:** MEDIUM | **Category:** Bug | **Verified:** ✅ lead review
+
+`src/execution/lifecycle/run-completion.ts:544-554`
+
+```typescript
+statusWriter.setRunStatus(
+  regressionGateFailed
+    ? "failed"
+    : exitReason === "cost-limit"
+      ? "cost-limit"
+      : isComplete(prd)
+        ? "completed"
+        : isStalled(prd, config.execution.rectification?.maxAttemptsTotal)
+          ? "stalled"
+          : "running",            // ← fallback: run is over, status says it is live
+);
+```
+
+**What's wrong:** When the run stops with pending stories that are *not* stalled — `exitReason` `"pre-merge-aborted"` (declined pre-merge trigger), `"max-iterations"`, `"no-stories"` — the machine-readable `status.json` says `"running"` with the run's own PID.
+**Risk:** The TUI shows the run as live forever; external supervisors keyed on `status.json` wait on a finished run; resume tooling misreads state. Reachable with a single declined pre-merge prompt and any pending story.
+**Fix:** Map remaining exit reasons to a terminal status (add `"aborted"` to the `NaxStatusFile` union in `src/execution/status-file.ts:77`); the `"running"` fallback should be unreachable.
+
+---
+
+#### EXEC-3: Queue `.processing` unlink failure swallowed silently — re-apply invariant broken
+**Severity:** MEDIUM | **Category:** Bug | **Verified:** ✅ lead review
+
+`src/execution/queue-handler.ts:149-151`
+
+```typescript
+const result = await processor(commands);
+await unlink(processingPath).catch(() => {});    // ← failure invisible
+return result;
+```
+
+**What's wrong:** The module's own docstring (BUG-11) states the point of `processQueueFile` is that a crash after processing but before clearing must not re-apply commands. An unlink failure (permission, transient FS error, AV lock) is silently swallowed — no log, no error. The next run's `claimCommandsLocked` finds `.queue.txt.processing` and **re-applies the batch**: `INJECT` stories duplicated, `ABORT`/`SKIP` re-marked.
+**Risk:** Exactly the double-apply class BUG-11 was built to eliminate, on a rare-but-real failure mode, with zero trace in logs.
+**Fix:** Log a warn (or throw and leave the lock held so a retry is safe) on unlink failure.
+
+---
+
+#### CFG-1: Per-package config guard omits `rejectUnimplementedPermissionsBlock` — `execution.permissions` silently stripped
+**Severity:** MEDIUM | **Category:** Config / security-intent | **Verified:** ✅ lead review
+
+`src/config/loader.ts:376-379` (per-package chain) vs `loader.ts:228` (root chain)
+
+```typescript
+// loadConfigForWorkdir (per-package) — 4 of 5 guards
+rejectLegacyAgentKeys(rawMerged);
+rejectLegacyRectificationKeys(rawMerged);
+rejectDeadQualityFlags(rawMerged);
+rejectUnimplementedScopedProfile(rawMerged);
+// root chain (loader.ts:228) additionally calls: rejectUnimplementedPermissionsBlock(rawConfig)
+```
+
+**What's wrong:** The root chain rejects `execution.permissions` with `CONFIG_PERMISSIONS_BLOCK_UNIMPLEMENTED` (`config-guards.ts:310-322`) because nothing reads it. The per-package chain skips this guard, and `mergePackageConfig` spreads `...packageOverride.execution` wholesale (`merge.ts:87-89`) — so `.nax/mono/<pkg>/config.json` with `execution.permissions` flows through and is **silently dropped by Zod `.strip()`**.
+**Risk:** A user writing a per-stage permission policy for a package gets no error and no enforcement — silent security-intent loss.
+**Fix:** Add `rejectUnimplementedPermissionsBlock(rawMerged)` to the per-package guard block.
+
+---
+
+#### CFG-2 / CFG-3: `$VAR` env interpolation applies only to root profiles — project/global config and package profiles keep literal `$VAR`
+**Severity:** MEDIUM | **Category:** Config | **Verified:** ✅ lead review
+
+`src/config/loader.ts:145-184` (only `resolveEnvVars` call site in the load path) vs `361-369` (package profile loop)
+
+```typescript
+// root profile chain: resolves $VAR against the profile's companion .env, throws UnresolvedEnvVarError
+for (const name of overlayChain) { ... resolveEnvVars(profileData, profileEnv) ... }
+
+// per-package profile chain: loadProfile() but NO loadProfileEnv() / resolveEnvVars()
+for (const name of packageChain) {
+  const profileData = await loadProfile(name, packageRoot);
+  rawMerged = deepMergeConfig(rawMerged, profileData);
+}
+```
+
+**What's wrong:** (CFG-2) Global and project layers (`loader.ts:114-140`) never run through `resolveEnvVars` — a user writing `"test": "$TEST_CMD"` in `.nax/config.json` gets the literal string executed. (CFG-3) The per-package profile chain never resolves env either — same silent no-substitution on the monorepo path, while the same file at root level either resolves or fails loudly.
+**Risk:** Silent misconfiguration; `$`-prefixed values land verbatim in shell commands / model strings.
+**Fix:** Run `resolveEnvVars` over the merged config (and package-profile overlays) with the same SENSITIVE-filtered env map; warn on any `$VAR` remnant.
+
+---
+
+#### CFG-4: `parseDotenv` violates its own "Strips comments" contract and mis-parses standard forms
+**Severity:** MEDIUM | **Category:** Config | **Verified:** ✅ lead review
+
+`src/config/dotenv.ts:16-34`
+
+```typescript
+const eqIndex = stripped.indexOf("=");
+...
+let value = stripped.slice(eqIndex + 1).trim();
+if ((value.startsWith('"') && value.endsWith('"')) || ...) {
+  value = value.slice(1, -1);
+}
+```
+
+Empirically verified:
+- `FOO=bar # comment` → value `"bar # comment"` (inline comment baked in, despite docstring "Strips comments" at line 9)
+- `export "FOO=bar"` → key `"FOO`, value `bar"`
+- `FOO="a\"b"` → `a\"b` (escapes never unescaped)
+- CFG-5 (LOW): `${VAR}` brace form silently passes through unsubstituted (`resolveString` at dotenv.ts:86-96 only handles bare `$IDENT`)
+
+**Risk:** Profile `.env` values silently differ from what the author wrote — and the comment case can leak a human-readable annotation into substituted secrets/commands.
+**Fix:** Implement minimal dotenv semantics: strip `# ...` outside quotes, handle `export "KEY=value"`, unescape `\"`/`\\`/`\n` in quoted values, `KEY=` → `""`, and support `${VAR}`.
+
+---
+
+#### VER-2: `buildSmartTestCommand` splits the base command on whitespace — quoted base commands produce corrupt commands
+**Severity:** MEDIUM | **Category:** Bug | **Verified:** ✅ lead review
+
+`src/verification/smart-runner.ts:356-389`
+
+```typescript
+const parts = baseCommand.trim().split(/\s+/);
+...
+// Find the last token that looks like a path (contains '/') ...
+let lastPathIndex = -1;
+for (let i = parts.length - 1; i >= 0; i--) { ... }
+const newParts = [...beforePath, ...quotedTestFiles, ...afterPath];
+return newParts.join(" ");
+```
+
+Verified trace: base `bun test "test dir/"` → parts `["bun","test","\"test","dir/\""]`; the path-like token `"test` is replaced → `bun test 'a.test.ts' 'b.test.ts' dir/"` — unterminated double-quote. `quality/runner.ts:112-113` even documents that whitespace splitting loses quoted args — yet this function does exactly that when replacing a path argument (append-only cases are fine).
+**Risk:** Smart-runner scoping on any repo with spaces in test paths yields a shell syntax error; wasteful full-suite fallback (`verify-scoped.ts:219-231`).
+**Fix:** Quote-aware tokenization (small shell-word splitter), or replace only path-like tokens on quote-safe tokens. Add regression tests for `"test dir/"` and `--config "./vitest config.ts"`.
+
+---
+
+#### VER-4: 75 ms git tree-capture deadline SIGKILLs legitimately-slow git; timer never cleared on the happy path
+**Severity:** MEDIUM | **Category:** Bug / reliability | **Verified:** ✅ lead review
+
+`src/execution/checkpoint/resume-hydrate.ts:22,39-61`
+
+```typescript
+const TREE_CAPTURE_TIMEOUT_MS = 75;                    // line 22
+
+async function spawnWithTimeout(proc: SpawnedProc, timeoutMs: number) {
+  const result = await Promise.race([
+    (async () => { ... proc.exited ... })(),
+    new Promise((resolve) => setTimeout(() => { proc.kill("SIGKILL"); resolve({ stdout: "", exitCode: 1 }); }, timeoutMs)),
+  ]);                                                    // ← losing timer never cleared
+```
+
+**What's wrong:** (1) The timer is never cleared when git wins the race — it later SIGKILLs an already-exited pid and holds the event loop. (2) 75 ms is the budget for *each* of `git status --porcelain` + `git diff` + `git diff --cached` + `hash-object`; on cold page cache, large monorepos, or network-mounted repos, a slow-but-healthy git gets SIGKILLed and the capture fails → `captureFailureSentinel()` (lines 72-74) makes the tree never equal any checkpoint → **`nax resume` silently re-runs everything**.
+**Risk:** The checkpoint/resume feature degrades to a no-op on exactly the large repos it was built for (fail-safe direction — never skips work — which is why this is MEDIUM).
+**Fix:** Clear the timer in the race's `.finally()`; raise the budget to ~1-2 s or make it configurable.
+
+---
+
+#### OTLP-1: `flushNow()` is fire-and-forget — final span/log batches can be dropped on hard exit
+**Severity:** MEDIUM (rev 2: downgraded from HIGH) | **Category:** Reliability | **Verified:** ✅ lead review
+
+`src/plugins/builtin/otel-reporter/batch-queue.ts:60-70` + `index.ts:475-484`
+
+```typescript
+// design comment: flushNow() resolves once the batch is dequeued, not once the network send settles
+const doFlush = (): Promise<void> => {
+  if (tornDown || queue.length === 0) return Promise.resolve();
+  const batch = queue;
+  queue = [];
+  void sendWithRetry(batch);          // ← detached; never tracked, never awaited
+  return Promise.resolve();
+};
+```
+```typescript
+// index.ts:475-484 — teardown path treats flushNow() as a real flush
+await st.spanQueue.flushNow();
+st.spanQueue.teardown();
+```
+
+**What's wrong:** `onRunEnd`/`teardown` `await flushNow()` and then proceed, but the in-flight `sendWithRetry` (up to 5s of retries) is detached with `void`. Rev-2 finding: on the **normal** run path the CLI exits naturally (`process.exit(0)` in `bin/nax.ts` is bake-off-cancel only), so the event loop drains in-flight network I/O and data usually ships — but any explicit `process.exit(1)` on an error path, or a process kill mid-export, drops the final batches, and send failures are unobservable.
+**Risk:** Silent telemetry loss of run-end spans/logs under hard exit; the "flush on crash/exit" guarantee is illusory.
+**Fix:** Track the in-flight send promise and have `flushNow()`/`teardown()` await it within the existing `timeoutMs` cap.
+
+---
+
+#### WEB-1: Compat shim monkey-patches `globalThis.fetch` — shadows every in-process localhost fetch
+**Severity:** MEDIUM | **Category:** Security | **Verified:** ✅ lead review
+
+`src/interaction/plugins/webhook-serve-compat.ts:88-102`
+
+```typescript
+globalThis.fetch = (async (input: Request | string | URL, init?: RequestInit): Promise<Response> => {
+    const request = input instanceof Request ? input : new Request(...);
+    const url = new URL(request.url);
+    const port = Number.parseInt(url.port, 10);
+    if ((url.hostname === "localhost" || url.hostname === "127.0.0.1") && inMemoryServers.has(port)) {
+      return await server.fetch(request);    // any code, any URL on that port
+    }
+    return originalFetch(...);
+}) as typeof globalThis.fetch;
+```
+
+**What's wrong:** Once installed, *every* `fetch()` in the process — plugins, libraries, the OTLP exporter pointed at `localhost:4318` — is routed through this interceptor, matched on **port only**. The compat port space is 40_000-59_999 — exactly where users run dev servers. A real service on a registered port is silently shadowed; unrelated code fetching nax's own in-memory ports receives arbitrary webhook responses. `@design`: the shim exists for sandboxed environments where `Bun.serve` fails; the hazard is that it is process-global.
+**Fix:** Scope interception to the exact advertised `callbackUrl` (match port **and** path prefix `/nax/interact/`), or use a private module-scoped fetch for the webhook plugin's own calls.
+
+---
+
+#### EXEC-2: Crash handlers leak when lock acquisition fails
+**Severity:** MEDIUM | **Category:** Resource leak | **Verified:** ✅ lead review (rev 2)
+
+`src/execution/lifecycle/run-setup.ts:262-284, 367-376` + `src/execution/runner.ts:218-223`
+
+```typescript
+const cleanupCrashHandlers = installCrashHandlers({ statusWriter, ... });   // line 262
+...
+// Acquire lock to prevent concurrent execution
+const lockAcquired = await acquireLock(workdir);                            // line 367
+if (!lockAcquired) {
+  ...
+  throw new LockAcquisitionError(workdir);                                  // line 371 — BEFORE try at line 376
+}
+// Everything after lock acquisition is wrapped in try-catch ... (cleanupCrashHandlers in finally at line 485)
+```
+
+**What's wrong:** `installCrashHandlers` runs *before* `acquireLock`. The `LockAcquisitionError` is thrown at line 371 — before the try/finally (line 376 → finally at 485) that calls `cleanupCrashHandlers`. The SIGTERM/SIGINT/uncaughtException/unhandledRejection handlers stay installed, bound to a `StatusWriter` for a run that never started.
+**Risk:** In in-process consumers (tests, watch mode, embedded TUI), a later signal or uncaught exception writes a bogus "crashed" status and runs `performTeardown` + `pidRegistry.killAll()` for a nonexistent run.
+**Fix:** Acquire the lock before installing handlers, or thread cleanup through the error path.
+
+---
+
+#### EXEC-9: Checkpoint `recordGreen` failure fails the story on an infra error
+**Severity:** MEDIUM | **Category:** Bug | **Verified:** ✅ lead review (rev 2)
+
+`src/execution/story-orchestrator/execution-plan.ts:130-168` + `src/execution/checkpoint/writer.ts:91-99`
+
+```typescript
+try {
+  await runPhase(this.ctx, phase.slot, ...);       // ← inside try/catch
+} catch (error) { ... throw error; }
+if (!phasePassed(...)) { break; }
+...
+} else {
+  const currentTree = await _storyOrchestratorDeps.captureTreeState(this.ctx.packageDir);
+  await _storyOrchestratorDeps.recordGreen(this.ctx.storyId, name, currentTree);   // ← line 167: OUTSIDE the try
+}
+```
+
+**What's wrong:** `recordGreen` sits outside the per-phase try/catch and the writer deliberately rethrows `CHECKPOINT_WRITE_FAILED` (disk full, permission) as a NaxError. The checkpoint-write failure therefore surfaces as a pipeline-stage exception → story marked failed/escalated even though the phase genuinely passed.
+**Risk:** Disk-full during a long run escalates stories through paid tiers for an infra error a warn + skip-resume would survive.
+**Fix:** Swallow-and-warn at the call site (story verdict is the SSOT), or document the tradeoff.
+
+---
+
+#### CLI-1: `runSetupGate` has no timeout and splits the test command on whitespace
+**Severity:** MEDIUM | **Category:** Bug / reliability | **Verified:** ✅ lead review (rev 2)
+
+`src/cli/setup-verify.ts:25-28`
+
+```typescript
+const parts = testCmd.trim().split(/\s+/).filter(Boolean) as [string, ...string[]];
+const proc = _setupVerifyDeps.spawn(parts, { cwd: workdir });
+return await proc.exited;                       // ← no timeout
+```
+
+**What's wrong:** (1) `await proc.exited` with no deadline — a hung `quality.commands.test` hangs `nax setup` forever, unlike every other runner in the codebase. (2) Whitespace split without a shell breaks quoted commands (`bun test "test dir/"`) — same anti-pattern as VER-2.
+**Fix:** Reuse `runQualityCommand`/`executeWithTimeout` (timeouts, process groups, env stripping).
+
+---
+
+#### CTX-2: Canonical rules + test coverage re-read/re-linted/re-scanned on every stage assembly
+**Severity:** MEDIUM | **Category:** Performance | **Verified:** ✅ lead review (rev 2)
+
+`src/context/engine/providers/static-rules.ts:256`, `orchestrator-factory.ts:52-59`, `providers/test-coverage.ts:74-97`
+
+**What's wrong:** `loadCanonicalRules` re-globs `.nax/rules/**/*.md`, re-reads every file, and re-runs the per-line neutrality lint — per `fetch()` (confirmed at static-rules.ts:256 inside `fetch`). `createDefaultOrchestrator` builds a fresh provider per `assemble()`, and assembly happens for the context stage plus execution/rectify/tdd/review stages (~6-8 per story). Rules are immutable within a run; this is pure repeat I/O. `TestCoverageProvider` likewise re-globs+re-scans on every assembly.
+**Risk:** Real wall-clock cost on large rules stores and test corpora, multiplied by N stories.
+**Fix:** Memoize canonical rules per (repoRoot, packageDir) for the run; cache the test-coverage scan keyed by packageDir + touched files.
+
+---
+
+#### CTX-3: Whole scratch.jsonl read + parse on every fetch; file grows unbounded during a run
+**Severity:** MEDIUM | **Category:** Performance | **Verified:** ✅ lead review (rev 2)
+
+`src/context/engine/providers/session-scratch.ts:128-129`, `providers/tool-diagnostics.ts:95-96`, `handlers/query-scratch.ts:162-164`
+
+**What's wrong:** `scratch.jsonl` is append-only and grows with every verify/rectify/TDD/lint result for the whole run. Each `fetch()` reads and JSON-parses the *entire* file (twice per assembly — once per provider). `MAX_ENTRIES_PER_DIR = 20` caps only the render/truncation, not the parse.
+**Risk:** Per-assembly cost grows linearly with run progress; on long rectification loops this dominates provider I/O.
+**Fix:** Tail-read (last ~64 KB, tolerate a torn first line) and/or cache by path+mtime with incremental parse offset.
+
+---
+
+#### CTX-4: `ToolDiagnosticsProvider` chunk is unbounded — no entry or token cap
+**Severity:** MEDIUM | **Category:** Performance | **Verified:** ✅ lead review (rev 2)
+
+`src/context/engine/providers/tool-diagnostics.ts:95-102`
+
+```typescript
+const entries = parseToolDiagnosticsJsonl(raw);
+if (entries.length === 0) return null;
+const content = renderEntries(entries);        // ← ALL entries ever recorded
+```
+
+**What's wrong:** The sibling `SessionScratchProvider` caps at 20 entries / 500 tokens; ToolDiagnostics renders *every* `tool-diagnostics` entry ever recorded into one `diagnostics` chunk. A story that fails lint/typecheck repeatedly accumulates dozens of full diagnostic blocks.
+**Risk:** One chunk balloons past every per-chunk token ceiling other providers honour, crowding the budget with repeated identical errors.
+**Fix:** Mirror session-scratch: most-recent-N entries + char/token cap, ideally deduping identical diagnostics.
+
+---
+
+#### CTX-5: Digest ordering uses `localeCompare` — AC-24 byte-identical determinism broken across locales/ICU versions
+**Severity:** MEDIUM | **Category:** Bug | **Verified:** ✅ lead review (rev 2)
+
+`src/context/engine/digest.ts:71-75`
+
+```typescript
+const sorted = [...chunks].sort((a, b) => {
+  const scopeDiff = (scopeRank[a.scope] ?? 99) - (scopeRank[b.scope] ?? 99);
+  return scopeDiff !== 0 ? scopeDiff : a.id.localeCompare(b.id);   // line 74
+});
+```
+
+**What's wrong:** The digest contract (digest.ts:8-11) and AC-24 demand byte-identical output across runs; `localeCompare` with default locale/ICU is not byte-stable across machines (chunk IDs mix case and `-`/`:` punctuation: `feature-fragment:US-001` vs `feature-context:...`).
+**Risk:** Same id set on two machines → different digest bytes → different prompts, breaking the determinism the digest/dedup design rests on.
+**Fix:** Code-point comparison: `a.id < b.id ? -1 : a.id > b.id ? 1 : 0`. Same fix for `static-rules.ts:288`.
+
+---
+
+#### CTX-6: No in-flight dedup in per-run caches; stale re-population after `invalidate()`
+**Severity:** MEDIUM | **Category:** Race condition | **Verified:** ✅ lead review (rev 2)
+
+`src/context/engine/providers/plugin-cache.ts:97-114`, `provider-weights-cache.ts:28-36`
+
+```typescript
+// plugin-cache.ts — no in-flight dedup: both parallel callers miss and both load+init
+const hit = this.cache.get(key);
+if (hit) return hit;
+const providers = await _pluginCacheDeps.loadProviders(enabled, workdir);
+this.cache.set(key, providers);
+```
+
+**What's wrong:** (1) The plugin cache claims "Concurrency-safe" but nothing guards the first-load race — parallel stories both miss, both `loadProviders` → plugin `init()` runs twice with duplicated side effects, last-writer-wins. (2) The weights cache: `assembleForStage` writes a manifest then `invalidate(featureId)` (`stage-assembler.ts:280-281`); a parallel story's load that started before the invalidate but resolves after re-`set`s the cache — repopulating stale weights (excluding the fresh manifest) for the rest of the run. Both require parallel stories to trigger.
+**Fix:** Memoize the in-flight promise (`Map<string, Promise<…>>`); add a generation counter checked before `cache.set` after `invalidate()`.
+
+---
+
+#### CTX-7: Auto-detect hardcodes top-level `src/` pathspec — silently no-ops in `lib/`, `app/`, monorepo layouts
+**Severity:** MEDIUM | **Category:** Bug | **Verified:** ✅ lead review (rev 2)
+
+`src/context/auto-detect.ts:134-146`
+
+```typescript
+const grepCommand = ["git", "grep", "-i", "-l", "-I", "-E", "-e", grepPattern, "--", "src/"];
+```
+
+**What's wrong:** The git pathspec `src/` matches only the **top-level** `src/` directory; monorepos (`packages/*/src/`) and `lib/`/`app/` layouts get zero matches, and `autoDetectContextFiles` returns `[]` with no fallback. `git grep` also cannot see untracked files. Runs only when the PRD omits `contextFiles`, so the failure is silent.
+**Fix:** Drop the pathspec and filter results (exclude `node_modules/`, `.git/`, `.nax/`), or pass per-package source-root pathspecs.
+
+---
+
+### 🟢 LOW
+
+#### CTX-8: Prototype-pollution guards applied to one of five manifest maps (rev 2: downgraded, mechanics corrected)
+**Severity:** LOW | **Category:** Correctness (defense-in-depth) | **Verified:** ✅ lead review (rev 2)
+
+`src/context/engine/manifest-builder.ts:62-93`
+
+```typescript
+const chunkSummaries: Record<string, string> = {};      // plain {}
+const chunkScopePaths: Record<string, string[]> = {};   // plain {}
+...
+const chunkProviders: Record<string, string> = Object.create(null);   // the ONLY guard (line 82)
+```
+
+**What's wrong:** Only `chunkProviders` is null-prototyped although the US-003 comment establishes "chunk IDs are not trusted input". Rev-2 correction: for the string/number maps, `chunkSummaries["__proto__"] = "x"` invokes the `Object.prototype.__proto__` setter, which silently **no-ops for string/number values** — the key is lost (silent data drop) but Object.prototype is **not** polluted. The only object-value map (`chunkScopePaths["__proto__"] = [...]`) does swap that object's local `[[Prototype]]` to the array — local corruption, again not global pollution. Realistic trigger: a chunk literally named `__proto__` (derivable from git paths/rule fileNames).
+**Risk:** Silent loss of summary/token/score/scope attribution for such chunk IDs + local prototype swap on the scopePaths map.
+**Fix:** Use `Object.create(null)` (or `Object.fromEntries`) for all five maps.
+
+#### OTLP-2: Endpoint URL (with creds) logged on failure (rev 2: path corrected)
+**Severity:** LOW | **Category:** Security | **Verified:** ✅ lead review
+
+`src/plugins/builtin/reporter-shared/post-json.ts:32,37` (shared by otel-reporter and webhook-reporter; rev 1 reported a non-existent `otel-reporter/post-json.ts`)
+
+```typescript
+if (!res.ok) {
+  logger?.warn(opts.stage, "Telemetry POST returned non-2xx", { url, status: res.status });   // line 32
+  return false;
+}
+...
+logger?.warn(opts.stage, "Telemetry POST failed", { url, error: errorMessage(err) });        // line 37
+```
+
+**What's wrong:** An endpoint like `https://user:pass@collector:4318` (or with a token in the path/query) lands verbatim in the JSONL file on failure. `redact.ts` has no URL-userinfo pattern. Headers are never logged (docstring claim holds) — the URL is the leak.
+**Fix:** Strip credentials from the logged URL (`new URL(url)` → drop `username`/`password`).
+
+#### SEC-1: Weak request-id entropy in the interaction bridge (rev 2: path corrected)
+**Severity:** LOW | **Category:** Security | **Verified:** ✅ lead review
+
+`src/interaction/bridge-builder.ts:55` (rev 1 reported a non-existent `interaction-bridge.ts`)
+
+```typescript
+const requestId = `ix-${context.stage}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+```
+
+**What's wrong:** `Math.random()` (not CSPRNG) for request ids while `triggers.ts:93` uses `crypto.randomUUID()`; the registered-ID gate (`webhook.ts:391`) is the last line of defense when `requireSecret: false`. Unify on `crypto.randomUUID()`.
+
+#### OTLP-3: Batch retry with no backoff
+**Severity:** LOW | **Category:** Reliability | **Verified:** ✅ lead review — `batch-queue.ts:49-58` retries immediately; a saturated collector (429/5xx) is hit repeatedly back-to-back. Add jittered delay.
+
+#### SINK-1: SinkRegistry "shallow clone" — nested `data` mutation leaks to the JSONL file
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `sink-registry.ts:36-43` `sink({ ...entry })` shares the `data` object, though the comment claims the clone prevents mutation leaks; a mutating sink can rewrite redacted data back into the on-disk log. Clone `data` too.
+
+#### MEM-1: Logger write path grows O(N) promises + buffer per log call in a burst
+**Severity:** LOW | **Category:** Memory | **Verified:** ✅ lead review — `logger.ts:208-226` every `writeToFile` pushes to `pendingLines` **and** chains a new `.then` onto `writeQueueTail`; the chain grows by one link per call until microtasks drain. Transient O(burst) memory; single-flight flag fixes it.
+
+#### ACP-1: Unbounded `state.text` accumulation in the parser
+**Severity:** LOW | **Category:** Memory | **Verified:** ✅ lead review — `agents/acp/parser.ts:134-135` `state.text += text` per `agent_message_chunk` has no total cap (the 10MB cap in stdout-line-reader bounds one line's remainder, not accumulated output). Cap accumulated text.
+
+#### TEL-3: Callback `action` unvalidated against the enum
+**Severity:** LOW | **Category:** Security | **Verified:** ✅ lead review — `telegram.ts:422` `const action = parts[1] as InteractionResponse["action"]`; any string flows into `applyFallback` and compares false — behaves as "continue" in gates like `checkPreMerge`. Use `z.enum([...]).safeParse`.
+
+#### PLG-1: Auto-discovery + dynamic `import()` of every `.ts` in plugin dirs (untrusted code execution)
+**Severity:** LOW (rev 2: MEDIUM→LOW — plugin execution is the plugin system's contract, explicitly designed; the gap is absence of user-visible loading notice) | **Category:** Security / supply chain | **Verified:** ✅ lead review
+
+`src/plugins/loader.ts:317-360, 434` + `run-setup.ts:404-406`
+
+```typescript
+const imported = await import(modulePath);   // line 434 — full code execution
+```
+
+Every run scans `~/.nax/plugins/` **and** `<workdir>/.nax/plugins/` and dynamically imports all `.ts/.js/.mjs` found with full user privileges. A checked-in plugin dir in a cloned repo runs arbitrary code on first `nax run` with zero prompt. `@design`: dynamic plugin import is inherent to the plugin system (plugins are code by contract) — but log a prominent warning with the source path when loading project-dir plugins, and consider `plugins.allowProjectPlugins: false` default.
+
+#### TDDF-1: `coerceVerdict` inverts pass/fail counts for "N/M FAIL" strings
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `tdd/verdict-reader.ts:113-118` `"42/45 FAIL"` parses as passCount=42/failCount=3; the in-code comment only documents the PASS shape, so the FAIL branch is mis-handled. Verdict stays correct (`allPassing` false) — only error messages report wrong counts. Parse `(pass|fail)` and assign accordingly.
+
+#### TDDF-2: `getAddedLinesPerFile` never drains stderr and ignores the exit code
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `tdd/isolation.ts:103-119` reads stdout then awaits exit; stderr never drained (a git failure emitting >64KB deadlocks on the full pipe) and non-zero exits treated as empty map. Fail-safe direction (missing entries → hard-violation), but a hang is possible. Drain stdout+stderr concurrently and check the exit code.
+
+#### WK-1: Rebase target branch name passed unvalidated to `git rebase`
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `worktree/merge.ts:349` `spawn(["git", "rebase", currentBranch])`; no shell (argv array, no injection), but a branch name starting with `-` is parsed as an option. Refname regex guard `/^[A-Za-z0-9/._-]+$/`.
+
+#### TIM-1: `withProcessTimeout` is dead code with an inconsistent hard-deadline kill
+**Severity:** LOW | **Category:** Dead code | **Verified:** ✅ lead review — `execution/timeout-handler.ts:40,84-94`; grep confirms **zero call sites** outside the module. Hard-deadline path uses raw `process.kill(-pid, "SIGKILL")` while siblings use `killProcessGroup`. Delete or align.
+
+#### EXEC-4: Documented `--parallel 0` "auto-detect" is dead code that would hang if wired
+**Severity:** LOW | **Category:** Latent bug | **Verified:** ✅ lead review — `runner.ts:82`, `unified-executor.ts:253` (`(ctx.parallelCount ?? 0) > 0` gate), `parallel-worker.ts:226-228` (`while (executing.size >= maxConcurrency) await Promise.race(executing)` — hangs forever on an empty set if `maxConcurrency` is 0). Currently unreachable; implement or remove the contract, add `if (maxConcurrency < 1) throw`.
+
+#### EXEC-5: `PidRegistry.killAll()` doesn't await the coalesced follow-up write
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `pid-registry.ts:167-175, 449-470`; `enqueueWrite()` returns the in-flight tail and only schedules the follow-up (which persists the cleared state) without awaiting it. On fast process exit after `killAll()`, `.nax-pids` can still list killed PIDs (mitigated by `cleanupStale()` at next startup).
+
+#### EXEC-6: `spawnWithTimeout` timers never cleared on the fast path
+**Severity:** LOW | **Category:** Timer hygiene | **Verified:** ✅ lead review — `checkpoint/resume-hydrate.ts:39-61`; losing `setTimeout` never cleared → orphaned 75-250ms timers per git call (same file as VER-4; both fixed by a race-with-clearTimeout pattern like `verification/executor.ts:23-29`).
+
+#### EXEC-7: `spawnGitWithDeadline` has no deadline on `proc.exited` itself
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `deferred-review.ts:39-58`; timer kills but `await proc.exited` is unbounded — a child that ignores SIGKILL (D-state on hung NFS) stalls the run. Race `proc.exited` against the timer like `boundedProcRead`.
+
+#### EXEC-8: `startHeartbeat()` doesn't abort the previous loop's in-flight sleep
+**Severity:** LOW | **Category:** Timer hygiene | **Verified:** ✅ lead review — `crash-heartbeat.ts:90-96`; the old `AbortController` is replaced without aborting — a stale loop keeps its 60s `cancellableDelay` sleeping (generation check only fires when it wakes). Abort the old controller in `startHeartbeat()`.
+
+#### BUG-1: `checkStaleLock` treats a recycled PID as a live holder — run blocked indefinitely
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `precheck/checks-config.ts:43-46`; `holderAlive || ageMs < twoHoursMs` — a crashed holder whose PID was reused blocks `nax run` forever. Note: the in-code comment explicitly documents this tradeoff (PID-live is treated as authoritative to survive NTP/sleep skew) — but the backstop was designed for exactly this case and the live check defeats it. Require PID-live AND recent timestamp, or verify the PID's command line.
+
+#### BUG-2: `nax migrate` partial move on mid-loop conflict — idempotency contract broken
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `commands/migrate.ts:251-289`; the per-candidate conflict check throws after earlier candidates were already renamed; a re-run can neither continue nor report. Two-phase: pre-check all destinations first.
+
+#### SEC-2: Symlink management shells out to `rm`/`ln` instead of native fs
+**Severity:** LOW | **Category:** Hygiene | **Verified:** ✅ lead review — `bin/nax.ts:813-818`; PATH-resolved external binaries for trivial fs ops (argv arrays, no user data — but Windows-incompatible and PATH-tamperable). Use `Bun.write`/`unlinkSync`/`Bun.symlink`.
+
+#### CFG-5: `${VAR}` / `$${VAR}` brace forms silently unresolved
+**Severity:** LOW | **Category:** Config | **Verified:** ✅ lead review — `dotenv.ts:86-96` `resolveString` only handles bare `$IDENT`; `${FOO}` passes through literally. Support the brace form or throw `UnresolvedEnvVarError`.
+
+#### CTX-9: Read-modify-write manifest updates without locking
+**Severity:** LOW | **Category:** Race condition | **Verified:** ✅ lead review — `manifest-store.ts:148-162`, `effectiveness.ts:449-461`, `manifest-purge.ts:136-142`; tmp+rename makes each write atomic, but read-modify-write is not — two writers lose one update. `writeRebuildManifest` should be append-only (JSONL) or single-writer scoped.
+
+#### CTX-10: Handler re-exports contradict the module's own STYLE-6 fix comment
+**Severity:** LOW | **Category:** Dead code | **Verified:** ✅ lead review — `pull-tools.ts:308-319`; the comment declares handler re-exports removed, but `handleQueryNeighbor` and `handleQueryFeatureContext` remain exported, keeping the `pull-tools → handlers/query-neighbor → pull-tools` cycle. Finish the job.
+
+#### CTX-11: Reverse-dep scan is O(touchedFiles × globFiles) `content.includes()` scans per fetch
+**Severity:** LOW | **Category:** Performance | **Verified:** ✅ lead review — `code-neighbor.ts:391-407`; up to 10 × 500 files × 1MB strings scanned per fetch, bounded by constants but the dominant provider CPU on large repos. Invert the loop (basename index once per fetch).
+
+#### CTX-12: `truncateToTokenBudget` re-formats the whole summary per dropped file — O(n²)
+**Severity:** LOW | **Category:** Performance | **Verified:** ✅ lead review — `test-scanner.ts:403-410`; rebuilds the full summary per iteration; incremental drop-and-measure fixes it.
+
+#### CTX-13: `readCached` re-reads the same path from disk after the aggregate budget is hit
+**Severity:** LOW | **Category:** Performance | **Verified:** ✅ lead review — `code-neighbor-cache.ts:116-119`; no budget-exhausted negative marker (the `cache.set(path, "")` at 122-124 only covers unreadable files); track a `budgetExhausted` flag.
+
+#### CTX-14: `ProviderWeightsCache` keyed by featureId only; `projectDir` ignored
+**Severity:** LOW | **Category:** Bug | **Verified:** ✅ lead review — `provider-weights-cache.ts:25-36`; key on `${projectDir}:${featureId}` to avoid cross-project contamination in shared worktree runs.
+
+---
+
+## Verified-Clean Highlights (checked, no findings)
+
+- **Command injection:** all 61 spawn sites use argv arrays; the only shell execution (`verification/executor.ts:81`) is a documented `@design` config trust boundary. All interpolation sites shell-quote correctly (`flake-probe.ts`, `scoped-lint.ts`, `command-resolver.ts`).
+- **Path security:** `isWithinDirectory` (path-security.ts:66-81) trailing-slash check is correct; profile-name traversal rejected; `__proto__`/`constructor` merge keys blocked (`merger.ts:21,46-48`).
+- **Webhook hardening:** loopback-only bind, HMAC `timingSafeEqual`, two-bucket rate limiting, body-size enforcement with stream abort, `AbortSignal.timeout` on reporter POSTs (`reporter-shared/post-json.ts:29`).
+- **TUI hooks:** all subscriptions/timers cleaned up in effect cleanup; no setState-after-unmount; throttled rendering.
+- **Event bus:** every `wire*` returns unsubscribers; errors caught per subscriber; `drain()` has a 5s deadline.
+- **Permission resolver:** `resolvePermissions` is the single source of truth; no hardcoded fallbacks found in reviewed paths.
+- **Timeout races:** `executeWithTimeout`/`runQualityCommand` timeout paths verified empirically (Bun resolves with 128+signal) — no rejection bug.
+- **OTLP payload builders** (`otlp.ts`): pure functions, no network/logging — clean.
+
+---
+
+## Priority Fix Order
+
+| Priority | ID | Effort | Description |
+|:---|:---|:---|:---|
+| P0 | VER-1 | S | Quote/redirect-aware flag insertion in `appendFlag` + unit tests |
+| P0 | CTX-1 | S | Keep the slash in `globToRegex`; tests for `src/**/*.ts` vs `srcfoo.ts` |
+| P1 | TEL-1 | S | Add AbortController + timeout to `sendTimeoutMessage`/`cancel` |
+| P1 | TEL-2 | S | Sanitize `featureName`/`storyId` in `buildHeader` (or drop parse_mode) |
+| P1 | LOG-1 | S | Add `github_pat_` / Telegram-token patterns; fix Basic lookahead |
+| P1 | EXEC-1 | S | Terminal status for `pre-merge-aborted`/`max-iterations`/`no-stories` |
+| P1 | CFG-1 | S | Add `rejectUnimplementedPermissionsBlock` to per-package guards |
+| P1 | EXEC-3 | S | Make queue unlink failure observable |
+| P2 | OTLP-1 | S | Track + await in-flight send in `flushNow`/`teardown` |
+| P2 | WEB-1 | M | Scope fetch interception to the callback path prefix |
+| P2 | VER-4 | S | Clear timer in `finally`; raise git-capture budget to ~1s |
+| P2 | CFG-2/3/4 | M | `resolveEnvVars` for all layers; dotenv comment/quote/escape fixes |
+| P2 | VER-2 | M | Quote-aware tokenization in `buildSmartTestCommand` |
+| P2 | CLI-1 | S | Reuse `runQualityCommand` in `runSetupGate` |
+| P2 | EXEC-2 | S | Install crash handlers after lock acquisition |
+| P2 | EXEC-9 | S | Swallow-and-warn on checkpoint `recordGreen` infra failure |
+| P3 | EXEC-4/5/6/7/8 | S/M | Parallel/checkpoint/timer hygiene |
+| P3 | CTX-2/3/4/5/6/7/8 | S/M | Context-engine memoization, caps, determinism, null-prototype maps |
+| P3 | LOW bucket | S | TUI/parser/telegram validation, migrate two-phase, native fs symlinks, post-json URL scrubbing |

--- a/src/cli/setup-verify.ts
+++ b/src/cli/setup-verify.ts
@@ -1,13 +1,16 @@
 import type { NaxConfig } from "../config";
 import { getLogger } from "../logger";
-
-export const _setupVerifyDeps = {
-  spawn: Bun.spawn.bind(Bun) as typeof Bun.spawn,
-};
+import { runQualityCommand } from "../quality/runner";
 
 /**
  * Runs the configured quality.commands.test command to verify the generated
  * .nax config produces a working setup. Returns the process exit code.
+ *
+ * CLI-1: previously spawned via a bare whitespace split (breaking quoted
+ * commands like `bun test "test dir/"`) with no timeout, so a hung test
+ * command hung `nax setup` forever. Delegates to runQualityCommand, the
+ * shared shell-quoting-safe, timeout-enforced runner every other quality
+ * command in nax uses.
  */
 export async function runSetupGate(workdir: string, config: NaxConfig): Promise<number> {
   const logger = getLogger();
@@ -22,8 +25,11 @@ export async function runSetupGate(workdir: string, config: NaxConfig): Promise<
   }
 
   logger.info("setup-verify", "Running verification gate", { storyId: "setup", cmd: testCmd });
-  const parts = testCmd.trim().split(/\s+/).filter(Boolean) as [string, ...string[]];
-  if (parts.length === 0) return 0;
-  const proc = _setupVerifyDeps.spawn(parts, { cwd: workdir });
-  return await proc.exited;
+  const result = await runQualityCommand({
+    commandName: "setup-verify",
+    command: testCmd,
+    workdir,
+    storyId: "setup",
+  });
+  return result.exitCode;
 }

--- a/src/config/dotenv.ts
+++ b/src/config/dotenv.ts
@@ -5,8 +5,58 @@
  */
 
 /**
+ * Parses a dotenv value that starts with a quote character. Returns the
+ * unescaped value (double-quoted values support `\"`, `\\`, `\n` escapes;
+ * single-quoted values are literal, per standard dotenv semantics). Anything
+ * after the closing quote (e.g. a trailing `# comment`) is discarded.
+ */
+function parseQuotedValue(raw: string, quote: '"' | "'"): string {
+  let value = "";
+  for (let i = 1; i < raw.length; i++) {
+    const c = raw[i];
+    if (quote === '"' && c === "\\" && i + 1 < raw.length) {
+      const next = raw[i + 1];
+      if (next === "n") {
+        value += "\n";
+        i++;
+        continue;
+      }
+      if (next === '"' || next === "\\") {
+        value += next;
+        i++;
+        continue;
+      }
+      value += c;
+      continue;
+    }
+    if (c === quote) {
+      return value;
+    }
+    value += c;
+  }
+  // Unterminated quote — treat the rest of the line as the (unescaped) value.
+  return value;
+}
+
+/**
+ * Strips an inline `# comment` from an unquoted value — a `#` counts as a
+ * comment marker only when it starts the value or is preceded by whitespace,
+ * matching standard dotenv/shell behaviour (`FOO=bar#baz` keeps the `#`).
+ */
+function stripInlineComment(raw: string): string {
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i] === "#" && (i === 0 || /\s/.test(raw[i - 1] ?? ""))) {
+      return raw.slice(0, i);
+    }
+  }
+  return raw;
+}
+
+/**
  * Parses dotenv file contents into a string record.
- * Strips comments, blank lines, export prefixes, and quotes.
+ * Strips comments (outside quotes), blank lines, export prefixes (including
+ * the whole-assignment-quoted `export "KEY=value"` form), and quotes —
+ * unescaping `\"`/`\\`/`\n` in double-quoted values.
  */
 export function parseDotenv(content: string): Record<string, string> {
   if (!content) return {};
@@ -14,20 +64,29 @@ export function parseDotenv(content: string): Record<string, string> {
   const result: Record<string, string> = {};
 
   for (const rawLine of content.split("\n")) {
-    const line = rawLine.trim();
+    let line = rawLine.trim();
 
     if (!line || line.startsWith("#")) continue;
 
-    const stripped = line.startsWith("export ") ? line.slice(7).trim() : line;
+    if (line.startsWith("export ")) {
+      line = line.slice(7).trim();
+      // `export "KEY=value"` — the whole assignment is quoted, not just the value.
+      if (line.length >= 2 && (line[0] === '"' || line[0] === "'") && line.endsWith(line[0])) {
+        line = line.slice(1, -1);
+      }
+    }
 
-    const eqIndex = stripped.indexOf("=");
+    const eqIndex = line.indexOf("=");
     if (eqIndex === -1) continue;
 
-    const key = stripped.slice(0, eqIndex).trim();
-    let value = stripped.slice(eqIndex + 1).trim();
+    const key = line.slice(0, eqIndex).trim();
+    const rawValue = line.slice(eqIndex + 1).trim();
 
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
+    let value: string;
+    if (rawValue.startsWith('"') || rawValue.startsWith("'")) {
+      value = parseQuotedValue(rawValue, rawValue[0] as '"' | "'");
+    } else {
+      value = stripInlineComment(rawValue).trim();
     }
 
     result[key] = value;
@@ -84,14 +143,21 @@ export class UnresolvedEnvVarError extends Error {
 const DOUBLE_DOLLAR_PLACEHOLDER = "__DOLLAR_ESCAPE__";
 
 function resolveString(str: string, env: Record<string, string>, path: string[]): string {
-  // First protect $$VAR escapes, then resolve $VAR references, then restore
+  const resolveOne = (varName: string): string => {
+    if (!(varName in env)) {
+      throw new UnresolvedEnvVarError(varName, path);
+    }
+    return env[varName];
+  };
+  // First protect $$VAR/$${VAR} escapes, then resolve $VAR and ${VAR}
+  // references (CFG-5 — the brace form previously passed through literally),
+  // then restore the escaped form.
   return str
-    .replace(/\$\$([A-Za-z_][A-Za-z0-9_]*)/g, `${DOUBLE_DOLLAR_PLACEHOLDER}$1`)
-    .replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, varName: string) => {
-      if (!(varName in env)) {
-        throw new UnresolvedEnvVarError(varName, path);
-      }
-      return env[varName];
-    })
-    .replace(new RegExp(`${DOUBLE_DOLLAR_PLACEHOLDER}([A-Za-z_][A-Za-z0-9_]*)`, "g"), "$$$1");
+    .replace(/\$\$(\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)/g, `${DOUBLE_DOLLAR_PLACEHOLDER}$1`)
+    .replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_match, varName: string) => resolveOne(varName))
+    .replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, varName: string) => resolveOne(varName))
+    .replace(
+      new RegExp(`${DOUBLE_DOLLAR_PLACEHOLDER}(\\{[A-Za-z_][A-Za-z0-9_]*\\}|[A-Za-z_][A-Za-z0-9_]*)`, "g"),
+      "$$$1",
+    );
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -90,6 +90,7 @@ export {
   loadProfile,
   loadProfileEnv,
   listProfiles,
+  sensitiveFilteredProcessEnv,
 } from "./profile";
 export { pickSelector, reshapeSelector } from "./selector";
 export { getProjectKey } from "./project-key";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -28,8 +28,43 @@ import { mergePackageConfig } from "./merge";
 import { deepMergeConfig } from "./merger";
 import { MAX_DIRECTORY_DEPTH } from "./path-security";
 import { PROJECT_NAX_DIR, globalConfigDir } from "./paths";
-import { loadProfile, loadProfileEnv, parseProfileList, resolveProfileNames } from "./profile";
+import {
+  loadProfile,
+  loadProfileEnv,
+  parseProfileList,
+  resolveProfileNames,
+  sensitiveFilteredProcessEnv,
+} from "./profile";
 import { DEFAULT_CONFIG, type NaxConfig, NaxConfigSchema } from "./schema";
+
+/**
+ * CFG-2/CFG-3: resolve `$VAR`/`${VAR}` references in a config layer that has
+ * no companion `.env` file of its own (global/project config, per-package
+ * profile overlays) against the ambient, secret-key-filtered process.env.
+ * Unlike the profile chain (which fail-fasts via loadProfile's own
+ * resolveEnvVars call — an intentional, reviewed profile.json), this warns
+ * and leaves the layer unresolved rather than throwing: these layers are
+ * loaded implicitly on every run, and a literal "$" that was never meant as
+ * a var reference must not hard-fail config load.
+ */
+function resolveEnvVarsWarnOnFailure(
+  config: Record<string, unknown>,
+  logger: ReturnType<typeof getLogger> | null,
+  layerName: string,
+): Record<string, unknown> {
+  try {
+    return resolveEnvVars(config, sensitiveFilteredProcessEnv()) as Record<string, unknown>;
+  } catch (err) {
+    if (err instanceof UnresolvedEnvVarError) {
+      logger?.warn("config", `${layerName} references undefined environment variable — left unresolved`, {
+        varName: err.varName,
+        path: err.path.join(".") || "(root)",
+      });
+      return config;
+    }
+    throw err;
+  }
+}
 
 /** Global config path */
 export function globalConfigPath(): string {
@@ -138,6 +173,12 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
       });
     }
   }
+
+  // CFG-2: global + project config never ran through $VAR resolution — a value
+  // like "test": "$TEST_CMD" landed in the run config as the literal
+  // unresolved string. Resolve against the ambient (secret-filtered)
+  // process.env, same as the profile chain below.
+  rawConfig = resolveEnvVarsWarnOnFailure(rawConfig, logger, "global/project config");
 
   // Layer 3: Profile chain (overrides global + project — it's a run-time mode selection).
   // Profiles overlay in order; a later profile overrides an earlier one. A missing
@@ -352,17 +393,45 @@ export async function loadConfigForWorkdir(
     defaultConfigWarn,
   ) as unknown as NaxConfig;
 
+  // CFG-3: the plain per-package overlay (.nax/mono/<pkg>/config.json) also
+  // never ran through $VAR resolution — same gap as CFG-2 at the root layer.
+  const envResolvedMerged = resolveEnvVarsWarnOnFailure(
+    merged as unknown as Record<string, unknown>,
+    logger,
+    `per-package config (${packageDir})`,
+  );
+
   // Per-package profile: apply the profile chain overlay on top of merged config.
   // Accepts the comma form; profiles overlay left-to-right (later overrides earlier).
   const packageChain = parseProfileList(packageProfile as string | string[] | undefined).filter(
     (name) => name && name !== "default",
   );
-  let rawMerged = merged as unknown as Record<string, unknown>;
+  let rawMerged = envResolvedMerged;
   if (packageChain.length > 0) {
     const packageRoot = join(repoRoot, packageDir);
     for (const name of packageChain) {
       const profileData = await loadProfile(name, packageRoot);
-      rawMerged = deepMergeConfig<Record<string, unknown>>(rawMerged, profileData);
+      // CFG-3: mirror the root profile chain's $VAR resolution (loader.ts
+      // layer 3) — without this, a per-package profile's "$VAR"-style
+      // references land in the merged config as literal unresolved strings
+      // while the same profile file at root level either resolves or throws.
+      const profileEnv = await loadProfileEnv(name, packageRoot);
+      let resolvedProfileData: Record<string, unknown>;
+      try {
+        resolvedProfileData =
+          Object.keys(profileEnv).length > 0
+            ? (resolveEnvVars(profileData, profileEnv) as Record<string, unknown>)
+            : profileData;
+      } catch (err) {
+        const varName = err instanceof UnresolvedEnvVarError ? err.varName : undefined;
+        const path = err instanceof UnresolvedEnvVarError ? err.path.join(".") : undefined;
+        throw new NaxError(
+          `Per-package profile "${name}" (${packageDir}) references an undefined environment variable${varName ? ` $${varName}` : ""}${path ? ` at "${path}"` : ""}.`,
+          "PROFILE_ENV_VAR_UNRESOLVED",
+          { stage: "config", profileName: name, packageDir, varName, path, cause: err },
+        );
+      }
+      rawMerged = deepMergeConfig<Record<string, unknown>>(rawMerged, resolvedProfileData);
     }
     rawMerged.profile = packageChain.join("+");
     rawMerged.profileChain = packageChain;
@@ -377,6 +446,10 @@ export async function loadConfigForWorkdir(
   rejectLegacyRectificationKeys(rawMerged);
   rejectDeadQualityFlags(rawMerged);
   rejectUnimplementedScopedProfile(rawMerged);
+  // CFG-1: same guard as the root chain — without it, a per-package
+  // `execution.permissions` block sails through and is silently stripped by
+  // Zod's `.strip()`, giving the user no error and no enforcement.
+  rejectUnimplementedPermissionsBlock(rawMerged);
   // Strip the four inert no-op keys again post-profile-overlay (a package
   // profile can reintroduce one). Runs after the reject guards and before
   // safeParse, mirroring the root chain. Post-merge placement yields one

--- a/src/config/profile.ts
+++ b/src/config/profile.ts
@@ -112,6 +112,22 @@ export async function loadProfile(profileName: string, projectRoot: string): Pro
 }
 
 /**
+ * Snapshot of `process.env` (via `_profileDeps.env` for testability) with
+ * secret-shaped keys excluded — see SENSITIVE_ENV_KEY_PATTERN. Used as the
+ * base `$VAR` substitution env everywhere config `$VAR`/`${VAR}` references
+ * are resolved: profile chains (loadProfileEnv) and the global/project/
+ * per-package config layers (CFG-2/CFG-3), which have no companion .env file
+ * of their own.
+ */
+export function sensitiveFilteredProcessEnv(): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(_profileDeps.env)) {
+    if (value !== undefined && !SENSITIVE_ENV_KEY_PATTERN.test(key)) filtered[key] = value;
+  }
+  return filtered;
+}
+
+/**
  * Loads and merges .env files for a named profile.
  * Project values override global, and both override process.env entries.
  * Returns an empty record when no .env files exist.
@@ -132,10 +148,7 @@ export async function loadProfileEnv(profileName: string, projectRoot: string): 
   // process.env entries"). Previously process.env was never folded in at
   // all, so any reference to an ambient (not profile-redefined) var
   // hard-failed config load before zod ever ran.
-  let merged: Record<string, string> = {};
-  for (const [key, value] of Object.entries(_profileDeps.env)) {
-    if (value !== undefined && !SENSITIVE_ENV_KEY_PATTERN.test(key)) merged[key] = value;
-  }
+  let merged: Record<string, string> = sensitiveFilteredProcessEnv();
 
   if (!globalExists && !projectExists) {
     return merged;

--- a/src/context/auto-detect.ts
+++ b/src/context/auto-detect.ts
@@ -130,7 +130,12 @@ export async function autoDetectContextFiles(options: AutoDetectOptions): Promis
 
   // Build git grep command
   // Use -i for case-insensitive, -l for filename-only, -I to skip binary files
-  // Search in src/ directories only (exclude test, node_modules, etc.)
+  //
+  // CTX-7: no pathspec — a hardcoded "src/" pathspec only matches the
+  // TOP-LEVEL src/ directory (git pathspec semantics, not a glob), so
+  // monorepos (packages/*/src/) and lib/app layouts got zero matches and
+  // silently returned []. Repo-wide search + post-filtering below excludes
+  // node_modules/.git/.nax instead.
   const grepPattern = keywords.join("|"); // OR pattern
   const grepCommand = [
     "git",
@@ -141,8 +146,6 @@ export async function autoDetectContextFiles(options: AutoDetectOptions): Promis
     "-E", // extended regex
     "-e",
     grepPattern,
-    "--", // separator
-    "src/", // limit to src directory
   ];
 
   try {
@@ -177,6 +180,17 @@ export async function autoDetectContextFiles(options: AutoDetectOptions): Promis
     // Filter out test files, index files, generated files
     const filtered = allFiles.filter((filePath) => {
       const lower = filePath.toLowerCase();
+      // CTX-7: node_modules/.git/.nax exclusion, now that grep is repo-wide
+      // rather than scoped to a (monorepo-breaking) "src/" pathspec.
+      if (
+        lower.includes("node_modules/") ||
+        lower.startsWith(".git/") ||
+        lower.includes("/.git/") ||
+        lower.startsWith(".nax/") ||
+        lower.includes("/.nax/")
+      ) {
+        return false;
+      }
       // Exclude test files (ADR-009: use config-aware classification)
       if (isTestFileByPatterns(filePath, testFilePatterns)) {
         return false;

--- a/src/context/engine/digest.ts
+++ b/src/context/engine/digest.ts
@@ -71,7 +71,11 @@ export function buildDigest(chunks: PackedChunk[]): string {
   const scopeRank = Object.fromEntries(SCOPE_ORDER.map((s, i) => [s, i]));
   const sorted = [...chunks].sort((a, b) => {
     const scopeDiff = (scopeRank[a.scope] ?? 99) - (scopeRank[b.scope] ?? 99);
-    return scopeDiff !== 0 ? scopeDiff : a.id.localeCompare(b.id);
+    if (scopeDiff !== 0) return scopeDiff;
+    // CTX-5: code-point comparison, not localeCompare — the digest contract
+    // (AC-24) requires byte-identical output across machines, and
+    // localeCompare's ordering is not stable across locale/ICU versions.
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
 
   const lines: string[] = [];

--- a/src/context/engine/index.ts
+++ b/src/context/engine/index.ts
@@ -18,7 +18,13 @@ export { rebuild, type RebuildDeps } from "./rebuild";
 export { estimateAvailableBudgetTokens } from "./available-budget";
 export { getStageContextConfig, STAGE_CONTEXT_MAP, DEFAULT_STAGE_CONFIG } from "./stage-config";
 export type { StageContextConfig } from "./stage-config";
-export { StaticRulesProvider, _staticRulesDeps, globToRegex, normalizePath } from "./providers/static-rules";
+export {
+  StaticRulesProvider,
+  _staticRulesDeps,
+  globToRegex,
+  normalizePath,
+  _resetCanonicalRulesCache,
+} from "./providers/static-rules";
 export { FeatureContextProviderV2, _featureContextV2Deps } from "./providers/feature-context";
 export { SessionScratchProvider, _sessionScratchDeps } from "./providers/session-scratch";
 export { ToolDiagnosticsProvider, _toolDiagnosticsDeps } from "./providers/tool-diagnostics";

--- a/src/context/engine/provider-weights-cache.ts
+++ b/src/context/engine/provider-weights-cache.ts
@@ -23,20 +23,30 @@ export const _providerWeightsCacheDeps = {
 
 export class ProviderWeightsCache {
   private readonly cache = new Map<string, Record<string, number>>();
+  // CTX-6: a parallel story's load that started before invalidate() but
+  // resolves after it must not re-set the cache — that would repopulate
+  // stale weights (excluding the fresh manifest the invalidate() was for)
+  // for the rest of the run. Track a generation per featureId; a loadOrGet
+  // only writes its result if the generation it started with is still current.
+  private readonly generations = new Map<string, number>();
 
   /** Returns cached weights for featureId, deriving and caching them on a miss. */
   async loadOrGet(featureId: string, projectDir: string): Promise<Record<string, number>> {
     const cached = this.cache.get(featureId);
     if (cached) return cached;
 
+    const startGeneration = this.generations.get(featureId) ?? 0;
     const stored = await _providerWeightsCacheDeps.loadFeatureManifests({ featureId, projectDir });
     const weights = _providerWeightsCacheDeps.deriveProviderWeights(stored.map((s) => s.manifest));
-    this.cache.set(featureId, weights);
+    if ((this.generations.get(featureId) ?? 0) === startGeneration) {
+      this.cache.set(featureId, weights);
+    }
     return weights;
   }
 
   /** Drops the cached weights for a feature so the next loadOrGet re-derives them. */
   invalidate(featureId: string): void {
     this.cache.delete(featureId);
+    this.generations.set(featureId, (this.generations.get(featureId) ?? 0) + 1);
   }
 }

--- a/src/context/engine/providers/canonical-rules-cache.ts
+++ b/src/context/engine/providers/canonical-rules-cache.ts
@@ -1,0 +1,32 @@
+/**
+ * CTX-2: loadCanonicalRules re-globs `.nax/rules/**\/*.md`, re-reads every
+ * file, and re-runs the per-line neutrality lint — INSIDE fetch(), which
+ * createDefaultOrchestrator calls fresh per stage assembly (~6-8 times per
+ * story). Rules are immutable within a run, so this is pure repeat I/O.
+ * Memoized per (workdir) for the process lifetime. `_resetCanonicalRulesCache`
+ * exists for tests that mutate a rules dir mid-suite and need a fresh read.
+ */
+
+import { loadCanonicalRules } from "../../rules/canonical-loader";
+import type { CanonicalRule } from "../../rules/canonical-loader";
+
+const canonicalRulesCache = new Map<string, Promise<CanonicalRule[]>>();
+
+export function memoizedLoadCanonicalRules(
+  workdir: string,
+  options?: Parameters<typeof loadCanonicalRules>[1],
+): Promise<CanonicalRule[]> {
+  const cached = canonicalRulesCache.get(workdir);
+  if (cached) return cached;
+  const loaded = loadCanonicalRules(workdir, options);
+  canonicalRulesCache.set(workdir, loaded);
+  // Don't cache a rejection — a transient read failure shouldn't poison every
+  // subsequent assembly for the rest of the run.
+  loaded.catch(() => canonicalRulesCache.delete(workdir));
+  return loaded;
+}
+
+/** Test-only: clear the per-workdir canonical-rules memoization cache. */
+export function _resetCanonicalRulesCache(): void {
+  canonicalRulesCache.clear();
+}

--- a/src/context/engine/providers/plugin-cache.ts
+++ b/src/context/engine/providers/plugin-cache.ts
@@ -84,7 +84,11 @@ function stableCacheKey(configs: ContextPluginProviderConfig[], workdir: string)
  *   4. Call disposeAll() in handleRunCompletion() before session teardown ends.
  */
 export class PluginProviderCache {
-  private readonly cache = new Map<string, IContextProvider[]>();
+  // CTX-6: cache the in-flight Promise, not just the resolved value — two
+  // parallel stories both missing the cache and both calling loadProviders()
+  // ran plugin init() twice with duplicated side effects (last-writer-wins).
+  // Caching the promise makes the second caller await the first's load.
+  private readonly cache = new Map<string, Promise<IContextProvider[]>>();
   private disposed = false;
 
   /**
@@ -108,9 +112,12 @@ export class PluginProviderCache {
     const hit = this.cache.get(key);
     if (hit) return hit;
 
-    const providers = await _pluginCacheDeps.loadProviders(enabled, workdir);
-    this.cache.set(key, providers);
-    return providers;
+    const loading = _pluginCacheDeps.loadProviders(enabled, workdir);
+    this.cache.set(key, loading);
+    // Don't cache a rejection — a transient load failure shouldn't poison
+    // every subsequent caller for the rest of the run.
+    loading.catch(() => this.cache.delete(key));
+    return loading;
   }
 
   /**
@@ -127,10 +134,15 @@ export class PluginProviderCache {
 
     const logger = getLogger();
 
-    // Dispose concurrently: a single hanging provider must not serialize the
-    // whole teardown behind its own deadline.
+    // Await every cached load concurrently first — a still-in-flight load
+    // must not serialize the loads behind each other before teardown even
+    // starts. Dispose concurrently too: a single hanging provider must not
+    // serialize the whole teardown behind its own deadline.
+    const allProviders = await Promise.all(
+      [...this.cache.values()].map((loading) => loading.catch(() => [] as IContextProvider[])),
+    );
     const disposals: Promise<void>[] = [];
-    for (const providers of this.cache.values()) {
+    for (const providers of allProviders) {
       for (const provider of providers) {
         const initialisable = provider as InitialisableProvider;
         if (typeof initialisable.dispose !== "function") continue;

--- a/src/context/engine/providers/session-scratch.ts
+++ b/src/context/engine/providers/session-scratch.ts
@@ -16,9 +16,10 @@
  */
 
 import { createHash } from "node:crypto";
-import type { ScratchEntry } from "../../../session/scratch-writer";
-import { scratchFilePath } from "../../../session/scratch-writer";
-import { type NaxIgnoreMatcher, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../../../utils/path-filters";
+import { scratchFilePath } from "@/session";
+import type { ScratchEntry } from "@/session";
+import { readJsonlTail } from "@/utils/jsonl-tail";
+import { type NaxIgnoreMatcher, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "@/utils/path-filters";
 import { neutralizeForAgent } from "../scratch-neutralizer";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
@@ -38,7 +39,9 @@ const MAX_CHUNK_TOKENS = 500;
 
 export const _sessionScratchDeps = {
   fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
-  readFile: (path: string): Promise<string> => Bun.file(path).text(),
+  // CTX-3: tail-read, not a full read — only the most recent
+  // MAX_ENTRIES_PER_DIR entries are ever rendered.
+  readFile: (path: string): Promise<string> => readJsonlTail(path),
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -25,10 +25,13 @@ import { getLogger } from "@/logger";
 // number the budget admitted it on.
 import { estimateTokens } from "@/optimizer";
 import { errorMessage } from "@/utils/errors";
-import { DEFAULT_CANONICAL_RULES_BUDGET_TOKENS, loadCanonicalRules } from "../../rules/canonical-loader";
+import { DEFAULT_CANONICAL_RULES_BUDGET_TOKENS } from "../../rules/canonical-loader";
 import type { CanonicalRule } from "../../rules/canonical-loader";
 import type { ProviderBudgetPressure, ProviderScopingReport } from "../manifest-types";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
+import { memoizedLoadCanonicalRules } from "./canonical-rules-cache";
+
+export { _resetCanonicalRulesCache } from "./canonical-rules-cache";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Injectable deps
@@ -44,7 +47,7 @@ export const _staticRulesDeps = {
       return [];
     }
   },
-  loadCanonicalRules,
+  loadCanonicalRules: memoizedLoadCanonicalRules,
   splitRuleIntoSections,
   applySectionBudget,
 };
@@ -125,7 +128,7 @@ export function globToRegex(pattern: string): RegExp {
         const beforeSlash = i > 0 && pattern[i - 1] === "/";
         const afterSlash = pattern[i + 2] === "/";
         if (beforeSlash && afterSlash) {
-          regex = `${regex.slice(0, -1)}(?:.*\\/)?`;
+          regex = `${regex}(?:.*\\/)?`;
           i += 3;
         } else if (afterSlash) {
           regex += "(?:.*\\/)?";
@@ -283,10 +286,14 @@ export class StaticRulesProvider implements IContextProvider {
         }
       }
 
-      mergedRules.sort(
-        (a, b) =>
-          canonicalRulePriority(a) - canonicalRulePriority(b) || canonicalRuleId(a).localeCompare(canonicalRuleId(b)),
-      );
+      mergedRules.sort((a, b) => {
+        const priorityDiff = canonicalRulePriority(a) - canonicalRulePriority(b);
+        if (priorityDiff !== 0) return priorityDiff;
+        // CTX-5: code-point comparison, not localeCompare — see digest.ts.
+        const idA = canonicalRuleId(a);
+        const idB = canonicalRuleId(b);
+        return idA < idB ? -1 : idA > idB ? 1 : 0;
+      });
 
       // #558: rules exist but none apply to this package context — skip legacy fallback
       if (mergedRules.length === 0 && (repoRulesAll.length > 0 || packageRulesCount > 0)) {

--- a/src/context/engine/providers/tool-diagnostics.ts
+++ b/src/context/engine/providers/tool-diagnostics.ts
@@ -20,6 +20,7 @@
 import { createHash } from "node:crypto";
 import { scratchFilePath } from "@/session";
 import type { ToolDiagnosticsScratchEntry } from "@/session";
+import { readJsonlTail } from "@/utils/jsonl-tail";
 import { formatDiagnostic } from "../diagnostic-formatter";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
@@ -29,7 +30,9 @@ import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk 
 
 export const _toolDiagnosticsDeps = {
   fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
-  readFile: (path: string): Promise<string> => Bun.file(path).text(),
+  // CTX-3: tail-read — only the most recent MAX_ENTRIES_PER_DIR entries are
+  // ever rendered (see below).
+  readFile: (path: string): Promise<string> => readJsonlTail(path),
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -39,6 +42,13 @@ export const _toolDiagnosticsDeps = {
 function contentHash8(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 8);
 }
+
+// CTX-4: mirrors SessionScratchProvider's caps — without them a story that
+// fails lint/typecheck repeatedly accumulates dozens of full diagnostic
+// blocks into one chunk, crowding out the rest of the token budget.
+const MAX_ENTRIES_PER_DIR = 20;
+const MAX_CHUNK_TOKENS = 500;
+const MAX_CHUNK_CHARS = MAX_CHUNK_TOKENS * 4;
 
 /** Parse JSONL text into an array of tool-diagnostics entries, skipping malformed lines. */
 function parseToolDiagnosticsJsonl(raw: string): ToolDiagnosticsScratchEntry[] {
@@ -92,11 +102,15 @@ async function readDiagnosticsDir(scratchDir: string): Promise<RawChunk | null> 
     // be readable. Mirrors the "never throws" contract for malformed JSONL.
     return null;
   }
-  const entries = parseToolDiagnosticsJsonl(raw);
-  if (entries.length === 0) return null;
+  const parsedEntries = parseToolDiagnosticsJsonl(raw);
+  if (parsedEntries.length === 0) return null;
 
-  const content = renderEntries(entries);
+  // Most-recent-N entries, matching SessionScratchProvider (CTX-4).
+  const entries = parsedEntries.slice(-MAX_ENTRIES_PER_DIR);
+
+  let content = renderEntries(entries);
   if (!content) return null;
+  if (content.length > MAX_CHUNK_CHARS) content = content.slice(0, MAX_CHUNK_CHARS);
 
   const hash = contentHash8(content);
   const tokens = Math.ceil(content.length / 4);

--- a/src/execution/checkpoint/resume-hydrate.ts
+++ b/src/execution/checkpoint/resume-hydrate.ts
@@ -18,8 +18,14 @@ export interface CaptureTreeStateOptions {
  * process is caught quickly rather than blocking the orchestrator startup.
  * Mirrors the intent of gitWithTimeout (GIT_TIMEOUT_MS) but with a tighter
  * bound appropriate for git sub-second commands.
+ *
+ * VER-4: was 75ms, budgeted for a *single* call — but each of status/diff/
+ * diff-cached/hash-object gets its own 75ms deadline, and on cold page
+ * cache, large monorepos, or network-mounted repos a slow-but-healthy git
+ * call was routinely SIGKILLed, making `captureFailureSentinel()` fire and
+ * `nax resume` silently re-run everything. Raised to 1s of headroom per call.
  */
-const TREE_CAPTURE_TIMEOUT_MS = 75;
+const TREE_CAPTURE_TIMEOUT_MS = 1000;
 
 interface SpawnedProc {
   exited: Promise<number>;
@@ -37,27 +43,35 @@ function spawnGit(deps: CaptureTreeStateDeps, args: string[], workdir: string): 
 }
 
 async function spawnWithTimeout(proc: SpawnedProc, timeoutMs: number): Promise<{ stdout: string; exitCode: number }> {
-  const result = await Promise.race([
-    (async () => {
-      const [exitCode, stdout] = await Promise.all([
-        proc.exited,
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      return { stdout, exitCode };
-    })(),
-    new Promise<{ stdout: string; exitCode: number }>((resolve) =>
-      setTimeout(() => {
-        try {
-          proc.kill("SIGKILL");
-        } catch {
-          // ignore kill failure
-        }
-        resolve({ stdout: "", exitCode: 1 });
-      }, timeoutMs),
-    ),
-  ]);
-  return result;
+  // VER-4/EXEC-6: the losing side of this race must be cleared, or a timer
+  // that never fires (git won) still holds the event loop and later
+  // SIGKILLs an already-exited pid.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      (async () => {
+        const [exitCode, stdout] = await Promise.all([
+          proc.exited,
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        return { stdout, exitCode };
+      })(),
+      new Promise<{ stdout: string; exitCode: number }>((resolve) => {
+        timer = setTimeout(() => {
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            // ignore kill failure
+          }
+          resolve({ stdout: "", exitCode: 1 });
+        }, timeoutMs);
+      }),
+    ]);
+    return result;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -8,7 +8,7 @@
  * - Update final status
  */
 
-import { purgeStaleManifests } from "@/context/engine";
+import { _resetCanonicalRulesCache, purgeStaleManifests } from "@/context/engine";
 import { pipelineEventBus } from "@/pipeline";
 import { resolveDefaultAgent } from "../../agents";
 import type { IAgentManager } from "../../agents";
@@ -418,6 +418,11 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   clearLanguageCache();
   clearWorkspaceCache();
   clearGitRootCache();
+  // CTX-2: canonical-rules memoization joins the same per-run-cache-clear
+  // convention as the caches above — without this, a long-lived in-process
+  // consumer (embedded TUI, watch mode) would keep serving the first run's
+  // .nax/rules/ content to every subsequent run in the same process.
+  _resetCanonicalRulesCache();
 
   // Compute final story counts before emitting completion event (RL-002)
   const finalCounts = countStories(prd);
@@ -550,7 +555,11 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
           ? "completed"
           : isStalled(prd, config.execution.rectification?.maxAttemptsTotal)
             ? "stalled"
-            : "running",
+            : // The run has stopped (this is the completion phase) with stories
+              // still pending but not stalled — e.g. exitReason "pre-merge-aborted",
+              // "max-iterations", "no-stories". "running" would leave status.json
+              // claiming the (now-dead) PID is still live (EXEC-1).
+              "aborted",
   );
   await statusWriter.update(reportedTotal, iterations);
 

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -368,6 +368,13 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
   if (!lockAcquired) {
     logger?.error("execution", "Another nax process is already running in this directory");
     logger?.error("execution", "If you believe this is an error, remove nax.lock manually");
+    // EXEC-2: installCrashHandlers ran above, before lock acquisition. This
+    // throw is outside the try/finally below (whose finally calls
+    // cleanupCrashHandlers), so without this call the SIGTERM/SIGINT/
+    // uncaughtException handlers stay installed — bound to a StatusWriter
+    // for a run that never started — for the lifetime of the process (e.g.
+    // in-process consumers like tests or an embedded TUI).
+    cleanupCrashHandlers();
     throw new LockAcquisitionError(workdir);
   }
 

--- a/src/execution/queue-handler.ts
+++ b/src/execution/queue-handler.ts
@@ -147,7 +147,17 @@ export async function processQueueFile<T>(
       if (commands === null) return undefined;
 
       const result = await processor(commands);
-      await unlink(processingPath).catch(() => {});
+      // EXEC-3: an unlink failure here (permission, transient FS error, AV
+      // lock) must not be silently swallowed — a leftover
+      // .queue.txt.processing makes the next run's claimCommandsLocked
+      // re-apply this already-processed batch, exactly the double-apply
+      // BUG-11 built this function to eliminate.
+      await unlink(processingPath).catch((error) => {
+        logger?.warn("queue", "Failed to clear processed queue file — next run may re-apply this batch", {
+          error: (error as Error).message,
+          processingPath,
+        });
+      });
       return result;
     });
   } catch (error) {

--- a/src/execution/status-file.ts
+++ b/src/execution/status-file.ts
@@ -74,7 +74,7 @@ export interface NaxStatusFile {
     /** ISO 8601 start timestamp */
     startedAt: string;
     /** Current run status */
-    status: "running" | "completed" | "failed" | "stalled" | "crashed" | "precheck-failed" | "cost-limit";
+    status: "running" | "completed" | "failed" | "stalled" | "crashed" | "precheck-failed" | "cost-limit" | "aborted";
     /** Whether this is a dry run */
     dryRun: boolean;
     /** Process ID for crash detection */

--- a/src/execution/story-orchestrator/execution-plan.ts
+++ b/src/execution/story-orchestrator/execution-plan.ts
@@ -1,3 +1,4 @@
+import { NaxError } from "@/errors";
 import type { Finding } from "@/findings";
 import { getSafeLogger } from "@/logger";
 import type { CallContext } from "@/operations";
@@ -164,7 +165,28 @@ export class ExecutionPlan {
         });
       } else {
         const currentTree = await _storyOrchestratorDeps.captureTreeState(this.ctx.packageDir);
-        await _storyOrchestratorDeps.recordGreen(this.ctx.storyId, name, currentTree);
+        try {
+          await _storyOrchestratorDeps.recordGreen(this.ctx.storyId, name, currentTree);
+        } catch (error) {
+          // EXEC-9: recordGreen's CHECKPOINT_WRITE_FAILED (disk full, permission)
+          // is an infra failure, not a verdict on the phase that just genuinely
+          // passed. The story verdict (phasePassed above) is the SSOT — losing a
+          // resume checkpoint costs a full rerun on resume, which is recoverable;
+          // escalating the story through paid tiers for an infra error is not.
+          if (error instanceof NaxError && error.code === "CHECKPOINT_WRITE_FAILED") {
+            logger?.warn(
+              "story-orchestrator",
+              "recordGreen failed — resume checkpoint lost, story verdict unaffected",
+              {
+                storyId: this.ctx.storyId,
+                phase: name,
+                error: errorMessage(error),
+              },
+            );
+          } else {
+            throw error;
+          }
+        }
       }
     }
 

--- a/src/interaction/plugins/telegram-format.ts
+++ b/src/interaction/plugins/telegram-format.ts
@@ -99,9 +99,9 @@ function buildCallbackData(id: string, suffix: string): string {
 export function buildHeader(request: InteractionRequest): string {
   const emoji = getStageEmoji(request.stage);
   let text = `${emoji} *${request.stage.toUpperCase()}*\n`;
-  text += `*Feature:* ${request.featureName}\n`;
+  text += `*Feature:* ${sanitizeMarkdown(request.featureName)}\n`;
   if (request.storyId) {
-    text += `*Story:* ${request.storyId}\n`;
+    text += `*Story:* ${sanitizeMarkdown(request.storyId)}\n`;
   }
   text += "\n";
   return text;

--- a/src/interaction/plugins/telegram.ts
+++ b/src/interaction/plugins/telegram.ts
@@ -232,8 +232,9 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   }
 
   async cancel(requestId: string): Promise<void> {
-    await this.sendTimeoutMessage(requestId);
+    const pending = this.pendingMessages.get(requestId);
     this.resolveReceiver(requestId, "skip", "timeout");
+    void this.sendTimeoutMessage(requestId, pending);
   }
 
   private ensurePoller(): void {
@@ -290,8 +291,13 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   }
 
   private async expireReceiver(requestId: string): Promise<void> {
-    await this.sendTimeoutMessage(requestId);
+    // Snapshot the pending message before resolving clears it out of
+    // pendingMessages, then resolve immediately — a hung network must not
+    // delay the interaction result past the configured deadline. The edit
+    // below is fire-and-forget best-effort cleanup.
+    const pending = this.pendingMessages.get(requestId);
     this.resolveReceiver(requestId, "skip", "timeout");
+    void this.sendTimeoutMessage(requestId, pending);
   }
 
   private resolveReceiver(requestId: string, action: InteractionResponse["action"], respondedBy: string): void {
@@ -526,10 +532,18 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
   }
 
   /**
-   * Edit message to show timeout/expired
+   * Edit message to show timeout/expired.
+   *
+   * Callers on the timeout/cancel path snapshot `pending` before resolving
+   * the receiver (which clears pendingMessages) and pass it in here, since
+   * this call is fire-and-forget and must not block resolution on a
+   * potentially-hung network (TEL-1).
    */
-  private async sendTimeoutMessage(requestId: string): Promise<void> {
-    const pending = this.pendingMessages.get(requestId);
+  private async sendTimeoutMessage(
+    requestId: string,
+    pendingArg?: { type: InteractionRequest["type"]; ids: number[] },
+  ): Promise<void> {
+    const pending = pendingArg ?? this.pendingMessages.get(requestId);
     if (!pending || !this.botToken || !this.chatId) {
       this.pendingMessages.delete(requestId);
       return;
@@ -538,16 +552,23 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
     // Edit only the last message to avoid redundant notifications
     const lastId = pending.ids[pending.ids.length - 1];
     try {
-      await _telegramPluginDeps.fetch(`https://api.telegram.org/bot${this.botToken}/editMessageText`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          chat_id: this.chatId,
-          message_id: lastId,
-          text: "⏱ EXPIRED — Interaction timed out",
-          reply_markup: { inline_keyboard: [] }, // Remove buttons so expired interactions can't be re-tapped
-        }),
-      });
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), CALLBACK_API_TIMEOUT_MS);
+      try {
+        await _telegramPluginDeps.fetch(`https://api.telegram.org/bot${this.botToken}/editMessageText`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chat_id: this.chatId,
+            message_id: lastId,
+            text: "⏱ EXPIRED — Interaction timed out",
+            reply_markup: { inline_keyboard: [] }, // Remove buttons so expired interactions can't be re-tapped
+          }),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
     } catch {
       // Non-critical - fire-and-forget, no logging needed
     } finally {

--- a/src/interaction/plugins/webhook-serve-compat.ts
+++ b/src/interaction/plugins/webhook-serve-compat.ts
@@ -14,6 +14,17 @@ type ServeCompatReturn = ReturnType<typeof Bun.serve>;
 const PORT_ZERO_COMPAT_BASE = 40_000;
 const PORT_ZERO_COMPAT_SPAN = 20_000;
 
+/**
+ * WEB-1: the only requests this shim needs to intercept are nax's own
+ * webhook-interaction callbacks. Matching on port alone routes EVERY
+ * in-process fetch() through the interceptor — plugins, libraries, the OTLP
+ * exporter pointed at localhost:4318 — and the compat port span
+ * (40_000-59_999) overlaps exactly where users run dev servers, so a real
+ * service on a registered port would be silently shadowed. Path-prefix
+ * matching narrows the intercept to nax's own callback route.
+ */
+const CALLBACK_PATH_PREFIX = "/nax/interact/";
+
 let servePortZeroCompatInstalled = false;
 let servePortZeroCounter = 0;
 const inMemoryServers = new Map<number, { fetch: (request: Request) => Response | Promise<Response> }>();
@@ -91,7 +102,11 @@ export function installServePortZeroCompat(): void {
       input instanceof Request ? input : new Request(input instanceof URL ? input.toString() : input, init);
     const url = new URL(request.url);
     const port = Number.parseInt(url.port, 10);
-    if ((url.hostname === "localhost" || url.hostname === "127.0.0.1") && inMemoryServers.has(port)) {
+    if (
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1") &&
+      url.pathname.startsWith(CALLBACK_PATH_PREFIX) &&
+      inMemoryServers.has(port)
+    ) {
       const server = inMemoryServers.get(port);
       if (!server) {
         return new Response("Not Found", { status: 404 });

--- a/src/logger/redact.ts
+++ b/src/logger/redact.ts
@@ -22,9 +22,14 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   /sk-[A-Za-z0-9_-]{16,}/g,
   /ghp_[A-Za-z0-9]{16,}/g,
   /gh[opsu]_[A-Za-z0-9]{16,}/g,
+  // LOG-1: GitHub fine-grained PATs — gh[opsu]_ above never matches "github_pat_"
+  // ("gh" + "i" is not one of [opsu]).
+  /github_pat_[A-Za-z0-9_]{20,}/g,
   /npm_[A-Za-z0-9]{8,}/g,
   /AKIA[0-9A-Z]{16}/g,
   /xox[baprs]-[A-Za-z0-9-]{10,}/g,
+  // LOG-1: Telegram bot tokens ("<bot-id>:<35-char secret>").
+  /\b\d{6,}:[A-Za-z0-9_-]{30,}\b/g,
   // KEY=value assignments inside strings (e.g. "NPM_TOKEN=somevalue")
   /(?:SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)=[^\s"',]+/gi,
   // MED-01: PEM-encoded key/cert blocks (private keys, certificates, incl.
@@ -45,7 +50,17 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   // essentially never do. Length floor kept at 8 (not raised to 16) so
   // short-but-real base64 credentials (e.g. "user:pass" -> ~16 raw chars,
   // shorter inputs shorter still) aren't under-redacted.
-  /\b(?:Bearer|Basic)\s+(?=[A-Za-z0-9\-._~+/]*[0-9+/_-])[A-Za-z0-9\-._~+/]{8,}={0,2}/gi,
+  /\bBearer\s+(?=[A-Za-z0-9\-._~+/]*[0-9+/_-])[A-Za-z0-9\-._~+/]{8,}={0,2}/gi,
+  // LOG-1: Basic creds are base64(user:pass) and are frequently pure-alphabetic
+  // (no digit/symbol), which the digit-requiring lookahead above misses. Require
+  // mixed case instead — real base64 output almost always mixes upper/lower,
+  // while English prose like "Basic authentication" does not. No `i` flag here
+  // (unlike Bearer): case-insensitivity would make [A-Z]/[a-z] equivalent,
+  // defeating the mixed-case check — so the "basic" keyword is spelled out
+  // char-by-char to stay case-insensitive for the scheme name only (the
+  // scheme is case-insensitive per RFC 7617; "basic"/"BASIC" are as valid as
+  // "Basic") while the payload lookaheads remain case-sensitive.
+  /\b[Bb][Aa][Ss][Ii][Cc]\s+(?=[A-Za-z0-9+/]*[A-Z])(?=[A-Za-z0-9+/]*[a-z])[A-Za-z0-9+/]{8,}={0,2}/g,
   // MED-01: header-style key:value / key=value pairs for api-key headers
   // that SECRET_KEY_PATTERN's object-key check can't reach because the
   // key/value are both embedded in one free-text string (e.g. raw HTTP logs).

--- a/src/plugins/builtin/otel-reporter/batch-queue.ts
+++ b/src/plugins/builtin/otel-reporter/batch-queue.ts
@@ -36,6 +36,12 @@ export function createBatchQueue<T>(opts: BatchQueueOptions<T>): BatchQueue<T> {
   let overflowing = false;
   let tornDown = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  // OTLP-1: doFlush() is deliberately fire-and-forget for the periodic timer
+  // and the maxBatchSize auto-flush (a hung send must never block those), but
+  // flushNow()/teardown() need to know when the network call actually
+  // settles — track every detached send so they can wait on it, bounded by
+  // send()'s own retry/timeout budget.
+  const inFlightSends = new Set<Promise<void>>();
 
   const armTimer = (): void => {
     // forbidden-patterns.md: setInterval is banned; setTimeout is permitted here
@@ -57,15 +63,15 @@ export function createBatchQueue<T>(opts: BatchQueueOptions<T>): BatchQueue<T> {
     }
   };
 
-  // Dispatch is fire-and-forget: flushNow() resolves once the current batch has
-  // been dequeued and handed to `send`, not once the network call (plus its
-  // retry) settles. This lets an in-flight send that never resolves (e.g. a
-  // hung connection) never block a caller awaiting flushNow().
+  // Dequeue is synchronous/immediate; the network send is dispatched
+  // detached (tracked in inFlightSends) so periodic/auto-flush callers never
+  // block on it. flushNow() awaits the tracked set explicitly instead.
   const doFlush = (): Promise<void> => {
     if (tornDown || queue.length === 0) return Promise.resolve();
     const batch = queue;
     queue = [];
-    void sendWithRetry(batch);
+    const sendPromise = sendWithRetry(batch).finally(() => inFlightSends.delete(sendPromise));
+    inFlightSends.add(sendPromise);
     return Promise.resolve();
   };
 
@@ -90,7 +96,12 @@ export function createBatchQueue<T>(opts: BatchQueueOptions<T>): BatchQueue<T> {
 
   return {
     enqueue,
-    flushNow: () => doFlush(),
+    flushNow: async () => {
+      await doFlush();
+      // OTLP-1: wait for every in-flight send (this one plus any still
+      // settling from an earlier auto-flush), not just the dequeue.
+      await Promise.all(inFlightSends);
+    },
     teardown: () => {
       tornDown = true;
       if (timer !== undefined) clearTimeout(timer);

--- a/src/utils/jsonl-tail.ts
+++ b/src/utils/jsonl-tail.ts
@@ -1,0 +1,24 @@
+/**
+ * CTX-3: bounded tail-read for append-only JSONL scratch files.
+ *
+ * scratch.jsonl grows for the whole run (every verify/rectify/TDD/lint
+ * result), and only the most-recent-N entries are ever rendered. Reading and
+ * parsing the entire file on every `fetch()` (multiple times per story) made
+ * per-assembly cost grow linearly with run progress. This reads only the
+ * last `maxBytes` and drops a possibly-torn first line.
+ */
+
+/** Default tail window — generous for the ~20-entry caps callers apply on top. */
+export const DEFAULT_JSONL_TAIL_BYTES = 65_536;
+
+export async function readJsonlTail(path: string, maxBytes: number = DEFAULT_JSONL_TAIL_BYTES): Promise<string> {
+  const file = Bun.file(path);
+  const size = file.size;
+  if (size <= maxBytes) return file.text();
+
+  const tail = await file.slice(size - maxBytes).text();
+  const newlineIndex = tail.indexOf("\n");
+  // No newline in the tail window at all — the whole window is one torn
+  // line; nothing usable to return.
+  return newlineIndex === -1 ? "" : tail.slice(newlineIndex + 1);
+}

--- a/src/verification/executor.ts
+++ b/src/verification/executor.ts
@@ -208,11 +208,42 @@ export function appendForceExitFlag(command: string): string {
 
 /**
  * Append a flag to a command, inserting before any pipe/redirect.
+ *
+ * Quote-aware: a `|`/`>` inside a single- or double-quoted argument is not a
+ * split point. A `>` immediately preceded by a fd number (e.g. `2>&1`) is
+ * treated as part of the redirect token, so the flag is inserted before the
+ * whole `N>` sequence rather than in the middle of it.
  */
 function appendFlag(command: string, flag: string): string {
-  const pipeIndex = command.search(/[|>]/);
-  if (pipeIndex > 0) {
-    return `${command.slice(0, pipeIndex).trimEnd()} ${flag} ${command.slice(pipeIndex)}`;
+  let quote: string | null = null;
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === "|" || char === ">") {
+      let splitIndex = i;
+      if (char === ">") {
+        // A digit run before `>` is only an fd number (e.g. `2>&1`) when it is
+        // a standalone token — preceded by whitespace, start-of-string, or a
+        // shell operator. Digits glued onto a longer word (e.g. `file123>out`)
+        // are part of that word, not an fd: real shells treat `file123>out`
+        // as the single argument "file123" followed by a plain redirect, not
+        // as fd 123.
+        let digitStart = splitIndex;
+        while (digitStart > 0 && /[0-9]/.test(command[digitStart - 1] ?? "")) digitStart--;
+        const charBeforeDigits = command[digitStart - 1];
+        const isStandaloneFdToken =
+          digitStart < splitIndex && (digitStart === 0 || /[\s|;&]/.test(charBeforeDigits ?? ""));
+        if (isStandaloneFdToken) splitIndex = digitStart;
+      }
+      return `${command.slice(0, splitIndex).trimEnd()} ${flag} ${command.slice(splitIndex)}`;
+    }
   }
   return `${command} ${flag}`;
 }

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -353,6 +353,49 @@ function buildTestCandidates(
 // breaking scoped runs like `pnpm --filter ./packages/api test`.
 const PATH_TAKING_FLAGS = ["--config", "-c", "--project", "-p", "--filter", "--dir", "-F"];
 
+/**
+ * VER-2: quote-aware split of a shell command line into tokens. Preserves
+ * each token's raw text (quotes included) so `parts.join(" ")` reconstructs
+ * an equivalent command; a plain `split(/\s+/)` breaks any argument
+ * containing whitespace inside quotes (e.g. `"test dir/"`) into multiple
+ * bogus parts.
+ */
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  for (const char of command.trim()) {
+    if (quote) {
+      current += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+/** Strips one layer of matching surrounding quotes, for content inspection only. */
+function unquote(token: string): string {
+  if (token.length >= 2 && (token[0] === '"' || token[0] === "'") && token[token.length - 1] === token[0]) {
+    return token.slice(1, -1);
+  }
+  return token;
+}
+
 export function buildSmartTestCommand(testFiles: string[], baseCommand: string): string {
   if (testFiles.length === 0) {
     return baseCommand;
@@ -361,15 +404,16 @@ export function buildSmartTestCommand(testFiles: string[], baseCommand: string):
   const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
   const quotedTestFiles = testFiles.map(shellQuote);
 
-  const parts = baseCommand.trim().split(/\s+/);
+  const parts = tokenizeCommand(baseCommand);
 
   // Find the last token that looks like a path (contains '/') and is a
   // genuinely positional argument — not the value of a path-taking flag.
   let lastPathIndex = -1;
   for (let i = parts.length - 1; i >= 0; i--) {
-    if (!parts[i].includes("/")) continue;
-    const precededByPathFlag = i > 0 && PATH_TAKING_FLAGS.includes(parts[i - 1]);
-    const isCombinedFlagValue = PATH_TAKING_FLAGS.some((flag) => parts[i].startsWith(`${flag}=`));
+    const bare = unquote(parts[i]);
+    if (!bare.includes("/")) continue;
+    const precededByPathFlag = i > 0 && PATH_TAKING_FLAGS.includes(unquote(parts[i - 1]));
+    const isCombinedFlagValue = PATH_TAKING_FLAGS.some((flag) => bare.startsWith(`${flag}=`));
     if (precededByPathFlag || isCombinedFlagValue) continue;
     lastPathIndex = i;
     break;

--- a/test/unit/execution/checkpoint/resume-hydrate.test.ts
+++ b/test/unit/execution/checkpoint/resume-hydrate.test.ts
@@ -285,12 +285,16 @@ describe("captureTreeState (AC8)", () => {
     // unkillable git subprocess. Every other git call in the project routes
     // through `gitWithTimeout` (src/utils/git.ts:45, GIT_TIMEOUT_MS=10_000)
     // which enforces a SIGKILL deadline. This test asserts the same invariant
-    // via an unresolvable proc — the helper must return within a small
-    // budget. The 200 ms ceiling is far below GIT_TIMEOUT_MS because the
-    // helper either runs its own kill timer (true positive) or hangs forever
-    // and the test's own timeout trips (true negative). With the source fix,
-    // the helper's internal timeout-aborted proc.exited resolves and the
-    // outer Promise.all completes; without it, this test times out.
+    // via an unresolvable proc — the helper must return within a bounded
+    // budget. captureTreeState makes two sequential git calls before the hung
+    // status hides the diff calls (rev-parse HEAD, then status --porcelain),
+    // each bounded by TREE_CAPTURE_TIMEOUT_MS (1000ms — VER-4 raised this
+    // from 75ms), so up to ~2000ms is expected; the race ceiling gives
+    // headroom above that. Either the helper runs its own kill timer (true
+    // positive) or hangs forever and the test's own timeout trips (true
+    // negative). With the source fix, the helper's internal timeout-aborted
+    // proc.exited resolves and the outer Promise.all completes; without it,
+    // this test times out.
     let killCalls = 0;
     _gitDeps.spawn = mock((_args: string[]) => {
       // proc.exited NEVER resolves — the hung-process scenario.
@@ -318,10 +322,11 @@ describe("captureTreeState (AC8)", () => {
     // default per-test timeout is much larger, so the runner will report
     // the test as failed rather than deadlocking the suite). The race
     // gives us a deterministic failure mode even if the fix is missing.
+    const RACE_CEILING_MS = 2500;
     const timedCapture = async (): Promise<TreeState | "TIMEOUT"> => {
       return Promise.race<Promise<TreeState> | Promise<"TIMEOUT">>([
         captureTreeState(tempDir!, { _deps: _gitDeps }),
-        new Promise<"TIMEOUT">((resolve) => setTimeout(() => resolve("TIMEOUT"), 200)),
+        new Promise<"TIMEOUT">((resolve) => setTimeout(() => resolve("TIMEOUT"), RACE_CEILING_MS)),
       ]);
     };
     const result = await timedCapture();
@@ -337,7 +342,7 @@ describe("captureTreeState (AC8)", () => {
     }
     // Belt-and-braces: directly bound the elapsed time, even if the helper
     // resolves correctly today but starts hanging tomorrow.
-    expect(elapsed).toBeLessThan(500);
+    expect(elapsed).toBeLessThan(RACE_CEILING_MS);
 
     // Source-level invariant: the helper must call kill on hung procs
     // exactly the same way gitWithTimeout does (one signal per proc). With

--- a/test/unit/logger/redact.test.ts
+++ b/test/unit/logger/redact.test.ts
@@ -92,6 +92,36 @@ describe("redactSecrets", () => {
       expect(out.output).toContain("[REDACTED]");
     });
 
+    // LOG-1 regression: splitting the combined Bearer|Basic pattern into two
+    // (to keep the mixed-case payload heuristic case-sensitive) must not
+    // lose case-insensitivity on the "Basic" scheme keyword itself — the
+    // scheme name is case-insensitive per RFC 7617.
+    test("redacts a Basic authorization header regardless of scheme-name casing", () => {
+      const lower = redactSecrets({ output: "Authorization: basic dXNlcjpwYXNzd29yZA==" }) as any;
+      expect(lower.output).not.toContain("dXNlcjpwYXNzd29yZA==");
+      expect(lower.output).toContain("[REDACTED]");
+
+      const upper = redactSecrets({ output: "Authorization: BASIC dXNlcjpwYXNzd29yZA==" }) as any;
+      expect(upper.output).not.toContain("dXNlcjpwYXNzd29yZA==");
+      expect(upper.output).toContain("[REDACTED]");
+    });
+
+    // LOG-1: gh[opsu]_ never matches "github_pat_" ("gh" + "i" is not one of [opsu]).
+    test("redacts a GitHub fine-grained PAT (github_pat_...)", () => {
+      const token = `github_pat_${"A".repeat(22)}_${"B".repeat(59)}`;
+      const out = redactSecrets({ output: `token: ${token}` }) as any;
+      expect(out.output).not.toContain(token);
+      expect(out.output).toContain("[REDACTED]");
+    });
+
+    // LOG-1: Telegram bot tokens ("<bot-id>:<secret>") had no dedicated pattern.
+    test("redacts a Telegram bot token", () => {
+      const token = "123456789:AAHfj93kdLp2mZ8xQvN4rT6yU1wX0sB7cD-EfG";
+      const out = redactSecrets({ output: `bot token: ${token}` }) as any;
+      expect(out.output).not.toContain(token);
+      expect(out.output).toContain("[REDACTED]");
+    });
+
     test("redacts an x-api-key header captured in free text", () => {
       const out = redactSecrets({ output: "x-api-key: abcd1234efgh5678" }) as any;
       expect(out.output).not.toContain("abcd1234efgh5678");

--- a/test/unit/plugins/builtin/otel-batch-queue.test.ts
+++ b/test/unit/plugins/builtin/otel-batch-queue.test.ts
@@ -212,7 +212,12 @@ describe("createBatchQueue", () => {
     // not silently folded into the in-flight batch
     expect(calls).toHaveLength(1);
 
-    await queue.flushNow();
+    // OTLP-1: flushNow() now awaits the in-flight send, so the second send
+    // must be resolved concurrently or this await never settles.
+    const secondFlush = queue.flushNow();
+    await waitForCondition(() => calls.length === 2, 1_000, 10);
+    pending[1]?.(true);
+    await secondFlush;
     expect(calls).toHaveLength(2);
     expect(calls[1]).toEqual([{ id: "span-in-flight" }]);
   });

--- a/test/unit/verification/executor.test.ts
+++ b/test/unit/verification/executor.test.ts
@@ -10,7 +10,35 @@
 
 import { describe, expect, test } from "bun:test";
 import { withTimerSpy } from "@test/helpers";
-import { executeWithTimeout, normalizeEnvironment } from "@/verification";
+import { appendForceExitFlag, executeWithTimeout, normalizeEnvironment } from "@/verification";
+
+describe("appendForceExitFlag (VER-1)", () => {
+  test("inserts before a pipe, not inside the redirect tail", () => {
+    expect(appendForceExitFlag("bun test 2>&1 | tee out")).toBe("bun test --forceExit 2>&1 | tee out");
+  });
+
+  test("inserts before a fd-redirect chain (> log 2>&1)", () => {
+    expect(appendForceExitFlag("bun test > log 2>&1")).toBe("bun test --forceExit > log 2>&1");
+  });
+
+  test("does not split on a pipe inside a quoted argument", () => {
+    expect(appendForceExitFlag("bun test -t 'a|b'")).toBe("bun test -t 'a|b' --forceExit");
+  });
+
+  test("does not split a filename that happens to end in digits before a redirect", () => {
+    // Regression: a naive "back up over any preceding digits" rule treats the
+    // "123" in "file123" as if it were a standalone fd number (like the "2" in
+    // "2>&1"), splitting the argument into "file" and "123". Real shells only
+    // treat a digit run as an fd number when it is its own token (preceded by
+    // whitespace/start-of-string/an operator) — verified against bash directly:
+    // `echo file123>out.txt` writes "file123" to out.txt, not to fd 123.
+    expect(appendForceExitFlag("bun test file123>out.txt")).toBe("bun test file123 --forceExit >out.txt");
+  });
+
+  test("appends at the end when there is no pipe or redirect", () => {
+    expect(appendForceExitFlag("bun test")).toBe("bun test --forceExit");
+  });
+});
 
 describe("normalizeEnvironment", () => {
   test("strips AI-optimized env vars by default", () => {


### PR DESCRIPTION
## Summary

Fixes all 4 HIGH and 15 MEDIUM findings from `docs/20260816-review-nax.md`.

**HIGH**
- `VER-1` — `appendFlag` no longer corrupts commands with quoted args or fd redirects (`2>&1`, `-t 'a|b'`) on the timeout-retry path
- `TEL-1` — Telegram `sendTimeoutMessage` has its own timeout and no longer blocks receiver resolution on a hung network
- `TEL-2` — `buildHeader` sanitizes `featureName`/`storyId` before Markdown send
- `CTX-1` — `globToRegex` no longer over-matches outside its declared glob

**MEDIUM**
- `LOG-1` — redaction covers `github_pat_` tokens, Telegram bot tokens, and case-insensitive Basic-auth
- `EXEC-1` — terminal `"aborted"` status instead of a stale `"running"` fallback
- `EXEC-3` — queue `.processing` unlink failures are logged, not swallowed
- `CFG-1` — per-package config rejects an unimplemented permissions block
- `CFG-2/3/4` — `$VAR`/`${VAR}` resolution wired into every config layer; `parseDotenv` handles inline comments, `export "KEY=value"`, and escapes
- `VER-2` — quote-aware tokenizer in `buildSmartTestCommand`
- `VER-4/EXEC-6` — git tree-capture timer leak fixed, budget 75ms → 1s
- `OTLP-1` — `flushNow()`/`teardown()` actually await in-flight sends
- `WEB-1` — fetch-shim interception scoped to `/nax/interact/` path prefix
- `EXEC-2` — crash handlers cleaned up on lock-acquisition failure
- `EXEC-9` — checkpoint `recordGreen` infra failures swallow-and-warn instead of failing the story
- `CLI-1` — `runSetupGate` uses the shared timeout-enforced `runQualityCommand`
- `CTX-2/3/4/5/6/7` — context-engine memoization, tail-reads, diagnostics cap, locale-independent digest ordering, cache-race fixes, monorepo-aware auto-detect

A self-review of this branch caught and fixed 3 additional bugs introduced by the fixes above:
- `appendFlag` was splitting filenames ending in digits before a redirect (e.g. `file123>out.txt`) — verified against real bash behavior and fixed to only treat a standalone digit token as an fd number
- The Basic-auth redaction regex split lost case-insensitivity on the scheme keyword ("basic"/"BASIC" stopped being redacted)
- The new canonical-rules cache was never cleared alongside its sibling per-run caches in `run-completion.ts`, risking stale rules in long-lived in-process consumers (embedded TUI, watch mode)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (Biome + 20+ custom check scripts) — clean
- [x] `bun test test/unit` — 13,647 pass, 0 fail
- [x] `bun test test/integration` — 1,124 pass, 0 fail
- [x] Added regression tests: `appendForceExitFlag` quote/redirect/digit-boundary cases (none existed before), Basic-auth case-insensitivity + `github_pat_` + Telegram-token redaction, plus updated two pre-existing tests that encoded the old buggy behavior (`otel-batch-queue` fire-and-forget flush, `resume-hydrate` 75ms timeout assumption)