### PR TITLE
fix(review): P0-P3 fixes from 2026-08-17 code review

### DIFF
--- a/docs/20260817-review-nax.md
+++ b/docs/20260817-review-nax.md
@@ -1,0 +1,174 @@
+# Code Review: @nathapp/nax
+
+**Date:** 2026-08-17
+**Reviewer:** Claude (AI)
+**Version:** 0.80.0
+**Commit:** 268339f3
+**Scope:** `src/execution/`, `src/agents/acp/`, `src/worktree/`, `src/queue/`, `src/config/`, `src/routing/`, `src/pipeline/stages/`, `src/review/`, `src/plugins/`, `src/runtime/`, `src/verification/`, `src/logger/`, `src/prd/`
+**Depth:** Standard (targeted, checklist-driven — not an exhaustive line-by-line of every file in the repo)
+
+---
+
+## Overall Grade: B+ (83/100)
+
+The codebase is disciplined about the things that are hardest to get right by convention alone: process/subprocess lifecycle, shutdown ordering, lock reclamation, and shell-argument quoting are all correct and, in several places, explicitly documented as fixes for prior bugs (`crash-signals.ts`, `pid-registry.ts`, `lock.ts`). Security posture is strong — no hardcoded secrets, no command injection, no unsafe `eval`, prototype-pollution guards in the config merger, and centralized log redaction. The main gap is in the review-orchestration subsystem (`src/review/`), where several functions have grown to 450–570 lines, concentrating retry logic, telemetry, and control flow in a way that makes them hard to test in isolation and increases regression risk on future changes. One redaction gap (prompt/response audit logs) and a couple of narrow, currently-unexploited path/fail-open gaps round out the findings.
+
+| Dimension | Score | Notes |
+|:---|:---:|:---|
+| Security | 17/20 | Strong fundamentals; one MEDIUM redaction gap, two LOW defense-in-depth gaps |
+| Reliability | 19/20 | Cleanup, cancellation, and shutdown ordering all verified sound |
+| API Design | 16/20 | Minor type duplication; otherwise consistent |
+| Code Quality | 15/20 | Several oversized functions in `src/review/` drag this down |
+| Best Practices | 16/20 | One unguarded `JSON.parse` on a plugin read path |
+| **Total** | **83/100** | |
+
+---
+
+## Findings
+
+### 🟠 HIGH
+
+#### TYPE-1: `runSemanticReview` is a 461-line monolith
+**Severity:** HIGH | **Category:** Code Quality
+**File:** `src/review/semantic.ts:99-559`
+
+The entire semantic-review flow — session setup, retry/parse loop, finding normalization, telemetry — lives in one function, ~15x the project's own ≤30-line function guideline.
+
+**Risk:** Hard to unit test individual phases (prompt build vs. dispatch vs. post-processing) in isolation; any future change risks touching unrelated control flow.
+**Fix:** Extract prompt-build, dispatch, and post-processing into named helpers in the same file or a sibling, mirroring the decomposition already used elsewhere (e.g. `recordSemanticAudit`).
+
+#### TYPE-2: `runReview` orchestrator is a 248-line function mixing mechanical and LLM check dispatch
+**Severity:** HIGH | **Category:** Code Quality
+**File:** `src/review/runner.ts:250-497`
+
+**Risk:** Same testability/regression concern as TYPE-1; the mechanical-check loop and LLM-check dispatch are independent concerns bundled together.
+**Fix:** Split into `runMechanicalChecks()` and `runLlmChecks()` (or similar), called from a thin `runReview` orchestrator.
+
+---
+
+### 🔴 CRITICAL
+
+#### TYPE-0: `runAdversarialReview` is a 507-line function
+**Severity:** CRITICAL | **Category:** Code Quality
+**File:** `src/review/adversarial.ts:66-572`
+
+The entire body of the file after imports/types is one function covering retry, telemetry, recurrence-demotion, and fix-target routing — ~17x the project's ≤30-line guideline. This is the largest and most control-flow-dense function found in the reviewed scope, and it sits on the critical path for every adversarial review cycle (a subsystem already flagged in prior harness-audit memory as a major source of rectification spend).
+
+**Risk:** The size and branching density make this function disproportionately likely to accumulate subtle bugs under future edits (e.g. the kind of `outcome`/telemetry mismatches already recorded in project memory for this subsystem), and disproportionately hard to unit test without full end-to-end review runs.
+**Fix:** Extract cohesive sub-steps (session setup, retry/parse loop, finding normalization, telemetry recording) into named helpers, following the pattern already used in `semantic.ts`'s `recordSemanticAudit`. Prioritize this over TYPE-1/TYPE-2 since it's both the largest function and the one with the most documented historical fragility.
+
+---
+
+### 🟡 MEDIUM
+
+#### SEC-1: Prompt/response audit artifacts written to disk unredacted
+**Severity:** MEDIUM | **Category:** Security
+**File:** `src/runtime/prompt-auditor.ts:252,261`
+
+`_writeEntry` writes full prompts and responses to `<auditDir>/<feature>/*.jsonl` and `.txt` with no redaction, even though the project already has `redactEntry`/`redactSecrets` (`src/logger/redact.ts`) — currently applied at exactly one site (`src/logger/logger.ts:136`). Prompts carry injected repo context (file contents, git history, config), which is exactly where a `DATABASE_URL` or PAT would end up. `.nax/prompt-audit/` is gitignored, so this is on-disk exposure rather than a commit risk, but still a real gap given prompt-audit files are read back by tooling (per project memory: "prompt-audit join for older rows").
+
+**Fix:**
+```ts
+await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(redactSecrets(entry))}\n`);
+// txt path: route through redactSecrets or export redactString from redact.ts
+```
+
+#### TYPE-3: `loadConfig` mixes four concerns in one 185-line function
+**Severity:** MEDIUM | **Category:** Code Quality
+**File:** `src/config/loader.ts:103-287`
+
+Env-var resolution, global/project/CLI layering, migration shims, and validation are all inline in one function.
+
+**Fix:** Split per layering step, matching the documented "Layering Order" in `config-patterns.md` — that order is itself already a natural decomposition boundary.
+
+#### TYPE-4: `Severity`-shaped types redeclared independently in 6+ files instead of a shared alias
+**Severity:** MEDIUM | **Category:** Type Safety / DRY
+**Files:** `src/review/ac-quote-validator.ts:24`, `src/review/adversarial-helpers.ts:17-18`, `src/review/review-audit.ts:123`, `src/review/semantic-helpers.ts:16`, `src/review/semantic-evidence.ts:40`, `src/review/ac-structural-counterfactual.ts:71,84`
+
+`src/review/severity.ts` already centralizes `SEVERITY_RANK: Record<string, number>` as the stated SSOT rank table but exports no reusable `Severity` type alias, so each consuming file redeclares its own `severity: string` shape.
+
+**Fix:** Add `export type Severity = keyof typeof SEVERITY_RANK | (string & {})` (or a plain string-literal union) to `severity.ts` and import it at each site.
+
+---
+
+### 🟢 LOW
+
+#### SEC-2: Plugin loader's module-path validation fails open when `allowedRoots` is empty
+**Severity:** LOW | **Category:** Security (defense-in-depth)
+**File:** `src/plugins/loader.ts:410,419`
+
+`allowedRoots: string[] = []` defaults to empty, and an empty array skips traversal validation entirely before `await import(modulePath)` at line 434. All three production call sites (lines 237, 257, 278) currently pass non-empty roots, so this is not exploitable today, but the default is fail-open on a code-execution path.
+
+**Fix:** Make `allowedRoots` required (no default), and reject rather than skip when empty.
+
+#### SEC-3: `featureId` isn't validated before path construction, unlike `storyId`
+**Severity:** LOW | **Category:** Security
+**File:** `src/config/paths.ts:73-75`
+
+`featureDir(root, featureId)` does a plain `join` with no traversal/charset check, in contrast to `validateStoryId` (`src/prd/validate.ts:24-44`), which rejects `..`, leading `--`, and enforces `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`. `featureDir` anchors ~38 call sites including `mkdir(recursive)` and artifact writes. `featureId` originates from the CLI `--feature` flag, so exploitation is self-inflicted today, but the asymmetry with the story-ID path is a real gap that would matter if `featureId` ever came from a less-trusted source (e.g. a webhook payload).
+
+**Fix:** Extract `validateStoryId`'s pattern into a shared `validateIdSegment(id, kind)` and call it at the top of `featureDir`.
+
+#### BUG-1: Unguarded `JSON.parse` on a plugin result-read path
+**Severity:** LOW | **Category:** Error Handling
+**File:** `src/plugins/builtin/nax-finish/index.ts:129`
+
+```ts
+return JSON.parse(await f.text()) as FinishResult;
+```
+`defaultReadResult` guards `f.exists()` but not malformed content — a truncated `result.json` (flow killed mid-write, disk full) throws out of the post-run action. The sibling curator code handles this correctly (`src/plugins/builtin/curator/collect.ts:68-72`, catches and returns null).
+
+**Fix:** Wrap in try/catch, return `null` on parse failure, matching the not-found contract.
+
+#### STYLE-1: `unified-executor.ts`'s `executeUnified` is a 637-line orchestrator
+**Severity:** LOW | **Category:** Code Quality
+**File:** `src/execution/unified-executor.ts:91-728`
+
+Mixes cost-limit checks, PRD persistence, deferred review, batch reconciliation, and iteration bookkeeping in one function.
+
+**Fix:** Extract cohesive phases (cost-limit enforcement, per-iteration bookkeeping, deferred-review kickoff) into named helpers, mirroring the pattern already used for `closeStoryIfTerminal`/`enforceCostLimit` at the top of the same file.
+
+#### STYLE-2: Several files approach the repo's file-size ratchet
+**Severity:** LOW | **Category:** Code Quality
+**Files:** `src/config/runtime-types.ts` (581 lines), `src/config/schemas.ts` (574), `src/review/adversarial.ts` (572), `src/review/semantic.ts` (559), `src/review/runner.ts` (497), `src/pipeline/stages/acceptance-setup.ts` (528), `src/pipeline/stages/acceptance.ts` (468), `src/config/loader.ts` (477), `src/pipeline/stages/context.ts` (427), `src/pipeline/stages/completion.ts` (404)
+
+None currently breach the repo's actual enforced 600-line ratchet (`.claude/rules/project-conventions.md`), but `runtime-types.ts` and `schemas.ts` are within ~20 lines of it, and the CLAUDE.md-documented "400-line typical, 800 max" guidance is already exceeded by 10 files in the reviewed scope.
+
+**Fix:** No immediate action required; worth revisiting if `runtime-types.ts`/`schemas.ts` grow further. The `src/review/*` entries overlap with TYPE-0/TYPE-1/TYPE-2 above and will shrink naturally if those are addressed.
+
+---
+
+## What's Already Solid (no action needed)
+
+Verified clean, not just assumed:
+- **Subprocess safety:** every `Bun.spawn` outside the documented shell boundary uses argv arrays; shell interpolation goes through a correct POSIX-quoting helper (`shellQuoteArg`); no command injection found.
+- **Shutdown/cleanup:** `crash-signals.ts`, `pid-registry.ts`, `crash-heartbeat.ts`, `lock.ts`, `worktree/manager.ts`, `worktree/merge.ts`, `parallel-worker.ts` all correctly clear timers, dedupe kill signals, verify process identity before signaling, and avoid TOCTOU races on lock reclamation — several with inline comments documenting the specific prior bug (BUG-07, BUG-11, BUG-34, MEM-3) each pattern fixes.
+- **No hardcoded secrets, no `eval`/`new Function`**, config merger explicitly guards against prototype pollution, log redaction (`src/logger/redact.ts`) is applied at the logger boundary.
+- **No `console.log`**, no dead/commented-out code, no untracked TODO/FIXME found in the reviewed directories.
+- The one `any` usage found (`src/pipeline/stages/acceptance-setup.ts:149-158`) is explicitly justified with a `biome-ignore` comment per the project's own convention.
+
+---
+
+## Priority Fix Order
+
+| Priority | ID | Effort | Description |
+|:---|:---|:---|:---|
+| P0 | TYPE-0 | L | Decompose `runAdversarialReview` (507 lines) — highest-risk, most control-flow-dense function on the review critical path |
+| P1 | SEC-1 | S | Apply `redactSecrets` to prompt-auditor disk writes |
+| P1 | TYPE-1 | M | Decompose `runSemanticReview` (461 lines) |
+| P2 | TYPE-2 | M | Split `runReview`'s mechanical vs. LLM check dispatch |
+| P2 | TYPE-3 | S | Split `loadConfig` by layering step |
+| P2 | TYPE-4 | S | Add shared `Severity` type alias in `severity.ts`, adopt at 6 call sites |
+| P3 | SEC-2 | S | Make `allowedRoots` required in plugin loader (fail-closed) |
+| P3 | SEC-3 | S | Validate `featureId` the same way `storyId` is validated |
+| P3 | BUG-1 | S | Guard `JSON.parse` in `nax-finish/index.ts:129` |
+| P4 | STYLE-1 | M | Decompose `executeUnified` (637 lines) |
+| P4 | STYLE-2 | — | Monitor; no action unless files grow further |
+
+**Effort key:** S = <1hr, M = 1-4hrs, L = 4hrs+
+
+---
+
+## Scope Note
+
+This review targeted `src/execution/`, `src/agents/acp/`, `src/worktree/`, `src/queue/`, `src/config/`, `src/routing/`, `src/pipeline/stages/`, `src/review/`, plus focused checks in `src/plugins/`, `src/runtime/`, `src/verification/`, `src/logger/`, and `src/prd/`. It did not cover `src/tui/`, `src/debate/`, `src/analyze/`, `src/hooks/`, `src/optimizer/`, `src/project/`, `src/constitution/`, `src/metrics/`, `src/acceptance/`, `src/tdd/`, `src/cli/`/`src/commands/`, or the `test/` suite itself. A follow-up pass on those directories, and a coverage check against `test:coverage`, would be needed for a full-repo grade.

--- a/docs/20260818-review-p0-p1-p2-p3-branch.md
+++ b/docs/20260818-review-p0-p1-p2-p3-branch.md
@@ -1,0 +1,107 @@
+# Code Review: fix/review-p0-p1-nax-quality (branch diff vs main)
+
+**Date:** 2026-08-18
+**Reviewer:** Claude (AI), 4 independent sub-agents + synthesis
+**Scope:** `git diff main...fix/review-p0-p1-nax-quality` — 8 commits implementing P0–P3 of `docs/20260817-review-nax.md`
+**Baseline:** 14,929 tests (unit + integration + ui), full pre-commit gate per commit
+
+---
+
+## Overall Grade: A- (88/100)
+
+This branch is a self-review of refactors and security fixes made in response to a prior full-repo review, not a new feature. Four independent review agents each took one risk area (the `adversarial.ts` split, the `semantic.ts` split, the `config/loader.ts` split, and the bundled security fixes + `runner.ts` split) and were asked to adversarially verify the claim, made in every commit message, that each refactor preserves behavior exactly. Three of the four areas checked out completely. One area — the two review-runner decompositions — had a real, if narrow, regression that two independent agents caught by the same method (diffing old vs. new argument values at each `record*Audit()` call site): `blockingThreshold` was eagerly defaulted to `"error"` in a shared context object, changing what three early-exit audit events recorded from `undefined` to `"error"` when the caller omitted the option. That regression, plus a legitimate SEC-3 follow-on risk (an unguarded `featureDir()` throw reaching a function documented as "best-effort"), a type-safety fix that hadn't actually taken effect, and a couple of low-severity nits, are all fixed in this pass.
+
+| Dimension | Score | Notes |
+|:---|:---:|:---|
+| Security | 19/20 | SEC-1/2/3 fixes verified correct; SEC-3's blast radius into a best-effort path was found and closed |
+| Reliability | 18/20 | The blockingThreshold regression was real; caught and fixed before merge |
+| API Design | 17/20 | Extracted helpers are cohesive; some exceed the 3-positional-param guideline (non-blocking) |
+| Code Quality | 18/20 | `Severity` type alias didn't achieve its stated goal until this pass; now fixed |
+| Best Practices | 16/20 | `loader.ts` grew to 544 lines (still under the 600 hard limit, but past the 400 "typical") |
+| **Total** | **88/100** | |
+
+---
+
+## Findings — fixed in this pass
+
+### 🟠 HIGH
+
+#### BUG-2: `blockingThreshold` eagerly defaulted, changing audit telemetry on 3 early-exit paths (adversarial.ts + semantic.ts)
+**Severity:** HIGH | **Category:** Bug (regression from claimed pure refactor)
+**Files:** `src/review/adversarial.ts`, `src/review/adversarial-outcomes.ts`, `src/review/semantic.ts`, `src/review/semantic-outcomes.ts`
+
+Two independent review agents (one per file) found the identical defect by the identical method. Both `AdversarialOutcomeCtx.blockingThreshold` and `SemanticOutcomeCtx.blockingThreshold` were typed as the non-optional `"error" | "warning" | "info"`, forcing the orchestrator to write `blockingThreshold: blockingThreshold ?? "error"` at context-construction time. Three pre-classification outcome helpers per file (`catchDispatchFailure`, `handleRetryExhaustedFailOpen`, `handleTruncatedLooksLikeFail`) read this defaulted field and forward it into `recordAdversarialAudit()` / `recordSemanticAudit()`, which is forwarded verbatim into the emitted `review-decision` event. Pre-refactor, these three call sites passed the **raw, possibly-`undefined`** option. Post-refactor (pre-fix), they always recorded `"error"`.
+
+The four post-classification outcome builders in each file were unaffected — they always read `classification.threshold` (which already applies the same `?? "error"` default, matching pre-refactor behavior exactly), never `ctx.blockingThreshold`.
+
+**Fix applied:** widened `blockingThreshold` on both `*OutcomeCtx` types to `"error" | "warning" | "info" | undefined`, and removed the `?? "error"` at both context-construction sites. Verified via `grep` that `ctx.blockingThreshold` is read only by the three pre-classification helpers in each file — the classification/outcome-builder path is untouched.
+
+### 🟡 MEDIUM
+
+#### SEC-3-follow: `featureDir()`'s new validation could throw out of a documented best-effort path
+**Severity:** MEDIUM | **Category:** Reliability (SEC-3 follow-on risk)
+**File:** `src/context/engine/stage-assembler.ts`
+
+`discoverSessionScratchDirsOnDisk` — whose own docstring says "Best-effort: any I/O or parse failure... never propagated" — called `featureDir(projectDir, featureName)` *before* its `try/catch`, so SEC-3's new traversal/charset validation could throw an uncaught `NaxError` out of a function every caller treats as safe to call unconditionally. No CLI-level slugification exists for feature names (`grep` for `slugify`/`sanitizeFeature` in `src/cli/` returned nothing), so a free-text `--feature` value or a pre-existing legacy feature directory could trigger this.
+
+**Fix applied:** moved the `featureDir()` call inside its own `try/catch`, logging at debug and returning `[]` (matching the existing "sessions directory does not exist yet" degradation one line below) instead of propagating.
+
+**Deferred (documented, not fixed):** the reviewing agent additionally flagged that `--feature` accepts free text with no boundary validation, so a `nax plan --feature "my feature"` now fails deep in `featureDir()` (a NaxError from a path helper) instead of at CLI arg-parse time with an actionable message. Fixing this properly means adding validation at the CLI/PRD-load boundary (`src/prd/schema.ts` / `src/cli/plan*.ts`), which is out of scope for a security-hardening pass on an existing SSOT helper. Tracked as a follow-up; not a regression introduced by this branch (the CLI never validated feature names before either — SEC-3 just moved the failure point earlier and gave it a name).
+
+#### TYPE-4-follow: `Severity` type alias was vacuous as originally written
+**Severity:** MEDIUM | **Category:** Type Safety
+**File:** `src/review/severity.ts`, `src/log-format/formatter.ts`
+
+`SEVERITY_RANK` was annotated `: Record<string, number>`, so `keyof typeof SEVERITY_RANK` evaluated to `string`, collapsing `Severity = keyof typeof SEVERITY_RANK | (string & {})` to plain `string`. The 6 call-site edits from the original TYPE-4 fix compiled and ran correctly but added zero type information — no autocomplete, no self-documentation, exactly the outcome the finding was written to avoid.
+
+**Fix applied:** changed `SEVERITY_RANK` to `as const satisfies Record<string, number>`, which makes `keyof typeof SEVERITY_RANK` the literal 6-key union and `Severity` genuinely informative. This required two follow-on changes to keep runtime lookups compiling: `isBlockingSeverity` now indexes via `(SEVERITY_RANK as Record<string, number>)[sev]` (its `sev` parameter stays `string` — LLM output is never trusted as one of the six literals), and one other production call site (`src/log-format/formatter.ts:456`, sorting `AdvisoryFindingSummaryEntry[]` by `.severity`, a field this branch's TYPE-4 pass had already retyped to `Severity`) needed the same cast to keep indexing a `Severity`-typed value against the now-literal `SEVERITY_RANK`.
+
+### 🟢 LOW
+
+#### BUG-1-follow: malformed-JSON diagnostic silently dropped
+**Severity:** LOW | **Category:** Reliability
+**File:** `src/plugins/builtin/nax-finish/index.ts`
+
+The original BUG-1 fix correctly stopped `defaultReadResult` from throwing on malformed JSON, but the `catch {}` swallowed the parse error entirely — an operator debugging a "no result file" message would see the same message whether the flow never ran or the result file exists and is corrupt, with no way to tell which.
+
+**Fix applied:** log the caught error via `getSafeLogger()?.warn(...)` before returning `null`, so the two cases stay distinguishable in logs even though both resolve to the same caller-facing outcome.
+
+#### STYLE: `NAX_RUNTIME_PATTERNS` rebuilt on every `guardUncommittedFiles` call
+**Severity:** LOW | **Category:** Performance
+**File:** `src/review/runner.ts`
+
+19 `RegExp` literals were constructed inside the function body on every review run; the array is static. Hoisted to module scope — zero behavior change (no `g` flag, so no cross-call `lastIndex` state to worry about).
+
+#### PERF: prompt-audit content redacted twice per call
+**Severity:** LOW | **Category:** Performance
+**File:** `src/runtime/prompt-auditor.ts`
+
+The original SEC-1 fix called `redactSecrets()` independently on the JSONL entry and again on the rendered txt content — since the txt content re-embeds the same `prompt`/`response` strings (which can run hundreds of KB), this scanned the same text through all ~14 secret patterns twice per audited call. Fixed to redact the entry once and derive both artifacts from the redacted copy; the `.txt` filename still derives from the *original* (unredacted) entry so filename generation stays provably unaffected by redaction.
+
+---
+
+## Findings — verified clean (no action taken)
+
+- **`config/loader.ts` split (TYPE-3):** independently verified behavior-preserving across all 6 extracted layer functions — merge order, all three `warnSecuritySensitiveOverrides()` call sites' `sourceLayerConf` arguments (the specific way this refactor could have silently broken the SEC-2 warning), `hasMergedConfigs`, and the finalize/validate sequence all match `main` exactly. One cosmetic note: `loader.ts` grew from 477 to 544 lines (still under the 600 hard limit).
+- **`runner.ts` split (TYPE-2):** `guardUncommittedFiles`/`runSemanticCheck`/`runAdversarialCheck`/`runMechanicalCheck` extraction and the new `buildReviewStory()` dedup helper are byte-identical to the pre-refactor inline logic.
+- **`plugins/loader.ts` (SEC-2):** all three production call sites pass non-empty `allowedRoots`; the fail-closed branch cannot fire in production today, confirmed by reading both call chains that could theoretically produce an empty array.
+- **`config/paths.ts` (SEC-3) regex/error-type:** charset correct, `NaxError` used per convention, no import cycle.
+- **`prompt-auditor.ts` redaction correctness:** `redactSecrets()` on a string input returns a string before any other branch (verified by reading `redactValue` in `src/logger/redact.ts`), so the removed `as string` cast was already safe — now it's gone entirely.
+- **Adversarial/semantic control flow, logging, and all `record*Audit()` argument sets** (apart from the blockingThreshold finding above): verified field-for-field identical across every branch, in the same order, with the same conditions.
+
+---
+
+## Priority Fix Order (all items in this table are already applied)
+
+| Priority | ID | Effort | Description | Status |
+|:---|:---|:---|:---|:---|
+| P0 | BUG-2 | S | Stop eagerly defaulting `blockingThreshold` in adversarial/semantic outcome contexts | ✅ Fixed |
+| P1 | SEC-3-follow | S | Guard `featureDir()` call in `discoverSessionScratchDirsOnDisk` | ✅ Fixed |
+| P1 | TYPE-4-follow | S | Make `Severity` a real literal union via `as const satisfies` | ✅ Fixed |
+| P2 | BUG-1-follow | S | Log the swallowed JSON parse error in nax-finish | ✅ Fixed |
+| P3 | STYLE | S | Hoist `NAX_RUNTIME_PATTERNS` to module scope | ✅ Fixed |
+| P3 | PERF | S | Redact prompt-audit content once instead of twice | ✅ Fixed |
+
+**Deferred (tracked, not blocking):** CLI-boundary validation for `--feature` free text (would give an actionable error at arg-parse time instead of a `NaxError` from deep in `featureDir()`) — out of scope for this security-hardening pass; not a regression introduced by this branch.
+
+**Effort key:** S = <1hr

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -71,6 +71,196 @@ export function globalConfigPath(): string {
   return join(globalConfigDir(), "config.json");
 }
 
+/** Shared plumbing threaded through every `loadConfig` layer function below. */
+interface ConfigLoadCtx {
+  logger: ReturnType<typeof getLogger> | null;
+  warnDedupe: ReturnType<typeof createConfigWarnDedupe>;
+}
+
+/**
+ * Resolve `projDir` (the `.nax/` directory) and `projectRoot` (its parent) from
+ * `startDir`, per the three cases documented on `loadConfig`'s own docstring:
+ * project root, `.nax/` dir directly, or omitted (falls back to `process.cwd()`).
+ */
+function resolveProjectPaths(startDir: string | undefined): { projDir: string | null; projectRoot: string } {
+  const projDir = startDir
+    ? basename(startDir) === PROJECT_NAX_DIR
+      ? startDir
+      : findProjectDir(startDir)
+    : findProjectDir();
+
+  const projectRoot = startDir
+    ? basename(startDir) === PROJECT_NAX_DIR
+      ? dirname(startDir)
+      : startDir
+    : process.cwd();
+
+  return { projDir, projectRoot };
+}
+
+/** Layer 1: Global config (~/.nax/config.json) — strip "profile" field before merging (AC 7). */
+async function applyGlobalLayer(
+  rawConfig: Record<string, unknown>,
+  ctx: ConfigLoadCtx,
+): Promise<{
+  rawConfig: Record<string, unknown>;
+  globalConfRaw: Record<string, unknown> | null;
+  // SEC-2 — the raw (post-shim, pre-defaults-merge) global layer, kept around so the
+  // project-layer warn check can tell "the global layer explicitly set this
+  // security-sensitive key" apart from "this key is just the unset schema default
+  // flowing through defaults + global merge". null when there is no global config file.
+  globalLayerConf: Record<string, unknown> | null;
+}> {
+  const globalConfRaw = await loadJsonFile<Record<string, unknown>>(globalConfigPath(), "config");
+  if (!globalConfRaw) return { rawConfig, globalConfRaw: null, globalLayerConf: null };
+  const { profile: _gProfile, ...globalConfStripped } = globalConfRaw;
+  const globalConf = applyConfigCompatShims(globalConfStripped, ctx.logger, ctx.warnDedupe);
+  return {
+    rawConfig: deepMergeConfig(rawConfig, globalConf),
+    globalConfRaw,
+    globalLayerConf: globalConf,
+  };
+}
+
+/** Layer 2: Project config (.nax/config.json) — strip "profile" field before merging (AC 8). */
+async function applyProjectLayer(
+  rawConfig: Record<string, unknown>,
+  projDir: string | null,
+  globalLayerConf: Record<string, unknown> | null,
+  ctx: ConfigLoadCtx,
+): Promise<Record<string, unknown>> {
+  if (!projDir) return rawConfig;
+  const projConf = await loadJsonFile<Record<string, unknown>>(join(projDir, "config.json"), "config");
+  if (!projConf) return rawConfig;
+  const { profile: _pProfile, ...projConfStripped } = projConf;
+  const resolvedProjConf = applyConfigCompatShims(projConfStripped, ctx.logger, ctx.warnDedupe);
+  const preProjectMergeConfig = rawConfig;
+  const merged = deepMergeConfig<Record<string, unknown>>(rawConfig, resolvedProjConf);
+  // SEC-2 / D-2 — warn (do not block, do not change precedence) when the
+  // project layer changed a security-sensitive key from the global value.
+  // `sourceLayerConf: globalLayerConf` scopes the check to keys the global
+  // layer actually set — with no global config file (globalLayerConf is
+  // null) this never warns, since there is nothing the project layer could
+  // be said to have "changed" from.
+  warnSecuritySensitiveOverrides(preProjectMergeConfig, merged, ctx.warnDedupe.warn, {
+    layerName: "project",
+    sourceLayerConf: globalLayerConf,
+  });
+  return merged;
+}
+
+/**
+ * Layer 3: Profile chain (overrides global + project — it's a run-time mode selection).
+ * Profiles overlay in order; a later profile overrides an earlier one. A missing
+ * profile file throws fail-fast (loadProfile). "default"-only chains apply no overlay.
+ */
+async function applyProfileChainLayer(
+  rawConfig: Record<string, unknown>,
+  overlayChain: readonly string[],
+  projectRoot: string,
+  ctx: ConfigLoadCtx,
+): Promise<Record<string, unknown>> {
+  let merged = rawConfig;
+  for (const name of overlayChain) {
+    const profileData = await loadProfile(name, projectRoot);
+    // Load companion .env for $VAR resolution — do NOT write to process.env (AC 9).
+    // Must resolve BEFORE merging, otherwise a "$MODEL_FAST"-style reference lands
+    // in the run config as the literal unresolved string (BUG-17) — the load path
+    // previously discarded loadProfileEnv's return value and never called
+    // resolveEnvVars, so this only ever worked via the separate `config profile show
+    // --unmask` command path.
+    const profileEnv = await loadProfileEnv(name, projectRoot);
+    let resolvedProfileData: Record<string, unknown>;
+    try {
+      resolvedProfileData =
+        Object.keys(profileEnv).length > 0
+          ? (resolveEnvVars(profileData, profileEnv) as Record<string, unknown>)
+          : profileData;
+    } catch (err) {
+      // BUG-21 — surface which profile and which key path referenced the
+      // unresolved $VAR, instead of a bare Error with no config context.
+      const varName = err instanceof UnresolvedEnvVarError ? err.varName : undefined;
+      const path = err instanceof UnresolvedEnvVarError ? err.path.join(".") : undefined;
+      throw new NaxError(
+        `Profile "${name}" references an undefined environment variable${varName ? ` $${varName}` : ""}${path ? ` at "${path}"` : ""}.`,
+        "PROFILE_ENV_VAR_UNRESOLVED",
+        { stage: "config", profileName: name, varName, path, cause: err },
+      );
+    }
+    // Same compat-shim chain as the file layers above (BUG-51) — a profile can carry
+    // the same legacy shapes (e.g. routing.strategy: "manual") and must be remapped
+    // rather than hard-failing Zod validation.
+    const shimmedProfileData = applyConfigCompatShims(resolvedProfileData, ctx.logger, ctx.warnDedupe);
+    const preProfileMergeConfig = merged;
+    merged = deepMergeConfig<Record<string, unknown>>(merged, shimmedProfileData);
+    // SEC-2 — profiles merge AFTER global + project and can just as easily undo a
+    // security-sensitive setting, invisibly (profile files live outside the repo,
+    // outside code review). Only warn when this profile itself sets the key.
+    warnSecuritySensitiveOverrides(preProfileMergeConfig, merged, ctx.warnDedupe.warn, {
+      layerName: `profile:${name}`,
+      sourceLayerConf: shimmedProfileData,
+    });
+  }
+  return merged;
+}
+
+/** Layer 4: CLI overrides (highest priority). */
+function applyCliOverridesLayer(
+  rawConfig: Record<string, unknown>,
+  cliOverrides: Record<string, unknown> | undefined,
+  ctx: ConfigLoadCtx,
+): Record<string, unknown> {
+  if (!cliOverrides) return rawConfig;
+  const shimmedCliOverrides = applyConfigCompatShims(cliOverrides, ctx.logger, ctx.warnDedupe);
+  const preCliMergeConfig = rawConfig;
+  const merged = deepMergeConfig<Record<string, unknown>>(rawConfig, shimmedCliOverrides);
+  // SEC-2 — CLI overrides win over every other layer; warn when one changes a
+  // security-sensitive key so the change isn't silently invisible.
+  warnSecuritySensitiveOverrides(preCliMergeConfig, merged, ctx.warnDedupe.warn, {
+    layerName: "CLI override",
+    sourceLayerConf: shimmedCliOverrides,
+  });
+  return merged;
+}
+
+/**
+ * Reject-guards + no-op-key strip + Zod validation for the fully-merged root config.
+ * Shared exit path for `loadConfig` once every layer above has merged.
+ */
+function finalizeAndValidateRootConfig(rawConfig: Record<string, unknown>): NaxConfig {
+  // ADR-012 Phase 6 — reject pre-migration agent keys with a migration pointer.
+  // Must run BEFORE Zod safeParse, otherwise .strip() silently drops the keys.
+  rejectLegacyAgentKeys(rawConfig);
+  // Rectification-config consolidation — reject the four legacy attempt-cap keys
+  // that were split across quality.autofix and execution.rectification before
+  // unification. Same Zod-strip rationale.
+  rejectLegacyRectificationKeys(rawConfig);
+  rejectDeadQualityFlags(rawConfig);
+  // Fail fast on the not-yet-implemented scoped permission profile (GitHub #374)
+  // rather than letting it silently degrade to "safe".
+  rejectUnimplementedScopedProfile(rawConfig);
+  // Same feature, same treatment: the per-stage policy block is read by nothing,
+  // so accepting it would silently provide no enforcement.
+  rejectUnimplementedPermissionsBlock(rawConfig);
+  // Strip the four inert no-op keys (warn-and-strip, not throw — see
+  // config-guards.ts for the divergence rationale). Runs AFTER the reject guards
+  // and BEFORE safeParse, so the removed key is gone before the schema sees it.
+  // Post-merge placement yields one warning per resolved config regardless of
+  // which layer supplied the key.
+  const stripped = stripRemovedNoOpKeys(rawConfig, defaultConfigWarn);
+
+  const result = NaxConfigSchema.safeParse(stripped);
+  if (!result.success) {
+    const errors = result.error.issues.map((err) => {
+      const path = String(err.path.join("."));
+      return path ? `${path}: ${err.message}` : err.message;
+    });
+    throw new Error(`Invalid configuration:\n${errors.join("\n")}`);
+  }
+
+  return result.data as NaxConfig;
+}
+
 /** Find project nax directory (walks up from cwd) */
 export function findProjectDir(startDir: string = process.cwd()): string | null {
   let dir = resolve(startDir);
@@ -108,20 +298,7 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   // legacy key set in more than one layer would otherwise warn once per layer.
   const warnDedupe = createConfigWarnDedupe();
 
-  // Resolve projDir: if startDir is already the .nax/ dir (basename === ".nax"), use it
-  // directly; otherwise treat startDir as the project root and walk up to find .nax/.
-  const projDir = startDir
-    ? basename(startDir) === PROJECT_NAX_DIR
-      ? startDir
-      : findProjectDir(startDir)
-    : findProjectDir();
-
-  // Determine projectRoot for profile resolution
-  const projectRoot = startDir
-    ? basename(startDir) === PROJECT_NAX_DIR
-      ? dirname(startDir)
-      : startDir
-    : process.cwd();
+  const { projDir, projectRoot } = resolveProjectPaths(startDir);
 
   // Resolve profile chain: CLI > NAX_PROFILE env > project config.json > global > ["default"].
   // Each source accepts the comma form; the chain overlays left-to-right (later wins).
@@ -133,46 +310,18 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   // "default" entries carry no overlay — drop them so only meaningful profiles merge.
   const overlayChain = profileChain.filter((name) => name && name !== "default");
 
-  // Layer 1: Global config (~/.nax/config.json) — strip "profile" field before merging (AC 7)
-  const globalConfRaw = await loadJsonFile<Record<string, unknown>>(globalConfigPath(), "config");
   let logger: ReturnType<typeof getLogger> | null = null;
   try {
     logger = getLogger();
   } catch {
     /* logger may not be init yet */
   }
-  // SEC-2 — the raw (post-shim, pre-defaults-merge) global layer, kept around so the
-  // project-layer warn check below can tell "the global layer explicitly set this
-  // security-sensitive key" apart from "this key is just the unset schema default
-  // flowing through defaults + global merge". null when there is no global config file.
-  let globalLayerConf: Record<string, unknown> | null = null;
-  if (globalConfRaw) {
-    const { profile: _gProfile, ...globalConfStripped } = globalConfRaw;
-    const globalConf = applyConfigCompatShims(globalConfStripped, logger, warnDedupe);
-    globalLayerConf = globalConf;
-    rawConfig = deepMergeConfig(rawConfig, globalConf);
-  }
+  const ctx: ConfigLoadCtx = { logger, warnDedupe };
 
-  // Layer 2: Project config (.nax/config.json) — strip "profile" field before merging (AC 8)
-  if (projDir) {
-    const projConf = await loadJsonFile<Record<string, unknown>>(join(projDir, "config.json"), "config");
-    if (projConf) {
-      const { profile: _pProfile, ...projConfStripped } = projConf;
-      const resolvedProjConf = applyConfigCompatShims(projConfStripped, logger, warnDedupe);
-      const preProjectMergeConfig = rawConfig;
-      rawConfig = deepMergeConfig(rawConfig, resolvedProjConf);
-      // SEC-2 / D-2 — warn (do not block, do not change precedence) when the
-      // project layer changed a security-sensitive key from the global value.
-      // `sourceLayerConf: globalLayerConf` scopes the check to keys the global
-      // layer actually set — with no global config file (globalLayerConf is
-      // null) this never warns, since there is nothing the project layer could
-      // be said to have "changed" from.
-      warnSecuritySensitiveOverrides(preProjectMergeConfig, rawConfig, warnDedupe.warn, {
-        layerName: "project",
-        sourceLayerConf: globalLayerConf,
-      });
-    }
-  }
+  const globalLayer = await applyGlobalLayer(rawConfig, ctx);
+  rawConfig = globalLayer.rawConfig;
+
+  rawConfig = await applyProjectLayer(rawConfig, projDir, globalLayer.globalLayerConf, ctx);
 
   // CFG-2: global + project config never ran through $VAR resolution — a value
   // like "test": "$TEST_CMD" landed in the run config as the literal
@@ -180,62 +329,9 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   // process.env, same as the profile chain below.
   rawConfig = resolveEnvVarsWarnOnFailure(rawConfig, logger, "global/project config");
 
-  // Layer 3: Profile chain (overrides global + project — it's a run-time mode selection).
-  // Profiles overlay in order; a later profile overrides an earlier one. A missing
-  // profile file throws fail-fast (loadProfile). "default"-only chains apply no overlay.
-  for (const name of overlayChain) {
-    const profileData = await loadProfile(name, projectRoot);
-    // Load companion .env for $VAR resolution — do NOT write to process.env (AC 9).
-    // Must resolve BEFORE merging, otherwise a "$MODEL_FAST"-style reference lands
-    // in the run config as the literal unresolved string (BUG-17) — the load path
-    // previously discarded loadProfileEnv's return value and never called
-    // resolveEnvVars, so this only ever worked via the separate `config profile show
-    // --unmask` command path.
-    const profileEnv = await loadProfileEnv(name, projectRoot);
-    let resolvedProfileData: Record<string, unknown>;
-    try {
-      resolvedProfileData =
-        Object.keys(profileEnv).length > 0
-          ? (resolveEnvVars(profileData, profileEnv) as Record<string, unknown>)
-          : profileData;
-    } catch (err) {
-      // BUG-21 — surface which profile and which key path referenced the
-      // unresolved $VAR, instead of a bare Error with no config context.
-      const varName = err instanceof UnresolvedEnvVarError ? err.varName : undefined;
-      const path = err instanceof UnresolvedEnvVarError ? err.path.join(".") : undefined;
-      throw new NaxError(
-        `Profile "${name}" references an undefined environment variable${varName ? ` $${varName}` : ""}${path ? ` at "${path}"` : ""}.`,
-        "PROFILE_ENV_VAR_UNRESOLVED",
-        { stage: "config", profileName: name, varName, path, cause: err },
-      );
-    }
-    // Same compat-shim chain as the file layers above (BUG-51) — a profile can carry
-    // the same legacy shapes (e.g. routing.strategy: "manual") and must be remapped
-    // rather than hard-failing Zod validation.
-    const shimmedProfileData = applyConfigCompatShims(resolvedProfileData, logger, warnDedupe);
-    const preProfileMergeConfig = rawConfig;
-    rawConfig = deepMergeConfig(rawConfig, shimmedProfileData);
-    // SEC-2 — profiles merge AFTER global + project and can just as easily undo a
-    // security-sensitive setting, invisibly (profile files live outside the repo,
-    // outside code review). Only warn when this profile itself sets the key.
-    warnSecuritySensitiveOverrides(preProfileMergeConfig, rawConfig, warnDedupe.warn, {
-      layerName: `profile:${name}`,
-      sourceLayerConf: shimmedProfileData,
-    });
-  }
+  rawConfig = await applyProfileChainLayer(rawConfig, overlayChain, projectRoot, ctx);
 
-  // Layer 4: CLI overrides (highest priority)
-  if (cliOverrides) {
-    const shimmedCliOverrides = applyConfigCompatShims(cliOverrides, logger, warnDedupe);
-    const preCliMergeConfig = rawConfig;
-    rawConfig = deepMergeConfig(rawConfig, shimmedCliOverrides);
-    // SEC-2 — CLI overrides win over every other layer; warn when one changes a
-    // security-sensitive key so the change isn't silently invisible.
-    warnSecuritySensitiveOverrides(preCliMergeConfig, rawConfig, warnDedupe.warn, {
-      layerName: "CLI override",
-      sourceLayerConf: shimmedCliOverrides,
-    });
-  }
+  rawConfig = applyCliOverridesLayer(rawConfig, cliOverrides, ctx);
 
   // Force-set profile + chain to the resolved values after all merges (AC 6).
   // `profile` is the composite display string ("a+b"); "default" when no overlay applied.
@@ -243,7 +339,8 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   rawConfig.profileChain = overlayChain;
 
   // Track if any configs were merged (for optimization - skip safeParse when just using defaults)
-  const hasMergedConfigs = globalConfRaw || projDir !== null || cliOverrides !== undefined || overlayChain.length > 0;
+  const hasMergedConfigs =
+    globalLayer.globalConfRaw || projDir !== null || cliOverrides !== undefined || overlayChain.length > 0;
 
   // Parse and validate with Zod
   // Skip validation if no configs were merged (rawConfig is just DEFAULT_CONFIG).
@@ -253,37 +350,7 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     return structuredClone(DEFAULT_CONFIG as unknown as Record<string, unknown>) as unknown as NaxConfig;
   }
 
-  // ADR-012 Phase 6 — reject pre-migration agent keys with a migration pointer.
-  // Must run BEFORE Zod safeParse, otherwise .strip() silently drops the keys.
-  rejectLegacyAgentKeys(rawConfig);
-  // Rectification-config consolidation — reject the four legacy attempt-cap keys
-  // that were split across quality.autofix and execution.rectification before
-  // unification. Same Zod-strip rationale.
-  rejectLegacyRectificationKeys(rawConfig);
-  rejectDeadQualityFlags(rawConfig);
-  // Fail fast on the not-yet-implemented scoped permission profile (GitHub #374)
-  // rather than letting it silently degrade to "safe".
-  rejectUnimplementedScopedProfile(rawConfig);
-  // Same feature, same treatment: the per-stage policy block is read by nothing,
-  // so accepting it would silently provide no enforcement.
-  rejectUnimplementedPermissionsBlock(rawConfig);
-  // Strip the four inert no-op keys (warn-and-strip, not throw — see
-  // config-guards.ts for the divergence rationale). Runs AFTER the reject guards
-  // and BEFORE safeParse, so the removed key is gone before the schema sees it.
-  // Post-merge placement yields one warning per resolved config regardless of
-  // which layer supplied the key.
-  rawConfig = stripRemovedNoOpKeys(rawConfig, defaultConfigWarn);
-
-  const result = NaxConfigSchema.safeParse(rawConfig);
-  if (!result.success) {
-    const errors = result.error.issues.map((err) => {
-      const path = String(err.path.join("."));
-      return path ? `${path}: ${err.message}` : err.message;
-    });
-    throw new Error(`Invalid configuration:\n${errors.join("\n")}`);
-  }
-
-  return result.data as NaxConfig;
+  return finalizeAndValidateRootConfig(rawConfig);
 }
 
 /**

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -6,8 +6,52 @@
 
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { NaxError } from "../errors";
 
 const GLOBAL_CONFIG_DIR_ENV = "NAX_GLOBAL_CONFIG_DIR";
+
+/**
+ * Feature ID charset, mirroring `validateStoryId` (`src/prd/validate.ts`) but with
+ * a leading underscore also allowed — `"_unattached"` (`src/pipeline/stages/context.ts`,
+ * `src/context/engine/stage-assembler.ts`) is a real internal sentinel used when a
+ * context request has no attached feature, and it must keep resolving through this
+ * same path. Traversal (`..`) and a leading `--` (git-flag-shaped) are rejected
+ * explicitly first so the error names the actual problem instead of a generic
+ * pattern mismatch.
+ */
+const FEATURE_ID_PATTERN = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,63}$/;
+
+/**
+ * SEC-3 (code review 2026-08-17): `featureDir` is the SSOT anchor for every
+ * feature-tree path (~38 call sites — `mkdir(recursive)`, artifact writes) but,
+ * unlike `validateStoryId`, took `featureId` unvalidated. `featureId` today only
+ * ever comes from the trusted CLI `--feature` flag, but the asymmetry with the
+ * story-ID path was a real gap should that ever change.
+ */
+function validateFeatureId(featureId: string): void {
+  if (!featureId || featureId.length === 0) {
+    throw new NaxError("Feature ID cannot be empty", "INVALID_FEATURE_ID", { stage: "config" });
+  }
+  if (featureId.includes("..")) {
+    throw new NaxError("Feature ID cannot contain path traversal (..)", "INVALID_FEATURE_ID", {
+      stage: "config",
+      featureId,
+    });
+  }
+  if (featureId.startsWith("--")) {
+    throw new NaxError("Feature ID cannot start with git flags (--)", "INVALID_FEATURE_ID", {
+      stage: "config",
+      featureId,
+    });
+  }
+  if (!FEATURE_ID_PATTERN.test(featureId)) {
+    throw new NaxError(
+      `Feature ID must match pattern [a-zA-Z0-9_][a-zA-Z0-9._-]{0,63}. Got: ${featureId}`,
+      "INVALID_FEATURE_ID",
+      { stage: "config", featureId },
+    );
+  }
+}
 
 /**
  * Returns the global config directory path (~/.nax).
@@ -71,5 +115,6 @@ export function featuresDir(root: string): string {
  * because the segment was open-coded at each site and one site dropped `.nax`.
  */
 export function featureDir(root: string, featureId: string): string {
+  validateFeatureId(featureId);
   return join(featuresDir(root), featureId);
 }

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -88,7 +88,20 @@ export async function discoverSessionScratchDirsOnDisk(
   ttlMs: number,
 ): Promise<string[]> {
   const logger = getLogger();
-  const sessionsRoot = join(featureDir(projectDir, featureName), "sessions");
+  let sessionsRoot: string;
+  try {
+    // featureDir() validates featureName (SEC-3) and can throw for a legacy or
+    // malformed name — this function is documented best-effort, so that must
+    // degrade to "no sessions found" like every other failure here, not escape.
+    sessionsRoot = join(featureDir(projectDir, featureName), "sessions");
+  } catch (err) {
+    logger.debug("context-v2", "discoverSessionScratchDirsOnDisk: invalid featureName — treating as no sessions", {
+      storyId,
+      featureName,
+      error: errorMessage(err),
+    });
+    return [];
+  }
 
   let entries: string[];
   try {

--- a/src/log-format/formatter.ts
+++ b/src/log-format/formatter.ts
@@ -453,7 +453,8 @@ export function formatAdvisorySummary(
   }
 
   const c = useColor ? chalk : createNoopChalk();
-  const sorted = [...findings].sort((a, b) => (SEVERITY_RANK[b.severity] ?? 0) - (SEVERITY_RANK[a.severity] ?? 0));
+  const rank = SEVERITY_RANK as Record<string, number>;
+  const sorted = [...findings].sort((a, b) => (rank[b.severity] ?? 0) - (rank[a.severity] ?? 0));
 
   const lines: string[] = [];
   lines.push("");

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -8,6 +8,7 @@
 
 export { Logger, initLogger, getLogger, getSafeLogger, resetLogger, addSink } from "./logger.js";
 export { formatConsole, formatJsonl } from "./formatters.js";
+export { redactSecrets } from "./redact.js";
 export type {
   LogLevel,
   LogEntry,

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -122,11 +122,23 @@ export function finishResultPath(
   return path.join(finishAuditDir(ctx), `${runId}.result.json`);
 }
 
-/** Default result reader — reads the flow's terminal result off disk. */
+/**
+ * Default result reader — reads the flow's terminal result off disk.
+ *
+ * BUG-1 (code review 2026-08-17): a result file can exist but be malformed —
+ * the flow process killed mid-write, disk full — in which case treat it the
+ * same as "no result file" rather than letting JSON.parse throw. Mirrors
+ * `curator/collect.ts`'s `readJsonLines`, which already does this for its own
+ * on-disk reads with the same "must never fail the run" rationale.
+ */
 async function defaultReadResult(resultPath: string): Promise<FinishResult | null> {
   const f = Bun.file(resultPath);
   if (!(await f.exists())) return null;
-  return JSON.parse(await f.text()) as FinishResult;
+  try {
+    return JSON.parse(await f.text()) as FinishResult;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/plugins/builtin/nax-finish/index.ts
+++ b/src/plugins/builtin/nax-finish/index.ts
@@ -19,6 +19,7 @@
  */
 
 import * as path from "node:path";
+import { getSafeLogger } from "@/logger";
 import type { IPostRunAction, NaxPlugin, PluginLogger, PostRunActionResult, PostRunContext } from "@/plugins/types";
 import { errorMessage } from "@/utils/errors";
 import { type FinishAutoFlowSettings, getFinishAutoFlowConfig, telegramCreds } from "./config";
@@ -136,7 +137,15 @@ async function defaultReadResult(resultPath: string): Promise<FinishResult | nul
   if (!(await f.exists())) return null;
   try {
     return JSON.parse(await f.text()) as FinishResult;
-  } catch {
+  } catch (err) {
+    // Log the parse failure — a malformed file and a missing file both resolve
+    // to null (and the same downstream "no result file" message), but only the
+    // former has a diagnostic worth keeping, and swallowing it silently would
+    // have made the "file exists but is corrupt" case indistinguishable from
+    // "the flow never ran" in the logs.
+    getSafeLogger()?.warn("plugins", `nax-finish: malformed result file at ${resultPath}`, {
+      error: errorMessage(err),
+    });
     return null;
   }
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -401,13 +401,15 @@ function resolveModulePath(modulePath: string, projectRoot?: string): string {
  *
  * @param modulePath - Path to plugin module (should be resolved)
  * @param config - Plugin-specific config
+ * @param allowedRoots - Roots a file-path module must resolve under (SEC-2: required, not
+ *   defaulted — an empty list must fail closed rather than silently skip validation).
  * @param originalPath - Original path from config (for error messages)
  * @returns Validated plugin or null if invalid
  */
 async function loadAndValidatePlugin(
   initialModulePath: string,
   config: Record<string, unknown>,
-  allowedRoots: string[] = [],
+  allowedRoots: string[],
   originalPath?: string,
 ): Promise<NaxPlugin | null> {
   let attemptedPath = initialModulePath;
@@ -416,7 +418,17 @@ async function loadAndValidatePlugin(
     let modulePath = initialModulePath;
     const isFilePath = modulePath.startsWith("/") || modulePath.startsWith("./") || modulePath.startsWith("../");
 
-    if (isFilePath && allowedRoots.length > 0) {
+    if (isFilePath) {
+      // SEC-2: fail closed when no roots were supplied — the module-path check
+      // below would otherwise be silently skipped, letting an unvalidated file
+      // path reach `await import()` a few lines down.
+      if (allowedRoots.length === 0) {
+        const msg = `no allowed roots configured for file-path plugin module '${initialModulePath}'`;
+        const logger = getSafeLogger();
+        logger?.error("plugins", `Security: ${msg}`);
+        _pluginErrorSink(`[plugins] Security: ${msg}`);
+        return null;
+      }
       const validation = validateModulePath(modulePath, allowedRoots);
       if (!validation.valid) {
         const logger = getSafeLogger();
@@ -486,3 +498,6 @@ async function loadAndValidatePlugin(
     return null;
   }
 }
+
+/** @internal — exposes loadAndValidatePlugin for direct SEC-2 (fail-closed empty allowedRoots) testing. */
+export const _loadAndValidatePlugin = loadAndValidatePlugin;

--- a/src/review/ac-quote-validator.ts
+++ b/src/review/ac-quote-validator.ts
@@ -17,11 +17,13 @@
  * next-tier escalation context.
  */
 
+import type { Severity } from "./severity";
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 /** Minimum shape required for AC-quote validation — satisfied by both LLMFinding and AdversarialLLMFinding. */
 export interface AcQuotable {
-  severity: string;
+  severity: Severity;
   file?: string;
   issue: string;
   acQuote?: string;

--- a/src/review/ac-structural-counterfactual.ts
+++ b/src/review/ac-structural-counterfactual.ts
@@ -12,6 +12,7 @@
  */
 
 import type { AcQuoteRejectionCode } from "./ac-quote-validator";
+import type { Severity } from "./severity";
 
 /**
  * Categories that should block a story under the structural alternative.
@@ -68,7 +69,7 @@ export function analyzeStructuralCounterfactual(
  * even when `categoryBlocking` is false.
  */
 export interface AdversarialDropAnalysis {
-  finding: { file: string; line: number; severity: string; category: string; issue: string };
+  finding: { file: string; line: number; severity: Severity; category: string; issue: string };
   dropCode: AcQuoteRejectionCode;
   acIndex?: number;
   rawCategory: string;
@@ -81,7 +82,7 @@ export interface AdversarialDropAnalysis {
  * Used to detect over-rejection risk if the structural alternative were adopted.
  */
 export interface AdversarialAcceptAnalysis {
-  finding: { file: string; line: number; severity: string; category: string };
+  finding: { file: string; line: number; severity: Severity; category: string };
   acIndex?: number;
   rawCategory: string;
   counterfactual: StructuralCounterfactual;

--- a/src/review/adversarial-helpers.ts
+++ b/src/review/adversarial-helpers.ts
@@ -10,11 +10,12 @@ import { tryParseLLMJson } from "../utils/llm-json";
 import { extractAcks } from "./acks";
 import { categoryToFixTarget, resolveFixTarget } from "./category-fix-target";
 import { isBlockingSeverity } from "./severity";
+import type { Severity } from "./severity";
 import type { ReviewAck } from "./types";
 export { isBlockingSeverity };
 
 export interface AdversarialLLMFinding {
-  severity: string;
+  severity: Severity;
   category: string;
   file: string;
   line: number;

--- a/src/review/adversarial-outcomes.ts
+++ b/src/review/adversarial-outcomes.ts
@@ -32,7 +32,16 @@ export interface AdversarialOutcomeCtx {
   projectDir: string | undefined;
   storyId: string;
   featureName: string | undefined;
-  blockingThreshold: "error" | "warning" | "info";
+  /**
+   * Raw, possibly-undefined caller option — deliberately NOT defaulted here.
+   * Only the three pre-classification helpers below (catchDispatchFailure,
+   * handleRetryExhaustedFailOpen, handleTruncatedLooksLikeFail) read this field,
+   * and they must record the same `undefined` the caller passed (matching the
+   * pre-decomposition behavior) rather than a defaulted "error" that would
+   * change what's recorded in the audit event. Post-classification outcome
+   * builders read the defaulted `classification.threshold` instead.
+   */
+  blockingThreshold: "error" | "warning" | "info" | undefined;
   startTime: number;
   logger: Logger | null;
 }

--- a/src/review/adversarial-outcomes.ts
+++ b/src/review/adversarial-outcomes.ts
@@ -1,0 +1,468 @@
+/**
+ * Outcome-building helpers for the adversarial review runner (REVIEW-003).
+ *
+ * Split out of adversarial.ts (TYPE-0, code review 2026-08-17) to keep both
+ * files under the 600-line file-size limit after decomposing the former
+ * 507-line `runAdversarialReview` monolith. Each function here reproduces,
+ * unchanged, one stage of that original function — logging, audit recording,
+ * and the exact `ReviewCheckResult` shape it used to build inline.
+ */
+
+import { filterContextByRole } from "../context";
+import type { ContextBundle } from "../context/engine";
+import type { Iteration } from "../findings";
+import type { Logger } from "../logger";
+import type { AdversarialReviewOutput } from "../operations/adversarial-review";
+import type { NaxRuntime } from "../runtime";
+import type { ResolvedTestPatterns } from "../test-runners";
+import { extractDiffFiles } from "../utils/diff-files";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
+import type { AdversarialAcceptAnalysis, AdversarialDropAnalysis } from "./ac-structural-counterfactual";
+import { recordAdversarialAudit } from "./adversarial-audit-event";
+import { type AdversarialLLMFinding, formatFindings, toAdversarialReviewFindings } from "./adversarial-helpers";
+import type { collectDiffFileList } from "./diff-utils";
+import { llmFindingsToReviewFindings } from "./finding-projection";
+import { classifyRecurrence, tagCoverageGap } from "./recurrence-demotion";
+import type { AdversarialReviewConfig, ReviewCheckResult } from "./types";
+
+/** Fields every audit-recording outcome helper needs — a slice of RunAdversarialReviewOptions plus derived run state. */
+export interface AdversarialOutcomeCtx {
+  runtime: NaxRuntime;
+  workdir: string;
+  projectDir: string | undefined;
+  storyId: string;
+  featureName: string | undefined;
+  blockingThreshold: "error" | "warning" | "info";
+  startTime: number;
+  logger: Logger | null;
+}
+
+export function skipResult(output: string, startTime: number): ReviewCheckResult {
+  return {
+    check: "adversarial",
+    success: true,
+    command: "",
+    exitCode: 0,
+    output,
+    durationMs: Date.now() - startTime,
+  };
+}
+
+export function buildFeatureCtxBlock(
+  contextBundle: ContextBundle | undefined,
+  featureContextMarkdown: string | undefined,
+): string {
+  // When a v2 ContextBundle is provided, use its pushMarkdown directly — the orchestrator
+  // already applied role filtering and dedup, so the v1 filterContextByRole() pass is
+  // skipped (it would silently drop ##-section content from v2's rendered output).
+  if (contextBundle) {
+    const md = contextBundle.pushMarkdown.trim();
+    return md ? `${md}\n\n---\n\n` : "";
+  }
+  if (featureContextMarkdown) {
+    const filtered = filterContextByRole(featureContextMarkdown, "reviewer-adversarial");
+    if (filtered.trim()) return `${filtered}\n\n---\n\n`;
+  }
+  return "";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dispatch — the three non-continuing outcomes (error, fail-open, truncated-fail)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function catchDispatchFailure(err: unknown, ctx: AdversarialOutcomeCtx): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, blockingThreshold, startTime, logger } = ctx;
+  logger?.warn("adversarial", "LLM call failed — fail-open", { storyId, cause: String(err) });
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: false,
+    looksLikeFail: false,
+    failOpen: true,
+    passed: true,
+    blockingThreshold,
+    result: null,
+  });
+  return {
+    check: "adversarial",
+    success: true,
+    failOpen: true,
+    command: "",
+    exitCode: 0,
+    output: `skipped: LLM call failed — ${String(err)}`,
+    durationMs: Date.now() - startTime,
+  };
+}
+
+export function handleRetryExhaustedFailOpen(ctx: AdversarialOutcomeCtx): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, blockingThreshold, startTime, logger } = ctx;
+  logger?.warn("adversarial", "Retry exhausted — fail-open", { storyId });
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: false,
+    looksLikeFail: false,
+    failOpen: true,
+    passed: true,
+    blockingThreshold,
+    result: null,
+  });
+  return {
+    check: "adversarial",
+    success: true,
+    failOpen: true,
+    command: "",
+    exitCode: 0,
+    output: "adversarial review: could not parse LLM response (fail-open)",
+    durationMs: Date.now() - startTime,
+  };
+}
+
+export function handleTruncatedLooksLikeFail(ctx: AdversarialOutcomeCtx): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, blockingThreshold, startTime, logger } = ctx;
+  logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", { storyId });
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: false,
+    looksLikeFail: true,
+    failOpen: false,
+    passed: false,
+    blockingThreshold,
+    result: null,
+  });
+  return {
+    check: "adversarial",
+    success: false,
+    command: "",
+    exitCode: 1,
+    output: "adversarial review: LLM response truncated but indicated failure (passed:false found in partial response)",
+    durationMs: Date.now() - startTime,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Finding classification — recurrence demotion + projections for audit/pipeline
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AdversarialClassification {
+  threshold: "error" | "warning" | "info";
+  allFindings: AdversarialLLMFinding[];
+  testFileMatch: (file: string) => boolean;
+  blockingFindings: AdversarialLLMFinding[];
+  advisoryFindings: AdversarialLLMFinding[];
+  advisoryReviewFindings: unknown[];
+  advisoryFindingsAsFindings: ReturnType<typeof toAdversarialReviewFindings>;
+  acDropped: AdversarialReviewOutput["acDropped"];
+  acks: AdversarialReviewOutput["acks"];
+}
+
+export function classifyAdversarialFindings(
+  opResult: AdversarialReviewOutput,
+  blockingThreshold: "error" | "warning" | "info" | undefined,
+  priorAdversarialIterations: Iteration[] | undefined,
+  adversarialConfig: AdversarialReviewConfig,
+  resolvedTestPatterns: ResolvedTestPatterns | undefined,
+): AdversarialClassification {
+  // verify() has already run the full filter pipeline (substantiate → AC-ground → split).
+  // opResult.findings = accepted findings (blocking + advisory); opResult.acDropped = drops for telemetry.
+  // opResult.passed preserves the model verdict after filtering so wrappers can
+  // still fail-closed when passed:false survives without remaining blockers.
+  const threshold = blockingThreshold ?? "error";
+  const allFindings = opResult.findings as AdversarialLLMFinding[];
+  const patterns = resolvedTestPatterns?.regex ?? [];
+  const testFileMatch = (file: string): boolean => patterns.some((re) => re.test(file));
+  const recurrenceCfg = adversarialConfig.recurrenceDemotion ?? { enabled: true, maxBlockingRounds: 2 };
+  const {
+    blocking: blockingFindings,
+    advisory: advisoryOnly,
+    demoted,
+  } = classifyRecurrence(allFindings, priorAdversarialIterations ?? [], recurrenceCfg, testFileMatch, threshold);
+  const advisoryFindings = [...advisoryOnly, ...demoted];
+  // Precomputed conversions so every downstream `advisoryFindings` projection
+  // (ReviewFinding for review-audit persistence, Finding for the pipeline
+  // result) tags the recurrence-demoted subset with `meta.coverageGap: true`
+  // (Fix design §7) without re-deriving the split at each call site.
+  // #1368 — `testFileMatch` also decides the fix lane: a finding located in a test
+  // file goes to the test-writer whatever its category says, because the implementer
+  // may not edit test files and would answer UNRESOLVED.
+  const advisoryReviewFindings = [
+    ...llmFindingsToReviewFindings(advisoryOnly, { source: "adversarial-review", isTestFile: testFileMatch }),
+    ...tagCoverageGap(
+      llmFindingsToReviewFindings(demoted, { source: "adversarial-review", isTestFile: testFileMatch }),
+    ),
+  ];
+  const advisoryFindingsAsFindings = [
+    ...toAdversarialReviewFindings(advisoryOnly, { isTestFile: testFileMatch }),
+    ...tagCoverageGap(toAdversarialReviewFindings(demoted, { isTestFile: testFileMatch })),
+  ];
+
+  return {
+    threshold,
+    allFindings,
+    testFileMatch,
+    blockingFindings,
+    advisoryFindings,
+    advisoryReviewFindings,
+    advisoryFindingsAsFindings,
+    acDropped: opResult.acDropped ?? [],
+    acks: opResult.acks, // #1423 — recorded alongside findings, never as one.
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Diff file set — for structural counterfactual telemetry (issue #986)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function resolveDiffFileSet(
+  diff: string | undefined,
+  workdir: string,
+  projectDir: string | undefined,
+  effectiveRef: string,
+  naxIgnoreIndex: NaxIgnoreIndex | undefined,
+  collectDiffFileListFn: typeof collectDiffFileList,
+): Promise<{ diffFiles: ReadonlySet<string>; diffAvailable: boolean }> {
+  // Embedded mode: parse `diff` (already in memory). Ref mode: shell git diff
+  // --name-only via collectDiffFileList. diffAvailable=false signals "exclude
+  // this entry from percentage calculations" to the aggregation script.
+  if (diff && diff.length > 0) {
+    return { diffFiles: extractDiffFiles(diff), diffAvailable: true };
+  }
+  const repoRoot = projectDir ?? workdir;
+  const packageDir = workdir !== repoRoot ? workdir : undefined;
+  const list = await collectDiffFileListFn(workdir, effectiveRef, { naxIgnoreIndex, packageDir });
+  if (list === undefined) return { diffFiles: new Set(), diffAvailable: false };
+  return { diffFiles: new Set(list), diffAvailable: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Outcome builders — blocking failure / AC-dropped (hallucinated vs ungrounded) / passed
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildBlockingFailureResult(
+  ctx: AdversarialOutcomeCtx,
+  classification: AdversarialClassification,
+  telemetry: {
+    adversarialDropAnalysis: AdversarialDropAnalysis[];
+    adversarialAcceptAnalysis: AdversarialAcceptAnalysis[];
+  },
+  diffAvailable: boolean,
+  durationMs: number,
+): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, logger } = ctx;
+  const { threshold, allFindings, testFileMatch, blockingFindings, advisoryFindings, advisoryReviewFindings, acks } =
+    classification;
+  logger?.warn("review", `Adversarial review failed: ${blockingFindings.length} blocking findings`, {
+    storyId,
+    durationMs,
+    findings: blockingFindings.map((f) => ({
+      severity: f.severity,
+      category: f.category,
+      file: f.file,
+      line: f.line,
+      issue: f.issue,
+    })),
+  });
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: true,
+    failOpen: false,
+    passed: false,
+    blockingThreshold: threshold,
+    result: {
+      passed: false,
+      findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review", isTestFile: testFileMatch }),
+    },
+    advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
+    diffAvailable,
+    adversarialDropAnalysis: telemetry.adversarialDropAnalysis,
+    adversarialAcceptAnalysis: telemetry.adversarialAcceptAnalysis,
+    acks,
+  });
+  return {
+    check: "adversarial",
+    success: false,
+    command: "",
+    exitCode: 1,
+    output: `Adversarial review failed:\n\n${formatFindings(blockingFindings)}`,
+    durationMs,
+    findings: toAdversarialReviewFindings(blockingFindings, { isTestFile: testFileMatch }),
+    advisoryFindings: advisoryFindings.length > 0 ? classification.advisoryFindingsAsFindings : undefined,
+    cost: 0,
+  };
+}
+
+/** Case A: every blocking finding cited a quote that does not exist in any AC — the model fabricated its grounding. */
+export function buildHallucinatedAcQuoteResult(
+  ctx: AdversarialOutcomeCtx,
+  classification: AdversarialClassification,
+  telemetry: { adversarialDropAnalysis: AdversarialDropAnalysis[] },
+  diffAvailable: boolean,
+  durationMs: number,
+): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, logger } = ctx;
+  const { threshold, testFileMatch, acDropped, acks, advisoryFindingsAsFindings } = classification;
+
+  const demotedFindings = toAdversarialReviewFindings(
+    acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
+    { isTestFile: testFileMatch },
+  );
+  const allAdvisory = [...advisoryFindingsAsFindings, ...demotedFindings];
+
+  logger?.warn("review", "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes", {
+    storyId,
+    durationMs,
+    droppedCount: acDropped.length,
+    drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
+  });
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: true,
+    acks,
+    failOpen: false,
+    passed: true,
+    passReason: "ac_quote_not_substring_demoted",
+    blockingThreshold: threshold,
+    result: { passed: true, findings: [] },
+    advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+    diffAvailable,
+    adversarialDropAnalysis: telemetry.adversarialDropAnalysis,
+    adversarialAcceptAnalysis: [],
+  });
+  return {
+    check: "adversarial",
+    success: true,
+    passReason: "ac_quote_not_substring_demoted",
+    command: "",
+    exitCode: 0,
+    output: `Adversarial review passed: ${acDropped.length} blocking finding(s) demoted to advisory — all cited AC quotes were fabricated and could not be validated.`,
+    durationMs,
+    advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+    cost: 0,
+  };
+}
+
+/** Case B: mix includes missing_ac_quote or ac_quote_does_not_constrain_locus — fail-closed. */
+export function buildUngroundedFailClosedResult(
+  ctx: AdversarialOutcomeCtx,
+  classification: AdversarialClassification,
+  telemetry: { adversarialDropAnalysis: AdversarialDropAnalysis[] },
+  diffAvailable: boolean,
+  durationMs: number,
+): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, logger } = ctx;
+  const { threshold, acDropped, acks, advisoryFindings, advisoryReviewFindings, advisoryFindingsAsFindings } =
+    classification;
+
+  logger?.warn("review", "Adversarial review fail-closed: blocking findings dropped as ungrounded", {
+    storyId,
+    durationMs,
+    droppedCount: acDropped.length,
+    dropCodes: acDropped.map((d) => d.code),
+  });
+  const dropSummary = acDropped
+    .map((d, i) => `${i + 1}. [${d.code}] ${d.finding.file ?? "<unknown>"}: ${d.finding.issue}`)
+    .join("\n");
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: true,
+    acks,
+    failOpen: false,
+    passed: false,
+    blockingThreshold: threshold,
+    result: { passed: false, findings: [] },
+    advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
+    diffAvailable,
+    adversarialDropAnalysis: telemetry.adversarialDropAnalysis,
+    adversarialAcceptAnalysis: [],
+  });
+  return {
+    check: "adversarial",
+    success: false,
+    command: "",
+    exitCode: 1,
+    output: `Adversarial review failed: ${acDropped.length} blocking finding(s) dropped as ungrounded — the model emitted "passed: false" with concerns it could not ground in any acceptance criterion. Drops:\n\n${dropSummary}`,
+    durationMs,
+    advisoryFindings: advisoryFindings.length > 0 ? advisoryFindingsAsFindings : undefined,
+    cost: 0,
+  };
+}
+
+/** Model passed with no blocking findings, or only advisory findings remained after filtering with no AC-grounding drops. */
+export function buildPassedResult(
+  ctx: AdversarialOutcomeCtx,
+  classification: AdversarialClassification,
+  telemetry: {
+    adversarialDropAnalysis: AdversarialDropAnalysis[];
+    adversarialAcceptAnalysis: AdversarialAcceptAnalysis[];
+  },
+  diffAvailable: boolean,
+  durationMs: number,
+): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, logger } = ctx;
+  const {
+    threshold,
+    allFindings,
+    testFileMatch,
+    advisoryFindings,
+    advisoryReviewFindings,
+    advisoryFindingsAsFindings,
+    acks,
+  } = classification;
+
+  logger?.info("review", "Adversarial review passed", { storyId, durationMs });
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: true,
+    acks,
+    failOpen: false,
+    passed: true,
+    blockingThreshold: threshold,
+    result: {
+      passed: true,
+      findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review", isTestFile: testFileMatch }),
+    },
+    advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
+    diffAvailable,
+    adversarialDropAnalysis: telemetry.adversarialDropAnalysis,
+    adversarialAcceptAnalysis: telemetry.adversarialAcceptAnalysis,
+  });
+  return {
+    check: "adversarial",
+    success: true,
+    command: "",
+    exitCode: 0,
+    output:
+      allFindings.length === 0
+        ? "Adversarial review passed"
+        : "Adversarial review passed (all findings were advisory — below blocking threshold)",
+    durationMs,
+    advisoryFindings: advisoryFindings.length > 0 ? advisoryFindingsAsFindings : undefined,
+    cost: 0,
+  };
+}

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -11,25 +11,44 @@
  *   - Own ACP session (reviewer-adversarial), NOT the implementer session.
  *   - Default diffMode is "ref" (no 50KB cap; reviewer self-serves via git tools).
  *   - Findings carry a `category` field (input, error-path, abandonment, etc.).
+ *
+ * Decomposed per code-review TYPE-0 (2026-08-17): the orchestrator below stays a
+ * thin sequence of stages — skip checks, dispatch, finding classification,
+ * telemetry, outcome — with each stage's logic and its audit-recording extracted
+ * into named helpers in ./adversarial-outcomes.ts. Control-flow order and every
+ * side effect (logging, `recordAdversarialAudit` calls) are preserved exactly;
+ * only the grouping (and file) changed.
  */
 
 import type { IAgentManager } from "../agents";
 import type { ReviewConfig } from "../config/selectors";
-import { filterContextByRole } from "../context";
+import type { ContextBundle } from "../context/engine";
 import { NaxError } from "../errors";
 import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
+import type { AdversarialReviewOutput } from "../operations/adversarial-review";
 import { adversarialReviewOp } from "../operations/adversarial-review";
 import { callOp as _callOp } from "../operations/call";
-import { extractDiffFiles } from "../utils/diff-files";
+import type { NaxRuntime } from "../runtime";
+import type { ResolvedTestPatterns } from "../test-runners";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
-import { recordAdversarialAudit } from "./adversarial-audit-event";
 import { buildCounterfactualTelemetry } from "./adversarial-counterfactual-telemetry";
-import { type AdversarialLLMFinding, formatFindings, toAdversarialReviewFindings } from "./adversarial-helpers";
+import type { AdversarialOutcomeCtx } from "./adversarial-outcomes";
+import {
+  buildBlockingFailureResult,
+  buildFeatureCtxBlock,
+  buildHallucinatedAcQuoteResult,
+  buildPassedResult,
+  buildUngroundedFailClosedResult,
+  catchDispatchFailure,
+  classifyAdversarialFindings,
+  handleRetryExhaustedFailOpen,
+  handleTruncatedLooksLikeFail,
+  resolveDiffFileSet,
+  skipResult,
+} from "./adversarial-outcomes";
 import { collectDiffFileList as _collectDiffFileList } from "./diff-utils";
-import { llmFindingsToReviewFindings } from "./finding-projection";
 import { prepareAdversarialReviewInput } from "./prepare-inputs";
-import { classifyRecurrence, tagCoverageGap } from "./recurrence-demotion";
 import { writeReviewAudit } from "./review-audit";
 import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
 
@@ -51,12 +70,12 @@ export interface RunAdversarialReviewOptions {
   priorFailures?: Array<{ stage: string; modelTier: string }>;
   blockingThreshold?: "error" | "warning" | "info";
   featureContextMarkdown?: string;
-  contextBundle?: import("../context/engine").ContextBundle;
+  contextBundle?: ContextBundle;
   projectDir?: string;
   naxIgnoreIndex?: NaxIgnoreIndex;
-  runtime?: import("../runtime").NaxRuntime;
+  runtime?: NaxRuntime;
   priorAdversarialIterations?: Iteration[];
-  resolvedTestPatterns?: import("../test-runners").ResolvedTestPatterns;
+  resolvedTestPatterns?: ResolvedTestPatterns;
 }
 
 /**
@@ -96,14 +115,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   });
 
   if (prepared.skipReason === "no git ref") {
-    return {
-      check: "adversarial",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no git ref",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no git ref", startTime);
   }
 
   const diffMode = adversarialConfig.diffMode ?? "ref";
@@ -114,24 +126,10 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   });
 
   if (prepared.skipReason === "no changes detected") {
-    return {
-      check: "adversarial",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no changes detected",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no changes detected", startTime);
   }
   if (prepared.skipReason === "no code changes") {
-    return {
-      check: "adversarial",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no code changes",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no code changes", startTime);
   }
 
   // biome-ignore lint/style/noNonNullAssertion: skipReason undefined ⇒ effectiveRef present
@@ -151,28 +149,11 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       storyId: story.id,
       model: adversarialConfig.model,
     });
-    return {
-      check: "adversarial",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no agent available for model tier",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no agent available for model tier", startTime);
   }
 
   // Build feature context block for the prompt.
-  // When a v2 ContextBundle is provided, use its pushMarkdown directly — the orchestrator
-  // already applied role filtering and dedup, so the v1 filterContextByRole() pass is
-  // skipped (it would silently drop ##-section content from v2's rendered output).
-  let featureCtxBlock = "";
-  if (contextBundle) {
-    const md = contextBundle.pushMarkdown.trim();
-    if (md) featureCtxBlock = `${md}\n\n---\n\n`;
-  } else if (featureContextMarkdown) {
-    const filtered = filterContextByRole(featureContextMarkdown, "reviewer-adversarial");
-    if (filtered.trim()) featureCtxBlock = `${filtered}\n\n---\n\n`;
-  }
+  const featureCtxBlock = buildFeatureCtxBlock(contextBundle, featureContextMarkdown);
 
   // ADR-019 Pattern A: dispatch via callOp so the hop routes through
   // AgentManager.runWithFallback + buildHopCallback, firing the middleware chain
@@ -186,9 +167,17 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     );
   }
 
-  // NOTE: llmCost stays 0 on the runtime path — buildHopCallback charges cost via
-  // costAggregator. ReviewCheckResult.cost is 0 for pipeline-managed reviews.
-  const llmCost = 0;
+  const outcomeCtx: AdversarialOutcomeCtx = {
+    runtime,
+    workdir,
+    projectDir,
+    storyId: story.id,
+    featureName,
+    blockingThreshold: blockingThreshold ?? "error",
+    startTime,
+    logger,
+  };
+
   const callCtx = {
     runtime,
     packageView: runtime.packages.resolve(workdir),
@@ -198,7 +187,10 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     featureName,
     contextBundle,
   };
-  let opResult: import("../operations/adversarial-review").AdversarialReviewOutput;
+
+  // NOTE: llmCost stays 0 on the runtime path — buildHopCallback charges cost via
+  // costAggregator. ReviewCheckResult.cost is 0 for pipeline-managed reviews.
+  let opResult: AdversarialReviewOutput;
   try {
     opResult = await _adversarialDeps.callOp(callCtx, adversarialReviewOp, {
       workdir,
@@ -219,82 +211,10 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       resolvedTestPatterns,
     });
   } catch (err) {
-    logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
-    recordAdversarialAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail: false,
-      failOpen: true,
-      passed: true,
-      blockingThreshold,
-      result: null,
-    });
-    return {
-      check: "adversarial",
-      success: true,
-      failOpen: true,
-      command: "",
-      exitCode: 0,
-      output: `skipped: LLM call failed — ${String(err)}`,
-      durationMs: Date.now() - startTime,
-    };
+    return catchDispatchFailure(err, outcomeCtx);
   }
-  if (opResult.failOpen) {
-    logger?.warn("adversarial", "Retry exhausted — fail-open", { storyId: story.id });
-    recordAdversarialAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail: false,
-      failOpen: true,
-      passed: true,
-      blockingThreshold,
-      result: null,
-    });
-    return {
-      check: "adversarial",
-      success: true,
-      failOpen: true,
-      command: "",
-      exitCode: 0,
-      output: "adversarial review: could not parse LLM response (fail-open)",
-      durationMs: Date.now() - startTime,
-    };
-  }
-  if (opResult.looksLikeFail) {
-    logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
-      storyId: story.id,
-    });
-    recordAdversarialAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail: true,
-      failOpen: false,
-      passed: false,
-      blockingThreshold,
-      result: null,
-    });
-    return {
-      check: "adversarial",
-      success: false,
-      command: "",
-      exitCode: 1,
-      output:
-        "adversarial review: LLM response truncated but indicated failure (passed:false found in partial response)",
-      durationMs: Date.now() - startTime,
-    };
-  }
+  if (opResult.failOpen) return handleRetryExhaustedFailOpen(outcomeCtx);
+  if (opResult.looksLikeFail) return handleTruncatedLooksLikeFail(outcomeCtx);
 
   // Emit review-reprompt-on-drop telemetry if hopBody executed a reprompt.
   if (opResult.repromptEvent) {
@@ -308,62 +228,24 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     });
   }
 
-  // verify() has already run the full filter pipeline (substantiate → AC-ground → split).
-  // opResult.findings = accepted findings (blocking + advisory); opResult.acDropped = drops for telemetry.
-  // opResult.passed preserves the model verdict after filtering so wrappers can
-  // still fail-closed when passed:false survives without remaining blockers.
-  const threshold = blockingThreshold ?? "error";
-  const allFindings = opResult.findings as AdversarialLLMFinding[];
-  const patterns = resolvedTestPatterns?.regex ?? [];
-  const testFileMatch = (file: string): boolean => patterns.some((re) => re.test(file));
-  const recurrenceCfg = adversarialConfig.recurrenceDemotion ?? { enabled: true, maxBlockingRounds: 2 };
-  const {
-    blocking: blockingFindings,
-    advisory: advisoryOnly,
-    demoted,
-  } = classifyRecurrence(allFindings, priorAdversarialIterations ?? [], recurrenceCfg, testFileMatch, threshold);
-  const advisoryFindings = [...advisoryOnly, ...demoted];
-  // Precomputed conversions so every downstream `advisoryFindings` projection
-  // (ReviewFinding for review-audit persistence, Finding for the pipeline
-  // result) tags the recurrence-demoted subset with `meta.coverageGap: true`
-  // (Fix design §7) without re-deriving the split at each call site.
-  // #1368 — `testFileMatch` also decides the fix lane: a finding located in a test
-  // file goes to the test-writer whatever its category says, because the implementer
-  // may not edit test files and would answer UNRESOLVED.
-  const advisoryReviewFindings = [
-    ...llmFindingsToReviewFindings(advisoryOnly, { source: "adversarial-review", isTestFile: testFileMatch }),
-    ...tagCoverageGap(
-      llmFindingsToReviewFindings(demoted, { source: "adversarial-review", isTestFile: testFileMatch }),
-    ),
-  ];
-  const advisoryFindingsAsFindings = [
-    ...toAdversarialReviewFindings(advisoryOnly, { isTestFile: testFileMatch }),
-    ...tagCoverageGap(toAdversarialReviewFindings(demoted, { isTestFile: testFileMatch })),
-  ];
-  const acDropped = opResult.acDropped ?? [];
-  const acks = opResult.acks; // #1423 — recorded alongside findings, never as one.
+  const classification = classifyAdversarialFindings(
+    opResult,
+    blockingThreshold,
+    priorAdversarialIterations,
+    adversarialConfig,
+    resolvedTestPatterns,
+  );
+  const { threshold, blockingFindings, advisoryFindings, acDropped } = classification;
 
   // Issue #986 — build diff file set for structural counterfactual telemetry.
-  // Embedded mode: parse `diff` (already in memory). Ref mode: shell git diff
-  // --name-only via collectDiffFileList. diffAvailable=false signals "exclude
-  // this entry from percentage calculations" to the aggregation script.
-  let diffFiles: ReadonlySet<string>;
-  let diffAvailable: boolean;
-  if (diff && diff.length > 0) {
-    diffFiles = extractDiffFiles(diff);
-    diffAvailable = true;
-  } else {
-    const repoRoot = projectDir ?? workdir;
-    const packageDir = workdir !== repoRoot ? workdir : undefined;
-    const list = await _adversarialDeps.collectDiffFileList(workdir, effectiveRef, { naxIgnoreIndex, packageDir });
-    if (list === undefined) {
-      diffFiles = new Set();
-      diffAvailable = false;
-    } else {
-      diffFiles = new Set(list);
-      diffAvailable = true;
-    }
-  }
+  const { diffFiles, diffAvailable } = await resolveDiffFileSet(
+    diff,
+    workdir,
+    projectDir,
+    effectiveRef,
+    naxIgnoreIndex,
+    _adversarialDeps.collectDiffFileList,
+  );
 
   const { adversarialDropAnalysis, adversarialAcceptAnalysis } = buildCounterfactualTelemetry({
     acDropped,
@@ -389,57 +271,10 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   }
 
   const durationMs = Date.now() - startTime;
+  const telemetry = { adversarialDropAnalysis, adversarialAcceptAnalysis };
 
   if (blockingFindings.length > 0) {
-    logger?.warn("review", `Adversarial review failed: ${blockingFindings.length} blocking findings`, {
-      storyId: story.id,
-      durationMs,
-      findings: blockingFindings.map((f) => ({
-        severity: f.severity,
-        category: f.category,
-        file: f.file,
-        line: f.line,
-        issue: f.issue,
-      })),
-    });
-    recordAdversarialAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: true,
-      failOpen: false,
-      passed: false,
-      blockingThreshold: threshold,
-      result: {
-        passed: false,
-        findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review", isTestFile: testFileMatch }),
-      },
-      advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
-      diffAvailable,
-      adversarialDropAnalysis,
-      adversarialAcceptAnalysis,
-      acks,
-    });
-    const output =
-      blockingFindings.length > 0
-        ? `Adversarial review failed:\n\n${formatFindings(blockingFindings)}`
-        : "Adversarial review failed (no findings)";
-    return {
-      check: "adversarial",
-      success: false,
-      command: "",
-      exitCode: 1,
-      output,
-      durationMs,
-      findings:
-        blockingFindings.length > 0
-          ? toAdversarialReviewFindings(blockingFindings, { isTestFile: testFileMatch })
-          : undefined,
-      advisoryFindings: advisoryFindings.length > 0 ? advisoryFindingsAsFindings : undefined,
-      cost: llmCost,
-    };
+    return buildBlockingFailureResult(outcomeCtx, classification, telemetry, diffAvailable, durationMs);
   }
 
   // #1378 — MODEL verdict, not `opResult.passed`: the latter now honours blockingThreshold,
@@ -447,126 +282,12 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   // concerns the model could not ground (Case B) and losing the demoted drops (Case A).
   if (!opResult.modelPassed && acDropped.length > 0) {
     if (acDropped.every((d) => d.code === "ac_quote_not_substring")) {
-      // Case A: every blocking finding cited a quote that does not exist in any AC.
-      // The model fabricated its grounding. Treat as pass — demote each dropped finding
-      // to "warning" and surface as advisory so it remains auditable.
-      const demotedFindings = toAdversarialReviewFindings(
-        acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
-        { isTestFile: testFileMatch },
-      );
-      const allAdvisory = [...advisoryFindingsAsFindings, ...demotedFindings];
-
-      logger?.warn("review", "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes", {
-        storyId: story.id,
-        durationMs,
-        droppedCount: acDropped.length,
-        drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
-      });
-      recordAdversarialAudit({
-        runtime,
-        workdir,
-        projectDir,
-        storyId: story.id,
-        featureName,
-        parsed: true,
-        acks,
-        failOpen: false,
-        passed: true,
-        passReason: "ac_quote_not_substring_demoted",
-        blockingThreshold: threshold,
-        result: { passed: true, findings: [] },
-        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
-        diffAvailable,
-        adversarialDropAnalysis,
-        adversarialAcceptAnalysis: [],
-      });
-      return {
-        check: "adversarial",
-        success: true,
-        passReason: "ac_quote_not_substring_demoted",
-        command: "",
-        exitCode: 0,
-        output: `Adversarial review passed: ${acDropped.length} blocking finding(s) demoted to advisory — all cited AC quotes were fabricated and could not be validated.`,
-        durationMs,
-        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
-        cost: llmCost,
-      };
+      return buildHallucinatedAcQuoteResult(outcomeCtx, classification, telemetry, diffAvailable, durationMs);
     }
-
-    // Case B: mix includes missing_ac_quote or ac_quote_does_not_constrain_locus —
-    // fail-closed (existing behavior unchanged).
-    logger?.warn("review", "Adversarial review fail-closed: blocking findings dropped as ungrounded", {
-      storyId: story.id,
-      durationMs,
-      droppedCount: acDropped.length,
-      dropCodes: acDropped.map((d) => d.code),
-    });
-    const dropSummary = acDropped
-      .map((d, i) => `${i + 1}. [${d.code}] ${d.finding.file ?? "<unknown>"}: ${d.finding.issue}`)
-      .join("\n");
-    recordAdversarialAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: true,
-      acks,
-      failOpen: false,
-      passed: false,
-      blockingThreshold: threshold,
-      result: { passed: false, findings: [] },
-      advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
-      diffAvailable,
-      adversarialDropAnalysis,
-      adversarialAcceptAnalysis: [],
-    });
-    return {
-      check: "adversarial",
-      success: false,
-      command: "",
-      exitCode: 1,
-      output: `Adversarial review failed: ${acDropped.length} blocking finding(s) dropped as ungrounded — the model emitted "passed: false" with concerns it could not ground in any acceptance criterion. Drops:\n\n${dropSummary}`,
-      durationMs,
-      advisoryFindings: advisoryFindings.length > 0 ? advisoryFindingsAsFindings : undefined,
-      cost: llmCost,
-    };
+    return buildUngroundedFailClosedResult(outcomeCtx, classification, telemetry, diffAvailable, durationMs);
   }
 
   // passed — either the model passed with no blocking findings, or only advisory
   // findings remained after filtering and there were no AC-grounding drops.
-  logger?.info("review", "Adversarial review passed", { storyId: story.id, durationMs });
-  recordAdversarialAudit({
-    runtime,
-    workdir,
-    projectDir,
-    storyId: story.id,
-    featureName,
-    parsed: true,
-    acks,
-    failOpen: false,
-    passed: true,
-    blockingThreshold: threshold,
-    result: {
-      passed: true,
-      findings: llmFindingsToReviewFindings(allFindings, { source: "adversarial-review", isTestFile: testFileMatch }),
-    },
-    advisoryFindings: advisoryFindings.length > 0 ? advisoryReviewFindings : undefined,
-    diffAvailable,
-    adversarialDropAnalysis,
-    adversarialAcceptAnalysis: [],
-  });
-  return {
-    check: "adversarial",
-    success: true,
-    command: "",
-    exitCode: 0,
-    output:
-      allFindings.length === 0
-        ? "Adversarial review passed"
-        : "Adversarial review passed (all findings were advisory — below blocking threshold)",
-    durationMs,
-    advisoryFindings: advisoryFindings.length > 0 ? advisoryFindingsAsFindings : undefined,
-    cost: llmCost,
-  };
+  return buildPassedResult(outcomeCtx, classification, telemetry, diffAvailable, durationMs);
 }

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -173,7 +173,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     projectDir,
     storyId: story.id,
     featureName,
-    blockingThreshold: blockingThreshold ?? "error",
+    blockingThreshold,
     startTime,
     logger,
   };

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -18,6 +18,7 @@ import { getSafeLogger } from "../logger";
 import { findNaxProjectRoot } from "../utils/nax-project-root";
 import { NAX_COMMIT, NAX_VERSION } from "../version";
 import type { AdversarialAcceptAnalysis, AdversarialDropAnalysis } from "./ac-structural-counterfactual";
+import type { Severity } from "./severity";
 import type { ReviewAck } from "./types";
 
 export interface ReviewAuditEntry {
@@ -120,7 +121,7 @@ export interface AdvisoryFindingSummaryEntry {
   storyId?: string;
   featureName?: string;
   reviewer: "semantic" | "adversarial";
-  severity: string;
+  severity: Severity;
   category?: string;
   file?: string;
   line?: number;
@@ -234,7 +235,7 @@ function toAdvisorySummaryEntries(entry: ReviewAuditDecision): AdvisoryFindingSu
   if (!entry.advisoryFindings || entry.advisoryFindings.length === 0) return [];
   return entry.advisoryFindings.map((raw) => {
     const f = raw as {
-      severity?: string;
+      severity?: Severity;
       category?: string;
       file?: string;
       line?: number;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -245,41 +245,19 @@ export const _reviewGitDeps = {
 };
 
 /**
- * Run all configured review checks
+ * RQ-001: warn (never block) about tracked files left uncommitted before review runs.
+ * @design: BUG-074: autoCommitIfDirty runs first to sweep up dirty files the agent
+ * left (e.g. bun.lock / package.json after `bun add`) before the check. Mirrors BUG-058/063.
  */
-export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
-  const {
-    config,
-    workdir,
-    executionConfig,
-    qualityCommands,
-    storyId,
-    storyGitRef,
-    story,
-    agentManager,
-    naxConfig,
-    retrySkipChecks,
-    featureName,
-    priorFailures,
-    priorSemanticIterations,
-    featureContextMarkdown,
-    contextBundles,
-    projectDir,
-    env,
-    naxIgnoreIndex,
-    runtime,
-    priorAdversarialIterations,
-  } = opts;
-  const startTime = Date.now();
-  const logger = getSafeLogger();
-  const checks: ReviewCheckResult[] = [];
-  let firstFailure: string | undefined;
-
-  // @design: BUG-074: Auto-commit any dirty files the agent left (e.g. bun.lock / package.json
-  // after `bun add`) before the uncommitted-changes check. Mirrors BUG-058/063.
+async function guardUncommittedFiles(
+  workdir: string,
+  storyId: string | undefined,
+  runtime: RunReviewOptions["runtime"],
+  naxIgnoreIndex: NaxIgnoreIndex | undefined,
+  logger: ReturnType<typeof getSafeLogger>,
+): Promise<void> {
   await autoCommitIfDirty(workdir, "review", "agent", storyId ?? "review", runtime?.dirtyWorktrees);
 
-  // RQ-001: Check for uncommitted tracked files before running checks
   const allUncommittedFiles = await _reviewGitDeps.getUncommittedFiles(workdir);
   // Exclude nax runtime files — written by nax itself during the run, not by the agent.
   // Patterns use a suffix match (no leading ^) so they work in both single-package repos
@@ -328,6 +306,178 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
       uncommittedCount: uncommittedFiles.length,
     });
   }
+}
+
+/** Shared story shape both LLM reviewers (semantic, adversarial) build from RunReviewOptions. */
+function buildReviewStory(storyId: string | undefined, story: SemanticStory | undefined): SemanticStory {
+  return {
+    id: storyId ?? "",
+    title: story?.title ?? "",
+    description: story?.description ?? "",
+    acceptanceCriteria: story?.acceptanceCriteria ?? [],
+  };
+}
+
+/** Semantic check: delegate to the LLM-based semantic reviewer instead of a shell command. */
+async function runSemanticCheck(opts: RunReviewOptions): Promise<ReviewCheckResult> {
+  const {
+    workdir,
+    storyGitRef,
+    story,
+    storyId,
+    config,
+    agentManager,
+    naxConfig,
+    featureName,
+    priorSemanticIterations,
+    featureContextMarkdown,
+    contextBundles,
+    projectDir,
+    naxIgnoreIndex,
+    runtime,
+  } = opts;
+  const semanticCfg = config.semantic ?? {
+    model: "balanced" as const,
+    diffMode: "ref" as const,
+    resetRefOnRerun: false,
+    rules: [] as string[],
+    timeoutMs: 600_000,
+    // excludePatterns omitted — runSemanticReview derives via resolveReviewExcludePatterns (ADR-009)
+  };
+  const runSemantic = _reviewSemanticDeps.runSemanticReview;
+  return runSemantic({
+    workdir,
+    storyGitRef,
+    story: buildReviewStory(storyId, story),
+    semanticConfig: semanticCfg,
+    agentManager,
+    naxConfig,
+    featureName,
+    priorSemanticIterations,
+    blockingThreshold: config.blockingThreshold,
+    featureContextMarkdown,
+    contextBundle: contextBundles?.semantic,
+    projectDir,
+    naxIgnoreIndex,
+    runtime,
+  });
+}
+
+/** Adversarial check: delegate to the LLM-based adversarial reviewer instead of a shell command. */
+async function runAdversarialCheck(opts: RunReviewOptions): Promise<ReviewCheckResult> {
+  const {
+    workdir,
+    storyGitRef,
+    story,
+    storyId,
+    config,
+    agentManager,
+    naxConfig,
+    featureName,
+    priorFailures,
+    featureContextMarkdown,
+    contextBundles,
+    projectDir,
+    naxIgnoreIndex,
+    runtime,
+    priorAdversarialIterations,
+  } = opts;
+  const adversarialCfg = config.adversarial ?? {
+    model: "balanced" as const,
+    diffMode: "ref" as const,
+    rules: [] as string[],
+    timeoutMs: 600_000,
+    // excludePatterns omitted — collectDiff always appends ALWAYS_EXCLUDED (.nax/ etc.) (ADR-009)
+    parallel: false,
+    maxConcurrentSessions: 2,
+  };
+  const runAdversarial = _reviewAdversarialDeps.runAdversarialReview;
+  return runAdversarial({
+    workdir,
+    storyGitRef,
+    story: buildReviewStory(storyId, story),
+    adversarialConfig: adversarialCfg,
+    agentManager,
+    config: naxConfig,
+    featureName,
+    priorFailures,
+    blockingThreshold: config.blockingThreshold,
+    featureContextMarkdown,
+    contextBundle: contextBundles?.adversarial,
+    projectDir,
+    naxIgnoreIndex,
+    runtime,
+    priorAdversarialIterations,
+  });
+}
+
+/**
+ * Mechanical check (lint / typecheck / build / ...): resolve its command and run it via
+ * runQualityCommand (or the scoped-lint path for "lint"). Returns null when the check is
+ * skipped (command not configured or disabled).
+ */
+async function runMechanicalCheck(
+  checkName: ReviewCheckName,
+  opts: RunReviewOptions,
+): Promise<ReviewCheckResult | null> {
+  const {
+    config,
+    workdir,
+    executionConfig,
+    qualityCommands,
+    storyId,
+    story,
+    storyGitRef,
+    naxConfig,
+    projectDir,
+    env,
+    naxIgnoreIndex,
+  } = opts;
+
+  // Resolve command using resolution strategy
+  const command = await resolveCommand(checkName, config, executionConfig, workdir, qualityCommands);
+
+  // Skip if explicitly disabled or not found
+  if (command === null) {
+    getSafeLogger()?.warn("review", `Skipping ${checkName} check (command not configured or disabled)`);
+    return null;
+  }
+
+  // Run the check
+  return checkName === "lint"
+    ? await _reviewLintDeps.runScopedLintCheck({
+        resolvedLintCommand: command,
+        configCommands: config.commands,
+        qualityCommands,
+        lintOutputFormat: naxConfig?.quality?.lintOutput?.format ?? "auto",
+        workdir,
+        projectDir,
+        storyId,
+        story: story as UserStory | undefined,
+        storyGitRef,
+        env,
+        stripEnvVars: naxConfig?.quality?.stripEnvVars ?? [],
+        naxIgnoreIndex,
+      })
+    : normalizeMechanicalFindings(
+        checkName,
+        await runCheck(checkName, command, workdir, storyId, env, naxConfig?.quality?.stripEnvVars ?? []),
+        workdir,
+      );
+}
+
+/**
+ * Run all configured review checks
+ */
+export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
+  const { config, workdir, storyId, retrySkipChecks, naxIgnoreIndex, runtime } = opts;
+  const startTime = Date.now();
+  const logger = getSafeLogger();
+  const checks: ReviewCheckResult[] = [];
+  let firstFailure: string | undefined;
+
+  // RQ-001: Check for uncommitted tracked files before running checks
+  await guardUncommittedFiles(workdir, storyId, runtime, naxIgnoreIndex, logger);
 
   for (const checkName of config.checks) {
     // #136: Skip checks that already passed in a previous review pass within this pipeline run.
@@ -339,39 +489,8 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
       continue;
     }
 
-    // Semantic check: delegate to LLM-based runner instead of shell command
-    if (checkName === "semantic") {
-      const semanticStory: SemanticStory = {
-        id: storyId ?? "",
-        title: story?.title ?? "",
-        description: story?.description ?? "",
-        acceptanceCriteria: story?.acceptanceCriteria ?? [],
-      };
-      const semanticCfg = config.semantic ?? {
-        model: "balanced" as const,
-        diffMode: "ref" as const,
-        resetRefOnRerun: false,
-        rules: [] as string[],
-        timeoutMs: 600_000,
-        // excludePatterns omitted — runSemanticReview derives via resolveReviewExcludePatterns (ADR-009)
-      };
-      const runSemantic = _reviewSemanticDeps.runSemanticReview;
-      const result = await runSemantic({
-        workdir,
-        storyGitRef,
-        story: semanticStory,
-        semanticConfig: semanticCfg,
-        agentManager,
-        naxConfig,
-        featureName,
-        priorSemanticIterations,
-        blockingThreshold: config.blockingThreshold,
-        featureContextMarkdown,
-        contextBundle: contextBundles?.semantic,
-        projectDir,
-        naxIgnoreIndex,
-        runtime,
-      });
+    if (checkName === "semantic" || checkName === "adversarial") {
+      const result = checkName === "semantic" ? await runSemanticCheck(opts) : await runAdversarialCheck(opts);
       checks.push(result);
       if (!result.success && !firstFailure) {
         firstFailure = `${checkName} failed`;
@@ -382,82 +501,8 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
       continue;
     }
 
-    // Adversarial check: delegate to LLM-based adversarial runner
-    if (checkName === "adversarial") {
-      const adversarialStory: SemanticStory = {
-        id: storyId ?? "",
-        title: story?.title ?? "",
-        description: story?.description ?? "",
-        acceptanceCriteria: story?.acceptanceCriteria ?? [],
-      };
-      const adversarialCfg = config.adversarial ?? {
-        model: "balanced" as const,
-        diffMode: "ref" as const,
-        rules: [] as string[],
-        timeoutMs: 600_000,
-        // excludePatterns omitted — collectDiff always appends ALWAYS_EXCLUDED (.nax/ etc.) (ADR-009)
-        parallel: false,
-        maxConcurrentSessions: 2,
-      };
-      const runAdversarial = _reviewAdversarialDeps.runAdversarialReview;
-      const result = await runAdversarial({
-        workdir,
-        storyGitRef,
-        story: adversarialStory,
-        adversarialConfig: adversarialCfg,
-        agentManager,
-        config: naxConfig,
-        featureName,
-        priorFailures,
-        blockingThreshold: config.blockingThreshold,
-        featureContextMarkdown,
-        contextBundle: contextBundles?.adversarial,
-        projectDir,
-        naxIgnoreIndex,
-        runtime,
-        priorAdversarialIterations,
-      });
-      checks.push(result);
-      if (!result.success && !firstFailure) {
-        firstFailure = `${checkName} failed`;
-      }
-      if (!result.success) {
-        break;
-      }
-      continue;
-    }
-
-    // Resolve command using resolution strategy
-    const command = await resolveCommand(checkName, config, executionConfig, workdir, qualityCommands);
-
-    // Skip if explicitly disabled or not found
-    if (command === null) {
-      getSafeLogger()?.warn("review", `Skipping ${checkName} check (command not configured or disabled)`);
-      continue;
-    }
-
-    // Run the check
-    const result =
-      checkName === "lint"
-        ? await _reviewLintDeps.runScopedLintCheck({
-            resolvedLintCommand: command,
-            configCommands: config.commands,
-            qualityCommands,
-            lintOutputFormat: naxConfig?.quality?.lintOutput?.format ?? "auto",
-            workdir,
-            projectDir,
-            storyId,
-            story: story as UserStory | undefined,
-            storyGitRef,
-            env,
-            stripEnvVars: naxConfig?.quality?.stripEnvVars ?? [],
-            naxIgnoreIndex,
-          })
-        : normalizeMechanicalFindings(
-            checkName,
-            await runCheck(checkName, command, workdir, storyId, env, naxConfig?.quality?.stripEnvVars ?? []),
-            workdir,
-          );
+    const result = await runMechanicalCheck(checkName, opts);
+    if (result === null) continue;
     checks.push(result);
 
     // Log outcome of mechanical checks (lint / typecheck / build).

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -244,6 +244,39 @@ export const _reviewGitDeps = {
   getUncommittedFiles: getUncommittedFilesImpl,
 };
 
+// Exclude nax runtime files — written by nax itself during the run, not by the agent.
+// Patterns use a suffix match (no leading ^) so they work in both single-package repos
+// (nax/features/…) and monorepos where paths are prefixed (apps/cli/nax/features/…).
+// Module-scoped (not per-call): the pattern list is static, so rebuilding it inside
+// guardUncommittedFiles on every review would just be wasted allocation.
+const NAX_RUNTIME_PATTERNS = [
+  /nax\.lock$/,
+  /nax\/metrics\.json$/,
+  /nax\/status\.json$/,
+  /nax\/features\/[^/]+\/status\.json$/,
+  /nax\/features\/[^/]+\/prd\.json$/,
+  /nax\/features\/[^/]+\/runs\//,
+  /nax\/features\/[^/]+\/plan\//,
+  /nax\/features\/[^/]+\/acp-sessions\.json$/,
+  /nax\/features\/[^/]+\/interactions\//,
+  /nax\/features\/[^/]+\/progress\.txt$/,
+  /nax\/features\/[^/]+\/acceptance-refined\.json$/,
+  /nax\/features\/[^/]+\/stories\/[^/]+\/context-manifest-[^/]+\.json$/,
+  /nax\/features\/[^/]+\/stories\/[^/]+\/rebuild-manifest\.json$/,
+  /\.nax-verifier-verdict\.json$/,
+  /\.nax-pids$/,
+  /\.nax-wt\//,
+  /\.nax-acceptance[^/]*$/,
+  /_nax_acceptance_test\.py$/,
+  /_nax_suggested_test\.py$/,
+  // Test-output artifacts — transient files leaked by tests, not agent changes.
+  // 2B migrated logging.test.ts to a temp dir; these guard against future leak patterns.
+  // Patterns match both repo-root paths (test/...) and monorepo-prefixed paths (.../test/...).
+  /(?:^|\/)test\/.*\.jsonl$/,
+  /(?:^|\/)coverage\//,
+  /\.lcov$/,
+];
+
 /**
  * RQ-001: warn (never block) about tracked files left uncommitted before review runs.
  * @design: BUG-074: autoCommitIfDirty runs first to sweep up dirty files the agent
@@ -259,36 +292,6 @@ async function guardUncommittedFiles(
   await autoCommitIfDirty(workdir, "review", "agent", storyId ?? "review", runtime?.dirtyWorktrees);
 
   const allUncommittedFiles = await _reviewGitDeps.getUncommittedFiles(workdir);
-  // Exclude nax runtime files — written by nax itself during the run, not by the agent.
-  // Patterns use a suffix match (no leading ^) so they work in both single-package repos
-  // (nax/features/…) and monorepos where paths are prefixed (apps/cli/nax/features/…).
-  const NAX_RUNTIME_PATTERNS = [
-    /nax\.lock$/,
-    /nax\/metrics\.json$/,
-    /nax\/status\.json$/,
-    /nax\/features\/[^/]+\/status\.json$/,
-    /nax\/features\/[^/]+\/prd\.json$/,
-    /nax\/features\/[^/]+\/runs\//,
-    /nax\/features\/[^/]+\/plan\//,
-    /nax\/features\/[^/]+\/acp-sessions\.json$/,
-    /nax\/features\/[^/]+\/interactions\//,
-    /nax\/features\/[^/]+\/progress\.txt$/,
-    /nax\/features\/[^/]+\/acceptance-refined\.json$/,
-    /nax\/features\/[^/]+\/stories\/[^/]+\/context-manifest-[^/]+\.json$/,
-    /nax\/features\/[^/]+\/stories\/[^/]+\/rebuild-manifest\.json$/,
-    /\.nax-verifier-verdict\.json$/,
-    /\.nax-pids$/,
-    /\.nax-wt\//,
-    /\.nax-acceptance[^/]*$/,
-    /_nax_acceptance_test\.py$/,
-    /_nax_suggested_test\.py$/,
-    // Test-output artifacts — transient files leaked by tests, not agent changes.
-    // 2B migrated logging.test.ts to a temp dir; these guard against future leak patterns.
-    // Patterns match both repo-root paths (test/...) and monorepo-prefixed paths (.../test/...).
-    /(?:^|\/)test\/.*\.jsonl$/,
-    /(?:^|\/)coverage\//,
-    /\.lcov$/,
-  ];
   const afterRuntimeFilter = allUncommittedFiles.filter(
     (f) => !NAX_RUNTIME_PATTERNS.some((pattern) => pattern.test(f)),
   );

--- a/src/review/semantic-evidence.ts
+++ b/src/review/semantic-evidence.ts
@@ -2,6 +2,7 @@ import { getSafeLogger } from "../logger";
 import { validateModulePath } from "../utils/path-security";
 import type { LLMFinding } from "./semantic-helpers";
 import { isBlockingSeverity } from "./semantic-helpers";
+import type { Severity } from "./severity";
 import type { SemanticReviewConfig } from "./types";
 
 const OBSERVED_PREVIEW_CHARS = 160;
@@ -37,7 +38,7 @@ export const _evidenceDeps = {
  * fields. Issue #987.
  */
 export interface FindingWithEvidence {
-  severity: string;
+  severity: Severity;
   file: string;
   line: number;
   issue: string;

--- a/src/review/semantic-helpers.ts
+++ b/src/review/semantic-helpers.ts
@@ -9,11 +9,12 @@ import { extractAcks } from "./acks";
 import { resolveFixTarget } from "./category-fix-target";
 import { normalizeSemanticCategory } from "./semantic-categories";
 import { SEVERITY_RANK, isBlockingSeverity } from "./severity";
+import type { Severity } from "./severity";
 export { isBlockingSeverity };
 import type { ReviewAck, SemanticReviewConfig } from "./types";
 
 export interface LLMFinding {
-  severity: string;
+  severity: Severity;
   /**
    * Semantic taxonomy axis (see `semantic-categories.ts`). Optional on the wire —
    * a reviewer that omits it yields the pre-taxonomy empty category rather than

--- a/src/review/semantic-outcomes.ts
+++ b/src/review/semantic-outcomes.ts
@@ -24,7 +24,16 @@ export interface SemanticOutcomeCtx {
   projectDir: string | undefined;
   storyId: string;
   featureName: string | undefined;
-  blockingThreshold: "error" | "warning" | "info";
+  /**
+   * Raw, possibly-undefined caller option — deliberately NOT defaulted here.
+   * Only the three pre-classification helpers below (catchDispatchFailure,
+   * handleRetryExhaustedFailOpen, handleTruncatedLooksLikeFail) read this field,
+   * and they must record the same `undefined` the caller passed (matching the
+   * pre-decomposition behavior) rather than a defaulted "error" that would
+   * change what's recorded in the audit event. Post-classification outcome
+   * builders read the defaulted `classification.threshold` instead.
+   */
+  blockingThreshold: "error" | "warning" | "info" | undefined;
   startTime: number;
   logger: Logger | null;
   testFileMatch: (file: string) => boolean;

--- a/src/review/semantic-outcomes.ts
+++ b/src/review/semantic-outcomes.ts
@@ -1,0 +1,362 @@
+/**
+ * Outcome-building helpers for the semantic review runner.
+ *
+ * Split out of semantic.ts (TYPE-1, code review 2026-08-17) to keep the
+ * runner under the 600-line file-size limit after decomposing the former
+ * 461-line `runSemanticReview` monolith. Each function here reproduces,
+ * unchanged, one stage of that original function — logging, audit
+ * recording, and the exact `ReviewCheckResult` shape it used to build inline.
+ */
+
+import { filterContextByRole } from "../context";
+import type { ContextBundle } from "../context/engine";
+import type { Logger } from "../logger";
+import type { SemanticReviewOutput } from "../operations/semantic-review";
+import type { NaxRuntime } from "../runtime";
+import { llmFindingsToReviewFindings } from "./finding-projection";
+import { type LLMFinding, formatFindings, isBlockingSeverity, toReviewFindings } from "./semantic-helpers";
+import type { ReviewAck, ReviewCheckResult } from "./types";
+
+/** Fields every audit-recording outcome helper needs — a slice of RunSemanticReviewOptions plus derived run state. */
+export interface SemanticOutcomeCtx {
+  runtime: NaxRuntime;
+  workdir: string;
+  projectDir: string | undefined;
+  storyId: string;
+  featureName: string | undefined;
+  blockingThreshold: "error" | "warning" | "info";
+  startTime: number;
+  logger: Logger | null;
+  testFileMatch: (file: string) => boolean;
+}
+
+export function skipResult(output: string, startTime: number): ReviewCheckResult {
+  return {
+    check: "semantic",
+    success: true,
+    command: "",
+    exitCode: 0,
+    output,
+    durationMs: Date.now() - startTime,
+  };
+}
+
+export function buildFeatureCtxBlock(
+  contextBundle: ContextBundle | undefined,
+  featureContextMarkdown: string | undefined,
+): string {
+  // When a v2 ContextBundle is provided, use its pushMarkdown directly — the orchestrator
+  // already applied role filtering and dedup, so the v1 filterContextByRole() pass is
+  // skipped (it would silently drop ##-section content from v2's rendered output).
+  if (contextBundle) {
+    const md = contextBundle.pushMarkdown.trim();
+    return md ? `${md}\n\n---\n\n` : "";
+  }
+  if (featureContextMarkdown) {
+    const filtered = filterContextByRole(featureContextMarkdown, "reviewer-semantic");
+    if (filtered.trim()) return `${filtered}\n\n---\n\n`;
+  }
+  return "";
+}
+
+export function recordSemanticAudit(opts: {
+  runtime?: NaxRuntime;
+  workdir: string;
+  projectDir?: string;
+  storyId: string;
+  featureName?: string;
+  parsed: boolean;
+  looksLikeFail?: boolean;
+  failOpen?: boolean;
+  passed?: boolean;
+  blockingThreshold?: "error" | "warning" | "info";
+  result: { passed: boolean; findings: unknown[] } | null;
+  advisoryFindings?: unknown[];
+  /** #1423 — prior findings resolved or withdrawn, recorded outside `result.findings`. */
+  acks?: ReviewAck[];
+}): void {
+  opts.runtime?.dispatchEvents.emitReviewDecision({
+    kind: "review-decision",
+    reviewer: "semantic",
+    workdir: opts.workdir,
+    projectDir: opts.projectDir,
+    storyId: opts.storyId,
+    featureName: opts.featureName,
+    timestamp: Date.now(),
+    parsed: opts.parsed,
+    looksLikeFail: opts.looksLikeFail,
+    failOpen: opts.failOpen,
+    passed: opts.passed,
+    blockingThreshold: opts.blockingThreshold,
+    result: opts.result,
+    advisoryFindings: opts.advisoryFindings,
+    acks: opts.acks,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dispatch — the three non-continuing outcomes (error, fail-open, truncated-fail)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function catchDispatchFailure(err: unknown, ctx: SemanticOutcomeCtx): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, blockingThreshold, startTime, logger } = ctx;
+  logger?.warn("semantic", "LLM call failed — fail-open", { storyId, cause: String(err) });
+  recordSemanticAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: false,
+    looksLikeFail: false,
+    failOpen: true,
+    passed: true,
+    blockingThreshold,
+    result: null,
+  });
+  return {
+    check: "semantic",
+    success: true,
+    failOpen: true,
+    command: "",
+    exitCode: 0,
+    output: `skipped: LLM call failed — ${String(err)}`,
+    durationMs: Date.now() - startTime,
+  };
+}
+
+export function handleRetryExhaustedFailOpen(ctx: SemanticOutcomeCtx): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, blockingThreshold, startTime, logger } = ctx;
+  logger?.warn("semantic", "Retry exhausted — fail-open", { storyId });
+  recordSemanticAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: false,
+    looksLikeFail: false,
+    failOpen: true,
+    passed: true,
+    blockingThreshold,
+    result: null,
+  });
+  return {
+    check: "semantic",
+    success: true,
+    failOpen: true,
+    command: "",
+    exitCode: 0,
+    output: "semantic review: could not parse LLM response (fail-open)",
+    durationMs: Date.now() - startTime,
+  };
+}
+
+export function handleTruncatedLooksLikeFail(ctx: SemanticOutcomeCtx): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, blockingThreshold, startTime, logger } = ctx;
+  logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", { storyId });
+  recordSemanticAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: false,
+    looksLikeFail: true,
+    failOpen: false,
+    passed: false,
+    blockingThreshold,
+    result: null,
+  });
+  return {
+    check: "semantic",
+    success: false,
+    command: "",
+    exitCode: 1,
+    output: "semantic review: LLM response truncated but indicated failure (passed:false found in partial response)",
+    durationMs: Date.now() - startTime,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Finding classification
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SemanticClassification {
+  threshold: "error" | "warning" | "info";
+  allFindings: LLMFinding[];
+  acks: SemanticReviewOutput["acks"];
+  blockingFindings: LLMFinding[];
+  advisoryFindings: LLMFinding[];
+}
+
+export function classifySemanticFindings(
+  opResult: SemanticReviewOutput,
+  blockingThreshold: "error" | "warning" | "info" | undefined,
+): SemanticClassification {
+  // verify() has already run the full filter pipeline (sanitize → substantiate → AC-ground → split).
+  // opResult.findings = accepted findings (blocking + advisory); opResult.normalizedFindings = blocking only.
+  // opResult.passed preserves the model verdict after filtering so wrappers can
+  // still fail-closed when passed:false survives without remaining blockers.
+  const threshold = blockingThreshold ?? "error";
+  const allFindings = opResult.findings as LLMFinding[];
+  const blockingFindings = allFindings.filter((f) => isBlockingSeverity(f.severity, threshold));
+  const advisoryFindings = allFindings.filter((f) => !isBlockingSeverity(f.severity, threshold));
+  return {
+    threshold,
+    allFindings,
+    acks: opResult.acks, // #1423 — carry-forward bookkeeping, recorded alongside findings but never as one.
+    blockingFindings,
+    advisoryFindings,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Outcome builders — blocking failure / AC-dropped fail-closed / passed
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildBlockingFailureResult(
+  ctx: SemanticOutcomeCtx,
+  classification: SemanticClassification,
+  durationMs: number,
+): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, logger, testFileMatch } = ctx;
+  const { threshold, allFindings, acks, blockingFindings, advisoryFindings } = classification;
+
+  logger?.warn("review", `Semantic review failed: ${blockingFindings.length} blocking findings`, {
+    storyId,
+    durationMs,
+  });
+  logger?.debug("review", "Semantic review findings", {
+    storyId,
+    findings: blockingFindings.map((f) => ({
+      severity: f.severity,
+      file: f.file,
+      line: f.line,
+      issue: f.issue,
+      suggestion: f.suggestion,
+    })),
+  });
+  const output = `Semantic review failed:\n\n${formatFindings(blockingFindings)}`;
+  recordSemanticAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: true,
+    failOpen: false,
+    passed: false,
+    blockingThreshold: threshold,
+    acks,
+    result: {
+      passed: false,
+      findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review", isTestFile: testFileMatch }),
+    },
+    advisoryFindings:
+      advisoryFindings.length > 0
+        ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
+        : undefined,
+  });
+  return {
+    check: "semantic",
+    success: false,
+    command: "",
+    exitCode: 1,
+    output,
+    durationMs,
+    findings: toReviewFindings(blockingFindings, { isTestFile: testFileMatch }),
+    advisoryFindings:
+      advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
+    cost: 0,
+  };
+}
+
+export function buildAcIndexDroppedFailClosedResult(
+  ctx: SemanticOutcomeCtx,
+  classification: SemanticClassification,
+  durationMs: number,
+): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, logger, testFileMatch } = ctx;
+  const { threshold, acks, advisoryFindings } = classification;
+
+  logger?.warn("review", "Semantic review fail-closed: blocking findings dropped (acIndex invalid)", {
+    storyId,
+    durationMs,
+  });
+  recordSemanticAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: true,
+    acks,
+    failOpen: false,
+    passed: false,
+    blockingThreshold: threshold,
+    result: { passed: false, findings: [] },
+    advisoryFindings:
+      advisoryFindings.length > 0
+        ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
+        : undefined,
+  });
+  return {
+    check: "semantic",
+    success: false,
+    command: "",
+    exitCode: 1,
+    output:
+      'Semantic review failed: blocking finding(s) were dropped — acIndex was missing or out of range. The model emitted "passed: false" without valid AC attribution.',
+    durationMs,
+    advisoryFindings:
+      advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
+    cost: 0,
+  };
+}
+
+/** Model passed with no blocking findings, or there were no findings at all. */
+export function buildPassedResult(
+  ctx: SemanticOutcomeCtx,
+  classification: SemanticClassification,
+  durationMs: number,
+): ReviewCheckResult {
+  const { runtime, workdir, projectDir, storyId, featureName, logger, testFileMatch } = ctx;
+  const { threshold, allFindings, acks, advisoryFindings } = classification;
+
+  logger?.info("review", "Semantic review passed", { storyId, durationMs });
+  recordSemanticAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId,
+    featureName,
+    parsed: true,
+    acks,
+    failOpen: false,
+    passed: true,
+    blockingThreshold: threshold,
+    result: {
+      passed: true,
+      findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review", isTestFile: testFileMatch }),
+    },
+    advisoryFindings:
+      advisoryFindings.length > 0
+        ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
+        : undefined,
+  });
+  return {
+    check: "semantic",
+    success: true,
+    command: "",
+    exitCode: 0,
+    output:
+      allFindings.length === 0
+        ? "Semantic review passed"
+        : "Semantic review passed (all findings were advisory — below blocking threshold)",
+    durationMs,
+    advisoryFindings:
+      advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
+    cost: 0,
+  };
+}

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -5,26 +5,46 @@
  * Validates behavior — checks that the implementation satisfies the
  * story's acceptance criteria. Code quality (lint, style, conventions)
  * is handled by lint/typecheck, not semantic review.
+ *
+ * Decomposed per code-review TYPE-1 (2026-08-17): the orchestrator below stays a
+ * thin sequence of stages — skip checks, debate/dispatch, finding classification,
+ * outcome — with each stage's logic and its audit-recording extracted into named
+ * helpers in ./semantic-outcomes.ts. Control-flow order and every side effect
+ * (logging, `recordSemanticAudit` calls) are preserved exactly; only the
+ * grouping (and file) changed.
  */
 
 import type { IAgentManager } from "../agents";
 import type { ReviewConfig } from "../config/selectors";
-import { filterContextByRole } from "../context";
+import type { ContextBundle } from "../context/engine";
 import { DebateRunner } from "../debate";
 import type { DebateRunnerOptions } from "../debate";
 import { NaxError } from "../errors";
 import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { callOp as _callOp } from "../operations/call";
+import type { SemanticReviewOutput } from "../operations/semantic-review";
 import { semanticReviewOp } from "../operations/semantic-review";
 import { ReviewPromptBuilder } from "../prompts";
+import type { NaxRuntime } from "../runtime";
+import type { ResolvedTestPatterns } from "../test-runners";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
-import { llmFindingsToReviewFindings } from "./finding-projection";
 import { prepareSemanticReviewInput } from "./prepare-inputs";
 import { writeReviewAudit } from "./review-audit";
 import { runSemanticDebate } from "./semantic-debate";
-import { type LLMFinding, formatFindings, isBlockingSeverity, toReviewFindings } from "./semantic-helpers";
-import type { ReviewAck, ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
+import type { SemanticOutcomeCtx } from "./semantic-outcomes";
+import {
+  buildAcIndexDroppedFailClosedResult,
+  buildBlockingFailureResult,
+  buildFeatureCtxBlock,
+  buildPassedResult,
+  catchDispatchFailure,
+  classifySemanticFindings,
+  handleRetryExhaustedFailOpen,
+  handleTruncatedLooksLikeFail,
+  skipResult,
+} from "./semantic-outcomes";
+import type { ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
 
 // Re-export so existing callers (`import type { SemanticStory } from "./semantic"`) keep working.
 export type { SemanticStory };
@@ -35,41 +55,6 @@ export const _semanticDeps = {
   writeReviewAudit,
   callOp: _callOp,
 };
-
-function recordSemanticAudit(opts: {
-  runtime?: import("../runtime").NaxRuntime;
-  workdir: string;
-  projectDir?: string;
-  storyId: string;
-  featureName?: string;
-  parsed: boolean;
-  looksLikeFail?: boolean;
-  failOpen?: boolean;
-  passed?: boolean;
-  blockingThreshold?: "error" | "warning" | "info";
-  result: { passed: boolean; findings: unknown[] } | null;
-  advisoryFindings?: unknown[];
-  /** #1423 — prior findings resolved or withdrawn, recorded outside `result.findings`. */
-  acks?: ReviewAck[];
-}): void {
-  opts.runtime?.dispatchEvents.emitReviewDecision({
-    kind: "review-decision",
-    reviewer: "semantic",
-    workdir: opts.workdir,
-    projectDir: opts.projectDir,
-    storyId: opts.storyId,
-    featureName: opts.featureName,
-    timestamp: Date.now(),
-    parsed: opts.parsed,
-    looksLikeFail: opts.looksLikeFail,
-    failOpen: opts.failOpen,
-    passed: opts.passed,
-    blockingThreshold: opts.blockingThreshold,
-    result: opts.result,
-    advisoryFindings: opts.advisoryFindings,
-    acks: opts.acks,
-  });
-}
 
 export interface RunSemanticReviewOptions {
   workdir: string;
@@ -82,15 +67,15 @@ export interface RunSemanticReviewOptions {
   priorSemanticIterations?: Iteration[];
   blockingThreshold?: "error" | "warning" | "info";
   featureContextMarkdown?: string;
-  contextBundle?: import("../context/engine").ContextBundle;
+  contextBundle?: ContextBundle;
   projectDir?: string;
   naxIgnoreIndex?: NaxIgnoreIndex;
-  runtime?: import("../runtime").NaxRuntime;
+  runtime?: NaxRuntime;
   /**
    * Resolved test-file patterns (ADR-009 SSOT) — keeps a finding about a test
    * file in the test lane (#1368). Mirrors `runAdversarialReview`.
    */
-  resolvedTestPatterns?: import("../test-runners").ResolvedTestPatterns;
+  resolvedTestPatterns?: ResolvedTestPatterns;
 }
 
 /**
@@ -143,14 +128,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   });
 
   if (prepared.skipReason === "no git ref") {
-    return {
-      check: "semantic",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no git ref",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no git ref", startTime);
   }
 
   const diffMode = semanticConfig.diffMode ?? "ref";
@@ -162,24 +140,10 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   });
 
   if (prepared.skipReason === "no changes detected") {
-    return {
-      check: "semantic",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no changes detected",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no changes detected", startTime);
   }
   if (prepared.skipReason === "no production code changes") {
-    return {
-      check: "semantic",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no production code changes",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no production code changes", startTime);
   }
 
   // biome-ignore lint/style/noNonNullAssertion: skipReason undefined ⇒ effectiveRef present
@@ -197,28 +161,11 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       storyId: story.id,
       model: semanticConfig.model,
     });
-    return {
-      check: "semantic",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no agent available for model tier",
-      durationMs: Date.now() - startTime,
-    };
+    return skipResult("skipped: no agent available for model tier", startTime);
   }
 
   // Build feature context block for the prompt.
-  // When a v2 ContextBundle is provided, use its pushMarkdown directly — the orchestrator
-  // already applied role filtering and dedup, so the v1 filterContextByRole() pass is
-  // skipped (it would silently drop ##-section content from v2's rendered output).
-  let featureCtxBlock = "";
-  if (contextBundle) {
-    const md = contextBundle.pushMarkdown.trim();
-    if (md) featureCtxBlock = `${md}\n\n---\n\n`;
-  } else if (featureContextMarkdown) {
-    const filtered = filterContextByRole(featureContextMarkdown, "reviewer-semantic");
-    if (filtered.trim()) featureCtxBlock = `${filtered}\n\n---\n\n`;
-  }
+  const featureCtxBlock = buildFeatureCtxBlock(contextBundle, featureContextMarkdown);
 
   // Build prompt — mode determines whether diff is embedded or reviewer self-serves via tools.
   const basePrompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(story, semanticConfig, {
@@ -293,11 +240,17 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     );
   }
 
-  // NOTE: llmCost stays 0 on the runtime path — buildHopCallback charges cost via
-  // costAggregator directly. ReviewCheckResult.cost is 0 for pipeline-managed
-  // reviews; per-stage cost roll-up is the trade-off for ADR-019 session-lifecycle
-  // ownership. Track in follow-up if per-check cost breakdown is needed.
-  const llmCost = 0;
+  const outcomeCtx: SemanticOutcomeCtx = {
+    runtime,
+    workdir,
+    projectDir,
+    storyId: story.id,
+    featureName,
+    blockingThreshold: blockingThreshold ?? "error",
+    startTime,
+    logger,
+    testFileMatch,
+  };
 
   const callCtx = {
     runtime,
@@ -308,7 +261,12 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     featureName,
     contextBundle,
   };
-  let opResult: import("../operations/semantic-review").SemanticReviewOutput;
+
+  // NOTE: llmCost stays 0 on the runtime path — buildHopCallback charges cost via
+  // costAggregator directly. ReviewCheckResult.cost is 0 for pipeline-managed
+  // reviews; per-stage cost roll-up is the trade-off for ADR-019 session-lifecycle
+  // ownership. Track in follow-up if per-check cost breakdown is needed.
+  let opResult: SemanticReviewOutput;
   try {
     opResult = await _semanticDeps.callOp(callCtx, semanticReviewOp, {
       workdir,
@@ -325,81 +283,10 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       blockingThreshold,
     });
   } catch (err) {
-    logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
-    recordSemanticAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail: false,
-      failOpen: true,
-      passed: true,
-      blockingThreshold,
-      result: null,
-    });
-    return {
-      check: "semantic",
-      success: true,
-      failOpen: true,
-      command: "",
-      exitCode: 0,
-      output: `skipped: LLM call failed — ${String(err)}`,
-      durationMs: Date.now() - startTime,
-    };
+    return catchDispatchFailure(err, outcomeCtx);
   }
-  if (opResult.failOpen) {
-    logger?.warn("semantic", "Retry exhausted — fail-open", { storyId: story.id });
-    recordSemanticAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail: false,
-      failOpen: true,
-      passed: true,
-      blockingThreshold,
-      result: null,
-    });
-    return {
-      check: "semantic",
-      success: true,
-      failOpen: true,
-      command: "",
-      exitCode: 0,
-      output: "semantic review: could not parse LLM response (fail-open)",
-      durationMs: Date.now() - startTime,
-    };
-  }
-  if (opResult.looksLikeFail) {
-    logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
-      storyId: story.id,
-    });
-    recordSemanticAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail: true,
-      failOpen: false,
-      passed: false,
-      blockingThreshold,
-      result: null,
-    });
-    return {
-      check: "semantic",
-      success: false,
-      command: "",
-      exitCode: 1,
-      output: "semantic review: LLM response truncated but indicated failure (passed:false found in partial response)",
-      durationMs: Date.now() - startTime,
-    };
-  }
+  if (opResult.failOpen) return handleRetryExhaustedFailOpen(outcomeCtx);
+  if (opResult.looksLikeFail) return handleTruncatedLooksLikeFail(outcomeCtx);
   if (opResult.repromptEvent) {
     runtime.dispatchEvents.emitReviewReprompt({
       kind: "review-reprompt-on-drop",
@@ -410,21 +297,14 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       costUsd: opResult.repromptEvent.costUsd,
     });
   }
-  // verify() has already run the full filter pipeline (sanitize → substantiate → AC-ground → split).
-  // opResult.findings = accepted findings (blocking + advisory); opResult.normalizedFindings = blocking only.
-  // opResult.passed preserves the model verdict after filtering so wrappers can
-  // still fail-closed when passed:false survives without remaining blockers.
-  const threshold = blockingThreshold ?? "error";
-  const allFindings = opResult.findings as LLMFinding[];
-  // #1423 — carry-forward bookkeeping, recorded alongside findings but never as one.
-  const acks = opResult.acks;
-  const blockingFindings = allFindings.filter((f) => isBlockingSeverity(f.severity, threshold));
-  const advisoryFindings = allFindings.filter((f) => !isBlockingSeverity(f.severity, threshold));
+
+  const classification = classifySemanticFindings(opResult, blockingThreshold);
+  const { allFindings, blockingFindings, advisoryFindings } = classification;
 
   if (advisoryFindings.length > 0) {
     logger?.debug(
       "review",
-      `Semantic review: ${advisoryFindings.length} advisory findings (below threshold '${threshold}')`,
+      `Semantic review: ${advisoryFindings.length} advisory findings (below threshold '${classification.threshold}')`,
       {
         storyId: story.id,
         findings: advisoryFindings.map((f) => ({ severity: f.severity, file: f.file, issue: f.issue })),
@@ -435,125 +315,13 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   const durationMs = Date.now() - startTime;
 
   if (blockingFindings.length > 0) {
-    logger?.warn("review", `Semantic review failed: ${blockingFindings.length} blocking findings`, {
-      storyId: story.id,
-      durationMs,
-    });
-    logger?.debug("review", "Semantic review findings", {
-      storyId: story.id,
-      findings: blockingFindings.map((f) => ({
-        severity: f.severity,
-        file: f.file,
-        line: f.line,
-        issue: f.issue,
-        suggestion: f.suggestion,
-      })),
-    });
-    const output = `Semantic review failed:\n\n${formatFindings(blockingFindings)}`;
-    recordSemanticAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: true,
-      failOpen: false,
-      passed: false,
-      blockingThreshold: threshold,
-      acks,
-      result: {
-        passed: false,
-        findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review", isTestFile: testFileMatch }),
-      },
-      advisoryFindings:
-        advisoryFindings.length > 0
-          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
-          : undefined,
-    });
-    return {
-      check: "semantic",
-      success: false,
-      command: "",
-      exitCode: 1,
-      output,
-      durationMs,
-      findings: toReviewFindings(blockingFindings, { isTestFile: testFileMatch }),
-      advisoryFindings:
-        advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
-      cost: llmCost,
-    };
+    return buildBlockingFailureResult(outcomeCtx, classification, durationMs);
   }
 
   if (!opResult.passed && allFindings.length === 0) {
-    logger?.warn("review", "Semantic review fail-closed: blocking findings dropped (acIndex invalid)", {
-      storyId: story.id,
-      durationMs,
-    });
-    recordSemanticAudit({
-      runtime,
-      workdir,
-      projectDir,
-      storyId: story.id,
-      featureName,
-      parsed: true,
-      acks,
-      failOpen: false,
-      passed: false,
-      blockingThreshold: threshold,
-      result: { passed: false, findings: [] },
-      advisoryFindings:
-        advisoryFindings.length > 0
-          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
-          : undefined,
-    });
-    return {
-      check: "semantic",
-      success: false,
-      command: "",
-      exitCode: 1,
-      output:
-        'Semantic review failed: blocking finding(s) were dropped — acIndex was missing or out of range. The model emitted "passed: false" without valid AC attribution.',
-      durationMs,
-      advisoryFindings:
-        advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
-      cost: llmCost,
-    };
+    return buildAcIndexDroppedFailClosedResult(outcomeCtx, classification, durationMs);
   }
 
   // passed — either the model passed with no blocking findings, or there were no findings at all
-  logger?.info("review", "Semantic review passed", { storyId: story.id, durationMs });
-  recordSemanticAudit({
-    runtime,
-    workdir,
-    projectDir,
-    storyId: story.id,
-    featureName,
-    parsed: true,
-    acks,
-    failOpen: false,
-    passed: true,
-    blockingThreshold: threshold,
-    result: {
-      passed: true,
-      findings: llmFindingsToReviewFindings(allFindings, { source: "semantic-review", isTestFile: testFileMatch }),
-    },
-    advisoryFindings:
-      advisoryFindings.length > 0
-        ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review", isTestFile: testFileMatch })
-        : undefined,
-  });
-  return {
-    check: "semantic",
-    success: true,
-    command: "",
-    exitCode: 0,
-    output:
-      allFindings.length === 0
-        ? "Semantic review passed"
-        : "Semantic review passed (all findings were advisory — below blocking threshold)",
-    durationMs,
-    advisoryFindings:
-      advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings, { isTestFile: testFileMatch }) : undefined,
-    cost: llmCost,
-  };
+  return buildPassedResult(outcomeCtx, classification, durationMs);
 }

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -246,7 +246,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     projectDir,
     storyId: story.id,
     featureName,
-    blockingThreshold: blockingThreshold ?? "error",
+    blockingThreshold,
     startTime,
     logger,
     testFileMatch,

--- a/src/review/severity.ts
+++ b/src/review/severity.ts
@@ -3,23 +3,27 @@
  * Single source of truth used by both semantic-helpers.ts and adversarial-helpers.ts.
  */
 
-export const SEVERITY_RANK: Record<string, number> = {
+// `as const satisfies` (not `: Record<string, number>`) so `keyof typeof SEVERITY_RANK`
+// below is the literal key union, not `string` — a plain type annotation here would
+// make `Severity` collapse to `string` and defeat the point of the alias.
+export const SEVERITY_RANK = {
   info: 0,
   unverifiable: 0,
   low: 1,
   warning: 2,
   error: 3,
   critical: 4,
-};
+} as const satisfies Record<string, number>;
 
 /**
  * Reviewer-finding severity. Loosened to `(string & {})` alongside the known
  * ranks (rather than a closed union) because LLM output is never fully
- * trusted — `SEVERITY_RANK[sev] ?? 0` already treats an unrecognized value as
- * rank 0, and the type should permit what the code actually accepts.
+ * trusted — `isBlockingSeverity` already treats an unrecognized value as rank
+ * 0, and the type should permit what the code actually accepts.
  */
 export type Severity = keyof typeof SEVERITY_RANK | (string & {});
 
 export function isBlockingSeverity(sev: string, threshold: "error" | "warning" | "info" = "error"): boolean {
-  return (SEVERITY_RANK[sev] ?? 0) >= SEVERITY_RANK[threshold];
+  const rank = (SEVERITY_RANK as Record<string, number>)[sev] ?? 0;
+  return rank >= SEVERITY_RANK[threshold];
 }

--- a/src/review/severity.ts
+++ b/src/review/severity.ts
@@ -12,6 +12,14 @@ export const SEVERITY_RANK: Record<string, number> = {
   critical: 4,
 };
 
+/**
+ * Reviewer-finding severity. Loosened to `(string & {})` alongside the known
+ * ranks (rather than a closed union) because LLM output is never fully
+ * trusted — `SEVERITY_RANK[sev] ?? 0` already treats an unrecognized value as
+ * rank 0, and the type should permit what the code actually accepts.
+ */
+export type Severity = keyof typeof SEVERITY_RANK | (string & {});
+
 export function isBlockingSeverity(sev: string, threshold: "error" | "warning" | "info" = "error"): boolean {
   return (SEVERITY_RANK[sev] ?? 0) >= SEVERITY_RANK[threshold];
 }

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -24,7 +24,7 @@
 import { appendFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { getSafeLogger } from "../logger";
+import { getSafeLogger, redactSecrets } from "../logger";
 import { errorMessage } from "../utils/errors";
 
 export interface PromptAuditEntry {
@@ -249,7 +249,7 @@ export class PromptAuditor implements IPromptAuditor {
       this._dirCreated = true;
     }
     try {
-      await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(entry)}\n`);
+      await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(redactSecrets(entry))}\n`);
     } catch (err) {
       throw tagAuditError(err, "jsonl");
     }
@@ -258,7 +258,10 @@ export class PromptAuditor implements IPromptAuditor {
     const auditEntry = entry as PromptAuditEntry;
     const filename = deriveTxtFilename(auditEntry);
     try {
-      await _promptAuditorDeps.write(join(this._featureDir, filename), buildTxtContent(auditEntry));
+      await _promptAuditorDeps.write(
+        join(this._featureDir, filename),
+        redactSecrets(buildTxtContent(auditEntry)) as string,
+      );
     } catch (err) {
       throw tagAuditError(err, "txt");
     }

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -248,20 +248,23 @@ export class PromptAuditor implements IPromptAuditor {
       }
       this._dirCreated = true;
     }
+    // Redact once — entry.prompt/response can be hundreds of KB, and scanning that
+    // text a second time via buildTxtContent(entry) + a second redactSecrets() call
+    // would rerun all ~14 secret patterns over it again for no benefit.
+    const safeEntry = redactSecrets(entry) as PromptAuditEntry | PromptAuditErrorEntry;
     try {
-      await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(redactSecrets(entry))}\n`);
+      await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(safeEntry)}\n`);
     } catch (err) {
       throw tagAuditError(err, "jsonl");
     }
 
     if (!("prompt" in entry) || !("response" in entry)) return;
-    const auditEntry = entry as PromptAuditEntry;
-    const filename = deriveTxtFilename(auditEntry);
+    // Filename derives from the original entry, not safeEntry — session names,
+    // story IDs, etc. are never secret-shaped, but this keeps filename generation
+    // provably independent of redaction either way.
+    const filename = deriveTxtFilename(entry as PromptAuditEntry);
     try {
-      await _promptAuditorDeps.write(
-        join(this._featureDir, filename),
-        redactSecrets(buildTxtContent(auditEntry)) as string,
-      );
+      await _promptAuditorDeps.write(join(this._featureDir, filename), buildTxtContent(safeEntry as PromptAuditEntry));
     } catch (err) {
       throw tagAuditError(err, "txt");
     }

--- a/test/integration/config/paths.test.ts
+++ b/test/integration/config/paths.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { globalConfigDir, projectConfigDir } from "../../../src/config/paths";
+import { featureDir, globalConfigDir, projectConfigDir } from "../../../src/config/paths";
 
 describe("config/paths", () => {
   describe("globalConfigDir", () => {
@@ -56,6 +56,38 @@ describe("config/paths", () => {
       const result = projectConfigDir(projectRoot);
       expect(result).toContain("/project/.nax");
       expect(result.startsWith("/")).toBe(true);
+    });
+  });
+
+  describe("featureDir (SEC-3: featureId validation)", () => {
+    const root = "/path/to/project";
+
+    test("returns <root>/.nax/features/<featureId> for a normal slug", () => {
+      expect(featureDir(root, "auth-system")).toBe(join(root, ".nax", "features", "auth-system"));
+    });
+
+    test("allows the '_unattached' internal sentinel (leading underscore)", () => {
+      expect(featureDir(root, "_unattached")).toBe(join(root, ".nax", "features", "_unattached"));
+    });
+
+    test("rejects an empty featureId", () => {
+      expect(() => featureDir(root, "")).toThrow("Feature ID cannot be empty");
+    });
+
+    test("rejects path traversal", () => {
+      expect(() => featureDir(root, "../../etc/passwd")).toThrow("path traversal");
+    });
+
+    test("rejects a featureId shaped like a git flag", () => {
+      expect(() => featureDir(root, "--upload-pack=evil")).toThrow("git flags");
+    });
+
+    test("rejects a featureId with invalid characters", () => {
+      expect(() => featureDir(root, "has spaces")).toThrow("must match pattern");
+    });
+
+    test("rejects a featureId over 64 characters", () => {
+      expect(() => featureDir(root, "a".repeat(65))).toThrow("must match pattern");
     });
   });
 });

--- a/test/integration/plugins/loader.test.ts
+++ b/test/integration/plugins/loader.test.ts
@@ -9,7 +9,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadPlugins as loadPluginsWithBuiltins } from "../../../src/plugins/loader";
+import {
+  _loadAndValidatePlugin,
+  _resetPluginErrorSink,
+  _setPluginErrorSink,
+  loadPlugins as loadPluginsWithBuiltins,
+} from "../../../src/plugins/loader";
 import type { NaxPlugin, PluginConfigEntry } from "../../../src/plugins/types";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 
@@ -85,14 +90,16 @@ export default {
   await fs.writeFile(path.join(dir, filename), pluginCode, "utf-8");
 }
 
-function loadPlugins(
-  ...args: Parameters<typeof loadPluginsWithBuiltins>
-): ReturnType<typeof loadPluginsWithBuiltins> {
+function loadPlugins(...args: Parameters<typeof loadPluginsWithBuiltins>): ReturnType<typeof loadPluginsWithBuiltins> {
   const [globalDir, projectDir, configPlugins, projectRoot, disabledPlugins, isTestFile] = args;
-  return loadPluginsWithBuiltins(globalDir, projectDir, configPlugins, projectRoot, [
-    ...DISABLE_BUILTIN_PLUGINS,
-    ...(disabledPlugins ?? []),
-  ], isTestFile);
+  return loadPluginsWithBuiltins(
+    globalDir,
+    projectDir,
+    configPlugins,
+    projectRoot,
+    [...DISABLE_BUILTIN_PLUGINS, ...(disabledPlugins ?? [])],
+    isTestFile,
+  );
 }
 
 describe("loadPlugins", () => {
@@ -656,6 +663,50 @@ export default {
       // getReporters(), breaking the "each finding appears exactly once" invariant.
       expect(registry.plugins).toHaveLength(1);
       expect(registry.plugins[0].extensions?.optimizer?.name).toBe("project");
+    });
+  });
+
+  describe("SEC-2: fail-closed on empty allowedRoots", () => {
+    test("rejects a file-path module when allowedRoots is empty instead of skipping validation", async () => {
+      const pluginPath = path.join(tempDir, "unvalidated-plugin.ts");
+      await writePluginFile(tempDir, "unvalidated-plugin.ts", {
+        name: "unvalidated",
+        version: "1.0.0",
+        provides: [],
+        extensions: {},
+      });
+
+      const errorLogs: string[] = [];
+      _setPluginErrorSink((...args: unknown[]) => {
+        errorLogs.push(args.map((arg) => String(arg)).join(" "));
+      });
+      try {
+        const result = await _loadAndValidatePlugin(pluginPath, {}, []);
+        expect(result).toBeNull();
+        expect(errorLogs.join("\n")).toContain("no allowed roots configured");
+      } finally {
+        _resetPluginErrorSink();
+      }
+    });
+
+    test("loads the same file-path module when a matching allowedRoot is supplied", async () => {
+      const pluginPath = path.join(tempDir, "validated-plugin.ts");
+      await writePluginFile(tempDir, "validated-plugin.ts", {
+        name: "validated",
+        version: "1.0.0",
+        provides: ["router"],
+        extensions: {
+          router: {
+            name: "validated-router",
+            route() {
+              return null;
+            },
+          },
+        },
+      });
+
+      const result = await _loadAndValidatePlugin(pluginPath, {}, [tempDir]);
+      expect(result?.name).toBe("validated");
     });
   });
 });

--- a/test/unit/plugins/builtin/nax-finish/plugin-read-result.test.ts
+++ b/test/unit/plugins/builtin/nax-finish/plugin-read-result.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { _naxFinishDeps, naxFinishPlugin } from "@/plugins";
+import type { PostRunContext } from "@/plugins/types";
+import { withTempDir } from "@test/helpers";
+
+const action = naxFinishPlugin.extensions.postRunAction!;
+
+// _naxFinishDeps is module-level state shared across every test file in this
+// process — restore it after each test so a stub cannot leak sideways.
+const origDeps = { ...(_naxFinishDeps as Record<string, unknown>) };
+afterEach(() => {
+  Object.assign(_naxFinishDeps, origDeps);
+});
+const baseCtx = (over: Partial<PostRunContext> = {}): PostRunContext =>
+  ({
+    runId: "r",
+    feature: "x",
+    workdir: "/repo",
+    prdPath: "/repo/.nax/features/x/prd.json",
+    branch: "feat/x",
+    totalDurationMs: 1,
+    totalCost: 0,
+    storySummary: { completed: 2, failed: 0, skipped: 0, paused: 0 },
+    stories: [],
+    config: { finish: { autoFlow: { enabled: true } } },
+    logger: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    },
+    ...over,
+  }) as unknown as PostRunContext;
+
+describe("defaultReadResult (BUG-1: malformed result.json on disk)", () => {
+  // origDeps.readResult is the real defaultReadResult — untouched here since this
+  // block never assigns _naxFinishDeps.readResult itself.
+  const readResult = origDeps.readResult as (resultPath: string) => Promise<unknown>;
+
+  test("returns null (not a thrown parse error) for a truncated/malformed result file", async () => {
+    await withTempDir(async (dir) => {
+      const resultPath = `${dir}/run.result.json`;
+      await Bun.write(resultPath, '{"feature": "x", "status": "opened"'); // truncated — missing closing brace
+      await expect(readResult(resultPath)).resolves.toBeNull();
+    });
+  });
+
+  test("still returns null when the file is missing", async () => {
+    await withTempDir(async (dir) => {
+      await expect(readResult(`${dir}/nonexistent.result.json`)).resolves.toBeNull();
+    });
+  });
+
+  test("parses a well-formed result file normally", async () => {
+    await withTempDir(async (dir) => {
+      const resultPath = `${dir}/run.result.json`;
+      await Bun.write(resultPath, JSON.stringify({ feature: "x", status: "opened" }));
+      await expect(readResult(resultPath)).resolves.toEqual({ feature: "x", status: "opened" });
+    });
+  });
+
+  test("a malformed result file is treated as 'no result file' end-to-end", async () => {
+    await withTempDir(async (dir) => {
+      const resultPath = `${dir}/run.result.json`;
+      await Bun.write(resultPath, "not json at all");
+      _naxFinishDeps.run = async () => ({ exitCode: 0, stdout: "", stderr: "" });
+      _naxFinishDeps.clearResult = async () => {};
+      _naxFinishDeps.exists = async () => true;
+      // finishResultPath is opaque to the action (it doesn't take resultPath as an
+      // input), so point readResult straight at our temp file via a bound closure
+      // over the real defaultReadResult, rather than relying on real path derivation.
+      _naxFinishDeps.readResult = async () => readResult(resultPath) as never;
+      const r = await action.execute(baseCtx());
+      expect(r.success).toBe(false);
+      expect(r.message).toContain("no result file");
+    });
+  });
+});

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -160,6 +160,40 @@ describe("PromptAuditor", () => {
     });
   });
 
+  test("record() redacts secrets embedded in prompt/response before writing JSONL and txt", async () => {
+    await withTempDir(async (dir) => {
+      const flushDir = join(dir, "audit");
+      let jsonlLine = "";
+      let txtContent = "";
+      const origAppend = _promptAuditorDeps.appendLine;
+      const origWrite = _promptAuditorDeps.write;
+      _promptAuditorDeps.appendLine = async (_p, d) => {
+        jsonlLine = d;
+      };
+      _promptAuditorDeps.write = async (p, d) => {
+        if (p.endsWith(".txt")) txtContent = String(d);
+        return 0;
+      };
+      const aud = new PromptAuditor("r-secret", flushDir, FEATURE);
+      aud.record(
+        makeEntry({
+          sessionName: "nax-abc-my-feature-us-000-run",
+          prompt: "connect to postgres://admin:s3cret@db.internal:5432/prod",
+          response: "GITHUB_TOKEN=ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        }),
+      );
+      await aud.flush();
+      expect(jsonlLine).not.toContain("s3cret");
+      expect(jsonlLine).not.toContain("ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(jsonlLine).toContain("[REDACTED]");
+      expect(txtContent).not.toContain("s3cret");
+      expect(txtContent).not.toContain("ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(txtContent).toContain("[REDACTED]");
+      _promptAuditorDeps.appendLine = origAppend;
+      _promptAuditorDeps.write = origWrite;
+    });
+  });
+
   describe("interactions (issue #1226)", () => {
     test("appends an === INTERACTIONS === section with question, reply, and turn index", async () => {
       await withTempDir(async (dir) => {


### PR DESCRIPTION
## Summary

Implements P0–P3 of the code review at `docs/20260817-review-nax.md`, then self-reviews the resulting diff and fixes what that review found. See `docs/20260818-review-p0-p1-p2-p3-branch.md` for the full self-review.

**P0/P1 — decompose oversized review-runner functions:**
- `runAdversarialReview` (507 lines) → thin orchestrator + `src/review/adversarial-outcomes.ts`
- `runSemanticReview` (461 lines) → thin orchestrator + `src/review/semantic-outcomes.ts`
- Prompt/response audit files (`.nax/prompt-audit/`) are now redacted via the existing `redactSecrets` (previously only applied at the logger boundary)

**P2 — smaller quality fixes:**
- Shared `Severity` type alias, adopted at 6 call sites that each independently declared `severity: string`
- `loadConfig` (185 lines) split by layering step (global → project → profile chain → CLI overrides)
- `runReview` (248 lines) split into `guardUncommittedFiles` / `runSemanticCheck` / `runAdversarialCheck` / `runMechanicalCheck`, with a new `buildReviewStory()` de-duplicating identical story-construction logic

**P3 — security/reliability fixes:**
- `loadAndValidatePlugin`'s `allowedRoots` is now required (not defaulted to `[]`) — fails closed instead of silently skipping path validation for file-path plugin modules
- `featureDir()` now validates `featureId` (traversal, git-flag, charset, length cap) before path construction, mirroring the existing `validateStoryId`
- nax-finish's result reader now catches malformed JSON instead of throwing, matching the sibling `curator/collect.ts` pattern

**Self-review pass** (4 independent review agents, one per risk area) caught and fixed:
- A real regression: `blockingThreshold` was eagerly defaulted in the two new orchestrators' shared context objects, changing 3 early-exit audit-telemetry events from recording `undefined` to `"error"`
- The new `featureId` validation could throw out of a function documented as best-effort (`discoverSessionScratchDirsOnDisk`) — guarded
- The `Severity` type alias was vacuous as originally written (`SEVERITY_RANK`'s type annotation collapsed the literal union to `string`) — fixed via `as const satisfies`
- Two low-severity nits (a swallowed diagnostic, a redundant redaction pass)

Every commit passes the full pre-commit gate (typecheck + lint + 20 ratchet checks) individually. Control flow, logging, and audit-recording order in every decomposition were verified line-by-line against the pre-refactor original by independent review agents, not just re-run by the author.

## Test plan

- [x] Full `bun run test` (unit + integration + ui, 14,929 tests) passes on the final branch state
- [x] Each of the 10 commits individually passes the pre-commit gate (typecheck, biome, all ratchet checks)
- [x] Targeted regression coverage added: prompt-auditor redaction, plugin-loader fail-closed path, `featureDir` validation (incl. the `"_unattached"` internal sentinel), nax-finish malformed-JSON handling
- [x] `bun run test:coverage` — not re-run in this session; CI will gate