### PR TITLE
fix(config): run the full compat-shim chain on per-package config overlays

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -477,10 +477,11 @@ export async function loadConfigForWorkdir(
   // the case where a per-package overlay introduces a no-op key on a mergeable
   // field like acceptance.generateTests). Post-merge placement yields one
   // warning per resolved config regardless of which layer supplied the key.
-  merged = stripRemovedNoOpKeys(
-    merged as unknown as Record<string, unknown>,
-    defaultConfigWarn,
-  ) as unknown as NaxConfig;
+  // #1620: the shared per-resolution dedupe, not the bare sink — this strip and
+  // the post-profile one below are two layers of the same resolution, so a key in
+  // both the overlay and a package profile warned twice where the root path warns
+  // once.
+  merged = stripRemovedNoOpKeys(merged as unknown as Record<string, unknown>, warnDedupe.warn) as unknown as NaxConfig;
 
   // CFG-3: the plain per-package overlay (.nax/mono/<pkg>/config.json) also
   // never ran through $VAR resolution — same gap as CFG-2 at the root layer.
@@ -546,7 +547,7 @@ export async function loadConfigForWorkdir(
   // profile can reintroduce one). Runs after the reject guards and before
   // safeParse, mirroring the root chain. Post-merge placement yields one
   // warning per resolved config regardless of which layer supplied the key.
-  rawMerged = stripRemovedNoOpKeys(rawMerged, defaultConfigWarn);
+  rawMerged = stripRemovedNoOpKeys(rawMerged, warnDedupe.warn);
   // #574's single-shim patch here (`_applyRemovedWorktreeInheritShim` on the merged
   // result) is gone: #1620 replaced it with the full chain run on each overlay layer
   // above, which covers that case and every other shim.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -10,7 +10,6 @@ import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import { loadJsonFile } from "../utils/json-file";
 import {
-  _applyRemovedWorktreeInheritShim,
   applyConfigCompatShims,
   createConfigWarnDedupe,
   defaultConfigWarn,
@@ -448,7 +447,29 @@ export async function loadConfigForWorkdir(
 
   logger.debug("config", "Per-package config loaded", { packageConfigPath, packageDir });
   const { profile: packageProfile, ...packageFields } = packageOverride;
-  let merged = mergePackageConfig(rootConfig, packageFields);
+
+  // #1620: one dedupe per package resolution, mirroring `loadConfig`'s per-load
+  // dedupe — the overlay and its package profiles run the same chain, so a legacy
+  // key present in both would otherwise warn once per layer.
+  const warnDedupe = createConfigWarnDedupe();
+
+  // #1620: every overlay layer runs the SAME compat-shim chain as the root layers
+  // (global, project, profile, CLI). Without it a legacy value the root config
+  // migrates with a warning instead hard-failed `PER_PACKAGE_PROFILE_INVALID` here
+  // (e.g. `routing.strategy: "manual"`), and the mapping/warning shims that do not
+  // hard-fail lost their migration or their warning silently.
+  //
+  // Applied per LAYER (pre-merge), not to the merged result, because several shims
+  // only fire when the canonical key is absent — and the merged result always
+  // carries the root's resolved value for it. `routing.llm.batchMode` -> `mode` and
+  // `context.testCoverage.testPattern` -> `execution.smartTestRunner.testFilePatterns`
+  // would both silently no-op if the chain ran post-merge.
+  const shimmedPackageFields = applyConfigCompatShims(
+    packageFields as Record<string, unknown>,
+    logger,
+    warnDedupe,
+  ) as Partial<NaxConfig>;
+  let merged = mergePackageConfig(rootConfig, shimmedPackageFields);
 
   // Strip the four inert no-op keys from the per-package overlay result.
   // Runs for BOTH ordinary package overlays and package profiles (the profile
@@ -499,7 +520,10 @@ export async function loadConfigForWorkdir(
           { stage: "config", profileName: name, packageDir, varName, path, cause: err },
         );
       }
-      rawMerged = deepMergeConfig<Record<string, unknown>>(rawMerged, resolvedProfileData);
+      // #1620: same chain as the root profile layer (BUG-51) — a per-package
+      // profile can carry the same legacy shapes as any other layer.
+      const shimmedProfileData = applyConfigCompatShims(resolvedProfileData, logger, warnDedupe);
+      rawMerged = deepMergeConfig<Record<string, unknown>>(rawMerged, shimmedProfileData);
     }
     rawMerged.profile = packageChain.join("+");
     rawMerged.profileChain = packageChain;
@@ -523,13 +547,9 @@ export async function loadConfigForWorkdir(
   // safeParse, mirroring the root chain. Post-merge placement yields one
   // warning per resolved config regardless of which layer supplied the key.
   rawMerged = stripRemovedNoOpKeys(rawMerged, defaultConfigWarn);
-  // #574: this path never ran the compat-shim chain, so a per-package overlay
-  // carrying a removed value hard-fails safeParse below instead of migrating —
-  // and this is the config `prepareWorktreeDependencies` actually receives for a
-  // monorepo story (iteration-runner resolves it through here). Only the
-  // worktree shim is applied: the rest of the chain has the same hole today
-  // (e.g. `routing.strategy: "manual"`), but widening it belongs in its own change.
-  rawMerged = _applyRemovedWorktreeInheritShim(rawMerged, defaultConfigWarn);
+  // #574's single-shim patch here (`_applyRemovedWorktreeInheritShim` on the merged
+  // result) is gone: #1620 replaced it with the full chain run on each overlay layer
+  // above, which covers that case and every other shim.
   const result = NaxConfigSchema.safeParse(rawMerged);
   if (!result.success) {
     // Fail-fast — consistent with root-chain resolution (a missing profile file

--- a/test/unit/config/loader-legacy-shim.test.ts
+++ b/test/unit/config/loader-legacy-shim.test.ts
@@ -634,10 +634,14 @@ describe("loadConfigForWorkdir — compat-shim chain on per-package overlays (#1
   test("applyRemovedStrategyCompat: the removed value in a per-package PROFILE maps to keyword too", async () => {
     await writeRootConfig({});
     await writePackageOverride({ profile: "legacy", routing: { strategy: "keyword" } });
-    await writePackageProfile("legacy", { routing: { strategy: "adaptive" } });
+    // `maxIterations` is a non-legacy companion value: it pins that the profile layer
+    // really merged, so a future regression that drops package profiles entirely
+    // cannot make the strategy assertion below pass vacuously.
+    await writePackageProfile("legacy", { routing: { strategy: "adaptive" }, execution: { maxIterations: 7 } });
 
     const config = await loadForPackage();
 
+    expect(config.execution.maxIterations).toBe(7);
     expect(config.routing.strategy).toBe("keyword");
   });
 
@@ -712,10 +716,34 @@ describe("loadConfigForWorkdir — compat-shim chain on per-package overlays (#1
   test("a legacy key carried by BOTH the overlay and a per-package profile warns once per resolution", async () => {
     await writeRootConfig({});
     await writePackageOverride({ profile: "legacy", routing: { adaptive: { costThreshold: 0.5 } } });
-    await writePackageProfile("legacy", { routing: { adaptive: { costThreshold: 0.9 } } });
+    await writePackageProfile("legacy", {
+      routing: { adaptive: { costThreshold: 0.9 } },
+      execution: { maxIterations: 7 },
+    });
 
     const captured = await captureWorkdirWarnings(loadForPackage);
 
     expect(captured.filter((m) => m.includes("routing.adaptive"))).toHaveLength(1);
+    // Guards against a vacuous pass: one warning must mean "deduped across two
+    // layers", not "the profile layer was never merged".
+    expect((await loadForPackage()).execution.maxIterations).toBe(7);
+  });
+
+  // The two `stripRemovedNoOpKeys` calls on this path are two layers of ONE
+  // resolution, but each got the bare `defaultConfigWarn` sink — so a no-op key
+  // in both the overlay and a package profile warned twice, where the root path
+  // warns once per resolved config. They now share the per-resolution dedupe.
+  test("a removed no-op key in both the overlay and a per-package profile warns once, not twice", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ profile: "legacy", acceptance: { generateTests: false } });
+    await writePackageProfile("legacy", {
+      acceptance: { generateTests: false },
+      execution: { maxIterations: 7 },
+    });
+
+    const captured = await captureWorkdirWarnings(loadForPackage);
+
+    expect(captured.filter((m) => m.includes("generateTests"))).toHaveLength(1);
+    expect((await loadForPackage()).execution.maxIterations).toBe(7);
   });
 });

--- a/test/unit/config/loader-legacy-shim.test.ts
+++ b/test/unit/config/loader-legacy-shim.test.ts
@@ -20,7 +20,7 @@ import {
   _applyRemovedRoutingKeysShim,
   _applyRemovedWorktreeInheritShim,
 } from "../../../src/config/compat-shims";
-import { loadConfig, loadConfigForWorkdir } from "../../../src/config/loader";
+import { _clearRootConfigCache, loadConfig, loadConfigForWorkdir } from "../../../src/config/loader";
 
 describe("_applyRemovedRoutingKeysShim — routing keys removed with ROUTE-001", () => {
   test("warns and strips routing.customStrategyPath", () => {
@@ -555,5 +555,167 @@ describe("loadConfig — legacy key deprecation shim", () => {
 
     const config = await loadConfig(tempDir);
     expect(config.execution.worktreeDependencies.mode).toBe("off");
+  });
+});
+
+// #1620: `loadConfigForWorkdir` ran no compat-shim chain, so a legacy value the
+// root config migrates with a warning instead hard-failed with
+// PER_PACKAGE_PROFILE_INVALID when it appeared in a per-package overlay — on the
+// config path story execution actually uses (iteration-runner resolves a story's
+// effective config through here whenever the story has a `workdir`). The chain
+// now runs per overlay layer, mirroring the root loader's per-layer placement.
+describe("loadConfigForWorkdir — compat-shim chain on per-package overlays (#1620)", () => {
+  let tempDir: string;
+  let originalGlobalDir: string | undefined;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-workdir-shim-");
+    mkdirSync(join(tempDir, ".nax"), { recursive: true });
+    originalGlobalDir = process.env.NAX_GLOBAL_CONFIG_DIR;
+    process.env.NAX_GLOBAL_CONFIG_DIR = join(tempDir, ".global-nax");
+    _clearRootConfigCache();
+  });
+
+  afterEach(() => {
+    _clearRootConfigCache();
+    cleanupTempDir(tempDir);
+    if (originalGlobalDir === undefined) {
+      delete process.env.NAX_GLOBAL_CONFIG_DIR;
+    } else {
+      process.env.NAX_GLOBAL_CONFIG_DIR = originalGlobalDir;
+    }
+  });
+
+  const PKG = "packages/app";
+
+  async function writeRootConfig(config: Record<string, unknown>): Promise<void> {
+    await Bun.write(join(tempDir, ".nax", "config.json"), JSON.stringify(config));
+  }
+
+  async function writePackageOverride(override: Record<string, unknown>): Promise<void> {
+    const pkgDir = join(tempDir, ".nax", "mono", ...PKG.split("/"));
+    mkdirSync(pkgDir, { recursive: true });
+    await Bun.write(join(pkgDir, "config.json"), JSON.stringify(override));
+  }
+
+  async function writePackageProfile(name: string, data: Record<string, unknown>): Promise<void> {
+    const profilesDir = join(tempDir, ...PKG.split("/"), ".nax", "profiles");
+    mkdirSync(profilesDir, { recursive: true });
+    await Bun.write(join(profilesDir, `${name}.json`), JSON.stringify(data));
+  }
+
+  function loadForPackage() {
+    return loadConfigForWorkdir(join(tempDir, ".nax", "config.json"), PKG);
+  }
+
+  async function captureWorkdirWarnings(load: () => Promise<unknown>): Promise<string[]> {
+    const captured: string[] = [];
+    resetLogger();
+    initLogger({ level: "warn" });
+    const removeSink = addSink((entry) => captured.push(entry.message));
+    try {
+      await load();
+    } finally {
+      removeSink();
+      resetLogger();
+    }
+    return captured;
+  }
+
+  test("applyRemovedStrategyCompat: a removed routing.strategy in an overlay maps to keyword instead of throwing", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ routing: { strategy: "manual" } });
+
+    const config = await loadForPackage();
+
+    expect(config.routing.strategy).toBe("keyword");
+  });
+
+  test("applyRemovedStrategyCompat: the removed value in a per-package PROFILE maps to keyword too", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ profile: "legacy", routing: { strategy: "keyword" } });
+    await writePackageProfile("legacy", { routing: { strategy: "adaptive" } });
+
+    const config = await loadForPackage();
+
+    expect(config.routing.strategy).toBe("keyword");
+  });
+
+  test("_applyRemovedRoutingKeysShim: routing.adaptive in an overlay is stripped WITH a warning", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ routing: { adaptive: { costThreshold: 0.5 } } });
+
+    const captured = await captureWorkdirWarnings(loadForPackage);
+
+    expect(captured.filter((m) => m.includes("routing.adaptive") && m.includes("removed"))).toHaveLength(1);
+  });
+
+  test("_applyRemovedRoutingKeysShim: routing.customStrategyPath in an overlay is stripped WITH a warning", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ routing: { customStrategyPath: "./x.ts" } });
+
+    const captured = await captureWorkdirWarnings(loadForPackage);
+
+    expect(captured.filter((m) => m.includes("routing.customStrategyPath"))).toHaveLength(1);
+  });
+
+  test("applyBatchModeCompat: routing.llm.batchMode in an overlay maps to routing.llm.mode", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ routing: { llm: { batchMode: true } } });
+
+    const config = await loadForPackage();
+
+    // Root config always carries a resolved routing.llm.mode ("hybrid" by default),
+    // so the mapping only happens if the shim runs on the overlay LAYER, before merge.
+    expect(config.routing.llm?.mode).toBe("one-shot");
+  });
+
+  test("applyRoutingRetryDeprecationWarning: routing.llm.retries in an overlay warns", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ routing: { llm: { retries: 3 } } });
+
+    const captured = await captureWorkdirWarnings(loadForPackage);
+
+    expect(captured.filter((m) => m.includes("routing.llm.retries"))).toHaveLength(1);
+  });
+
+  test("migrateLegacyTestPattern: context.testCoverage.testPattern in an overlay migrates to smartTestRunner.testFilePatterns", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ context: { testCoverage: { testPattern: "**/*.spec.ts" } } });
+
+    const config = await loadForPackage();
+
+    const smartTestRunner = config.execution.smartTestRunner as { testFilePatterns?: unknown };
+    expect(smartTestRunner.testFilePatterns).toEqual(["**/*.spec.ts"]);
+    expect(config.context?.testCoverage).not.toHaveProperty("testPattern");
+  });
+
+  test("migrateLegacyReviewModelKey: review.semantic.modelTier in an overlay migrates to review.semantic.model", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ review: { semantic: { enabled: true, modelTier: "fast" } } });
+
+    const config = await loadForPackage();
+
+    expect(config.review.semantic?.model).toBe("fast");
+    expect(config.review.semantic).not.toHaveProperty("modelTier");
+  });
+
+  test("_applyLegacyReviewExecutionShim: execution.inlineReview in an overlay is stripped WITH a warning", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ execution: { inlineReview: true } });
+
+    const captured = await captureWorkdirWarnings(loadForPackage);
+
+    expect(captured.filter((m) => m.includes("execution.inlineReview"))).toHaveLength(1);
+  });
+
+  test("a legacy key carried by BOTH the overlay and a per-package profile warns once per resolution", async () => {
+    await writeRootConfig({});
+    await writePackageOverride({ profile: "legacy", routing: { adaptive: { costThreshold: 0.5 } } });
+    await writePackageProfile("legacy", { routing: { adaptive: { costThreshold: 0.9 } } });
+
+    const captured = await captureWorkdirWarnings(loadForPackage);
+
+    expect(captured.filter((m) => m.includes("routing.adaptive"))).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes #1620.

## Problem

`applyConfigCompatShims` runs on the global, project, profile and CLI layers in `loadConfig` — but never on the per-package path. `loadConfigForWorkdir` merged `.nax/mono/<pkg>/config.json` (plus per-package profiles), ran only the reject guards and `stripRemovedNoOpKeys`, then went straight to `safeParse`.

So a legacy value the root config **migrates with a deprecation warning** instead **hard-failed with `PER_PACKAGE_PROFILE_INVALID`** in a per-package overlay — a whole-run abort, on the config path story execution actually uses (`iteration-runner` resolves a story's effective config through here whenever the story has a `workdir`).

## Fix

The chain now runs on each overlay **layer** before merging — the package fields, then each per-package profile — mirroring the root loader's per-layer placement, and therefore ahead of the reject guards (issue's ordering point 2).

**Per-layer rather than post-merge, and that distinction is load-bearing.** Several shims only fire when the canonical key is absent, and the merged result always carries the root's resolved value for it:

- `applyBatchModeCompat` requires `!("mode" in llm)` — but `routing.llm.mode` defaults to `"hybrid"`, so it is always present post-merge.
- `migrateLegacyTestPattern` only aliases when `execution.smartTestRunner.testFilePatterns` is absent.

A post-merge chain would have silently no-op'd on exactly those two. Verified against the schema defaults rather than assumed.

**Warning dedupe** (issue's point 1): a fresh `ConfigWarnDedupe` per call — one warning per package resolution, matching `loadConfig`'s per-load semantics and the existing "dedupe is scoped per load" test. A story loop resolving the same package repeatedly will warn repeatedly; that is the tradeoff the issue named, and per-load consistency is why I took it.

#1619's single-shim `_applyRemovedWorktreeInheritShim` patch at the `safeParse` call site is removed — the chain covers it, and its regression test still passes.

## Adjacent fix found during self-review

The two `stripRemovedNoOpKeys` calls in `loadConfigForWorkdir` are two layers of *one* resolution but each got the bare `defaultConfigWarn` sink, so a removed no-op key present in both the overlay and a package profile warned **twice** where the root path warns once. Measured 2, not inferred. Both now share the same per-resolution dedupe.

## Tests

11 new cases in `test/unit/config/loader-legacy-shim.test.ts` — one per affected shim, plus a profile-layer case, the shim dedupe case, and the no-op-key dedupe case:

| Shim | Was |
|:--|:--|
| `applyRemovedStrategyCompat` | hard fail |
| `_applyRemovedRoutingKeysShim` (`adaptive`, `customStrategyPath`) | warning lost |
| `applyBatchModeCompat` | mapping lost |
| `applyRoutingRetryDeprecationWarning` | warning lost |
| `migrateLegacyTestPattern` | migration lost |
| `migrateLegacyReviewModelKey` | migration lost |
| `_applyLegacyReviewExecutionShim` | warning lost |

All of them were confirmed RED against the unfixed loader before the fix landed, and the no-op dedupe test was re-confirmed by reverting that one-line change (2 → 1). The two package-profile tests also pin a non-legacy companion value (`execution.maxIterations`) so a future regression that drops package profiles entirely cannot make them pass vacuously.

## Verification

- `bun run test` — full suite green (unit + integration + ui)
- `bun run typecheck`, `bun run lint`, all 22 pre-commit ratchets clean
- test-debt ratchets: typecheck 2014 = baseline; `as unknown as` 829 (↓1)

## Not changed

`loadPackageOverride` (the runtime registry's read-only path) still returns raw unshimmed fields. It neither validates nor feeds `safeParse`, so it cannot produce this failure — but if anything ever consumes it as an effective config, it has the same hole.