### PR TITLE
feat(init): scaffold .naxignore and reconcile ignore files idempotently

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -143,175 +143,21 @@ program
       process.exit(1);
     }
 
-    // --package: scaffold per-package nax/context.md only
-    if (options.package) {
-      const { initPackage: initPkg } = await import("../src/cli/init-context");
-      try {
-        await initPkg(workdir, options.package, options.force);
-        console.log(chalk.green("\n[OK] Package scaffold created."));
-        console.log(chalk.dim(`  Created: ${options.package}/nax/context.md`));
-        console.log(chalk.dim(`\nNext: nax generate --package ${options.package}`));
-      } catch (err) {
-        console.error(chalk.red(`Error: ${(err as Error).message}`));
-        process.exit(1);
-      }
-      return;
-    }
-
-    const naxDir = join(workdir, ".nax");
-
-    if (existsSync(naxDir) && !options.force) {
-      console.log(chalk.yellow("nax already initialized. Use --force to overwrite."));
-      return;
-    }
-
-    // Validate and collision-check --name when explicitly provided
-    if (options.name) {
-      const { validateProjectName, checkInitCollision } = await import("../src/cli/init");
-      const nameValidation = validateProjectName(options.name);
-      if (!nameValidation.valid) {
-        console.error(chalk.red(`Invalid project name "${options.name}": ${nameValidation.error}`));
-        process.exit(1);
-      }
-      if (!options.force) {
-        const collision = await checkInitCollision(options.name, workdir, null);
-        if (collision.collision && collision.existing) {
-          console.error(
-            chalk.red(
-              [
-                `Project name collision: "${options.name}"`,
-                `  This project:    ${workdir}`,
-                `  Already in use:  ${collision.existing.workdir}  (last run: ${collision.existing.lastSeen})`,
-                "  Resolve:",
-                "    1. Rename: choose a different --name",
-                `    2. Reclaim: nax migrate --reclaim ${options.name}`,
-                `    3. Merge:   nax migrate --merge ${options.name}`,
-              ].join("\n"),
-            ),
-          );
-          process.exit(1);
-        }
-      }
-    }
-
-    // Create directory structure
-    mkdirSync(join(naxDir, "features"), { recursive: true });
-    mkdirSync(join(naxDir, "hooks"), { recursive: true });
-
-    // Write config (include name when explicitly provided)
-    const initConfig = options.name ? { ...DEFAULT_CONFIG, name: options.name } : DEFAULT_CONFIG;
-    await Bun.write(join(naxDir, "config.json"), JSON.stringify(initConfig, null, 2));
-
-    // Write default hooks.json
-    await Bun.write(
-      join(naxDir, "hooks.json"),
-      JSON.stringify(
-        {
-          hooks: {
-            "on-start": { command: 'echo "nax started: $NAX_FEATURE"', enabled: false },
-            "on-complete": { command: 'echo "nax complete: $NAX_FEATURE"', enabled: false },
-            "on-pause": { command: 'echo "nax paused: $NAX_REASON"', enabled: false },
-            "on-error": { command: 'echo "nax error: $NAX_REASON"', enabled: false },
-          },
-        },
-        null,
-        2,
-      ),
-    );
-
-    // Write .gitignore
-    await Bun.write(join(naxDir, ".gitignore"), "# nax temp files\n*.tmp\n.paused.json\n.nax-verifier-verdict.json\n");
-
-    // Write starter context.md
-    await Bun.write(
-      join(naxDir, "context.md"),
-      `# Project Context
-
-This document defines coding standards, architectural decisions, and forbidden patterns for this project.
-Run \`nax generate\` to regenerate agent config files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) from this file.
-
-> Project metadata (dependencies, commands) is auto-injected by \`nax generate\`.
-
-## Coding Standards
-
-- Follow the project's existing code style and conventions
-- Write clear, self-documenting code with meaningful names
-- Keep functions small and focused (single responsibility)
-- Prefer immutability over mutation
-- Use consistent formatting throughout the codebase
-
-## Testing Requirements
-
-- All new code must include tests
-- Tests should cover happy paths, edge cases, and error conditions
-- Aim for high test coverage (80%+ recommended)
-- Tests must pass before marking a story as complete
-- Before writing tests, read existing test files to understand what is already covered
-- Do not duplicate test coverage that prior stories already wrote
-- Focus on testing NEW behavior introduced by this story
-
-## Architecture Rules
-
-- Follow the project's existing architecture patterns
-- Each module should have a clear, single purpose
-- Avoid tight coupling between modules
-- Use dependency injection where appropriate
-- Document architectural decisions in comments or docs
-
-## Forbidden Patterns
-
-- No hardcoded secrets, API keys, or credentials
-- No console.log in production code (use proper logging)
-- No \`any\` types in TypeScript (use proper typing)
-- No commented-out code (use version control instead)
-- No large files (split into smaller, focused modules)
-
-## Commit Standards
-
-- Write clear, descriptive commit messages
-- Follow conventional commits format (feat:, fix:, refactor:, etc.)
-- Commit early and often with atomic changes
-- Reference story IDs in commit messages
-
-## Documentation
-
-- Add JSDoc comments for public APIs
-- Update README when adding new features
-- Document complex algorithms or business logic
-- Keep documentation up-to-date with code changes
-
----
-
-**Note:** Customize this file to match your project's specific needs.
-`,
-    );
-
-    // Initialize prompt templates (final step, don't auto-wire config)
+    // All scaffolding lives in src/cli/init.ts — this action is wiring only.
+    // Init is idempotent: existing config/context files are preserved (unless
+    // --force), while .gitignore and .naxignore are reconciled on every run.
+    const { initCommand } = await import("../src/cli/init");
     try {
-      await promptsInitCommand({
-        workdir,
+      await initCommand({
+        projectRoot: workdir,
+        name: options.name,
         force: options.force,
-        autoWireConfig: false,
+        package: options.package,
       });
     } catch (err) {
-      console.error(chalk.red(`Failed to initialize templates: ${(err as Error).message}`));
+      console.error(chalk.red(`Error: ${(err as Error).message}`));
       process.exit(1);
     }
-
-    console.log(chalk.green("✅ Initialized nax"));
-    console.log(chalk.dim(`   ${naxDir}/`));
-    console.log(chalk.dim("   ├── config.json"));
-    console.log(chalk.dim("   ├── context.md"));
-    console.log(chalk.dim("   ├── hooks.json"));
-    console.log(chalk.dim("   ├── features/"));
-    console.log(chalk.dim("   ├── hooks/"));
-    console.log(chalk.dim("   └── templates/"));
-    console.log(chalk.dim("       ├── test-writer.md"));
-    console.log(chalk.dim("       ├── implementer.md"));
-    console.log(chalk.dim("       ├── verifier.md"));
-    console.log(chalk.dim("       ├── single-session.md"));
-    console.log(chalk.dim("       └── tdd-simple.md"));
-    console.log(chalk.dim("\nNext: nax features create <name>"));
   });
 
 // ── setup ─────────────────────────────────────────────

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,15 +7,20 @@
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { globalConfigDir, projectConfigDir } from "../config/paths";
+import { PROJECT_FEATURES_DIR, featuresDir, globalConfigDir, projectConfigDir } from "../config/paths";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import { readProjectIdentity } from "../runtime";
-import { NAX_GITIGNORE_ENTRIES } from "../utils/gitignore";
+import {
+  NAX_GITIGNORE_ENTRIES,
+  NAX_NAXIGNORE_ENTRIES,
+  NAX_NAXIGNORE_HEADER,
+  NAX_NAXIGNORE_SUGGESTIONS,
+  patchIgnoreFile,
+} from "../utils/gitignore";
 import { initContext, initPackage } from "./init-context";
 import { buildInitConfig, detectStack } from "./init-detect";
 import type { ProjectStack } from "./init-detect";
-import { promptsInitCommand } from "./prompts";
 
 export const _initDeps = {
   log: console.log.bind(console) as (...args: unknown[]) => void,
@@ -111,29 +116,51 @@ export interface InitProjectOptions {
 /**
  * Add nax-specific entries to .gitignore if not already present.
  *
- * Appends a clearly marked nax section to the project .gitignore.
+ * Additive and idempotent — see `patchIgnoreFile`.
  */
 async function updateGitignore(projectRoot: string): Promise<void> {
   const logger = getLogger();
   const gitignorePath = join(projectRoot, ".gitignore");
 
-  let existing = "";
-  if (existsSync(gitignorePath)) {
-    existing = await Bun.file(gitignorePath).text();
-  }
+  const result = await patchIgnoreFile(gitignorePath, NAX_GITIGNORE_ENTRIES);
 
-  const missingEntries = NAX_GITIGNORE_ENTRIES.filter((entry) => !existing.includes(entry));
-
-  if (missingEntries.length === 0) {
+  if (result.added.length === 0) {
     logger.info("init", ".gitignore already has nax entries", { path: gitignorePath });
     return;
   }
 
-  const naxSection = `\n# nax — generated files\n${missingEntries.join("\n")}\n`;
-  await Bun.write(gitignorePath, existing + naxSection);
   logger.info("init", "Updated .gitignore with nax entries", {
     path: gitignorePath,
-    added: missingEntries,
+    created: result.created,
+    added: result.added,
+  });
+}
+
+/**
+ * Create or reconcile .naxignore — the paths nax's own context, review and
+ * verification passes skip.
+ *
+ * The explanatory header and commented suggestions are written only when the
+ * file is created, so a re-run never resurrects a suggestion the user removed.
+ */
+async function updateNaxignore(projectRoot: string): Promise<void> {
+  const logger = getLogger();
+  const naxignorePath = join(projectRoot, ".naxignore");
+
+  const result = await patchIgnoreFile(naxignorePath, NAX_NAXIGNORE_ENTRIES, {
+    header: NAX_NAXIGNORE_HEADER,
+    footer: NAX_NAXIGNORE_SUGGESTIONS,
+    sectionComment: "# nax - scanning exclusions",
+  });
+
+  if (result.added.length === 0) {
+    logger.info("init", ".naxignore already has nax entries", { path: naxignorePath });
+    return;
+  }
+
+  logger.info("init", result.created ? "Created .naxignore" : "Updated .naxignore with nax entries", {
+    path: naxignorePath,
+    added: result.added,
   });
 }
 
@@ -346,22 +373,24 @@ export async function initProject(projectRoot: string, options?: InitProjectOpti
     logger.info("init", "Project constitution already exists", { path: constitutionPath });
   }
 
-  // Create .nax/hooks/ directory if it doesn't exist
-  const hooksDir = join(projectDir, "hooks");
-  if (!existsSync(hooksDir)) {
-    await mkdir(hooksDir, { recursive: true });
-    logger.info("init", "Created project hooks directory", { path: hooksDir });
-  } else {
-    logger.info("init", "Project hooks directory already exists", { path: hooksDir });
+  // Create the hooks and features directories if they don't exist
+  for (const [label, dir] of [
+    ["hooks", join(projectDir, "hooks")],
+    ["features", featuresDir(projectRoot)],
+  ] as const) {
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+      logger.info("init", `Created project ${label} directory`, { path: dir });
+    } else {
+      logger.info("init", `Project ${label} directory already exists`, { path: dir });
+    }
   }
 
-  // Update .gitignore to include nax-specific entries
+  // Reconcile the repo's ignore files. Both are additive and idempotent, so
+  // they run on every init — including a re-init over an existing .nax/, which
+  // is the case where a user's ignore file has drifted out of date.
   await updateGitignore(projectRoot);
-
-  // Create prompt templates
-  // Pass autoWireConfig: false to prevent auto-wiring prompts.overrides
-  // Templates are created but not activated until user explicitly configures them
-  await promptsInitCommand({ workdir: projectRoot, force: false, autoWireConfig: false });
+  await updateNaxignore(projectRoot);
 
   // Print summary
   _initDeps.log("\n[OK] nax init complete. Created files:");
@@ -369,13 +398,17 @@ export async function initProject(projectRoot: string, options?: InitProjectOpti
   _initDeps.log("  - .nax/context.md");
   _initDeps.log("  - .nax/constitution.md");
   _initDeps.log("  - .nax/hooks/");
-  _initDeps.log("  - .nax/templates/");
+  _initDeps.log(`  - ${PROJECT_FEATURES_DIR}/`);
+  _initDeps.log("  - .gitignore  (nax entries)");
+  _initDeps.log("  - .naxignore");
   _initDeps.log("\nNext steps:");
   _initDeps.log("  1. Review .nax/context.md and fill in TODOs");
-  _initDeps.log("  2. Review .nax/config.json and adjust quality commands");
-  _initDeps.log("  3. Run: nax generate");
-  _initDeps.log("  4. Run: nax plan");
-  _initDeps.log("  5. Run: nax run");
+  _initDeps.log("  2. Review .naxignore and add paths nax should not scan");
+  _initDeps.log("  3. Review .nax/config.json and adjust quality commands");
+  _initDeps.log("  4. Run: nax generate");
+  _initDeps.log("  5. Run: nax plan");
+  _initDeps.log("  6. Run: nax run");
+  _initDeps.log("\nOptional: nax prompts --init  (scaffold overridable prompt templates)");
 
   logger.info("init", "Project config initialized successfully", { path: projectDir });
 }
@@ -388,7 +421,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     await initGlobal();
   } else if (options.package) {
     const projectRoot = options.projectRoot ?? process.cwd();
-    await initPackage(projectRoot, options.package);
+    await initPackage(projectRoot, options.package, options.force);
     _initDeps.log("\n[OK] Package scaffold created.");
     _initDeps.log(`  Created: .nax/mono/${options.package}/context.md`);
     _initDeps.log("\nNext steps:");

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -1,9 +1,16 @@
 /**
- * Shared nax gitignore entries — runtime files that must never be committed.
+ * Shared nax ignore-file entries and the reconciler that applies them.
  *
- * Used by:
- *  - `nax init` → appends to project .gitignore
- *  - `WorktreeManager.ensureGitExcludes()` → writes to .git/info/exclude (no commit, all worktrees)
+ * Two lists live here, for two different consumers:
+ *  - `NAX_GITIGNORE_ENTRIES` — runtime files that must never be committed.
+ *    Used by `nax init` (project .gitignore) and
+ *    `WorktreeManager.ensureGitExcludes()` (.git/info/exclude — no commit,
+ *    applies to all worktrees).
+ *  - `NAX_NAXIGNORE_ENTRIES` — paths nax's own context engine, review and
+ *    verification passes should not scan. Used by `nax init` only; read back
+ *    by `src/utils/path-filters.ts`.
+ *
+ * `patchIgnoreFile` is the shared, additive reconciler both use.
  */
 
 import { PROJECT_FEATURES_DIR } from "@/config";
@@ -46,3 +53,112 @@ export const NAX_GITIGNORE_ENTRIES = [
   // src/verification/mutation/journal.ts.
   ".nax/mutation-journal/",
 ];
+
+/**
+ * Paths excluded from nax's context, review and verification scanning.
+ *
+ * Deliberately generic — anything repo-specific belongs in the commented
+ * suggestion block written at file creation (`NAX_NAXIGNORE_SUGGESTIONS`),
+ * not here. Only the entries in this list take part in re-run reconciliation.
+ */
+export const NAX_NAXIGNORE_ENTRIES = [
+  // nax's own state: prd.json, run logs, fragments. Feeding these back into
+  // the context engine as if they were project source is pure noise.
+  ".nax/",
+  "dist/",
+  "build/",
+  "coverage/",
+  "node_modules/",
+];
+
+/** Explanatory preamble, written only when `.naxignore` is first created. */
+export const NAX_NAXIGNORE_HEADER = `# nax - paths excluded from context, review
+# and verification scanning.
+# gitignore syntax. Also honoured per-package.
+
+`;
+
+/**
+ * Commented starting points, written only when `.naxignore` is first created.
+ *
+ * These stay commented so re-runs never resurrect a line the user deliberately
+ * removed — the reconciler treats a comment as absent by design.
+ */
+export const NAX_NAXIGNORE_SUGGESTIONS = `
+# Uncomment what applies to this repo:
+# examples/
+# fixtures/
+# vendor/
+# *.generated.*
+`;
+
+/** Outcome of reconciling one ignore file. */
+export interface PatchIgnoreFileResult {
+  /** True when the file did not exist (or held only whitespace) beforehand. */
+  created: boolean;
+  /** Entries actually appended; empty when the file was already complete. */
+  added: string[];
+}
+
+/** Options for {@link patchIgnoreFile}. */
+export interface PatchIgnoreFileOptions {
+  /** Preamble written above the entries, on creation only. */
+  header?: string;
+  /** Trailing block written below the entries, on creation only. */
+  footer?: string;
+  /** Comment introducing the appended section of an existing file. */
+  sectionComment?: string;
+}
+
+/**
+ * Active (rule-bearing) lines of an ignore file.
+ *
+ * Comments and blanks are excluded deliberately: a commented-out entry means
+ * the rule is NOT in force, so it must still count as missing. A substring
+ * scan over the raw text would read `# dist/` as "already present" and
+ * silently never apply the rule.
+ */
+function activeIgnoreLines(content: string): string[] {
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+/**
+ * Additively reconcile an ignore file against a list of entries.
+ *
+ * Creates the file when absent. When it exists, appends only the entries that
+ * are not already active, under a marked section — user content is never
+ * removed, reordered or rewritten, so the operation is idempotent.
+ */
+export async function patchIgnoreFile(
+  filePath: string,
+  entries: readonly string[],
+  options: PatchIgnoreFileOptions = {},
+): Promise<PatchIgnoreFileResult> {
+  const { header = "", footer = "", sectionComment = "# nax - generated files" } = options;
+
+  const file = Bun.file(filePath);
+  const existing = (await file.exists()) ? await file.text() : "";
+  // A whitespace-only file has no content worth preserving; treating it as new
+  // avoids emitting a section appended to a run of blank lines.
+  const isNew = existing.trim().length === 0;
+
+  const active = new Set(activeIgnoreLines(existing));
+  const missing = entries.filter((entry) => !active.has(entry));
+
+  if (missing.length === 0) return { created: false, added: [] };
+
+  if (isNew) {
+    await Bun.write(filePath, `${header}${missing.join("\n")}\n${footer}`);
+    return { created: true, added: [...missing] };
+  }
+
+  // Guarantee the section starts on its own line even when the existing file
+  // lacks a trailing newline — otherwise the last user rule and the section
+  // comment would merge and neither would match.
+  const separator = existing.endsWith("\n") ? "" : "\n";
+  await Bun.write(filePath, `${existing}${separator}\n${sectionComment}\n${missing.join("\n")}\n`);
+  return { created: false, added: [...missing] };
+}

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -126,6 +126,17 @@ function activeIgnoreLines(content: string): string[] {
 }
 
 /**
+ * Whether the file already states a position on `entry`.
+ *
+ * A negation (`!dist/`) counts: the user has deliberately un-ignored the path,
+ * and since later rules win in gitignore syntax, appending the bare entry
+ * below would silently reverse that choice on every init.
+ */
+function hasOpinionOn(activeLines: ReadonlySet<string>, entry: string): boolean {
+  return activeLines.has(entry) || activeLines.has(`!${entry}`);
+}
+
+/**
  * Additively reconcile an ignore file against a list of entries.
  *
  * Creates the file when absent. When it exists, appends only the entries that
@@ -137,7 +148,10 @@ export async function patchIgnoreFile(
   entries: readonly string[],
   options: PatchIgnoreFileOptions = {},
 ): Promise<PatchIgnoreFileResult> {
-  const { header = "", footer = "", sectionComment = "# nax - generated files" } = options;
+  const { footer = "", sectionComment = "# nax - generated files" } = options;
+  // Without a header the created file is a bare list of paths, giving the
+  // reader no clue where it came from. Fall back to the section comment.
+  const header = options.header ?? `${sectionComment}\n`;
 
   const file = Bun.file(filePath);
   const existing = (await file.exists()) ? await file.text() : "";
@@ -146,7 +160,7 @@ export async function patchIgnoreFile(
   const isNew = existing.trim().length === 0;
 
   const active = new Set(activeIgnoreLines(existing));
-  const missing = entries.filter((entry) => !active.has(entry));
+  const missing = entries.filter((entry) => !hasOpinionOn(active, entry));
 
   if (missing.length === 0) return { created: false, added: [] };
 

--- a/test/unit/cli/init.test.ts
+++ b/test/unit/cli/init.test.ts
@@ -1,66 +1,48 @@
 /**
  * Unit tests for `nax init` command (PT-004, INIT-003)
  *
- * Tests that nax init creates the project nax/ directory structure,
- * scaffolds prompt templates, prints a summary, and generates stack-aware
- * constitution.md and updated .gitignore entries.
+ * Tests that nax init creates the project nax/ directory structure, prints a
+ * summary, generates a stack-aware constitution.md, and reconciles the repo's
+ * .gitignore and .naxignore without disturbing user content.
  */
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
-import { _initDeps, initProject } from "../../../src/cli/init";
+import { _initDeps, initCommand, initProject } from "../../../src/cli/init";
 import { withTempDir } from "../../helpers/temp";
 
-
-const TEMPLATE_FILES = [
-  "test-writer.md",
-  "implementer.md",
-  "verifier.md",
-  "single-session.md",
-  "tdd-simple.md",
-] as const;
-
-describe("initProject — creates templates alongside config", () => {
-  test("creates templates/ directory and standard init files (config.json, constitution.md, hooks/); config.json has no prompts.overrides", async () => {
+describe("initProject — creates the project config scaffold", () => {
+  test("creates config.json, constitution.md, hooks/ and features/; config.json has no prompts.overrides", async () => {
     await withTempDir(async (tempDir) => {
       await initProject(tempDir);
-      expect(existsSync(join(tempDir, ".nax", "templates"))).toBe(true);
       expect(existsSync(join(tempDir, ".nax", "config.json"))).toBe(true);
       expect(existsSync(join(tempDir, ".nax", "constitution.md"))).toBe(true);
       expect(existsSync(join(tempDir, ".nax", "hooks"))).toBe(true);
+      expect(existsSync(join(tempDir, ".nax", "features"))).toBe(true);
       const configContent = JSON.parse(await Bun.file(join(tempDir, ".nax", "config.json")).text());
       expect(configContent.prompts?.overrides).toBeUndefined();
     });
   });
 
-  test("creates all 5 template files in nax/templates/ and each is non-empty", async () => {
+  test("does not scaffold prompt templates — `nax prompts --init` is the opt-in path", async () => {
     await withTempDir(async (tempDir) => {
       await initProject(tempDir);
-      for (const file of TEMPLATE_FILES) {
-        const filePath = join(tempDir, ".nax", "templates", file);
-        expect(existsSync(filePath)).toBe(true);
-        expect((await Bun.file(filePath).text()).length).toBeGreaterThan(0);
-      }
+      expect(existsSync(join(tempDir, ".nax", "templates"))).toBe(false);
     });
   });
-});
 
-describe("initProject — with force flag", () => {
-  test("overwrites existing template files when called with force: true", async () => {
+  test("does not write hooks.json — an absent file already means 'no hooks'", async () => {
     await withTempDir(async (tempDir) => {
-      // First init
       await initProject(tempDir);
+      expect(existsSync(join(tempDir, ".nax", "hooks.json"))).toBe(false);
+    });
+  });
 
-      const testWriterPath = join(tempDir, ".nax", "templates", "test-writer.md");
-
-      // Overwrite with marker content
-      await Bun.write(testWriterPath, "MARKER_CONTENT_FOR_TESTING");
-
-      // Second init with force — would need to pass force through initProject
-      // For now, this tests the expected behavior once initProject accepts force
-      const markedContent = await Bun.file(testWriterPath).text();
-      expect(markedContent).toBe("MARKER_CONTENT_FOR_TESTING");
+  test("does not write a nested .nax/.gitignore — the repo-root .gitignore covers it", async () => {
+    await withTempDir(async (tempDir) => {
+      await initProject(tempDir);
+      expect(existsSync(join(tempDir, ".nax", ".gitignore"))).toBe(false);
     });
   });
 });
@@ -106,6 +88,144 @@ describe("initProject — .gitignore includes new nax entries", () => {
       expect(gitignore).toContain(".env");
       expect(gitignore).toContain("nax.lock");
     });
+  });
+});
+
+describe("initProject — creates .naxignore", () => {
+  test("creates .naxignore excluding nax's own state directory", async () => {
+    await withTempDir(async (tempDir) => {
+      await initProject(tempDir);
+
+      const naxignore = await Bun.file(join(tempDir, ".naxignore")).text();
+      expect(naxignore).toContain(".nax/");
+      expect(naxignore).toContain("node_modules/");
+    });
+  });
+
+  test("explains what the file does and offers commented suggestions", async () => {
+    await withTempDir(async (tempDir) => {
+      await initProject(tempDir);
+
+      const naxignore = await Bun.file(join(tempDir, ".naxignore")).text();
+      expect(naxignore).toMatch(/^#/);
+      expect(naxignore).toContain("# vendor/");
+    });
+  });
+
+  test("preserves an existing .naxignore and appends only what is missing", async () => {
+    await withTempDir(async (tempDir) => {
+      await Bun.write(join(tempDir, ".naxignore"), "my-fixtures/\n.nax/\n");
+
+      await initProject(tempDir);
+
+      const naxignore = await Bun.file(join(tempDir, ".naxignore")).text();
+      expect(naxignore).toContain("my-fixtures/");
+      expect(naxignore).toContain("node_modules/");
+      // Already present — appending it again would be a duplicate rule.
+      expect(naxignore.split("\n").filter((l) => l.trim() === ".nax/")).toHaveLength(1);
+      // The suggestion block belongs to file creation only.
+      expect(naxignore).not.toContain("# vendor/");
+    });
+  });
+});
+
+describe("initProject — re-running is idempotent", () => {
+  test("a second init leaves .gitignore and .naxignore byte-identical", async () => {
+    await withTempDir(async (tempDir) => {
+      await initProject(tempDir);
+      const gitignoreAfterFirst = await Bun.file(join(tempDir, ".gitignore")).text();
+      const naxignoreAfterFirst = await Bun.file(join(tempDir, ".naxignore")).text();
+
+      await initProject(tempDir);
+
+      expect(await Bun.file(join(tempDir, ".gitignore")).text()).toBe(gitignoreAfterFirst);
+      expect(await Bun.file(join(tempDir, ".naxignore")).text()).toBe(naxignoreAfterFirst);
+    });
+  });
+
+  test("a second init does not overwrite an edited config.json or context.md", async () => {
+    await withTempDir(async (tempDir) => {
+      await initProject(tempDir);
+      await Bun.write(join(tempDir, ".nax", "context.md"), "MY OWN CONTEXT");
+
+      await initProject(tempDir);
+
+      expect(await Bun.file(join(tempDir, ".nax", "context.md")).text()).toBe("MY OWN CONTEXT");
+    });
+  });
+
+  test("reconciles ignore files even when .nax/ already exists", async () => {
+    await withTempDir(async (tempDir) => {
+      await initProject(tempDir);
+      // Simulate a user who wiped the nax section out of .gitignore.
+      await Bun.write(join(tempDir, ".gitignore"), "node_modules/\n");
+
+      await initProject(tempDir);
+
+      expect(await Bun.file(join(tempDir, ".gitignore")).text()).toContain("nax.lock");
+    });
+  });
+});
+
+describe("initCommand — package scaffold", () => {
+  const PKG = "packages/api";
+
+  test("scaffolds the package context under .nax/mono/<pkg>/", async () => {
+    await withTempDir(async (tempDir) => {
+      await initCommand({ projectRoot: tempDir, package: PKG });
+      expect(existsSync(join(tempDir, ".nax", "mono", PKG, "context.md"))).toBe(true);
+    });
+  });
+
+  test("leaves an edited package context.md alone without force", async () => {
+    await withTempDir(async (tempDir) => {
+      await initCommand({ projectRoot: tempDir, package: PKG });
+      const contextPath = join(tempDir, ".nax", "mono", PKG, "context.md");
+      await Bun.write(contextPath, "MY OWN PACKAGE CONTEXT");
+
+      await initCommand({ projectRoot: tempDir, package: PKG });
+
+      expect(await Bun.file(contextPath).text()).toBe("MY OWN PACKAGE CONTEXT");
+    });
+  });
+
+  test("overwrites the package context.md when force is set", async () => {
+    await withTempDir(async (tempDir) => {
+      await initCommand({ projectRoot: tempDir, package: PKG });
+      const contextPath = join(tempDir, ".nax", "mono", PKG, "context.md");
+      await Bun.write(contextPath, "MY OWN PACKAGE CONTEXT");
+
+      await initCommand({ projectRoot: tempDir, package: PKG, force: true });
+
+      expect(await Bun.file(contextPath).text()).not.toBe("MY OWN PACKAGE CONTEXT");
+    });
+  });
+});
+
+// ─── bin/nax.ts delegates to initCommand rather than scaffolding inline ──────
+//
+// Source-text assertions, matching the convention in
+// plan-decompose-cli-wiring.test.ts: importing bin/nax.ts would execute the
+// commander program, and spawning the binary is banned by
+// forbidden-patterns-tests.md. These guard against the inline scaffolder
+// being reintroduced; initProject's own tests above cover the behavior.
+
+describe("bin/nax.ts init command — delegates to initCommand", () => {
+  async function binSource(): Promise<string> {
+    return await Bun.file(join(import.meta.dir, "../../../bin/nax.ts")).text();
+  }
+
+  test("delegates to initCommand instead of scaffolding inline", async () => {
+    expect(await binSource()).toContain("initCommand");
+  });
+
+  test("does not write hooks.json", async () => {
+    expect(await binSource()).not.toContain("hooks.json");
+  });
+
+  test("does not bail out when the project is already initialized", async () => {
+    // The bail prevented a re-init from reconciling drifted ignore files.
+    expect(await binSource()).not.toContain("nax already initialized");
   });
 });
 

--- a/test/unit/context/engine/providers/static-rules-us006.test.ts
+++ b/test/unit/context/engine/providers/static-rules-us006.test.ts
@@ -4,8 +4,14 @@
  * US-006: stage scoping drives chunk emission from the real .nax/rules
  * store. The test-authoring rules declare `stages:` lists excluding
  * plan/acceptance/route so they never appear in plan or acceptance or
- * route contexts; rules that apply everywhere (forbidden-patterns.md,
- * project-conventions.md) emit chunks in every stage.
+ * route contexts.
+ *
+ * US-006 AC 4 originally asserted the opposite for forbidden-patterns-*
+ * and project-conventions: those declared no `stages:` key, so they loaded
+ * everywhere including plan. #1612 gave all three an explicit stage list
+ * precisely to stop that — 6749 tokens of freight per plan prompt — so the
+ * AC-4 cases below now assert exclusion at plan, paired with a positive
+ * case at execution so a rule scoped to nothing cannot pass vacuously.
  *
  * These tests run against the real `.nax/rules/` directory by importing
  * the real `loadCanonicalRules` and re-wiring `_staticRulesDeps` to
@@ -62,25 +68,30 @@ describe("StaticRulesProvider — US-006 real .nax/rules store stage scoping", (
     expect(result.chunks.some((c) => c.id.startsWith("static-rules:testing-commands:"))).toBe(false);
   });
 
-  // Split into -source/-tests by SPEC-bounded-rules-floor US-005; the plan-stage
-  // emission contract holds for both halves.
-  test("[US-006 AC 4] emits a static-rules:forbidden-patterns-source: chunk when request.stage is plan", async () => {
-    const provider = new StaticRulesProvider({ budgetTokens: 1_000_000 });
-    const result = await provider.fetch({ ...REAL_REPO_REQUEST, stage: "plan" });
-    expect(result.chunks.some((c) => c.id.startsWith("static-rules:forbidden-patterns-source:"))).toBe(true);
-  });
+  // Split into -source/-tests by SPEC-bounded-rules-floor US-005; the stage
+  // scoping introduced by #1612 applies to both halves.
+  const STAGE_SCOPED_EVERYWHERE_BUT_PLAN = [
+    "forbidden-patterns-source",
+    "forbidden-patterns-tests",
+    "project-conventions",
+  ] as const;
 
-  test("[US-006 AC 4] emits a static-rules:forbidden-patterns-tests: chunk when request.stage is plan", async () => {
-    const provider = new StaticRulesProvider({ budgetTokens: 1_000_000 });
-    const result = await provider.fetch({ ...REAL_REPO_REQUEST, stage: "plan" });
-    expect(result.chunks.some((c) => c.id.startsWith("static-rules:forbidden-patterns-tests:"))).toBe(true);
-  });
+  for (const rule of STAGE_SCOPED_EVERYWHERE_BUT_PLAN) {
+    test(`[US-006 AC 4] emits no static-rules:${rule}: chunk when request.stage is plan`, async () => {
+      const provider = new StaticRulesProvider({ budgetTokens: 1_000_000 });
+      const result = await provider.fetch({ ...REAL_REPO_REQUEST, stage: "plan" });
+      expect(result.chunks.some((c) => c.id.startsWith(`static-rules:${rule}:`))).toBe(false);
+    });
 
-  test("[US-006 AC 4] emits a static-rules:project-conventions: chunk when request.stage is plan", async () => {
-    const provider = new StaticRulesProvider({ budgetTokens: 1_000_000 });
-    const result = await provider.fetch({ ...REAL_REPO_REQUEST, stage: "plan" });
-    expect(result.chunks.some((c) => c.id.startsWith("static-rules:project-conventions:"))).toBe(true);
-  });
+    // Guards the exclusion above against passing vacuously: a rule scoped to
+    // no stage at all, or one that stopped loading entirely, would satisfy the
+    // plan-stage assertion while silently reaching no agent anywhere.
+    test(`[US-006 AC 4] emits a static-rules:${rule}: chunk when request.stage is execution`, async () => {
+      const provider = new StaticRulesProvider({ budgetTokens: 1_000_000 });
+      const result = await provider.fetch({ ...REAL_REPO_REQUEST, stage: "execution" });
+      expect(result.chunks.some((c) => c.id.startsWith(`static-rules:${rule}:`))).toBe(true);
+    });
+  }
 
   test("[US-006 AC 5] emits a static-rules:test-writing: chunk when request.stage is tdd-test-writer", async () => {
     const provider = new StaticRulesProvider({ budgetTokens: 1_000_000 });

--- a/test/unit/context/rules/rules-frontmatter.test.ts
+++ b/test/unit/context/rules/rules-frontmatter.test.ts
@@ -671,32 +671,26 @@ describe("loadCanonicalRules — US-006 real .nax/rules store stage scoping", ()
   });
 
   // forbidden-patterns.md was split into -source/-tests by SPEC-bounded-rules-floor
-  // US-005. Both halves keep the original "applies at every stage" semantics: they
-  // scope by `appliesTo:` only and still declare no `stages:` key.
-  test("[US-006 AC 2] returns forbidden-patterns-source.md with stages undefined", async () => {
-    const rules = await loadCanonicalRules(process.cwd());
-    const rule = rules.find(
-      (r) => r.path === "forbidden-patterns-source.md" || r.fileName === "forbidden-patterns-source.md",
-    );
-    expect(rule).toBeDefined();
-    expect(rule?.stages).toBeUndefined();
-  });
-
-  test("[US-006 AC 2] returns forbidden-patterns-tests.md with stages undefined", async () => {
-    const rules = await loadCanonicalRules(process.cwd());
-    const rule = rules.find(
-      (r) => r.path === "forbidden-patterns-tests.md" || r.fileName === "forbidden-patterns-tests.md",
-    );
-    expect(rule).toBeDefined();
-    expect(rule?.stages).toBeUndefined();
-  });
-
-  test("[US-006 AC 2] returns project-conventions.md with stages undefined", async () => {
-    const rules = await loadCanonicalRules(process.cwd());
-    const rule = rules.find((r) => r.path === "project-conventions.md" || r.fileName === "project-conventions.md");
-    expect(rule).toBeDefined();
-    expect(rule?.stages).toBeUndefined();
-  });
+  // US-005. Both halves, and project-conventions.md, originally declared no
+  // `stages:` key and so loaded at every stage. #1612 gave each an explicit stage
+  // list to keep them out of plan/route/verify/debate, where they were 6749
+  // tokens of freight per prompt. They must still be declared, still exclude
+  // plan, and still cover execution — an empty list would exclude plan while
+  // reaching no agent at all.
+  for (const fileName of [
+    "forbidden-patterns-source.md",
+    "forbidden-patterns-tests.md",
+    "project-conventions.md",
+  ]) {
+    test(`[US-006 AC 2] returns ${fileName} with stages that exclude plan`, async () => {
+      const rules = await loadCanonicalRules(process.cwd());
+      const rule = rules.find((r) => r.path === fileName || r.fileName === fileName);
+      expect(rule).toBeDefined();
+      expect(rule?.stages).toBeDefined();
+      expect(rule?.stages).not.toContain("plan");
+      expect(rule?.stages).toContain("execution");
+    });
+  }
 
   test("[US-006 AC 6] every CanonicalRule has an empty warnings list under the real .nax/rules store", async () => {
     const rules = await loadCanonicalRules(process.cwd());

--- a/test/unit/utils/gitignore.test.ts
+++ b/test/unit/utils/gitignore.test.ts
@@ -98,6 +98,20 @@ describe("patchIgnoreFile — creating a new file", () => {
     });
   });
 
+  test("labels the entries with the section comment when no header is supplied", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".gitignore");
+
+      await patchIgnoreFile(path, ["dist/"]);
+
+      // A bare list of paths in a fresh .gitignore gives the reader no clue
+      // where it came from or that it is safe to re-run init.
+      const content = await Bun.file(path).text();
+      expect(content.startsWith("#")).toBe(true);
+      expect(content).toContain("dist/");
+    });
+  });
+
   test("treats a whitespace-only existing file as new rather than appending to blank lines", async () => {
     await withTempDir(async (dir) => {
       const path = join(dir, ".naxignore");
@@ -202,6 +216,32 @@ describe("patchIgnoreFile — entry matching", () => {
       // "dist/" is a substring of "packages/dist/cache" but the standalone
       // rule is absent, so it must still be added.
       await Bun.write(path, "packages/dist/cache\n");
+
+      const result = await patchIgnoreFile(path, ["dist/"]);
+
+      expect(result.added).toEqual(["dist/"]);
+    });
+  });
+
+  test("does not re-add an entry the user explicitly negated", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".naxignore");
+      // "!dist/" means the user deliberately wants dist/ scanned. Appending
+      // "dist/" below it would silently win — later rules take precedence in
+      // gitignore syntax — reversing an explicit choice on every init.
+      await Bun.write(path, "!dist/\n");
+
+      const result = await patchIgnoreFile(path, ["dist/"]);
+
+      expect(result.added).toEqual([]);
+      expect(await Bun.file(path).text()).toBe("!dist/\n");
+    });
+  });
+
+  test("still adds an entry when an unrelated path is negated", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".naxignore");
+      await Bun.write(path, "!build/\n");
 
       const result = await patchIgnoreFile(path, ["dist/"]);
 

--- a/test/unit/utils/gitignore.test.ts
+++ b/test/unit/utils/gitignore.test.ts
@@ -10,8 +10,9 @@
 import { describe, expect, test } from "bun:test";
 import { dirname, join } from "node:path";
 import { fragmentPath } from "@/context";
-import { NAX_GITIGNORE_ENTRIES } from "@/utils/gitignore";
+import { NAX_GITIGNORE_ENTRIES, NAX_NAXIGNORE_ENTRIES, patchIgnoreFile } from "@/utils/gitignore";
 import { journalDir } from "@/verification";
+import { withTempDir } from "@test/helpers";
 
 describe("NAX_GITIGNORE_ENTRIES", () => {
   test("covers the mutation journal directory", () => {
@@ -49,5 +50,173 @@ describe("NAX_GITIGNORE_ENTRIES", () => {
 
   test("no duplicate entries", () => {
     expect(new Set(NAX_GITIGNORE_ENTRIES).size).toBe(NAX_GITIGNORE_ENTRIES.length);
+  });
+});
+
+describe("NAX_NAXIGNORE_ENTRIES", () => {
+  test("hides nax's own state directory from the context engine", () => {
+    // .nax/ holds prd.json, run logs and fragments. Feeding them back into the
+    // context engine as if they were project source is pure noise.
+    expect(NAX_NAXIGNORE_ENTRIES).toContain(".nax/");
+  });
+
+  test("entries are relative patterns — an absolute path would never match", () => {
+    for (const entry of NAX_NAXIGNORE_ENTRIES) {
+      expect(entry.startsWith("/")).toBe(false);
+    }
+  });
+
+  test("no duplicate entries", () => {
+    expect(new Set(NAX_NAXIGNORE_ENTRIES).size).toBe(NAX_NAXIGNORE_ENTRIES.length);
+  });
+
+  test("carries no commented lines — the suggestion block is written separately", () => {
+    // Only active entries take part in re-run reconciliation. A commented entry
+    // in this list would be re-appended on every init, since the reconciler
+    // treats comments as absent.
+    for (const entry of NAX_NAXIGNORE_ENTRIES) {
+      expect(entry.startsWith("#")).toBe(false);
+    }
+  });
+});
+
+describe("patchIgnoreFile — creating a new file", () => {
+  test("writes header, entries and footer when the file does not exist", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".naxignore");
+
+      const result = await patchIgnoreFile(path, ["dist/", "build/"], {
+        header: "# nax - scanning exclusions\n\n",
+        footer: "\n# Uncomment what applies:\n# vendor/\n",
+      });
+
+      expect(result.created).toBe(true);
+      expect(result.added).toEqual(["dist/", "build/"]);
+
+      const content = await Bun.file(path).text();
+      expect(content).toBe("# nax - scanning exclusions\n\ndist/\nbuild/\n\n# Uncomment what applies:\n# vendor/\n");
+    });
+  });
+
+  test("treats a whitespace-only existing file as new rather than appending to blank lines", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".naxignore");
+      await Bun.write(path, "\n\n  \n");
+
+      const result = await patchIgnoreFile(path, ["dist/"], { header: "# nax\n\n" });
+
+      expect(result.created).toBe(true);
+      expect(await Bun.file(path).text()).toBe("# nax\n\ndist/\n");
+    });
+  });
+});
+
+describe("patchIgnoreFile — patching an existing file", () => {
+  test("appends only the missing entries and preserves user content verbatim", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".gitignore");
+      await Bun.write(path, "node_modules/\ndist/\n");
+
+      const result = await patchIgnoreFile(path, ["dist/", "coverage/"], { sectionComment: "# nax" });
+
+      expect(result.created).toBe(false);
+      expect(result.added).toEqual(["coverage/"]);
+
+      const content = await Bun.file(path).text();
+      expect(content.startsWith("node_modules/\ndist/\n")).toBe(true);
+      expect(content).toContain("coverage/");
+      // "dist/" was already active — it must not be duplicated.
+      expect(content.split("\n").filter((l) => l === "dist/")).toHaveLength(1);
+    });
+  });
+
+  test("does not write the header or footer again when patching", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".naxignore");
+      await Bun.write(path, "# nax - scanning exclusions\n\ndist/\n");
+
+      await patchIgnoreFile(path, ["dist/", "coverage/"], {
+        header: "# nax - scanning exclusions\n\n",
+        footer: "\n# Uncomment what applies:\n# vendor/\n",
+      });
+
+      const content = await Bun.file(path).text();
+      expect(content.split("# nax - scanning exclusions")).toHaveLength(2);
+      expect(content).not.toContain("# Uncomment what applies:");
+    });
+  });
+
+  test("is a no-op when every entry is already active", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".gitignore");
+      const original = "node_modules/\ndist/\n";
+      await Bun.write(path, original);
+
+      const result = await patchIgnoreFile(path, ["dist/"]);
+
+      expect(result.created).toBe(false);
+      expect(result.added).toEqual([]);
+      expect(await Bun.file(path).text()).toBe(original);
+    });
+  });
+
+  test("separates the appended section from a file that lacks a trailing newline", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".gitignore");
+      await Bun.write(path, "node_modules/");
+
+      await patchIgnoreFile(path, ["dist/"], { sectionComment: "# nax" });
+
+      const lines = (await Bun.file(path).text()).split("\n");
+      // Without the guard, "node_modules/" and the section comment would merge
+      // into a single line and neither pattern would work.
+      expect(lines).toContain("node_modules/");
+      expect(lines).toContain("dist/");
+    });
+  });
+});
+
+describe("patchIgnoreFile — entry matching", () => {
+  test("appends an entry that is present only as a comment", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".gitignore");
+      // A user who deliberately commented the entry out still gets it back on
+      // init; a naive substring scan would read this as "already present" and
+      // silently never apply the rule.
+      await Bun.write(path, "# dist/\n");
+
+      const result = await patchIgnoreFile(path, ["dist/"]);
+
+      expect(result.added).toEqual(["dist/"]);
+      const active = (await Bun.file(path).text())
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0 && !l.startsWith("#"));
+      expect(active).toContain("dist/");
+    });
+  });
+
+  test("appends an entry that only appears as a substring of a longer path", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".gitignore");
+      // "dist/" is a substring of "packages/dist/cache" but the standalone
+      // rule is absent, so it must still be added.
+      await Bun.write(path, "packages/dist/cache\n");
+
+      const result = await patchIgnoreFile(path, ["dist/"]);
+
+      expect(result.added).toEqual(["dist/"]);
+    });
+  });
+
+  test("matches an existing entry despite surrounding whitespace", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, ".gitignore");
+      await Bun.write(path, "  dist/  \n");
+
+      const result = await patchIgnoreFile(path, ["dist/"]);
+
+      expect(result.added).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`nax init` had two implementations: an inline scaffolder in `bin/nax.ts` (the one the CLI actually ran) and `initProject` in `src/cli/init.ts`, reachable only from tests. Only the dead one patched the repo-root `.gitignore`.

This consolidates the scaffolding into `src/cli/init.ts`, makes the CLI delegate to it, and changes what init produces:

- **Drop prompt templates.** `nax prompts --init` remains the opt-in path; templates were never auto-wired (`autoWireConfig: false`).
- **Drop `hooks.json`.** An absent file already means "no hooks" — `loadHooksConfig` degrades to `{ hooks: {} }`.
- **Drop the nested `.nax/.gitignore`.** Its only live entry was already in `NAX_GITIGNORE_ENTRIES`; nothing writes `*.tmp` or `.paused.json` anymore.
- **Add `.naxignore`**, so the context engine, review and verify passes skip generated output by default. The format was already read by `src/utils/path-filters.ts` but never scaffolded.
- **Remove the "already initialized" bail**, so a re-run repairs ignore files that have drifted out of date.

Both ignore files go through a shared `patchIgnoreFile()` reconciler: creates when absent, appends only missing entries when present, never removes or reorders user content.

## Bugs fixed along the way

| Bug | Impact |
|:---|:---|
| Idempotence check used `existing.includes(entry)` | A commented-out `# dist/` read as "already present", so the rule was silently never applied |
| Appending over a negation | A user's explicit `!dist/` was silently reversed by an appended `dist/` — later rules win in gitignore syntax |
| Created ignore file had no header | A fresh `.gitignore` was a bare list of paths with no indication of origin |
| `initCommand` did not thread `force` to `initPackage` | `nax init --package X --force` was a no-op |
| `bin` reported the wrong package scaffold path | Printed `<pkg>/nax/context.md` instead of the actual `.nax/mono/<pkg>/context.md` |

## Unrelated fix included

`d6ac454c` repairs 6 tests that were **already failing on `main`**. #1612 gave `forbidden-patterns-source`, `forbidden-patterns-tests` and `project-conventions` explicit stage lists excluding `plan` (its commit message cites the 6749-token saving at plan as the goal), but the US-006 assertions still encoded the old "loads everywhere" contract. The rules are correct; the tests were stale.

Each inverted assertion is paired with a positive case at `execution`, so a rule scoped to no stage at all cannot satisfy the exclusion while reaching no agent anywhere. Verified by reverting `project-conventions.md` to its pre-#1612 frontmatter: two of the new assertions fail, confirming they catch the regression rather than passing trivially.

Happy to split this into its own PR if preferred — it is independently useful, since it unblocks anyone else running the suite on `main`.

## Test plan

- [x] `bun run test` — 13724 unit + 1125 integration + 37 UI, 0 failures
- [x] `bun run lint`, `bun run typecheck` — clean; all ratchets at baseline
- [x] Manual CLI runs against scratch repos: clean init, re-run byte-identical, drift repair, `--package`, invalid `--name` exits 1 with nothing written
- [x] `nax prompts --init` still scaffolds all 5 templates on demand

The `bin/nax.ts` delegation is covered only by source-text assertions, following the existing convention in `plan-decompose-cli-wiring.test.ts` — importing `bin/nax.ts` executes commander, and spawning the binary is banned by `forbidden-patterns-tests.md`. The behavior itself was verified by the manual runs above.