### PR TITLE
fix(context): surface budget-dropped rule sections in the emitted prompt

### DIFF
--- a/src/context/engine/providers/static-rules-budget-notice.ts
+++ b/src/context/engine/providers/static-rules-budget-notice.ts
@@ -1,0 +1,76 @@
+/**
+ * Context Engine v2 — StaticRulesProvider budget-drop notice (#1610)
+ *
+ * `applySectionBudget` (rule-budget.ts) drops rule sections silently — the
+ * surviving chunks carry no marker distinguishing a truncated ruleset from
+ * a complete one. `CodeNeighborProvider` already surfaces its own capped
+ * scan via a prompt-visible note (code-neighbor-chunk.ts); this module gives
+ * `StaticRulesProvider` the same treatment so a drop is never reachable
+ * without the consumer being told.
+ */
+
+import type { RuleSection, SectionBudgetResult } from "@/context";
+import { estimateTokens } from "@/optimizer";
+import type { ProviderBudgetPressure } from "../manifest-types";
+import type { RawChunk } from "../types";
+
+/**
+ * Build a `ProviderBudgetPressure` from the section budget result, or
+ * return `null` when there is no overage and nothing was dropped.
+ */
+export function buildSectionBudgetPressure(
+  allSections: RuleSection[],
+  budgetResult: SectionBudgetResult,
+): ProviderBudgetPressure | null {
+  const { droppedIds, overageTokens } = budgetResult;
+  const droppedCount = droppedIds.length;
+  if (droppedCount === 0 && overageTokens <= 0) return null;
+
+  const kept = new Set(budgetResult.retainedSections);
+  let droppedTokens = 0;
+  for (const section of allSections) {
+    if (!kept.has(section)) {
+      droppedTokens += section.tokens;
+    }
+  }
+
+  return { overageTokens, droppedCount, droppedTokens, droppedIds };
+}
+
+/**
+ * A budget overrun can drop tens-to-hundreds of sections; listing every id
+ * would make the notice itself a meaningful chunk of the (already exceeded)
+ * budget. Cap the visible list and summarize the remainder.
+ */
+const MAX_LISTED_DROPPED_IDS = 10;
+
+/** Prompt-visible sentence describing a budget-driven section drop. */
+export function budgetNoticeText(droppedCount: number, droppedIds?: string[]): string {
+  let detail = "";
+  if (droppedIds && droppedIds.length > 0) {
+    const shown = droppedIds.slice(0, MAX_LISTED_DROPPED_IDS);
+    const remainder = droppedIds.length - shown.length;
+    detail = ` (${shown.join(", ")}${remainder > 0 ? `, +${remainder} more` : ""})`;
+  }
+  return `Note: rule budget exceeded — ${droppedCount} lower-priority section(s) dropped${detail}. Increase \`context.v2.rules.rulesShare\` / \`context.v2.rules.budgetTokens\`, or set \`context.v2.rules.enforceBudget: false\`, to see the full ruleset.`;
+}
+
+/**
+ * Standalone notice chunk carrying the budget-drop notice. Used for BOTH the
+ * partial-drop case and the all-sections-dropped case (US-003 empty-chunks
+ * branch) — a standalone chunk, rather than text spliced into the last rule
+ * chunk's content, survives `dedupeChunks` independently of whatever rule
+ * section happens to be last (#1610).
+ */
+export function buildBudgetNoticeChunk(storyId: string, droppedCount: number, droppedIds?: string[]): RawChunk {
+  const content = `> ${budgetNoticeText(droppedCount, droppedIds)}`;
+  return {
+    id: `static-rules:__budget-notice__:${storyId}`,
+    kind: "static" as const,
+    scope: "project" as const,
+    role: ["all"] as ["all"],
+    content,
+    tokens: estimateTokens(content),
+    rawScore: 1.0,
+  };
+}

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -16,7 +16,6 @@
 import { createHash } from "node:crypto";
 import { join, relative } from "node:path";
 import { applySectionBudget } from "@/context";
-import type { SectionBudgetResult } from "@/context";
 import { splitRuleIntoSections } from "@/context";
 import type { RuleSection } from "@/context";
 import { getLogger } from "@/logger";
@@ -27,9 +26,10 @@ import { estimateTokens } from "@/optimizer";
 import { errorMessage } from "@/utils/errors";
 import { DEFAULT_CANONICAL_RULES_BUDGET_TOKENS } from "../../rules/canonical-loader";
 import type { CanonicalRule } from "../../rules/canonical-loader";
-import type { ProviderBudgetPressure, ProviderScopingReport } from "../manifest-types";
+import type { ProviderScopingReport } from "../manifest-types";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 import { memoizedLoadCanonicalRules } from "./canonical-rules-cache";
+import { buildBudgetNoticeChunk, buildSectionBudgetPressure } from "./static-rules-budget-notice";
 
 export { _resetCanonicalRulesCache } from "./canonical-rules-cache";
 
@@ -199,33 +199,6 @@ function ruleMatchesPackage(paths: string[] | undefined, repoRoot: string, packa
   const patterns = paths.map((p) => globToRegex(normalizePath(p)));
   // Also test rel + "/" so that "packages/api/**" matches the base dir "packages/api"
   return patterns.some((pattern) => pattern.test(rel) || pattern.test(`${rel}/`));
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Budget pressure helper (US-003)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Build a `ProviderBudgetPressure` from the section budget result, or
- * return `null` when there is no overage and nothing was dropped.
- */
-function buildSectionBudgetPressure(
-  allSections: RuleSection[],
-  budgetResult: SectionBudgetResult,
-): ProviderBudgetPressure | null {
-  const { droppedIds, overageTokens } = budgetResult;
-  const droppedCount = droppedIds.length;
-  if (droppedCount === 0 && overageTokens <= 0) return null;
-
-  const kept = new Set(budgetResult.retainedSections);
-  let droppedTokens = 0;
-  for (const section of allSections) {
-    if (!kept.has(section)) {
-      droppedTokens += section.tokens;
-    }
-  }
-
-  return { overageTokens, droppedCount, droppedTokens, droppedIds };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -423,14 +396,19 @@ export class StaticRulesProvider implements IContextProvider {
             });
           }
           const emptyPressure = buildSectionBudgetPressure(allSections, budgetResult);
+          const emptyChunks: RawChunk[] =
+            this.enforceBudget && budgetResult.droppedIds.length > 0
+              ? [buildBudgetNoticeChunk(request.storyId, budgetResult.droppedIds.length, budgetResult.droppedIds)]
+              : [];
           return {
-            chunks: [],
+            chunks: emptyChunks,
             pullTools: [],
             ...(emptyPressure && { budgetPressure: emptyPressure }),
             scopingReport,
           };
         }
-        const chunks = effectiveSections.map((section) => {
+
+        const chunks: RawChunk[] = effectiveSections.map((section) => {
           const ruleId = sectionRuleIdMap.get(section) ?? section.ruleId ?? "unknown";
           const rulePath = sectionRulePathMap.get(section) ?? section.rulePath ?? ruleId;
           const content = `### ${rulePath}\n\n${section.content}`;
@@ -461,6 +439,13 @@ export class StaticRulesProvider implements IContextProvider {
           totalCanonicalRules: mergedRules.length,
           files: effectiveSections.map((s) => s.rulePath ?? "unknown"),
         });
+
+        // Standalone notice chunk (not spliced into the last rule chunk) so
+        // it survives dedupeChunks independently of whatever rule section
+        // happens to sort last (#1610).
+        if (this.enforceBudget && budgetResult.droppedIds.length > 0) {
+          chunks.push(buildBudgetNoticeChunk(request.storyId, budgetResult.droppedIds.length, budgetResult.droppedIds));
+        }
 
         const pressure = buildSectionBudgetPressure(allSections, budgetResult);
         return {

--- a/test/unit/context/engine/providers/static-rules-budget-derivation.test.ts
+++ b/test/unit/context/engine/providers/static-rules-budget-derivation.test.ts
@@ -79,9 +79,42 @@ describe("StaticRulesProvider — US-003 per-stage rules budget derivation", () 
     const provider = new StaticRulesProvider({ budgetTokens: 8192, rulesShare: 0.4, enforceBudget: true });
     const request: ContextRequest = { ...BASE_REQUEST, budgetTokens: 4000 };
     const result = await provider.fetch(request);
-    // Effective budget 1600: a(800)+b(800)=1600 fits, c(400) does not → keep [a,b], drop c
-    expect(result.chunks).toHaveLength(2);
+    // Effective budget 1600: a(800)+b(800)=1600 fits, c(400) does not → keep [a,b], drop c,
+    // append a standalone notice chunk (#1610) — 2 rule chunks + 1 notice chunk.
+    expect(result.chunks).toHaveLength(3);
     expect(result.budgetPressure?.droppedCount).toBe(1);
+    // #1610: a dropped-tail must surface in the emitted prompt content, not just telemetry,
+    // and as its OWN chunk — not spliced into whichever rule chunk happens to sort last,
+    // so it can't be silently eaten by downstream dedupe of a rule chunk.
+    const noticeChunk = result.chunks[result.chunks.length - 1];
+    expect(noticeChunk?.id).toBe("static-rules:__budget-notice__:US-003");
+    expect(noticeChunk?.kind).toBe("static");
+    expect(noticeChunk?.content).toContain("rule budget exceeded");
+    expect(noticeChunk?.content).toContain("c#");
+    // The rule chunks themselves stay unmodified by the notice.
+    for (const chunk of result.chunks.slice(0, -1)) {
+      expect(chunk.content).not.toContain("rule budget exceeded");
+    }
+  });
+
+  test("[#1610] soft mode (enforceBudget: false) never appends a notice chunk even when droppedIds is non-empty", async () => {
+    setupCanonical([
+      { fileName: "a.md", id: "a", content: "A".repeat(40), tokens: 800, priority: 1 },
+      { fileName: "b.md", id: "b", content: "B".repeat(40), tokens: 800, priority: 2 },
+      { fileName: "c.md", id: "c", content: "C".repeat(40), tokens: 400, priority: 3 },
+    ]);
+    // enforceBudget defaults to false — soft mode keeps every section as a
+    // chunk even though applySectionBudget still reports droppedIds.
+    const provider = new StaticRulesProvider({ budgetTokens: 8192, rulesShare: 0.4 });
+    const request: ContextRequest = { ...BASE_REQUEST, budgetTokens: 4000 };
+    const result = await provider.fetch(request);
+    // Sanity: a drop is actually being reported by the section budget here —
+    // otherwise this test would pass vacuously regardless of the enforceBudget gate.
+    expect(result.budgetPressure?.droppedCount).toBeGreaterThan(0);
+    expect(result.chunks).toHaveLength(3);
+    for (const chunk of result.chunks) {
+      expect(chunk.content).not.toContain("rule budget exceeded");
+    }
   });
 
   test("[US-003 AC 6] global budgetTokens caps the effective budget (rulesShare * stage > global)", async () => {
@@ -110,9 +143,22 @@ describe("StaticRulesProvider — US-003 per-stage rules budget derivation", () 
     const provider = new StaticRulesProvider({ budgetTokens: 8192, rulesShare: 0.9, enforceBudget: true });
     const request: ContextRequest = { ...BASE_REQUEST, budgetTokens: 12000 };
     const result = await provider.fetch(request);
-    expect(result.chunks).toHaveLength(1);
+    // 1 retained rule chunk + 1 standalone notice chunk (#1610).
+    expect(result.chunks).toHaveLength(2);
     expect(result.chunks[0]?.id).toContain("a");
     expect(result.budgetPressure?.droppedCount).toBe(1);
+  });
+
+  test("[#1610] enforceBudget: true with an invalid effective budget (0) still surfaces a budget notice when sections existed", async () => {
+    setupCanonical([{ fileName: "a.md", id: "a", content: "A".repeat(40), tokens: 800, priority: 1 }]);
+    // rulesShare: 0 drives the derived effective budget to 0, an invalid
+    // threshold — applySectionBudget drops every section (droppedIds = all)
+    // and effectiveSections is empty, hitting the "totalScopedSections > 0"
+    // branch rather than the "everything filtered by scope" branch.
+    const provider = new StaticRulesProvider({ budgetTokens: 8192, rulesShare: 0, enforceBudget: true });
+    const result = await provider.fetch(BASE_REQUEST);
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]?.content).toContain("rule budget exceeded");
   });
 
   test("[US-003 AC 7] returns empty chunk list without throwing when .nax/rules/ is absent", async () => {

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -155,9 +155,11 @@ describe("StaticRulesProvider — canonical store (Phase 5.1)", () => {
     ]);
     const provider = new StaticRulesProvider({ budgetTokens: 400, enforceBudget: true });
     const result = await provider.fetch(BASE_REQUEST);
-    expect(result.chunks).toHaveLength(2);
+    // 2 retained rule chunks + 1 standalone budget-drop notice chunk (#1610).
+    expect(result.chunks).toHaveLength(3);
     expect(result.chunks[0]?.id).toContain("a");
     expect(result.chunks[1]?.id).toContain("b");
+    expect(result.chunks[2]?.id).toContain("__budget-notice__");
   });
 
   test("[US-002 AC 5] emits chunks only for the surviving leading run and none for the dropped tail when budget is smaller than the store", async () => {
@@ -170,7 +172,8 @@ describe("StaticRulesProvider — canonical store (Phase 5.1)", () => {
     ]);
     const provider = new StaticRulesProvider({ budgetTokens: 500, enforceBudget: true });
     const r1 = await provider.fetch(BASE_REQUEST);
-    expect(r1.chunks).toHaveLength(1);
+    // 1 retained rule chunk (fail-open) + 1 notice chunk for the dropped tiny/tiny2 tail.
+    expect(r1.chunks).toHaveLength(2);
     expect(r1.chunks[0]?.id).toContain("huge");
 
     // Case 2: a non-empty leading run survives, the dropped tail is excluded
@@ -182,9 +185,10 @@ describe("StaticRulesProvider — canonical store (Phase 5.1)", () => {
     ]);
     const provider2 = new StaticRulesProvider({ budgetTokens: 30, enforceBudget: true });
     const r2 = await provider2.fetch(BASE_REQUEST);
-    // Extract the rule-id segment from each chunk id (format: static-rules:<ruleId>:<hash>)
+    // Extract the rule-id segment from each chunk id (format: static-rules:<ruleId>:<hash>).
+    // The trailing "__budget-notice__" chunk reports the dropped c/d tail (#1610).
     const ruleIds = r2.chunks.map((c) => c.id.split(":")[1]);
-    expect(ruleIds).toEqual(["a", "b"]);
+    expect(ruleIds).toEqual(["a", "b", "__budget-notice__"]);
   });
 
   test("propagates NeutralityLintError without falling back to legacy", async () => {
@@ -686,9 +690,9 @@ describe("StaticRulesProvider — US-003 budget pressure (enforced, enforceBudge
     const provider = new StaticRulesProvider({ budgetTokens: 30, enforceBudget: true });
     const result = await provider.fetch(BASE_REQUEST);
     // Leading run that fits inside 30: a(10) + b(10) → kept. c would push past → drop.
-    // Dropped tail: c, d.
+    // Dropped tail: c, d. Plus 1 standalone notice chunk reporting the drop (#1610).
     expect(result.budgetPressure?.droppedCount).toBe(2);
-    expect(result.chunks).toHaveLength(2);
+    expect(result.chunks).toHaveLength(3);
   });
 
   test("[US-003 AC 5] budgetPressure.droppedTokens equals the token total of rules omitted from chunks", async () => {


### PR DESCRIPTION
## Summary

Fixes #1610. `applySectionBudget` (`src/context/rules/rule-budget.ts`) drops rule sections when a story's canonical rules corpus exceeds the per-stage token budget. `StaticRulesProvider` recorded this only as `budgetPressure` telemetry — nothing reached the actual prompt content, so neither the agent nor a human debugging a run could tell a truncated ruleset from a complete one. `CodeNeighborProvider` already handles the analogous situation correctly (`code-neighbor-chunk.ts:155`); this mirrors that.

- New `src/context/engine/providers/static-rules-budget-notice.ts` — `budgetNoticeText()` and `buildBudgetNoticeChunk()`, plus the pre-existing `buildSectionBudgetPressure()` moved unchanged (kept `static-rules.ts` under the 600-line file-size limit).
- `StaticRulesProvider.fetch()`: when `enforceBudget` is on and sections were dropped, appends a **standalone notice chunk** — not text spliced into the last rule chunk — so the note survives `dedupeChunks` independently of whichever rule section happens to sort last. Covers both the partial-drop case and the all-sections-dropped edge case.
- The dropped-id list in the notice is capped at 10 with a `+N more` summary, since a real overrun can drop dozens of sections and the notice itself must stay small relative to the (already exceeded) budget.
- Soft mode (`enforceBudget: false`, the default) is unaffected — it drops nothing, only reports `overageTokens`.

## Review

Ran an internal code-review pass before opening this PR. It found the original implementation (splicing the note into the last chunk's content) had a real hole: `dedupeChunks` runs over all chunks with no floor exemption, so a near-duplicate last rule section could silently eat the note-carrying chunk — reintroducing the exact invisibility the fix was meant to close. Reworked to always emit the notice as its own chunk, which resolves that and a couple of smaller issues (unbounded id list in the notice text, a vacuous soft-mode test assertion, a truncated config-path string in the notice copy).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (biome + all ratchets, including `check:file-sizes`)
- [x] `bun run test` — full suite (unit/integration/ui), 0 failures
- [x] New/updated unit tests in `static-rules-budget-derivation.test.ts` and `static-rules.test.ts` cover: partial-drop note content + id/kind, all-dropped edge case, soft-mode negative case (with a sanity assertion that a drop is actually occurring so the test isn't vacuous)