### PR TITLE
fix(finish): make nax-finish reviewer nodes report at post-impl-review fidelity

### DIFF
--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -124,6 +124,41 @@ rejected as an incomplete review. There is no JSON: a reply constrained to one
 JSON object has nowhere to put the two enumerations the review dimensions depend
 on, and an unreadable object used to discard the whole review (#1614).
 
+### What a fix node can reject
+
+`fix_<phase>` does not have to apply every finding it is handed. When it has
+cited counter-evidence that the reported behaviour is already correct — an
+existing test or spec line that pins the current behaviour — it can reject the
+finding instead, in a fourth reply section:
+
+```
+## DISPOSITIONS
+[1] fixed
+[2] rejected — evidence: test/config/loader.test.ts:42
+```
+
+Each line is `[N] fixed` or `[N] rejected — evidence: <file:line>`, where `N`
+is the finding's 1-based index in the same list the reviewer sent. A rejection
+requires the citation — it must point at a real test or spec line, not a
+description of what the fixer believes. `commit_<phase>` checks that the cited
+path resolves in the repo; a citation that does not is not discarded, only
+marked — the fixer may have cited a line rather than a path, or the file may
+have moved — and both the PR body and the commit message render it with an
+**evidence path not found** caveat rather than presenting it as verified.
+
+A rejected finding shows up in the PR body's "Review rounds" section as
+`_rejected_: \`file:line\`` (or with the caveat above when the path didn't
+resolve), and the shipped `commit_<phase>` commit message renders it the same
+way — as rejected with its citation, never as `Fix: <text>` for a change that
+was never made.
+
+This is a different, separately-scoped convention from a reviewer's
+`Judgment: yes` marker (see [§5 Escalation](#5-escalation)): `Judgment` is
+reviewer-authored and escalates a finding to a human before any fix is
+attempted; `## DISPOSITIONS … rejected` is fixer-authored and rejects a
+finding on cited evidence instead of applying it. Don't conflate the two —
+they run at different points in the loop and mean different things.
+
 ### Why acceptance runs twice
 
 The `acceptance` node is the cheap fail-fast gate: it proves the feature meets
@@ -492,6 +527,11 @@ re-verified. This is deliberate: the quality dimension runs at a >=60% confidenc
 bar specifically to surface design and maintainability concerns, and a
 whole-phase escalate route made reporting one of those equivalent to stopping the
 pipeline.
+
+`Judgment: yes` (reviewer-authored, escalates to a human) and `## DISPOSITIONS
+… rejected` (fixer-authored, rejects a finding on cited evidence — see [What a
+fix node can reject](#what-a-fix-node-can-reject)) are two distinct markers
+scoped to different nodes; neither substitutes for the other.
 
 **Telegram (preferred when configured).** Credentials come from the telegram
 interaction plugin, or from env:

--- a/docs/guides/nax-finish-autoflow.md
+++ b/docs/guides/nax-finish-autoflow.md
@@ -109,6 +109,21 @@ the window, which happens when the acceptance loop commits between a spec fix an
 its re-review) falls back to a full review rather than guessing at a window and
 silently hiding code from the reviewer.
 
+### What a reviewer node returns
+
+Each reviewer replies in three sections, and all three are checked:
+
+| Section | Content | If missing |
+|:--------|:--------|:-----------|
+| `## TOUCHPOINTS` | one line per external definition the reviewer opened, or `- none — <justification>` | the review is sent back once, then escalated — never treated as clean |
+| `## WALK` | one line per AC (spec phase) or per changed function (quality phase) | same |
+| `## FINDINGS` | `[SEVERITY]` blocks, or the literal `No findings.` | a reply with neither blocks nor the sentinel routes `reprompt` |
+
+The touchpoint paths are checked against the repo, so a fabricated list is
+rejected as an incomplete review. There is no JSON: a reply constrained to one
+JSON object has nowhere to put the two enumerations the review dimensions depend
+on, and an unreadable object used to discard the whole review (#1614).
+
 ### Why acceptance runs twice
 
 The `acceptance` node is the cheap fail-fast gate: it proves the feature meets
@@ -449,12 +464,34 @@ The plugin passes them as the env vars `NAX_FINISH_SPEC_PROFILE` and
 `NAX_FINISH_QUALITY_PROFILE`, which the flow module reads at load time. You can
 set them yourself when running the flow by hand (§6).
 
+### Reviewer tier parity
+
+`reviewers.spec` and `reviewers.quality` default to `null`, which means both
+reviewer nodes inherit acpx's `--default-agent`. The `post-impl-review` skill, by
+contrast, dispatches its quality worker on a reviewer-tuned agent type at the
+invoking session's model. If you are comparing the two — or trusting the flow's
+reviewers to match what the skill finds — pin the profiles explicitly:
+
+```json
+{ "finish": { "autoFlow": { "reviewers": { "spec": "reviewer", "quality": "code-reviewer" } } } }
+```
+
+An unpinned comparison measures model tier as much as it measures the flow.
+
 ---
 
 ## 5. Escalation
 
 On anything needing human judgment the flow pushes what it fixed and sends a
 "needs judgment" summary naming the reason and the findings.
+
+Escalation is decided per finding, not per phase. A reviewer marks a finding
+`Judgment: yes — <why>` when it is a spec conflict or a design call with no safe
+mechanical fix; only those halt the flow. Everything else is fixed and
+re-verified. This is deliberate: the quality dimension runs at a >=60% confidence
+bar specifically to surface design and maintainability concerns, and a
+whole-phase escalate route made reporting one of those equivalent to stopping the
+pipeline.
 
 **Telegram (preferred when configured).** Credentials come from the telegram
 interaction plugin, or from env:
@@ -553,6 +590,7 @@ Run state is kept under `~/.acpx/flows/runs/`.
 | Flow killed at 90 minutes | Raise `timeouts.flowMs`. |
 | PR opened without the flow's fixes | Should not happen — both terminal nodes push first. Check for a failed push in the run output or the escalation comment. |
 | Duplicate PRs vs nax autoPR | Not possible by design: the flow promotes an existing draft rather than opening a second PR. |
+| A review escalated with "never discharged its reading obligations" | The reviewer returned findings but omitted `## TOUCHPOINTS` or `## WALK` twice, or listed touchpoint paths that do not exist in the repo. Its reply is in the acpx run bundle. This is working as designed — the alternative is a verdict with no evidence behind it being treated as an approval. |
 
 ---
 

--- a/flows/nax-finish/commit-message.ts
+++ b/flows/nax-finish/commit-message.ts
@@ -12,7 +12,7 @@
  * Subject lines follow the repo's conventional-commit rule and the 72-column
  * git summary convention; the findings go in the body, one bullet each.
  */
-import type { Finding, FinishPhase } from "./types";
+import type { Finding, FindingDisposition, FinishPhase } from "./types";
 
 /** Git's conventional soft cap for a commit summary line. */
 const MAX_SUBJECT_LEN = 72;
@@ -89,6 +89,14 @@ interface MessageCtx {
 interface MessageOptions {
   /** Absolute repo root, used to rewrite quoted paths as repo-relative. */
   workdir?: string;
+  /**
+   * What `fix_<phase>` did with each finding it was handed, by 1-based index.
+   *
+   * Only `commit_<phase>` callers have this — `gate`/`acceptance` commits, and
+   * any caller that has not run a fix node yet, pass nothing, and every finding
+   * renders as before (`Fix: <text>`).
+   */
+  dispositions?: FindingDisposition[];
 }
 
 interface PhaseOutputs {
@@ -179,15 +187,31 @@ function bodyFor(phase: FinishPhase, ctx: MessageCtx, opts: MessageOptions): str
   }
   const findings = findingsFor(ctx, phase);
   if (findings.length === 0) return [];
-  return [
-    findings
-      .map((f) =>
-        [`- [${f.severity}] ${f.title}`, f.problem ? `  ${f.problem}` : "", f.fix ? `  Fix: ${f.fix}` : ""]
-          .filter(Boolean)
-          .join("\n"),
-      )
-      .join("\n"),
-  ];
+  const dispositions = opts.dispositions ?? [];
+  return [findings.map((f, i) => findingBody(f, i, dispositions)).join("\n")];
+}
+
+/**
+ * Render one finding's line(s) in the commit body, honouring `fix_<phase>`'s
+ * disposition when one exists.
+ *
+ * A rejected finding must not read `Fix: <the fix text>` — nothing was applied
+ * — so it renders the same way `pr-body.ts`'s `renderRejected` does: as
+ * rejected, with its evidence citation, so shipped git history and the PR body
+ * agree on what happened to the finding.
+ */
+function findingBody(f: Finding, index: number, dispositions: FindingDisposition[]): string {
+  const d = dispositions.find((x) => x.index === index + 1);
+  if (d?.disposition === "rejected") {
+    const evidence = d.evidence ? `\`${d.evidence}\`` : "no evidence cited";
+    const caveat = d.evidenceMissing ? " (evidence path not found)" : "";
+    return [`- [${f.severity}] ${f.title} — rejected: ${evidence}${caveat}`, f.problem ? `  ${f.problem}` : ""]
+      .filter(Boolean)
+      .join("\n");
+  }
+  return [`- [${f.severity}] ${f.title}`, f.problem ? `  ${f.problem}` : "", f.fix ? `  Fix: ${f.fix}` : ""]
+    .filter(Boolean)
+    .join("\n");
 }
 
 /** Human-readable phase label for the attribution trailer. */

--- a/flows/nax-finish/findings-parse.ts
+++ b/flows/nax-finish/findings-parse.ts
@@ -1,0 +1,150 @@
+/**
+ * Turning a reviewer's free-form reply into structured findings.
+ *
+ * The reviewer's contract is text, not JSON, for two reasons. The dimension
+ * references both hinge on an enumeration — a per-AC walk and a per-changed-
+ * function walk — and a reply constrained to one JSON object has nowhere to put
+ * one. And a text reply has no cliff: a malformed line costs that line, where an
+ * unparseable JSON object used to cost the entire review (#1614).
+ *
+ * Every function here is pure and non-throwing. `verdict.ts` documents why that
+ * is load-bearing: a throw inside an acpx `parse` fails the whole flow.
+ */
+import type { Finding, FindingDisposition, ReviewReport, Severity, Touchpoint } from "./types";
+
+type Section = "touchpoints" | "walk" | "findings";
+
+/** Headings are matched loosely — any level, any case, optional trailing colon. */
+const HEADING = /^\s*#{1,6}\s*(TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)\s*:?\s*$/i;
+const BLOCK = /^\s*\[(CRITICAL|HIGH|MEDIUM|LOW)\]\s+(.+?)\s*$/;
+const FIELD = /^\s*(Problem|Fix|Judgment)\s*:\s*(.*)$/i;
+const NO_FINDINGS = /^\s*no findings\.?\s*$/i;
+const BULLET = /^\s*[-*]\s+(.+?)\s*$/;
+const DISPOSITION = /^\s*\[?(\d+)\]?\s*[.:)]?\s*(fixed|rejected)\b\s*(.*)$/i;
+const EVIDENCE = /evidence\s*:\s*(\S+)/i;
+
+/** `- path/to/file.ts:symbol — why`, tolerant of backticks and of `-` for `—`. */
+function parseTouchpoint(text: string): Touchpoint | null {
+  const m = /^(\S+)\s*(?:[—–-]\s*)?(.*)$/.exec(text);
+  if (!m) return null;
+  const locator = m[1].replace(/[`,]/g, "");
+  const note = m[2].trim();
+  if (/^none$/i.test(locator)) return { path: "none", note };
+  const cut = locator.lastIndexOf(":");
+  return cut > 0 ? { path: locator.slice(0, cut), symbol: locator.slice(cut + 1), note } : { path: locator, note };
+}
+
+function parseJudgment(value: string): { judgment: boolean; judgmentReason?: string } {
+  const m = /^\s*(yes|true)\b\s*(?:[—–-]\s*)?(.*)$/i.exec(value);
+  if (!m) return { judgment: false };
+  const reason = m[2].trim();
+  return reason ? { judgment: true, judgmentReason: reason } : { judgment: true };
+}
+
+/**
+ * Parse a reviewer reply.
+ *
+ * Section state starts at `findings`, not "none": a reviewer that emits blocks
+ * and no headings at all is a partial failure of the contract, and its findings
+ * are still worth keeping — losing them is the exact failure this replaces. The
+ * `saw*Section` flags stay false in that case, which is what the audit gate in
+ * `steps/review-audit.ts` keys off.
+ */
+export function parseReviewReport(text: string): ReviewReport {
+  const report: ReviewReport = {
+    findings: [],
+    touchpoints: [],
+    walk: [],
+    sawNoFindings: false,
+    sawTouchpointsSection: false,
+    sawWalkSection: false,
+  };
+  let section: Section = "findings";
+  let current: Finding | null = null;
+  let lastField: "problem" | "fix" | null = null;
+
+  const flush = () => {
+    if (current) report.findings.push(current);
+    current = null;
+    lastField = null;
+  };
+
+  for (const line of text.split("\n")) {
+    const heading = HEADING.exec(line);
+    if (heading) {
+      flush();
+      const name = heading[1].toLowerCase();
+      if (name === "touchpoints") {
+        section = "touchpoints";
+        report.sawTouchpointsSection = true;
+      } else if (name === "walk") {
+        section = "walk";
+        report.sawWalkSection = true;
+      } else {
+        section = "findings";
+      }
+      continue;
+    }
+
+    if (section === "touchpoints") {
+      const bullet = BULLET.exec(line);
+      const tp = bullet ? parseTouchpoint(bullet[1]) : null;
+      if (tp) report.touchpoints.push(tp);
+      continue;
+    }
+    if (section === "walk") {
+      if (line.trim().length > 0) report.walk.push(line.trim());
+      continue;
+    }
+
+    const block = BLOCK.exec(line);
+    if (block) {
+      flush();
+      current = { severity: block[1] as Severity, title: block[2], problem: "", fix: "" };
+      continue;
+    }
+    if (NO_FINDINGS.test(line)) {
+      report.sawNoFindings = true;
+      continue;
+    }
+    if (!current) continue;
+    const field = FIELD.exec(line);
+    if (field) {
+      const key = field[1].toLowerCase();
+      if (key === "problem") {
+        current.problem = field[2].trim();
+        lastField = "problem";
+      } else if (key === "fix") {
+        current.fix = field[2].trim();
+        lastField = "fix";
+      } else {
+        Object.assign(current, parseJudgment(field[2]));
+        lastField = null;
+      }
+      continue;
+    }
+    // A continuation line for the field above it — the reviewer wraps prose, and
+    // a wrapped Problem read as nothing is how detail silently disappears.
+    if (lastField && line.trim().length > 0) {
+      current[lastField] = `${current[lastField]} ${line.trim()}`.trim();
+    }
+  }
+  flush();
+  return report;
+}
+
+/** Parse the `## DISPOSITIONS` section of a fix node's reply. */
+export function parseDispositions(text: string): FindingDisposition[] {
+  const out: FindingDisposition[] = [];
+  for (const line of text.split("\n")) {
+    const m = DISPOSITION.exec(line);
+    if (!m) continue;
+    const evidence = EVIDENCE.exec(m[3])?.[1];
+    out.push({
+      index: Number(m[1]),
+      disposition: m[2].toLowerCase() as "fixed" | "rejected",
+      ...(evidence ? { evidence } : {}),
+    });
+  }
+  return out;
+}

--- a/flows/nax-finish/flow-ctx.ts
+++ b/flows/nax-finish/flow-ctx.ts
@@ -131,6 +131,11 @@ export function findingsOf(ctx: OutputsCtx, phase: FinishPhase): Finding[] {
  * (round 1), no commit landed since it (nothing new to look at), or the commit
  * step recorded no `shaBefore`.
  */
+/** Why this phase's last review was sent back, so the retry is told what was missing. */
+export function reviewGapsOf(ctx: OutputsCtx, phase: "spec" | "quality"): string[] {
+  return ((ctx.outputs as Record<string, { gaps?: string[] } | undefined>)[`route_${phase}`]?.gaps ?? []) as string[];
+}
+
 export function incrementalSince(ctx: OutputsCtx & StepsCtx, phase: "spec" | "quality"): string | null {
   const steps = ctx.state.steps ?? [];
   const lastReview = steps.map((s) => s.nodeId).lastIndexOf(`review_${phase}`);

--- a/flows/nax-finish/flow-ctx.ts
+++ b/flows/nax-finish/flow-ctx.ts
@@ -131,11 +131,6 @@ export function findingsOf(ctx: OutputsCtx, phase: FinishPhase): Finding[] {
  * (round 1), no commit landed since it (nothing new to look at), or the commit
  * step recorded no `shaBefore`.
  */
-/** Why this phase's last review was sent back, so the retry is told what was missing. */
-export function reviewGapsOf(ctx: OutputsCtx, phase: "spec" | "quality"): string[] {
-  return ((ctx.outputs as Record<string, { gaps?: string[] } | undefined>)[`route_${phase}`]?.gaps ?? []) as string[];
-}
-
 export function incrementalSince(ctx: OutputsCtx & StepsCtx, phase: "spec" | "quality"): string | null {
   const steps = ctx.state.steps ?? [];
   const lastReview = steps.map((s) => s.nodeId).lastIndexOf(`review_${phase}`);
@@ -147,4 +142,9 @@ export function incrementalSince(ctx: OutputsCtx & StepsCtx, phase: "spec" | "qu
     );
   if (!firstCommit) return null;
   return (firstCommit.output as { shaBefore?: string | null } | undefined)?.shaBefore ?? null;
+}
+
+/** Why this phase's last review was sent back, so the retry is told what was missing. */
+export function reviewGapsOf(ctx: OutputsCtx, phase: "spec" | "quality"): string[] {
+  return ((ctx.outputs as Record<string, { gaps?: string[] } | undefined>)[`route_${phase}`]?.gaps ?? []) as string[];
 }

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -81,11 +81,12 @@ import {
   qualityGatesNode,
   resolveFeature,
   routeReviewAndRecord,
+  validateDispositions,
   writeResult,
 } from "./steps";
 import type { Forge } from "./steps/forge";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle } from "./steps/pr-body";
-import type { FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
+import type { FindingDisposition, FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
 import { parseFixVerdict, parseReviewVerdict } from "./verdict";
 
 /**
@@ -187,6 +188,16 @@ function commitFixNode(phase: FinishPhase) {
           : committed
             ? "changed"
             : "unchanged";
+      // A rejection is only as good as its citation, so the path is checked the
+      // same way a reviewer's touchpoints are. A missing file does not veto the
+      // rejection — the fixer may have cited a line rather than a path, or moved
+      // the file — it marks it, so the PR body can say the waiver is unverified
+      // rather than silently presenting it as evidenced.
+      const dispositions = await validateDispositions(
+        i.workdir,
+        (ctx.outputs as Record<string, { dispositions?: FindingDisposition[] } | undefined>)[`fix_${phase}`]
+          ?.dispositions ?? [],
+      );
       await appendRound(
         i,
         buildCommitRound({
@@ -198,6 +209,7 @@ function commitFixNode(phase: FinishPhase) {
           failing: phase === "gate" ? (gateOutputs(ctx).failing ?? []) : undefined,
           shaAfter,
           now: new Date().toISOString(),
+          dispositions,
         }),
       );
       return { committed, route, shaBefore, shaAfter };

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -50,7 +50,15 @@
  */
 import { defineFlow } from "acpx/flows";
 import { buildFixCommitMessage } from "./commit-message";
-import { findingsOf, fixAttemptCount, gateOutputs, incrementalSince, inputOf, loadCtxOf } from "./flow-ctx";
+import {
+  findingsOf,
+  fixAttemptCount,
+  gateOutputs,
+  incrementalSince,
+  inputOf,
+  loadCtxOf,
+  reviewGapsOf,
+} from "./flow-ctx";
 import { narrativePrompt, parseNarrativeNode } from "./narrative";
 import { buildReviewPrompt, fixPrompt } from "./review-prompts";
 import {
@@ -246,6 +254,7 @@ export default defineFlow({
           specPath: outs.specPath ?? "",
           since: incrementalSince(ctx, "spec"),
           priorFindings: findingsOf(ctx, "spec"),
+          gaps: reviewGapsOf(ctx, "spec"),
         });
       },
       parse: parseReviewVerdict,
@@ -271,6 +280,7 @@ export default defineFlow({
           specPath: outs.specPath ?? "",
           since: incrementalSince(ctx, "quality"),
           priorFindings: findingsOf(ctx, "quality"),
+          gaps: reviewGapsOf(ctx, "quality"),
         });
       },
       parse: parseReviewVerdict,
@@ -476,7 +486,13 @@ export default defineFlow({
       from: "route_spec",
       switch: {
         on: "$.route",
-        cases: { clean: "review_quality", fix: "fix_spec", escalate: "escalate", reprompt: "review_spec" },
+        cases: {
+          clean: "review_quality",
+          fix: "fix_spec",
+          escalate: "escalate",
+          reprompt: "review_spec",
+          incomplete: "review_spec",
+        },
       },
     },
     // Spec fixes re-run the acceptance gate first (they can break it), and the
@@ -488,7 +504,13 @@ export default defineFlow({
       from: "route_quality",
       switch: {
         on: "$.route",
-        cases: { clean: "quality_gates", fix: "fix_quality", escalate: "escalate", reprompt: "review_quality" },
+        cases: {
+          clean: "quality_gates",
+          fix: "fix_quality",
+          escalate: "escalate",
+          reprompt: "review_quality",
+          incomplete: "review_quality",
+        },
       },
     },
     // Quality fixes are re-reviewed by the same lens; the repo-root gates that

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -78,7 +78,7 @@ import {
 import type { Forge } from "./steps/forge";
 import { _prBodyDeps, buildFinishBody, buildFinishTitle } from "./steps/pr-body";
 import type { FinishInput, FinishPhase, FinishResult, ReviewVerdict } from "./types";
-import { parseFixVerdict, parseReviewVerdict, repromptCount } from "./verdict";
+import { parseFixVerdict, parseReviewVerdict } from "./verdict";
 
 /**
  * Disabled only on an explicit "0". An unset variable means enabled, so a flow
@@ -246,7 +246,6 @@ export default defineFlow({
           specPath: outs.specPath ?? "",
           since: incrementalSince(ctx, "spec"),
           priorFindings: findingsOf(ctx, "spec"),
-          retry: repromptCount(ctx, "spec") > 0,
         });
       },
       parse: parseReviewVerdict,
@@ -272,7 +271,6 @@ export default defineFlow({
           specPath: outs.specPath ?? "",
           since: incrementalSince(ctx, "quality"),
           priorFindings: findingsOf(ctx, "quality"),
-          retry: repromptCount(ctx, "quality") > 0,
         });
       },
       parse: parseReviewVerdict,

--- a/flows/nax-finish/nax-finish.flow.ts
+++ b/flows/nax-finish/nax-finish.flow.ts
@@ -170,12 +170,24 @@ function commitFixNode(phase: FinishPhase) {
     }): Promise<{ committed: boolean; route: string; shaBefore: string | null; shaAfter: string | null }> {
       const i = inputOf(ctx);
       const messageCtx = { outputs: ctx.outputs as Record<string, unknown> };
+      // A rejection is only as good as its citation, so the path is checked the
+      // same way a reviewer's touchpoints are. A missing file does not veto the
+      // rejection — the fixer may have cited a line rather than a path, or moved
+      // the file — it marks it, so the PR body (and the commit message below)
+      // can say the waiver is unverified rather than silently presenting it as
+      // evidenced. Resolved before the commit so the shipped commit message can
+      // render a rejection the same way the PR body does, instead of `Fix: …`.
+      const dispositions = await validateDispositions(
+        i.workdir,
+        (ctx.outputs as Record<string, { dispositions?: FindingDisposition[] } | undefined>)[`fix_${phase}`]
+          ?.dispositions ?? [],
+      );
       // skipHooks: an intermediate checkpoint must not be rejected by a repo's
       // pre-commit hook — quality_gates runs the repo's real gates before any
       // PR opens, and a hook failure here would kill the flow mid-loop.
       const { committed, shaBefore, shaAfter } = await commitFixes(
         i.workdir,
-        buildFixCommitMessage(phase, i.feature, messageCtx, { workdir: i.workdir }),
+        buildFixCommitMessage(phase, i.feature, messageCtx, { workdir: i.workdir, dispositions }),
         { skipHooks: true },
       );
       // Routed BEFORE the round is recorded: `buildCommitRound` needs the
@@ -188,16 +200,6 @@ function commitFixNode(phase: FinishPhase) {
           : committed
             ? "changed"
             : "unchanged";
-      // A rejection is only as good as its citation, so the path is checked the
-      // same way a reviewer's touchpoints are. A missing file does not veto the
-      // rejection — the fixer may have cited a line rather than a path, or moved
-      // the file — it marks it, so the PR body can say the waiver is unverified
-      // rather than silently presenting it as evidenced.
-      const dispositions = await validateDispositions(
-        i.workdir,
-        (ctx.outputs as Record<string, { dispositions?: FindingDisposition[] } | undefined>)[`fix_${phase}`]
-          ?.dispositions ?? [],
-      );
       await appendRound(
         i,
         buildCommitRound({

--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -411,22 +411,58 @@ export function buildReviewPrompt(
   ].join("\n\n");
 }
 
+/**
+ * The fix node's contract.
+ *
+ * For the two review phases it is no longer "apply these". Every finding used to
+ * be implemented unconditionally, so a false positive was always built — and on
+ * the diff behind #1614 the comparison review raised one finding a human
+ * withdrew, because the change it proposed contradicted a test deliberately
+ * pinning the current behaviour. `quality_gates` would then have proved the
+ * resulting suite green. Reporting more findings without a way to reject one
+ * scales the false-positive exposure with the true-positive one, so the two ship
+ * together.
+ *
+ * A rejection must cite the file:line that pins the behaviour: an unevidenced
+ * "I disagree" is how a real finding gets waived, and `commit_<phase>` checks
+ * that the cited path exists.
+ */
 export function fixPrompt(
   phase: "acceptance" | "spec" | "quality" | "gate",
   ctx: { outputs: Record<string, unknown> },
 ): string {
-  const outs = ctx.outputs as Record<string, { findings?: unknown; output?: string }>;
-  const detail =
-    phase === "gate"
-      ? (outs.quality_gates?.output ?? "")
-      : phase === "acceptance"
-        ? (outs.acceptance?.output ?? "")
-        : JSON.stringify(outs[`review_${phase}`]?.findings ?? []);
+  const outs = ctx.outputs as Record<string, { findings?: Finding[]; output?: string }>;
+  if (phase === "gate" || phase === "acceptance") {
+    const detail = phase === "gate" ? (outs.quality_gates?.output ?? "") : (outs.acceptance?.output ?? "");
+    return [
+      `Apply the recommended fixes for the ${phase} phase, directly in the repo.`,
+      "Do not commit, push, or open PRs — nax-finish commits and pushes your edits itself.",
+      `Context:\n${detail}`,
+      "After fixing, re-run the feature's acceptance tests and the relevant checks; only proceed when they pass.",
+      'Return exactly {"route":"proceed"} when done and green.',
+    ].join("\n\n");
+  }
+  const findings = outs[`review_${phase}`]?.findings ?? [];
+  const numbered = findings
+    .map((f, i) => `[${i + 1}] [${f.severity}] ${f.title}\n  Problem: ${f.problem}\n  Fix: ${f.fix}`)
+    .join("\n");
   return [
-    `Apply the recommended fixes for the ${phase} phase, directly in the repo.`,
+    `Resolve the ${phase} review findings below, directly in the repo.`,
     "Do not commit, push, or open PRs — nax-finish commits and pushes your edits itself.",
-    `Context:\n${detail}`,
-    "After fixing, re-run the feature's acceptance tests and the relevant checks; only proceed when they pass.",
-    'Return exactly {"route":"proceed"} when done and green.',
+    numbered,
+    [
+      "A finding may be REJECTED rather than fixed — but only on evidence, not on preference.",
+      "Reject when the change it asks for would contradict an existing test that deliberately",
+      "pins the current behaviour, or a spec statement that requires it. Cite the `file:line`.",
+      "Anything else you fix.",
+    ].join("\n"),
+    [
+      "After fixing, re-run the feature's acceptance tests and the relevant checks; only proceed when they pass.",
+      "Then end your reply with one line per finding, in this exact shape:",
+      "",
+      "## DISPOSITIONS",
+      "[1] fixed",
+      "[2] rejected — evidence: test/unit/foo.test.ts:42",
+    ].join("\n"),
   ].join("\n\n");
 }

--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -295,33 +295,51 @@ the dispatcher.
 `;
 
 const CLASSIFIER = [
-  "After producing findings, classify the OVERALL route for this phase:",
-  '- Route "proceed" when every finding has a clear recommended fix you can apply now',
-  "  (CRITICAL/HIGH, or MEDIUM whose fix is clear and low-risk) — you will fix them and re-verify.",
-  '- Route "escalate" when ANY finding is a spec conflict, a contradiction with the spec,',
-  "  or a design/judgment concern with no safe mechanical fix. Do not attempt to fix those.",
-].join("\n");
-
-const JSON_CONTRACT = [
-  "Return exactly one JSON object and nothing else. First char `{`, last char `}`.",
-  "Shape:",
-  "{",
-  '  "route": "proceed" | "escalate",',
-  '  "findings": [{ "severity": "CRITICAL"|"HIGH"|"MEDIUM"|"LOW", "title": string, "problem": string, "fix": string }],',
-  '  "escalationReason": string   // required when route is "escalate"; omit otherwise',
-  "}",
+  "Mark a finding for human judgment — and only such a finding — by adding a",
+  "`Judgment: yes — <why>` line to its block. Use it when the finding is a spec",
+  "conflict, or a design/judgment call with no safe mechanical fix. Everything",
+  "else will be fixed and re-verified automatically, so a finding with a clear,",
+  "low-risk fix must NOT carry the marker.",
 ].join("\n");
 
 /**
- * Prepended when a previous attempt at this review returned something that was
- * not JSON. Lead position, not appended: the failure mode is a model that
- * narrates its findings and forgets the contract at the end of a long turn.
+ * The reply contract.
+ *
+ * This supersedes the "Output format — return ONLY this" section of
+ * `WORKER_PROTOCOL` above, which is kept verbatim so it stays diffable against
+ * the skill's `references/worker-protocol.md`. Its `[SEVERITY]` blocks are
+ * exactly this contract's `## FINDINGS` section; the two sections before it are
+ * what the flow adds, because the flow — unlike the skill's dispatcher — has no
+ * human reading the reply and so must be able to check the obligations itself.
+ *
+ * There is no JSON. A reply constrained to one JSON object has nowhere to put
+ * the per-AC and per-function enumerations both dimension references depend on,
+ * and an unreadable object used to discard the entire review (#1614).
  */
-const RETRY_NOTICE = [
-  "IMPORTANT — your previous reply could not be parsed as JSON, so it was discarded entirely.",
-  "Do not narrate your findings in prose. Do not describe what you reported.",
-  "Your entire reply must be the JSON object described at the end of this prompt: first char `{`, last char `}`.",
-].join("\n");
+function outputContract(phase: "spec" | "quality"): string {
+  const walk =
+    phase === "spec"
+      ? "one line per AC in the spec: `AC-3 Covered|Partial|Missing — <one clause>`"
+      : "one line per function or method the diff adds or changes: `path.ts:name — earns its place|concern: <one clause>`";
+  return `# Reply contract — your reply must be these three sections, in this order
+
+## TOUCHPOINTS
+One line per external touchpoint whose definition you actually opened:
+\`- path/to/file.ts:symbol — why you opened it\`. If the diff genuinely has none,
+the single line \`- none — <justification>\`. The paths are checked against the
+repo: a list whose paths do not exist is treated as an incomplete review, not a
+clean one, and you will be asked again.
+
+## WALK
+${walk}. This is the enumeration your dimension reference requires. One line each,
+no prose. A missing or empty WALK section is an incomplete review.
+
+## FINDINGS
+The \`[SEVERITY] …\` blocks defined in the worker protocol above — or the literal
+line \`No findings.\` if you found none. This section is the only thing that
+becomes a finding; the two above are the evidence that you were in a position to
+write it.`;
+}
 
 /**
  * Build the reviewer prompt.
@@ -348,25 +366,21 @@ export function buildReviewPrompt(
     specPath: string;
     since?: string | null;
     priorFindings?: Finding[];
-    retry?: boolean;
   },
 ): string {
   const dims = phase === "spec" ? SPEC_REVIEW_DIMENSIONS : QUALITY_REVIEW_DIMENSIONS;
-  const lead = args.retry ? [RETRY_NOTICE] : [];
   if (!args.since) {
     return [
-      ...lead,
       `You are the ${phase.toUpperCase()} reviewer for a completed feature.`,
       `The spec/requirements source is: ${args.specPath}. Read it in full.`,
       `Fetch and review the diff: \`git diff ${args.base}...HEAD\` (also \`--name-only\` for the file list).`,
       WORKER_PROTOCOL,
       dims,
       CLASSIFIER,
-      JSON_CONTRACT,
+      outputContract(phase),
     ].join("\n\n");
   }
   return [
-    ...lead,
     `You are the ${phase.toUpperCase()} reviewer for a completed feature, continuing a review you already started.`,
     `On your previous pass over \`git diff ${args.base}...HEAD\` you raised the findings below, and they have since been fixed and committed. Everything else in that diff you already judged acceptable — do not re-derive a verdict on it.`,
     `Your findings from the previous pass:\n${JSON.stringify(args.priorFindings ?? [], null, 2)}`,
@@ -380,7 +394,7 @@ export function buildReviewPrompt(
     WORKER_PROTOCOL,
     dims,
     CLASSIFIER,
-    JSON_CONTRACT,
+    outputContract(phase),
   ].join("\n\n");
 }
 

--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -366,11 +366,23 @@ export function buildReviewPrompt(
     specPath: string;
     since?: string | null;
     priorFindings?: Finding[];
+    gaps?: string[];
   },
 ): string {
   const dims = phase === "spec" ? SPEC_REVIEW_DIMENSIONS : QUALITY_REVIEW_DIMENSIONS;
+  const gapNotice =
+    args.gaps && args.gaps.length > 0
+      ? [
+          [
+            "IMPORTANT — your previous review was not accepted, because it skipped a required section:",
+            ...args.gaps.map((g) => `- ${g}`),
+            "Do the reading this time and emit all three sections. A verdict without them is not a review.",
+          ].join("\n"),
+        ]
+      : [];
   if (!args.since) {
     return [
+      ...gapNotice,
       `You are the ${phase.toUpperCase()} reviewer for a completed feature.`,
       `The spec/requirements source is: ${args.specPath}. Read it in full.`,
       `Fetch and review the diff: \`git diff ${args.base}...HEAD\` (also \`--name-only\` for the file list).`,
@@ -381,6 +393,7 @@ export function buildReviewPrompt(
     ].join("\n\n");
   }
   return [
+    ...gapNotice,
     `You are the ${phase.toUpperCase()} reviewer for a completed feature, continuing a review you already started.`,
     `On your previous pass over \`git diff ${args.base}...HEAD\` you raised the findings below, and they have since been fixed and committed. Everything else in that diff you already judged acceptable — do not re-derive a verdict on it.`,
     `Your findings from the previous pass:\n${JSON.stringify(args.priorFindings ?? [], null, 2)}`,

--- a/flows/nax-finish/steps/commit-round.ts
+++ b/flows/nax-finish/steps/commit-round.ts
@@ -8,7 +8,7 @@
  *
  * Pairs with `./review-round`, which records the rounds that produce no commit.
  */
-import type { Finding, FinishPhase, FinishRound, FinishRoundOutcome } from "../types";
+import type { Finding, FindingDisposition, FinishPhase, FinishRound, FinishRoundOutcome } from "../types";
 
 /** Phases that own a reviewer node; every other phase's round has nobody behind it. */
 const REVIEWED_PHASES: FinishPhase[] = ["spec", "quality"];
@@ -40,6 +40,8 @@ export interface CommitRoundInput {
   /** Post-commit HEAD, when there was a commit. */
   shaAfter?: string | null;
   now: string;
+  /** What the fixer did with each finding it was handed (spec/quality phases). */
+  dispositions?: FindingDisposition[];
 }
 
 /**
@@ -60,5 +62,6 @@ export function buildCommitRound(i: CommitRoundInput): FinishRound {
     route: i.route,
     ...(i.failing ? { failing: i.failing } : {}),
     ...(i.committed && i.shaAfter ? { sha: i.shaAfter } : {}),
+    ...(i.dispositions && i.dispositions.length > 0 ? { dispositions: i.dispositions } : {}),
   };
 }

--- a/flows/nax-finish/steps/index.ts
+++ b/flows/nax-finish/steps/index.ts
@@ -9,4 +9,5 @@ export * from "./pr";
 export * from "./pr-narrative";
 export * from "./commit-round";
 export * from "./result";
+export * from "./review-audit";
 export * from "./review-round";

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -25,7 +25,7 @@ import { readSpecSummary, resolveNarrative } from "../narrative";
 import { findPrTemplate } from "../pr-template";
 import { type BodySection, type TemplateMode, mergeTemplate } from "../pr-template-merge";
 import { resolveTitle } from "../pr-title";
-import type { Finding, FinishInput, FinishRound, RunFn } from "../types";
+import type { Finding, FindingDisposition, FinishInput, FinishRound, RunFn } from "../types";
 import type { Forge } from "./forge";
 import { readRounds } from "./result";
 
@@ -370,7 +370,10 @@ function buildRoundBlock(round: FinishRound): string {
     if (round.outcome === "incomplete") {
       lines.push("- _not acted on — the review was sent back for missing evidence sections_");
     }
-    for (const finding of round.findings) lines.push(renderFinding(finding));
+    for (const [i, finding] of round.findings.entries()) {
+      const d = round.dispositions?.find((x) => x.index === i + 1);
+      lines.push(d?.disposition === "rejected" ? renderRejected(finding, d) : renderFinding(finding));
+    }
   }
   return lines.join("\n");
 }
@@ -382,6 +385,19 @@ function buildRoundsSection(rounds: FinishRound[]): string | null {
 
 function renderFinding(finding: Finding): string {
   return `- [${finding.severity}] ${finding.title}`;
+}
+
+/**
+ * A waived finding, shown as waived.
+ *
+ * The alternative — dropping it — would make a rejection indistinguishable from
+ * a fix in the only artifact a human reads, which is the failure this whole
+ * mechanism exists to avoid.
+ */
+function renderRejected(finding: Finding, d: FindingDisposition): string {
+  const evidence = d.evidence ? `\`${d.evidence}\`` : "_no evidence cited_";
+  const caveat = d.evidenceMissing ? " — **evidence path not found**" : "";
+  return `- [${finding.severity}] ${finding.title} — _rejected_: ${evidence}${caveat}`;
 }
 
 /**

--- a/flows/nax-finish/steps/pr-body.ts
+++ b/flows/nax-finish/steps/pr-body.ts
@@ -359,6 +359,7 @@ const EMPTY_ROUND_NOTE: Record<string, string> = {
   unparseable: "- _reviewer output could not be parsed_",
   escalated: "- _escalated for human review_",
   "review-skipped": "- _re-review skipped: this fix touched test files only_",
+  incomplete: "- _review sent back: required evidence sections missing_",
 };
 
 function buildRoundBlock(round: FinishRound): string {
@@ -366,6 +367,9 @@ function buildRoundBlock(round: FinishRound): string {
   if (round.findings.length === 0) {
     lines.push(EMPTY_ROUND_NOTE[round.outcome ?? ""] ?? "- _no findings_");
   } else {
+    if (round.outcome === "incomplete") {
+      lines.push("- _not acted on — the review was sent back for missing evidence sections_");
+    }
     for (const finding of round.findings) lines.push(renderFinding(finding));
   }
   return lines.join("\n");

--- a/flows/nax-finish/steps/review-audit.ts
+++ b/flows/nax-finish/steps/review-audit.ts
@@ -21,6 +21,13 @@
  * the new prompt contract produces a verdict the gate can actually check.
  *
  * `node:fs` — not `Bun.file` — because `flows/` runs inside acpx's Node process.
+ *
+ * Both `touchpoint.path` and a disposition's `evidence` come from the
+ * reviewer/fixer's reply text — untrusted the same way any parsed LLM output
+ * is. `exists()` confines its resolved path under `workdir` before stat-ing
+ * it, so a `../`-laden path can never be used to probe existence outside the
+ * repo; a path that escapes reads as "does not exist," which is the correct
+ * verdict anyway since a legitimate touchpoint is always inside it.
  */
 import { stat } from "node:fs/promises";
 import * as path from "node:path";
@@ -30,8 +37,11 @@ import type { FindingDisposition, ReviewVerdict } from "../types";
 const MAX_CHECKED = 20;
 
 async function exists(workdir: string, rel: string): Promise<boolean> {
+  const root = path.resolve(workdir);
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) return false;
   try {
-    await stat(path.resolve(workdir, rel));
+    await stat(resolved);
     return true;
   } catch {
     return false;

--- a/flows/nax-finish/steps/review-audit.ts
+++ b/flows/nax-finish/steps/review-audit.ts
@@ -24,7 +24,7 @@
  */
 import { stat } from "node:fs/promises";
 import * as path from "node:path";
-import type { ReviewVerdict } from "../types";
+import type { FindingDisposition, ReviewVerdict } from "../types";
 
 /** Paths stat-ed per review. A reviewer listing more than this is not the failure mode. */
 const MAX_CHECKED = 20;
@@ -64,4 +64,18 @@ export async function auditGaps(verdict: ReviewVerdict, workdir: string): Promis
     gaps.push("no `## WALK` section: the per-AC (spec) or per-function (quality) enumeration is required");
   }
   return gaps;
+}
+
+/** Mark any rejection whose cited `file:line` does not resolve in the repo. */
+export async function validateDispositions(
+  workdir: string,
+  dispositions: FindingDisposition[],
+): Promise<FindingDisposition[]> {
+  return Promise.all(
+    dispositions.map(async (d) => {
+      if (d.disposition !== "rejected" || !d.evidence) return d;
+      const file = d.evidence.split(":")[0];
+      return (await exists(workdir, file)) ? d : { ...d, evidenceMissing: true };
+    }),
+  );
 }

--- a/flows/nax-finish/steps/review-audit.ts
+++ b/flows/nax-finish/steps/review-audit.ts
@@ -1,0 +1,67 @@
+/**
+ * Checking that a review discharged its obligations before its verdict counts.
+ *
+ * `WORKER_PROTOCOL` has always told the reviewer to enumerate the external
+ * touchpoints and open their definitions, and both dimension references have
+ * always required a per-item enumeration. Neither was checkable: `routeReview`
+ * saw only a route and a finding list, so a reviewer that read the diff and
+ * nothing else was indistinguishable from one that did the work — and on the run
+ * behind #1614 that is exactly what happened, at 86 seconds for 3,716 changed
+ * lines.
+ *
+ * The disk check is what makes this a gate rather than a ritual. It proves the
+ * paths are real, not that they were read: a reviewer can still list files it
+ * only globbed. That raises the cost of faking the list without eliminating it,
+ * which is the honest ceiling for a check that costs one `stat` per line.
+ *
+ * A verdict from the legacy JSON parsing tier carries no `saw*` fields (they are
+ * optional), so it always reports both gaps and is sent back for one re-review
+ * under the new prompt. That is intentional, not a bug: the safe direction is
+ * an extra review, never a false approval, and the retry self-corrects because
+ * the new prompt contract produces a verdict the gate can actually check.
+ *
+ * `node:fs` — not `Bun.file` — because `flows/` runs inside acpx's Node process.
+ */
+import { stat } from "node:fs/promises";
+import * as path from "node:path";
+import type { ReviewVerdict } from "../types";
+
+/** Paths stat-ed per review. A reviewer listing more than this is not the failure mode. */
+const MAX_CHECKED = 20;
+
+async function exists(workdir: string, rel: string): Promise<boolean> {
+  try {
+    await stat(path.resolve(workdir, rel));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * What this review failed to do. Empty means it may be routed on.
+ *
+ * Only ever called for a verdict that already parsed; an unreadable reply is the
+ * `reprompt` path's business and is handled before this runs.
+ */
+export async function auditGaps(verdict: ReviewVerdict, workdir: string): Promise<string[]> {
+  const gaps: string[] = [];
+  const touchpoints = verdict.touchpoints ?? [];
+  if (!verdict.sawTouchpointsSection || touchpoints.length === 0) {
+    gaps.push("no `## TOUCHPOINTS` section: list every external definition you opened, or `- none — <justification>`");
+  } else if (!touchpoints.some((t) => t.path === "none")) {
+    const checked = touchpoints.slice(0, MAX_CHECKED);
+    const found = await Promise.all(checked.map((t) => exists(workdir, t.path)));
+    if (!found.some(Boolean)) {
+      gaps.push(
+        `touchpoint path does not exist in the repo (checked: ${checked
+          .map((t) => t.path)
+          .join(", ")}) — list files you actually opened`,
+      );
+    }
+  }
+  if (!verdict.sawWalkSection || (verdict.walk ?? []).length === 0) {
+    gaps.push("no `## WALK` section: the per-AC (spec) or per-function (quality) enumeration is required");
+  }
+  return gaps;
+}

--- a/flows/nax-finish/steps/review-round.ts
+++ b/flows/nax-finish/steps/review-round.ts
@@ -18,15 +18,17 @@
  */
 import { inputOf } from "../flow-ctx";
 import type { OutputsCtx, StepsCtx } from "../flow-ctx";
-import type { Finding, FinishRoundOutcome } from "../types";
-import { routeReview } from "../verdict";
+import type { Finding, FinishRoundOutcome, ReviewVerdict } from "../types";
+import { MAX_INCOMPLETE_ATTEMPTS, routeReview } from "../verdict";
 import { appendRound } from "./result";
+import { auditGaps } from "./review-audit";
 
 /** Route → what to call the round. `fix` is absent by construction — see below. */
 const OUTCOME_BY_ROUTE: Record<string, FinishRoundOutcome> = {
   clean: "passed",
   reprompt: "unparseable",
   escalate: "escalated",
+  incomplete: "incomplete",
 };
 
 /**
@@ -40,6 +42,20 @@ const OUTCOME_BY_ROUTE: Record<string, FinishRoundOutcome> = {
  */
 function reviewAttemptCount(ctx: StepsCtx, phase: "spec" | "quality"): number {
   return (ctx.state.steps ?? []).filter((s) => s.nodeId === `review_${phase}`).length;
+}
+
+/**
+ * How many previous rounds of this phase were sent back as incomplete.
+ *
+ * NOT self-inclusive, unlike `repromptCount` — that one counts `review_<phase>`
+ * steps, which acpx has already recorded by the time `route_<phase>` runs, while
+ * this counts `route_<phase>` steps and we are *inside* the current one. So the
+ * comparison below is `<`, where `routeReview`'s reprompt comparison is `<=`.
+ */
+function incompleteCount(ctx: StepsCtx, phase: "spec" | "quality"): number {
+  return (ctx.state.steps ?? []).filter(
+    (s) => s.nodeId === `route_${phase}` && (s.output as { route?: string } | undefined)?.route === "incomplete",
+  ).length;
 }
 
 /**
@@ -57,18 +73,37 @@ function reviewAttemptCount(ctx: StepsCtx, phase: "spec" | "quality"): number {
 export async function routeReviewAndRecord(
   ctx: { input: unknown } & OutputsCtx & StepsCtx,
   phase: "spec" | "quality",
-): Promise<{ route: string; escalationReason?: string; findings: Finding[] }> {
+): Promise<{ route: string; escalationReason?: string; findings: Finding[]; gaps?: string[] }> {
   const routed = routeReview(ctx, phase);
-  const outcome = OUTCOME_BY_ROUTE[routed.route];
+  const input = inputOf(ctx);
+  // The gate runs only on a verdict the flow would otherwise act on. `reprompt`
+  // and `escalate` already end the round, and re-checking a verdict with no
+  // content would report the same two gaps as a second failure mode.
+  let result: { route: string; escalationReason?: string; findings: Finding[]; gaps?: string[] } = routed;
+  if (routed.route === "clean" || routed.route === "fix") {
+    const verdict = (ctx.outputs as Record<string, ReviewVerdict | undefined>)[`review_${phase}`];
+    const gaps = verdict ? await auditGaps(verdict, input.workdir) : [];
+    if (gaps.length > 0) {
+      result =
+        incompleteCount(ctx, phase) < MAX_INCOMPLETE_ATTEMPTS
+          ? { ...routed, route: "incomplete", gaps }
+          : {
+              ...routed,
+              route: "escalate",
+              escalationReason: `${phase} review never discharged its reading obligations: ${gaps.join("; ")}`,
+            };
+    }
+  }
+  const outcome = OUTCOME_BY_ROUTE[result.route];
   if (outcome) {
-    await appendRound(inputOf(ctx), {
+    await appendRound(input, {
       ts: new Date().toISOString(),
       phase,
       attempt: reviewAttemptCount(ctx, phase),
       committed: false,
       outcome,
-      findings: routed.findings,
+      findings: result.findings,
     });
   }
-  return routed;
+  return result;
 }

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -142,7 +142,11 @@ export type FinishRoundOutcome =
    * new meaning — a reader hitting it in an old artifact must still be told
    * what it meant when it was written.
    */
-  | "review-skipped";
+  | "review-skipped"
+  /** The reviewer replied with findings but skipped a required audit section, so
+   * the verdict was not acted on. Distinct from `unparseable`: there was a
+   * readable verdict, it just had no evidence behind it. */
+  | "incomplete";
 
 export interface FinishRound {
   ts: string;

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -76,6 +76,13 @@ export interface ReviewVerdict {
   escalationReason?: string;
   /** Bounded tail of an unparseable reply; set only when `route` is `reprompt`. */
   raw?: string;
+  /** Touchpoints the reviewer listed; read by the audit gate in `routeReviewAndRecord`. */
+  touchpoints?: Touchpoint[];
+  /** The per-AC or per-function walk lines the reviewer emitted. */
+  walk?: string[];
+  /** Whether the section was present at all — absent and empty are different failures. */
+  sawTouchpointsSection?: boolean;
+  sawWalkSection?: boolean;
 }
 /** Wall-clock budgets, forwarded from `finish.autoFlow.timeouts` by the plugin. */
 export interface FinishTimeouts {

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -83,6 +83,8 @@ export interface ReviewVerdict {
   /** Whether the section was present at all — absent and empty are different failures. */
   sawTouchpointsSection?: boolean;
   sawWalkSection?: boolean;
+  /** Set on a `fix_<phase>` output: what the fixer did with each finding it was handed. */
+  dispositions?: FindingDisposition[];
 }
 /** Wall-clock budgets, forwarded from `finish.autoFlow.timeouts` by the plugin. */
 export interface FinishTimeouts {
@@ -181,6 +183,8 @@ export interface FinishRound {
    * than by matching round timestamps against `git log`.
    */
   sha?: string;
+  /** What the fixer did with each finding it was handed (spec/quality phases). */
+  dispositions?: FindingDisposition[];
 }
 
 export interface FinishInput {

--- a/flows/nax-finish/types.ts
+++ b/flows/nax-finish/types.ts
@@ -15,6 +15,49 @@ export interface Finding {
   title: string;
   problem: string;
   fix: string;
+  /**
+   * Set when the reviewer marked this finding as needing a human — a spec
+   * conflict or a design call with no safe mechanical fix. This replaces the
+   * whole-reply `escalate` route the reviewer used to choose: escalation is a
+   * property of one finding, not of the phase, so reporting a design concern no
+   * longer halts the pipeline by itself.
+   */
+  judgment?: boolean;
+  /** Why this finding needs a human; the escalation reason when it escalates. */
+  judgmentReason?: string;
+}
+
+/** One external definition the reviewer says it opened before judging. */
+export interface Touchpoint {
+  /** Repo-relative path, or the literal `none` sentinel. */
+  path: string;
+  /** Symbol or line after the final `:`, when the reviewer gave one. */
+  symbol?: string;
+  /** The reviewer's stated reason for opening it (or for there being none). */
+  note: string;
+}
+
+/** A reviewer reply, parsed. Sections are reported separately from their content
+ * so an *absent* section is distinguishable from an *empty* one — only the first
+ * is a reviewer that skipped the obligation. */
+export interface ReviewReport {
+  findings: Finding[];
+  touchpoints: Touchpoint[];
+  walk: string[];
+  sawNoFindings: boolean;
+  sawTouchpointsSection: boolean;
+  sawWalkSection: boolean;
+}
+
+/** What the fix node did with one finding it was handed. */
+export interface FindingDisposition {
+  /** 1-based index into the findings list the fix prompt numbered. */
+  index: number;
+  disposition: "fixed" | "rejected";
+  /** `file:line` pinning the current behaviour; required for a rejection. */
+  evidence?: string;
+  /** Set by `commit_<phase>` when the cited evidence path does not exist. */
+  evidenceMissing?: boolean;
 }
 export interface ReviewVerdict {
   /**

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -12,6 +12,7 @@
  * `escalate` node that exists to report precisely this.
  */
 import { extractJsonObject } from "acpx/flows";
+import { parseReviewReport } from "./findings-parse";
 import { type OutputsCtx, type StepsCtx, fixAttemptCount } from "./flow-ctx";
 import type { Finding, ReviewVerdict } from "./types";
 
@@ -52,11 +53,29 @@ function parseVerdictJson(text: string): ReviewVerdict {
 }
 
 /**
- * Parser for `review_spec` / `review_quality`, whose JSON is load-bearing —
- * `findingsOf` reads it and the fix loop is driven by it. An unreadable reply
- * routes to `reprompt` so `routeReview` can ask once more before escalating.
+ * Read a reviewer's reply, block format first.
+ *
+ * Three tiers, in cost order: the block contract the prompt asks for; then the
+ * JSON object older runs produced (a flow resumed from a journal recorded before
+ * #1614, or a reviewer that answered in the old shape anyway); then reprompt.
+ * The JSON tier is three lines and removes a whole class of resume failure, so
+ * it stays even though nothing asks for JSON any more.
  */
 export function parseReviewVerdict(text: string): ReviewVerdict {
+  const report = parseReviewReport(text);
+  if (report.findings.length > 0 || report.sawNoFindings) {
+    const judged = report.findings.find((f) => f.judgment);
+    const route = judged ? "escalate" : report.findings.length === 0 ? "clean" : "proceed";
+    return {
+      route,
+      findings: report.findings,
+      ...(judged ? { escalationReason: judged.judgmentReason ?? `Needs human judgment: ${judged.title}` } : {}),
+      touchpoints: report.touchpoints,
+      walk: report.walk,
+      sawTouchpointsSection: report.sawTouchpointsSection,
+      sawWalkSection: report.sawWalkSection,
+    };
+  }
   try {
     return parseVerdictJson(text);
   } catch {

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -36,6 +36,15 @@ export const MAX_FIX_ATTEMPTS = 3;
  */
 export const MAX_REPROMPT_ATTEMPTS = 1;
 
+/**
+ * Reviews sent back for missing evidence sections, per phase, before escalating.
+ *
+ * One, for the same reason `MAX_REPROMPT_ATTEMPTS` is one: a reviewer that
+ * ignores the reply contract twice is not going to honour it on a third ask, and
+ * a review is the most expensive node in the flow.
+ */
+export const MAX_INCOMPLETE_ATTEMPTS = 1;
+
 /** How much of an unparseable reply to carry forward — it lands in a PR comment and a Telegram message. */
 export const RAW_TAIL_LIMIT = 500;
 

--- a/flows/nax-finish/verdict.ts
+++ b/flows/nax-finish/verdict.ts
@@ -12,7 +12,7 @@
  * `escalate` node that exists to report precisely this.
  */
 import { extractJsonObject } from "acpx/flows";
-import { parseReviewReport } from "./findings-parse";
+import { parseDispositions, parseReviewReport } from "./findings-parse";
 import { type OutputsCtx, type StepsCtx, fixAttemptCount } from "./flow-ctx";
 import type { Finding, ReviewVerdict } from "./types";
 
@@ -101,10 +101,16 @@ export function parseReviewVerdict(text: string): ReviewVerdict {
  * (`fix_spec → commit_spec`), so a reprompt route would have nowhere to go.
  */
 export function parseFixVerdict(text: string): ReviewVerdict {
+  const dispositions = parseDispositions(text);
+  // Route is always "proceed" — nothing downstream reads it (see docstring
+  // above), and computing it from `parseVerdictJson` is unsafe here: acpx's
+  // balanced-JSON matcher happily parses a bare `[1]` (the disposition line
+  // `[1] fixed`) as a one-element JSON array, which would silently flip the
+  // route to "clean" on a perfectly good disposition-only reply.
   try {
-    return parseVerdictJson(text);
+    return { route: "proceed", findings: parseVerdictJson(text).findings, dispositions };
   } catch {
-    return { route: "proceed", findings: [] };
+    return { route: "proceed", findings: [], dispositions };
   }
 }
 

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -453,6 +453,13 @@ export const NaxConfigSchema = z
                 sectionMap: z.record(z.string(), z.string()).default({}),
               })
               .default({ template: "merge", sectionMap: {} }),
+            /**
+             * Per-node acpx profiles. Both reviewers default to `null`, i.e.
+             * acpx's `--default-agent` — which is a *weaker* control than the
+             * equivalent skill, whose quality worker runs on a reviewer-tuned
+             * agent type. Pin these when comparing the two, or the comparison
+             * measures tier rather than the flow (#1614).
+             */
             reviewers: z
               .object({
                 spec: z.string().nullable().default(null),

--- a/test/unit/flows/nax-finish/commit-message.test.ts
+++ b/test/unit/flows/nax-finish/commit-message.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildFixCommitMessage } from "@flows/nax-finish/commit-message";
-import type { Finding } from "@flows/nax-finish/types";
+import type { Finding, FindingDisposition } from "@flows/nax-finish/types";
 
 const finding = (over: Partial<Finding> = {}): Finding => ({
   severity: "HIGH",
@@ -168,5 +168,66 @@ describe("buildFixCommitMessage — gate body names the failure", () => {
     expect(msg).toContain("case 0");
     expect(msg).toContain("...and 4 more failing test(s)");
     expect(msg).not.toContain("case 13");
+  });
+});
+
+// #1614-followup: the fixer can now reject a finding on cited counter-evidence
+// (`fix_<phase>`'s `## DISPOSITIONS`), but the shipped commit body kept reading
+// `Fix: <the fix text>` for it regardless — disagreeing with the PR body, which
+// rendered the same finding as rejected. Threading `dispositions` through fixes
+// that.
+describe("buildFixCommitMessage — dispositions", () => {
+  const rejected = (over: Partial<FindingDisposition> = {}): FindingDisposition => ({
+    index: 1,
+    disposition: "rejected",
+    evidence: "test/config/loader.test.ts:42",
+    ...over,
+  });
+
+  test("a rejected finding renders as rejected with its evidence, not as a fix", () => {
+    const msg = buildFixCommitMessage(
+      "quality",
+      "f",
+      ctxOf({ review_quality: { findings: [finding({ fix: "pass 'resolved' into buildRequest." })] } }),
+      { dispositions: [rejected()] },
+    );
+    expect(msg).toContain("rejected: `test/config/loader.test.ts:42`");
+    expect(msg).not.toContain("Fix: pass 'resolved' into buildRequest.");
+  });
+
+  test("a rejection with no cited evidence says so", () => {
+    const msg = buildFixCommitMessage("quality", "f", ctxOf({ review_quality: { findings: [finding()] } }), {
+      dispositions: [rejected({ evidence: undefined })],
+    });
+    expect(msg).toContain("rejected: no evidence cited");
+  });
+
+  test("an evidence path that does not resolve on disk is flagged, not discarded", () => {
+    const msg = buildFixCommitMessage("quality", "f", ctxOf({ review_quality: { findings: [finding()] } }), {
+      dispositions: [rejected({ evidenceMissing: true })],
+    });
+    expect(msg).toContain("evidence path not found");
+  });
+
+  test("a mixed batch renders each finding by its own disposition", () => {
+    const msg = buildFixCommitMessage(
+      "quality",
+      "f",
+      ctxOf({
+        review_quality: {
+          findings: [finding({ title: "A", fix: "Fix A" }), finding({ title: "B", fix: "Fix B" })],
+        },
+      }),
+      { dispositions: [{ index: 2, disposition: "rejected", evidence: "a.ts:1" }] },
+    );
+    expect(msg).toContain("- [HIGH] A");
+    expect(msg).toContain("Fix: Fix A");
+    expect(msg).toContain("- [HIGH] B — rejected: `a.ts:1`");
+    expect(msg).not.toContain("Fix: Fix B");
+  });
+
+  test("callers with no dispositions render exactly as before (gate/acceptance never pass any)", () => {
+    const msg = buildFixCommitMessage("quality", "f", ctxOf({ review_quality: { findings: [finding()] } }));
+    expect(msg).toContain("Fix: Drop the extra guard.");
   });
 });

--- a/test/unit/flows/nax-finish/findings-parse.test.ts
+++ b/test/unit/flows/nax-finish/findings-parse.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { parseDispositions, parseReviewReport } from "@flows/nax-finish/findings-parse";
+
+const FULL_REPLY = `## TOUCHPOINTS
+- src/agents/registry.ts:resolveDefaultAgent — every caller of the changed arg
+- \`src/config/permissions.ts:resolvePermissions\` — the sibling implementations
+- none-of-the-above.ts — deliberately not a sentinel
+
+## WALK
+AC-1 Covered — the loader reads the new key
+AC-2 Missing — no test file exists for the refresh path
+
+## FINDINGS
+[HIGH] Loader ignores the validated value
+  Problem: src/config/loader.ts:88 computes \`resolved\` and then builds the
+  request from the raw input, so validation is dead.
+  Fix: pass \`resolved\` into buildRequest.
+[LOW] Stale docstring
+  Problem: src/config/loader.ts:12 still names the removed key.
+  Fix: update the docstring.
+  Judgment: yes — the right wording is a call for the module owner.
+`;
+
+describe("parseReviewReport", () => {
+  test("parses all three sections of a well-formed reply", () => {
+    const r = parseReviewReport(FULL_REPLY);
+    expect(r.sawTouchpointsSection).toBe(true);
+    expect(r.sawWalkSection).toBe(true);
+    expect(r.touchpoints).toHaveLength(3);
+    expect(r.touchpoints[0]).toEqual({
+      path: "src/agents/registry.ts",
+      symbol: "resolveDefaultAgent",
+      note: "every caller of the changed arg",
+    });
+    expect(r.walk).toEqual([
+      "AC-1 Covered — the loader reads the new key",
+      "AC-2 Missing — no test file exists for the refresh path",
+    ]);
+  });
+
+  test("strips backticks from a touchpoint locator", () => {
+    expect(parseReviewReport(FULL_REPLY).touchpoints[1].path).toBe("src/config/permissions.ts");
+  });
+
+  test("parses findings with multi-line Problem/Fix fields", () => {
+    const r = parseReviewReport(FULL_REPLY);
+    expect(r.findings).toHaveLength(2);
+    expect(r.findings[0].severity).toBe("HIGH");
+    expect(r.findings[0].title).toBe("Loader ignores the validated value");
+    expect(r.findings[0].problem).toContain("validation is dead");
+    expect(r.findings[0].fix).toBe("pass `resolved` into buildRequest.");
+  });
+
+  test("reads a per-finding judgment marker", () => {
+    const r = parseReviewReport(FULL_REPLY);
+    expect(r.findings[0].judgment).toBeUndefined();
+    expect(r.findings[1].judgment).toBe(true);
+    expect(r.findings[1].judgmentReason).toBe("the right wording is a call for the module owner.");
+  });
+
+  test("recognises the No findings. sentinel", () => {
+    const r = parseReviewReport("## TOUCHPOINTS\n- none — one-line docstring diff\n\n## WALK\nAC-1 Covered\n\n## FINDINGS\nNo findings.\n");
+    expect(r.sawNoFindings).toBe(true);
+    expect(r.findings).toEqual([]);
+    expect(r.touchpoints).toEqual([{ path: "none", note: "one-line docstring diff" }]);
+  });
+
+  test("salvages findings from a reply with no headings at all", () => {
+    const r = parseReviewReport("Here is what I found.\n[MEDIUM] Leaky handle\n  Problem: a.ts:3 never closes it.\n  Fix: close it.\n");
+    expect(r.findings).toHaveLength(1);
+    expect(r.sawTouchpointsSection).toBe(false);
+    expect(r.sawWalkSection).toBe(false);
+  });
+
+  test("returns an empty report for prose that contains no blocks", () => {
+    const r = parseReviewReport("I reviewed the diff and it all looks reasonable to me.");
+    expect(r.findings).toEqual([]);
+    expect(r.sawNoFindings).toBe(false);
+  });
+});
+
+describe("parseDispositions", () => {
+  test("parses fixed and rejected entries with evidence", () => {
+    const d = parseDispositions(
+      "## DISPOSITIONS\n[1] fixed\n[2] rejected — evidence: test/unit/config/loader.test.ts:42\n",
+    );
+    expect(d).toEqual([
+      { index: 1, disposition: "fixed" },
+      { index: 2, disposition: "rejected", evidence: "test/unit/config/loader.test.ts:42" },
+    ]);
+  });
+
+  test("returns an empty list when the section is absent", () => {
+    expect(parseDispositions('{"route":"proceed"}')).toEqual([]);
+  });
+});

--- a/test/unit/flows/nax-finish/findings-parse.test.ts
+++ b/test/unit/flows/nax-finish/findings-parse.test.ts
@@ -77,6 +77,18 @@ describe("parseReviewReport", () => {
     expect(r.findings).toEqual([]);
     expect(r.sawNoFindings).toBe(false);
   });
+
+  test("parses correctly even when sections appear out of the prescribed order", () => {
+    const r = parseReviewReport(
+      "## FINDINGS\n[MEDIUM] Out of order\n  Problem: p\n  Fix: f\n\n## WALK\nAC-1 Covered\n\n## TOUCHPOINTS\n- a.ts:sym — reason\n",
+    );
+    expect(r.sawTouchpointsSection).toBe(true);
+    expect(r.sawWalkSection).toBe(true);
+    expect(r.touchpoints).toEqual([{ path: "a.ts", symbol: "sym", note: "reason" }]);
+    expect(r.walk).toEqual(["AC-1 Covered"]);
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].title).toBe("Out of order");
+  });
 });
 
 describe("parseDispositions", () => {

--- a/test/unit/flows/nax-finish/flow-graph.test.ts
+++ b/test/unit/flows/nax-finish/flow-graph.test.ts
@@ -89,6 +89,11 @@ describe("nax-finish flow graph", () => {
     expect(switchOf("route_quality").cases.clean).toBe("quality_gates");
   });
 
+  test("an incomplete review re-enters its own reviewer", () => {
+    expect(switchOf("route_spec").cases.incomplete).toBe("review_spec");
+    expect(switchOf("route_quality").cases.incomplete).toBe("review_quality");
+  });
+
   test("review fixes are re-verified, not applied once and trusted", () => {
     // spec fixes re-run the acceptance gate, which routes back into review_spec
     expect(toOf("commit_spec")).toBe("acceptance");
@@ -325,10 +330,17 @@ describe("review parse + route_* nodes", () => {
   });
 
   const finding = { severity: "HIGH" as const, title: "t", problem: "p", fix: "f" };
+  /** Discharges the review-audit gate so route_* tests exercise routing, not the gate. */
+  const COMPLETE = {
+    sawTouchpointsSection: true,
+    sawWalkSection: true,
+    touchpoints: [{ path: "none", note: "n" }],
+    walk: ["AC-1 Covered — yes"],
+  };
 
   test("route_spec sends findings to the fix node while under the cap", async () => {
     const out = (await nodeRun<{ route: string }>("route_spec").run(
-      ctxOf({ outputs: { review_spec: { route: "proceed", findings: [finding] } } }),
+      ctxOf({ outputs: { review_spec: { route: "proceed", findings: [finding], ...COMPLETE } } }),
     )) as { route: string };
     expect(out.route).toBe("fix");
   });
@@ -361,7 +373,7 @@ describe("review parse + route_* nodes", () => {
       ctxOf({
         outputs: {
           review_spec: { route: "proceed", findings: [finding] },
-          review_quality: { route: "clean", findings: [] },
+          review_quality: { route: "clean", findings: [], ...COMPLETE },
         },
       }),
     )) as { route: string };

--- a/test/unit/flows/nax-finish/flow-reprompt.test.ts
+++ b/test/unit/flows/nax-finish/flow-reprompt.test.ts
@@ -90,17 +90,6 @@ describe("reprompt edges", () => {
     },
   );
 
-  test("review_quality leads with the retry notice after a reprompt", () => {
-    const node = flow.nodes.review_quality as unknown as { prompt: (c: FlowNodeContext) => string };
-    const prompt = node.prompt(
-      ctxOf({
-        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
-        steps: reviewRounds("quality", 1, REPROMPT_VERDICT),
-      }),
-    );
-    expect(prompt).toContain("previous reply could not be parsed");
-  });
-
   test("a retried review is a FULL review, not an incremental one", () => {
     // incrementalSince scopes a re-review to firstCommit.shaBefore..HEAD by finding
     // the first commit_* step after the last review_<phase>. On a reprompt re-entry
@@ -143,17 +132,6 @@ describe("reprompt edges", () => {
     );
     expect(out.route).toBe("escalate");
     expect(out.escalationReason).toContain("after 2 attempts");
-  });
-
-  test("review_spec leads with the retry notice after a reprompt", () => {
-    const node = flow.nodes.review_spec as unknown as { prompt: (c: FlowNodeContext) => string };
-    const prompt = node.prompt(
-      ctxOf({
-        outputs: { load_ctx: { base: "origin/main", specPath: "spec.md" } },
-        steps: reviewRounds("spec", 1, REPROMPT_VERDICT),
-      }),
-    );
-    expect(prompt).toContain("previous reply could not be parsed");
   });
 
   test("a retried spec review is a FULL review, not an incremental one", () => {

--- a/test/unit/flows/nax-finish/pr-body.test.ts
+++ b/test/unit/flows/nax-finish/pr-body.test.ts
@@ -151,6 +151,23 @@ describe("buildFinishBody — Review rounds (US-002 AC8-AC12)", () => {
     expect(body).toContain("- [LOW] Naming inconsistency");
   });
 
+  test("a rejected finding is rendered as waived, with its evidence", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        rounds: [
+          committedRound({
+            phase: "quality",
+            outcome: "fixed",
+            findings: [finding({ severity: "LOW", title: "Dead param" })],
+            dispositions: [{ index: 1, disposition: "rejected", evidence: "test/unit/a.test.ts:9" }],
+          }),
+        ],
+      }),
+    );
+    expect(body).toContain("_rejected_");
+    expect(body).toContain("test/unit/a.test.ts:9");
+  });
+
   test("renders the abbreviated seven-character SHA in the round heading when committed", () => {
     const body = buildFinishBody(
       baseCtx({

--- a/test/unit/flows/nax-finish/review-prompts.test.ts
+++ b/test/unit/flows/nax-finish/review-prompts.test.ts
@@ -50,14 +50,32 @@ describe("fixPrompt", () => {
     expect(p).toContain("test XYZ failed");
   });
 
-  test("spec phase pulls review_spec.findings as JSON", () => {
-    const p = fixPrompt("spec", { outputs: { review_spec: { findings: [{ severity: "HIGH", title: "t" }] } } });
-    expect(p).toContain('"severity":"HIGH"');
+  test("spec phase numbers review_spec.findings", () => {
+    const p = fixPrompt("spec", {
+      outputs: { review_spec: { findings: [{ severity: "HIGH", title: "t", problem: "p", fix: "f" }] } },
+    });
+    expect(p).toContain("[1] [HIGH] t");
   });
 
-  test("quality phase pulls review_quality.findings as JSON", () => {
-    const p = fixPrompt("quality", { outputs: { review_quality: { findings: [{ severity: "LOW", title: "q" }] } } });
-    expect(p).toContain('"severity":"LOW"');
+  test("quality phase numbers review_quality.findings", () => {
+    const p = fixPrompt("quality", {
+      outputs: { review_quality: { findings: [{ severity: "LOW", title: "q", problem: "p", fix: "f" }] } },
+    });
+    expect(p).toContain("[1] [LOW] q");
+  });
+
+  test("the spec fix prompt numbers its findings and demands a disposition for each", () => {
+    const p = fixPrompt("spec", {
+      outputs: { review_spec: { findings: [{ severity: "HIGH", title: "T", problem: "p", fix: "f" }] } },
+    });
+    expect(p).toContain("[1] [HIGH] T");
+    expect(p).toContain("## DISPOSITIONS");
+    expect(p).toContain("rejected — evidence:");
+  });
+
+  test("the gate fix prompt has no dispositions section — it has no findings", () => {
+    const p = fixPrompt("gate", { outputs: { quality_gates: { output: "lint failed" } } });
+    expect(p).not.toContain("## DISPOSITIONS");
   });
 });
 

--- a/test/unit/flows/nax-finish/review-prompts.test.ts
+++ b/test/unit/flows/nax-finish/review-prompts.test.ts
@@ -18,13 +18,22 @@ describe("review prompts", () => {
     expect(QUALITY_REVIEW_DIMENSIONS).toContain("≥60% confident");
   });
 
-  test("spec prompt carries the classifier + strict JSON contract", () => {
+  test("spec prompt carries the classifier and the three-section output contract", () => {
     const p = buildReviewPrompt("spec", { base: "origin/main", specPath: ".nax/features/x/prd.json" });
     expect(p).toContain("git diff origin/main...HEAD");
     expect(p).toContain(".nax/features/x/prd.json");
-    expect(p).toContain('"route": "proceed" | "escalate"');
-    expect(p).toContain("spec conflict"); // escalate trigger
-    expect(p).toContain("recommended fix"); // proceed trigger
+    expect(p).toContain("## TOUCHPOINTS");
+    expect(p).toContain("## WALK");
+    expect(p).toContain("## FINDINGS");
+    expect(p).toContain("Judgment: yes");
+    expect(p).not.toContain("First char `{`");
+  });
+
+  test("the quality prompt asks for a per-function walk, the spec prompt for a per-AC walk", () => {
+    const spec = buildReviewPrompt("spec", { base: "origin/main", specPath: "s.md" });
+    const quality = buildReviewPrompt("quality", { base: "origin/main", specPath: "s.md" });
+    expect(spec).toContain("one line per AC");
+    expect(quality).toContain("one line per function");
   });
 });
 
@@ -99,36 +108,11 @@ describe("buildReviewPrompt — incremental re-review", () => {
     expect(p).toContain("assertion weakened, test deleted, check disabled");
   });
 
-  test("both rounds keep the full dimensions and the JSON contract", () => {
+  test("both rounds keep the full dimensions and the output contract", () => {
     for (const since of [null, "abc123"]) {
       const p = buildReviewPrompt("quality", { base: "origin/main", specPath: "s.md", since, priorFindings: PRIOR });
       expect(p).toContain("Confidence threshold");
-      expect(p).toContain('"route"');
+      expect(p).toContain("## FINDINGS");
     }
-  });
-});
-
-describe("buildReviewPrompt retry variant", () => {
-  const base = { base: "origin/main", specPath: "spec.md" };
-
-  test("omits the retry notice by default", () => {
-    expect(buildReviewPrompt("quality", base)).not.toContain("previous reply could not be parsed");
-  });
-
-  test("leads a full review with the retry notice when retrying", () => {
-    const p = buildReviewPrompt("quality", { ...base, retry: true });
-    expect(p).toContain("previous reply could not be parsed");
-    expect(p.indexOf("previous reply could not be parsed")).toBeLessThan(p.indexOf("You are the QUALITY reviewer"));
-  });
-
-  test("leads an incremental review with the retry notice too", () => {
-    const p = buildReviewPrompt("spec", { ...base, since: "abc123", priorFindings: [], retry: true });
-    expect(p).toContain("previous reply could not be parsed");
-    expect(p).toContain("abc123");
-  });
-
-  test("keeps the JSON contract last on a retry", () => {
-    const p = buildReviewPrompt("quality", { ...base, retry: true });
-    expect(p.trimEnd().endsWith("}")).toBe(true);
   });
 });

--- a/test/unit/flows/nax-finish/steps/review-audit.test.ts
+++ b/test/unit/flows/nax-finish/steps/review-audit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { auditGaps } from "@flows/nax-finish/steps/review-audit";
+import { auditGaps, validateDispositions } from "@flows/nax-finish/steps/review-audit";
 import type { ReviewVerdict } from "@flows/nax-finish/types";
 
 const REPO = process.cwd();
@@ -48,5 +48,27 @@ describe("auditGaps", () => {
   test("a missing or empty WALK is a gap", async () => {
     expect((await auditGaps(base({ walk: [] }), REPO)).join(" ")).toContain("WALK");
     expect((await auditGaps(base({ sawWalkSection: false, walk: [] }), REPO)).join(" ")).toContain("WALK");
+  });
+
+  test("a touchpoint path escaping workdir via `../` is treated as not existing", async () => {
+    const gaps = await auditGaps(
+      base({ touchpoints: [{ path: "../../../../../../etc/passwd", note: "n" }] }),
+      REPO,
+    );
+    expect(gaps.join(" ")).toContain("does not exist");
+  });
+});
+
+describe("validateDispositions", () => {
+  test("a rejection whose evidence path exists is left untouched", async () => {
+    const d = await validateDispositions(REPO, [{ index: 1, disposition: "rejected", evidence: "package.json:1" }]);
+    expect(d[0].evidenceMissing).toBeUndefined();
+  });
+
+  test("a rejection whose evidence escapes workdir via `../` is marked evidenceMissing", async () => {
+    const d = await validateDispositions(REPO, [
+      { index: 1, disposition: "rejected", evidence: "../../../../../../etc/passwd:1" },
+    ]);
+    expect(d[0].evidenceMissing).toBe(true);
   });
 });

--- a/test/unit/flows/nax-finish/steps/review-audit.test.ts
+++ b/test/unit/flows/nax-finish/steps/review-audit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { auditGaps } from "@flows/nax-finish/steps/review-audit";
+import type { ReviewVerdict } from "@flows/nax-finish/types";
+
+const REPO = process.cwd();
+const base = (over: Partial<ReviewVerdict> = {}): ReviewVerdict => ({
+  route: "proceed",
+  findings: [],
+  sawTouchpointsSection: true,
+  sawWalkSection: true,
+  touchpoints: [{ path: "package.json", note: "the scripts block" }],
+  walk: ["AC-1 Covered — yes"],
+  ...over,
+});
+
+describe("auditGaps", () => {
+  test("a complete review has no gaps", async () => {
+    expect(await auditGaps(base(), REPO)).toEqual([]);
+  });
+
+  test("a missing TOUCHPOINTS section is a gap", async () => {
+    const gaps = await auditGaps(base({ sawTouchpointsSection: false, touchpoints: [] }), REPO);
+    expect(gaps.join(" ")).toContain("TOUCHPOINTS");
+  });
+
+  test("an empty TOUCHPOINTS section is a gap", async () => {
+    const gaps = await auditGaps(base({ touchpoints: [] }), REPO);
+    expect(gaps.join(" ")).toContain("TOUCHPOINTS");
+  });
+
+  test("the explicit none sentinel discharges the touchpoint obligation", async () => {
+    expect(await auditGaps(base({ touchpoints: [{ path: "none", note: "one-line docstring" }] }), REPO)).toEqual([]);
+  });
+
+  test("touchpoint paths that do not exist are a gap", async () => {
+    const gaps = await auditGaps(base({ touchpoints: [{ path: "src/does-not-exist.ts", note: "n" }] }), REPO);
+    expect(gaps.join(" ")).toContain("does not exist");
+  });
+
+  test("one real path among fabricated ones is enough to pass", async () => {
+    const gaps = await auditGaps(
+      base({ touchpoints: [{ path: "src/nope.ts", note: "n" }, { path: "package.json", note: "n" }] }),
+      REPO,
+    );
+    expect(gaps).toEqual([]);
+  });
+
+  test("a missing or empty WALK is a gap", async () => {
+    expect((await auditGaps(base({ walk: [] }), REPO)).join(" ")).toContain("WALK");
+    expect((await auditGaps(base({ sawWalkSection: false, walk: [] }), REPO)).join(" ")).toContain("WALK");
+  });
+});

--- a/test/unit/flows/nax-finish/steps/review-round.test.ts
+++ b/test/unit/flows/nax-finish/steps/review-round.test.ts
@@ -18,6 +18,14 @@ const INPUT = {
 
 const FINDING = { severity: "HIGH", title: "t", problem: "p", fix: "f" };
 
+/** A verdict that discharges the review-audit gate — no `incomplete` gaps. */
+const COMPLETE = {
+  sawTouchpointsSection: true,
+  sawWalkSection: true,
+  touchpoints: [{ path: "none", note: "n" }],
+  walk: ["AC-1 Covered — yes"],
+};
+
 /** Capture every round `routeReviewAndRecord` appends, parsed back from JSONL. */
 function captureRounds(): FinishRound[] {
   const written: FinishRound[] = [];
@@ -36,7 +44,7 @@ const ctxWith = (verdict: unknown, steps = [makeFlowStep("review_quality")]) => 
 describe("routeReviewAndRecord", () => {
   test("records a round when the review passes with no findings", async () => {
     const rounds = captureRounds();
-    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [] }), "quality");
+    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [], ...COMPLETE }), "quality");
 
     expect(r.route).toBe("clean");
     expect(rounds).toHaveLength(1);
@@ -53,7 +61,7 @@ describe("routeReviewAndRecord", () => {
     // The round is appended at `commit_<phase>`, where the findings AND the
     // resulting commit are both known. Recording here too would double-count it.
     const rounds = captureRounds();
-    const r = await routeReviewAndRecord(ctxWith({ route: "proceed", findings: [FINDING] }), "quality");
+    const r = await routeReviewAndRecord(ctxWith({ route: "proceed", findings: [FINDING], ...COMPLETE }), "quality");
 
     expect(r.route).toBe("fix");
     expect(rounds).toEqual([]);
@@ -89,7 +97,7 @@ describe("routeReviewAndRecord", () => {
       makeFlowStep("commit_quality"),
       makeFlowStep("review_quality"),
     ];
-    await routeReviewAndRecord(ctxWith({ route: "clean", findings: [] }, steps), "quality");
+    await routeReviewAndRecord(ctxWith({ route: "clean", findings: [], ...COMPLETE }, steps), "quality");
 
     expect(rounds[0].attempt).toBe(2);
   });
@@ -105,7 +113,7 @@ describe("routeReviewAndRecord", () => {
     _resultDeps.appendText = async () => {
       throw new Error("EACCES");
     };
-    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [] }), "quality");
+    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [], ...COMPLETE }), "quality");
     expect(r.route).toBe("clean");
   });
 });

--- a/test/unit/flows/nax-finish/steps/review-round.test.ts
+++ b/test/unit/flows/nax-finish/steps/review-round.test.ts
@@ -26,6 +26,18 @@ const COMPLETE = {
   walk: ["AC-1 Covered — yes"],
 };
 
+/**
+ * A verdict `auditGaps` flags: TOUCHPOINTS is fine but `## WALK` never showed
+ * up. Mirrors `COMPLETE` except for the one field that makes it gapped, so
+ * the only thing under test is the WALK obligation.
+ */
+const MISSING_WALK = {
+  sawTouchpointsSection: true,
+  sawWalkSection: false,
+  touchpoints: [{ path: "none", note: "n" }],
+  walk: [],
+};
+
 /** Capture every round `routeReviewAndRecord` appends, parsed back from JSONL. */
 function captureRounds(): FinishRound[] {
   const written: FinishRound[] = [];
@@ -115,5 +127,35 @@ describe("routeReviewAndRecord", () => {
     };
     const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [], ...COMPLETE }), "quality");
     expect(r.route).toBe("clean");
+  });
+
+  test("routes a gapped verdict to incomplete and records the round with that outcome", async () => {
+    const rounds = captureRounds();
+    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [], ...MISSING_WALK }), "quality");
+
+    expect(r.route).toBe("incomplete");
+    expect(r.gaps).toBeDefined();
+    expect(r.gaps?.length).toBeGreaterThan(0);
+    expect(r.gaps?.[0]).toContain("WALK");
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0]).toMatchObject({ phase: "quality", committed: false, outcome: "incomplete" });
+  });
+
+  test("escalates a second consecutive incomplete review, naming the reading obligations", async () => {
+    const rounds = captureRounds();
+    // A prior `route_quality` step already routed `incomplete` once — that is
+    // how `incompleteCount` learns this phase already used its one resend, the
+    // same way the reprompt-then-escalate tests simulate a prior attempt via
+    // the steps array.
+    const steps = [
+      makeFlowStep("review_quality"),
+      makeFlowStep("route_quality", { output: { route: "incomplete" } }),
+      makeFlowStep("review_quality"),
+    ];
+    const r = await routeReviewAndRecord(ctxWith({ route: "clean", findings: [], ...MISSING_WALK }, steps), "quality");
+
+    expect(r.route).toBe("escalate");
+    expect(r.escalationReason).toContain("reading obligations");
+    expect(rounds[0]).toMatchObject({ outcome: "escalated" });
   });
 });

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -71,6 +71,55 @@ describe("parseReviewVerdict", () => {
   });
 });
 
+const BLOCK_REPLY = `## TOUCHPOINTS
+- src/a.ts:run — the only caller
+
+## WALK
+AC-1 Covered — done
+
+## FINDINGS
+[HIGH] Broken thing
+  Problem: a.ts:1 breaks.
+  Fix: unbreak it.
+`;
+
+describe("parseReviewVerdict — block format", () => {
+  test("parses severity blocks and routes proceed", () => {
+    const v = parseReviewVerdict(BLOCK_REPLY);
+    expect(v.route).toBe("proceed");
+    expect(v.findings).toHaveLength(1);
+    expect(v.findings[0].title).toBe("Broken thing");
+  });
+
+  test("carries the audit sections through for the gate to read", () => {
+    const v = parseReviewVerdict(BLOCK_REPLY);
+    expect(v.sawTouchpointsSection).toBe(true);
+    expect(v.sawWalkSection).toBe(true);
+    expect(v.touchpoints?.[0]?.path).toBe("src/a.ts");
+    expect(v.walk).toHaveLength(1);
+  });
+
+  test("No findings. routes clean", () => {
+    expect(parseReviewVerdict("## FINDINGS\nNo findings.").route).toBe("clean");
+  });
+
+  test("a judgment-marked finding escalates, and names its reason", () => {
+    const v = parseReviewVerdict(
+      "[MEDIUM] Design call\n  Problem: p\n  Fix: f\n  Judgment: yes — two valid designs, pick one\n",
+    );
+    expect(v.route).toBe("escalate");
+    expect(v.escalationReason).toContain("two valid designs");
+  });
+
+  test("findings without a judgment marker never escalate", () => {
+    expect(parseReviewVerdict(BLOCK_REPLY).route).toBe("proceed");
+  });
+
+  test("the real unparseable reply still routes reprompt", () => {
+    expect(parseReviewVerdict(REAL_UNPARSEABLE).route).toBe("reprompt");
+  });
+});
+
 describe("parseFixVerdict", () => {
   test("parses JSON like the review parser", () => {
     expect(parseFixVerdict(JSON.stringify({ route: "proceed", findings: [FINDING] })).findings).toHaveLength(1);

--- a/test/unit/flows/nax-finish/verdict.test.ts
+++ b/test/unit/flows/nax-finish/verdict.test.ts
@@ -134,6 +134,19 @@ describe("parseFixVerdict", () => {
   test("never throws on empty output", () => {
     expect(parseFixVerdict("").route).toBe("proceed");
   });
+
+  test("keeps the dispositions it was given", () => {
+    const v = parseFixVerdict("## DISPOSITIONS\n[1] fixed\n[2] rejected — evidence: test/a.test.ts:9\n");
+    expect(v.dispositions).toHaveLength(2);
+    expect(v.dispositions?.[1]).toMatchObject({ index: 2, disposition: "rejected" });
+    expect(v.route).toBe("proceed");
+  });
+
+  test("still proceeds on an unreadable fix reply", () => {
+    const v = parseFixVerdict("I did the thing.");
+    expect(v.route).toBe("proceed");
+    expect(v.dispositions ?? []).toEqual([]);
+  });
 });
 
 const stepsCtx = (steps: FlowStepRecord[]) => ({ state: { steps }, outputs: {} });


### PR DESCRIPTION
## Summary

On an identical diff, `flows/nax-finish`'s reviewer nodes produced 2 findings where the `post-impl-review` skill produced 14, with no overlap (issue #1614). Root cause: the reviewer prompt carried two contradictory output contracts (a `[SEVERITY]`-block instruction and a strict-JSON instruction), the JSON contract had nowhere to put the per-AC/per-function enumeration the review dimensions require, the collaborator-read obligation was unchecked, and a finding could never be rejected — so every reported finding was always applied, with no way to catch a false positive.

- Replace the JSON reply contract with a deterministic three-section text format (`## TOUCHPOINTS`, `## WALK`, `## FINDINGS`), parsed by a new pure, non-throwing regex module (`flows/nax-finish/findings-parse.ts`). `parseReviewVerdict` tries this block tier first, falls back to the legacy JSON tier, then to `reprompt`.
- Move escalation from a whole-reply verdict to a per-finding `Judgment: yes — <why>` marker, so reporting a design concern no longer halts the pipeline by itself.
- Gate the collaborator read and enumeration: `auditGaps` verifies a review claiming `clean`/`fix` actually populated TOUCHPOINTS/WALK and that at least one touchpoint path resolves on disk. An incomplete review is sent back once, then escalated — never routed clean.
- Give the fix node a rejection path: `fix_<phase>` can reject a finding with a `file:line` evidence citation instead of always applying it. Rejections are recorded, rendered distinctly in the PR body, and (after a final-review fix) in the shipped commit message too — so git history and the PR body agree on what happened to each finding.
- Document the new reply contract, per-finding escalation semantics, the rejection/DISPOSITIONS mechanism, and a reviewer-tier-parity caveat for A/B comparisons against the skill.

## Process

Implemented via subagent-driven development: 5 tasks, each with an isolated implementer + task-scoped review (one fix round in Task 3 for a misplaced doc comment), followed by a final whole-branch review that found 3 Important cross-task issues (commit-message/PR-body disagreement on rejections, missing docs for the rejection mechanism, and missing test coverage of the `incomplete` route's actual gate-triggering path) — all fixed in one wave and re-verified clean.

## Test plan

- [x] `bun test test/unit/flows/nax-finish/ --timeout=30000` — 532 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Full suite (`bun run test`): 13754 unit + 1125 integration + 37 ui — all pass, 0 fail
- [ ] Re-run the #1614 A/B (same branch/base/spec through the autoflow and through `post-impl-review`, with `finish.autoFlow.reviewers.quality` pinned per the new tier-parity docs) and post finding counts + escalation outcome on the issue — noted in the plan as the follow-up that actually closes #1614.