### PR TITLE
fix(context): give reverse deps an independent budget in code-neighbor

### DIFF
--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -367,43 +367,57 @@ async function collectNeighbors(
   contentCacheState: ContentCacheState,
   siblingTestContext?: { globs: readonly string[]; regex: readonly RegExp[] },
 ): Promise<{ neighbors: string[]; truncated: boolean }> {
-  const neighbors = new Set<string>();
+  // Forward/reverse deps use independent budgets so import-heavy files can't
+  // starve the reverse-dep scan (#1611).
+  const forwardNeighbors = new Set<string>();
   let anyTruncated = false;
 
-  // Forward deps (JS/TS only) — check existence first (consistent with original
-  // behaviour), then read via the shared cache.
   const ownAbsPath = join(workdir, filePath);
   if (await _codeNeighborDeps.fileExists(ownAbsPath)) {
     const ownContent = await readCached(ownAbsPath, contentCacheState, _codeNeighborDeps);
     if (ownContent !== null && ownContent.length > 0) {
       for (const spec of parseImportSpecifiers(ownContent)) {
         const resolved = resolveImport(spec, filePath, workdir);
-        if (resolved && resolved !== filePath) neighbors.add(resolved);
+        if (resolved && resolved !== filePath) forwardNeighbors.add(resolved);
       }
     }
   }
 
-  // Reverse deps — scan for files that import this file.
   // Quick check uses the base name (without extension) — broad but avoids parsing every file.
   const fileBaseName = (filePath.split("/").pop() ?? filePath).replace(/\.[^.]+$/, "");
   const fileNoExt = filePath.replace(/\.[^.]+$/, "");
 
+  const reverseNeighbors = new Set<string>();
   outer: for (const { workdir: scanWorkdir, files: srcFiles, truncated } of scannedDirs) {
     if (truncated) anyTruncated = true;
     for (const srcFile of srcFiles) {
-      if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break outer;
+      if (reverseNeighbors.size >= MAX_NEIGHBORS_PER_FILE) break outer;
       if (srcFile === filePath) continue;
       const content = await readCached(join(scanWorkdir, srcFile), contentCacheState, _codeNeighborDeps);
       if (content?.includes(fileBaseName)) {
         for (const spec of parseImportSpecifiers(content)) {
           const resolved = resolveImport(spec, srcFile, scanWorkdir);
           if (resolved === filePath || resolved === fileNoExt) {
-            neighbors.add(srcFile);
+            reverseNeighbors.add(srcFile);
             break;
           }
         }
       }
     }
+  }
+
+  // Reserve a share of slots for reverse deps — otherwise forward deps
+  // (inserted first) would crowd them out at the final slice() below.
+  const reverseSlots = Math.min(reverseNeighbors.size, Math.ceil(MAX_NEIGHBORS_PER_FILE / 2));
+  const forwardSlots = MAX_NEIGHBORS_PER_FILE - reverseSlots;
+  const neighbors = new Set<string>();
+  for (const f of forwardNeighbors) {
+    if (neighbors.size >= forwardSlots) break;
+    neighbors.add(f);
+  }
+  for (const r of reverseNeighbors) {
+    if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break;
+    neighbors.add(r);
   }
 
   // Sibling test — resolver-driven (ADR-009). Skipped entirely when no context

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -406,10 +406,11 @@ async function collectNeighbors(
     }
   }
 
-  // Reserve a share of slots for reverse deps — otherwise forward deps
-  // (inserted first) would crowd them out at the final slice() below.
-  const reverseSlots = Math.min(reverseNeighbors.size, Math.ceil(MAX_NEIGHBORS_PER_FILE / 2));
-  const forwardSlots = MAX_NEIGHBORS_PER_FILE - reverseSlots;
+  // Guarantee reverse deps a minimum share of slots — otherwise forward deps
+  // (inserted first) would crowd them out at the final slice() below. The
+  // reverse loop still backfills past this minimum into unused forward slots.
+  const minReverseSlots = Math.min(reverseNeighbors.size, Math.ceil(MAX_NEIGHBORS_PER_FILE / 2));
+  const forwardSlots = MAX_NEIGHBORS_PER_FILE - minReverseSlots;
   const neighbors = new Set<string>();
   for (const f of forwardNeighbors) {
     if (neighbors.size >= forwardSlots) break;

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -169,6 +169,22 @@ describe("CodeNeighborProvider", () => {
     expect(content).toContain("src/consumer.ts");
   });
 
+  test("reverse deps backfill unused forward slots past their guaranteed minimum (#1611)", async () => {
+    // 1 forward dep leaves 7 slots free; 6 reverse-dep consumers should all
+    // appear, not just the 4-slot minimum reserved for reverse deps.
+    const consumers = Array.from({ length: 6 }, (_, i) => `src/consumer${i}.ts`);
+    const files: Record<string, string> = {
+      "src/service.ts": 'import "./dep0"',
+      "src/dep0.ts": "",
+    };
+    for (const c of consumers) files[c] = 'import "./service"';
+
+    setupDeps({ files, globFiles: consumers });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/service.ts"] }));
+    const content = result.chunks[0]?.content ?? "";
+    for (const c of consumers) expect(content).toContain(c);
+  });
+
   test("combines neighbors from multiple files into one chunk", async () => {
     setupDeps({
       files: { "src/a.ts": "", "src/b.ts": "" },

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -155,6 +155,20 @@ describe("CodeNeighborProvider", () => {
     expect((await provider.fetch(makeRequest({ touchedFiles: ["src/utils/helper.ts"] }))).chunks[0]?.content ?? "").toContain("src/service.ts");
   });
 
+  test("reverse deps are not starved when forward deps alone reach MAX_NEIGHBORS_PER_FILE (#1611)", async () => {
+    // 8 forward deps (own file's imports) — meets MAX_NEIGHBORS_PER_FILE on their own.
+    const forwardDeps = Array.from({ length: 8 }, (_, i) => `./dep${i}`);
+    const serviceContent = forwardDeps.map((d) => `import "${d}"`).join("\n");
+    const files: Record<string, string> = { "src/service.ts": serviceContent };
+    for (let i = 0; i < 8; i++) files[`src/dep${i}.ts`] = "";
+    files["src/consumer.ts"] = 'import "./service"';
+
+    setupDeps({ files, globFiles: ["src/consumer.ts"] });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/service.ts"] }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("src/consumer.ts");
+  });
+
   test("combines neighbors from multiple files into one chunk", async () => {
     setupDeps({
       files: { "src/a.ts": "", "src/b.ts": "" },


### PR DESCRIPTION
## Summary

- `collectNeighbors()` in `src/context/engine/providers/code-neighbor.ts` populated a single shared `neighbors` Set with forward deps first, then broke the reverse-dep scan loop as soon as that set reached `MAX_NEIGHBORS_PER_FILE` (8). Files with 8+ forward imports (orchestrators, pipeline stages, barrel consumers) got **zero** reverse-dep scanning — silently, and tuning `context.v2.providers.maxGlobFiles` had no effect since the scan never got far enough to consult the candidate list.
- Forward and reverse deps are now collected into independent sets with independent budgets, then merged with a guaranteed minimum share of slots reserved for reverse deps — since the final result is bounded by `slice(0, MAX_NEIGHBORS_PER_FILE)` in insertion order, simply decoupling the loop's break condition wasn't sufficient on its own; forward deps (inserted first) would still crowd out reverse deps at that step.
- The reverse-dep loop backfills past its guaranteed minimum into any forward slots left unused, so no capacity is wasted when a file has few forward deps.

## Related (not addressed here, per the issue)

The issue also notes that the glob at line ~120 truncates in filesystem `readdir` order rather than relevance-ranked order, making truncation non-deterministic. That's flagged in the issue as a separate design change, not a patch, and is out of scope for this fix.

Fixes #1611

## Test plan

- [x] Added a regression test reproducing the starvation bug (8 forward deps + 1 reverse-dep consumer) — confirmed it fails against pre-fix code and passes with the fix.
- [x] Added a second regression test covering the backfill path (1 forward dep, 6 reverse-dep consumers exceeding the guaranteed minimum reverse slots).
- [x] `bun run typecheck` passes.
- [x] `bun run lint` passes (all ratchets/checks green).
- [x] `bun test test/unit/context/engine/` — 1047+ tests pass.