### PR TITLE
fix(nax-finish): read a section heading glued to the preceding narration line

### DIFF
--- a/flows/nax-finish/findings-parse.ts
+++ b/flows/nax-finish/findings-parse.ts
@@ -16,6 +16,26 @@ type Section = "touchpoints" | "walk" | "findings";
 
 /** Headings are matched loosely — any level, any case, optional trailing colon. */
 const HEADING = /^\s*#{1,6}\s*(TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)\s*:?\s*$/i;
+/**
+ * A heading that ends its line but does not start it.
+ *
+ * The reply the parser sees is the agent's whole message stream joined with no
+ * separator, so the first heading of the final report lands mid-line whenever
+ * the preceding narration message did not end in a newline — `…confidence
+ * bar.## TOUCHPOINTS`. `HEADING` is line-anchored and misses it, and because
+ * only the *first* heading can be glued this way, `WALK` and `FINDINGS` still
+ * parse: the review reads as one that skipped its touchpoints, and
+ * `steps/review-audit.ts` sends back a review that in fact did the reading. The
+ * re-review cannot help — the same reviewer narrates again and glues again — so
+ * it escalates on the second pass, which is how a clean quality review reached a
+ * human as an incomplete one.
+ *
+ * `[^\s#]` is what keeps a well-formed `## TOUCHPOINTS` out: without it the
+ * leading `#` satisfies the prefix group and the heading is split into `#` and
+ * `# TOUCHPOINTS`, breaking the case that already worked. Requiring the tail
+ * anchor (`$`) is what keeps a section word mentioned inside prose out.
+ */
+const GLUED_HEADING = /^(.*[^\s#])(#{1,6}[ \t]*(?:TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)[ \t]*:?[ \t]*)$/gim;
 const BLOCK = /^\s*\[(CRITICAL|HIGH|MEDIUM|LOW)\]\s+(.+?)\s*$/;
 const FIELD = /^\s*(Problem|Fix|Judgment)\s*:\s*(.*)$/i;
 const NO_FINDINGS = /^\s*no findings\.?\s*$/i;
@@ -62,6 +82,9 @@ export function parseReviewReport(text: string): ReviewReport {
   let section: Section = "findings";
   let current: Finding | null = null;
   let lastField: "problem" | "fix" | null = null;
+  // `String.replace` with a /g regex resets `lastIndex` itself, so the shared
+  // literal carries no state between calls.
+  const normalized = text.replace(GLUED_HEADING, "$1\n$2");
 
   const flush = () => {
     if (current) report.findings.push(current);
@@ -69,7 +92,7 @@ export function parseReviewReport(text: string): ReviewReport {
     lastField = null;
   };
 
-  for (const line of text.split("\n")) {
+  for (const line of normalized.split("\n")) {
     const heading = HEADING.exec(line);
     if (heading) {
       flush();

--- a/flows/nax-finish/findings-parse.ts
+++ b/flows/nax-finish/findings-parse.ts
@@ -30,10 +30,23 @@ const HEADING = /^\s*#{1,6}\s*(TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)\s*:?\s*$/
  * it escalates on the second pass, which is how a clean quality review reached a
  * human as an incomplete one.
  *
- * `[^\s#]` is what keeps a well-formed `## TOUCHPOINTS` out: without it the
- * leading `#` satisfies the prefix group and the heading is split into `#` and
- * `# TOUCHPOINTS`, breaking the case that already worked. Requiring the tail
- * anchor (`$`) is what keeps a section word mentioned inside prose out.
+ * Three guards, each load-bearing, each pinned by a test that fails without it:
+ *
+ * - **`\s`** in `[^\s#]` — the prefix must *abut* the `#`. This is what tells a
+ *   concatenation artifact from prose: the join leaves no space (`bar.##`),
+ *   while prose that mentions a section always has one (`marked ## FINDINGS`).
+ *   Relax it and that Problem line becomes a heading, flushing the finding and
+ *   dropping its `Fix:` — detail lost silently, the very failure this seam
+ *   exists to prevent.
+ * - **`#`** in `[^\s#]` — keeps a well-formed `## TOUCHPOINTS` out. Without it
+ *   the leading `#` satisfies the prefix group and the heading is rewritten to
+ *   `#` + `# TOUCHPOINTS`, breaking the case that already worked.
+ * - **`$`** — the heading must end its line, so a section word quoted
+ *   mid-sentence is not one.
+ *
+ * `[ \t]` rather than `\s` inside the heading: `\s` matches `\n`, which under
+ * `/m` would let the tail span into following lines. `\r` needs no mention —
+ * `$` under `/m` matches before it, so CRLF replies are already handled.
  */
 const GLUED_HEADING = /^(.*[^\s#])(#{1,6}[ \t]*(?:TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)[ \t]*:?[ \t]*)$/gim;
 const BLOCK = /^\s*\[(CRITICAL|HIGH|MEDIUM|LOW)\]\s+(.+?)\s*$/;
@@ -79,12 +92,13 @@ export function parseReviewReport(text: string): ReviewReport {
     sawTouchpointsSection: false,
     sawWalkSection: false,
   };
-  let section: Section = "findings";
-  let current: Finding | null = null;
-  let lastField: "problem" | "fix" | null = null;
   // `String.replace` with a /g regex resets `lastIndex` itself, so the shared
   // literal carries no state between calls.
   const normalized = text.replace(GLUED_HEADING, "$1\n$2");
+
+  let section: Section = "findings";
+  let current: Finding | null = null;
+  let lastField: "problem" | "fix" | null = null;
 
   const flush = () => {
     if (current) report.findings.push(current);

--- a/test/unit/flows/nax-finish/findings-parse.test.ts
+++ b/test/unit/flows/nax-finish/findings-parse.test.ts
@@ -97,10 +97,36 @@ describe("parseReviewReport", () => {
     expect(r.walk).toHaveLength(2);
   });
 
-  test("does not treat a section word inside prose as a heading", () => {
-    const r = parseReviewReport("I read the FINDINGS section of the spec.\n[LOW] t\n  Problem: p\n  Fix: f\n");
-    expect(r.sawTouchpointsSection).toBe(false);
+  // The three guards on GLUED_HEADING, each pinned by the case that fails
+  // without it. Relaxing any of them silently costs a finding's detail, which is
+  // the failure this whole seam exists to prevent — so none may go untested.
+
+  test("does not split when whitespace separates the prose from the #", () => {
+    // Adjacency is the signal: a concatenation artifact has no space before the
+    // `#`, prose always does. Without the `\\s` half of `[^\\s#]` this splits, the
+    // spurious heading flushes the finding, and its `Fix:` line is dropped.
+    const r = parseReviewReport(
+      "## FINDINGS\n[HIGH] t\n  Problem: see the block marked ## FINDINGS\n  Fix: do the thing\n",
+    );
     expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].problem).toBe("see the block marked ## FINDINGS");
+    expect(r.findings[0].fix).toBe("do the thing");
+  });
+
+  test("does not split when the section word is not at end of line", () => {
+    // Adjacency holds here (`.` abuts `##`), so only the `$` anchor rejects it.
+    const r = parseReviewReport("## FINDINGS\n[HIGH] t\n  Problem: as noted.## FINDINGS below\n  Fix: f\n");
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].problem).toBe("as noted.## FINDINGS below");
+    expect(r.findings[0].fix).toBe("f");
+  });
+
+  test("does not split a well-formed heading at its own leading #", () => {
+    // Without the `#` half of `[^\\s#]` the leading `#` satisfies the prefix
+    // group and `## WALK` is rewritten to `#` + `# WALK`.
+    const r = parseReviewReport("## WALK\nAC-1 Covered\n");
+    expect(r.sawWalkSection).toBe(true);
+    expect(r.walk).toEqual(["AC-1 Covered"]);
   });
 
   test("parses correctly even when sections appear out of the prescribed order", () => {

--- a/test/unit/flows/nax-finish/findings-parse.test.ts
+++ b/test/unit/flows/nax-finish/findings-parse.test.ts
@@ -78,6 +78,31 @@ describe("parseReviewReport", () => {
     expect(r.sawNoFindings).toBe(false);
   });
 
+  test("reads a heading glued to the tail of the preceding narration line", () => {
+    // acpx joins the agent's messages with no separator, so the first heading of
+    // the final report lands mid-line whenever the last narration message did not
+    // end in a newline. Real reply, run-2026-08-18T04-13-00-511Z.
+    const r = parseReviewReport(
+      "No defects cleared the confidence bar.## TOUCHPOINTS\n- a.ts:sym — why\n\n## WALK\nb.ts:fn — earns its place\n\n## FINDINGS\nNo findings.\n",
+    );
+    expect(r.sawTouchpointsSection).toBe(true);
+    expect(r.touchpoints).toEqual([{ path: "a.ts", symbol: "sym", note: "why" }]);
+    expect(r.walk).toEqual(["b.ts:fn — earns its place"]);
+    expect(r.sawNoFindings).toBe(true);
+  });
+
+  test("leaves a well-formed heading at line start untouched", () => {
+    const r = parseReviewReport(FULL_REPLY);
+    expect(r.touchpoints).toHaveLength(3);
+    expect(r.walk).toHaveLength(2);
+  });
+
+  test("does not treat a section word inside prose as a heading", () => {
+    const r = parseReviewReport("I read the FINDINGS section of the spec.\n[LOW] t\n  Problem: p\n  Fix: f\n");
+    expect(r.sawTouchpointsSection).toBe(false);
+    expect(r.findings).toHaveLength(1);
+  });
+
   test("parses correctly even when sections appear out of the prescribed order", () => {
     const r = parseReviewReport(
       "## FINDINGS\n[MEDIUM] Out of order\n  Problem: p\n  Fix: f\n\n## WALK\nAC-1 Covered\n\n## TOUCHPOINTS\n- a.ts:sym — reason\n",


### PR DESCRIPTION
## Problem

`nax-finish` escalated a feature whose quality review was clean, reporting that the reviewer "never discharged its reading obligations".

The reviewer had. The reply the parser sees is the agent's whole message stream joined with no separator, so the **first** heading of the final report lands mid-line whenever the preceding narration message did not end in a newline:

```
No defects cleared the confidence bar.## TOUCHPOINTS
- path/to/file.ts:symbol — why I opened it
```

`HEADING` is line-anchored (`/^\s*#{1,6}\s*(TOUCHPOINTS|…)…$/`), so it misses that line. Only the first heading can be glued this way, which is what makes the failure so misleading: `## WALK` and `## FINDINGS` still parse, so the verdict comes back `route: clean` with a full `walk` and `touchpoints: []` — indistinguishable from a reviewer that read the diff and nothing else.

`auditGaps` then sends back a review that in fact did the reading. The re-review cannot help — the same reviewer narrates again and glues again — so `MAX_INCOMPLETE_ATTEMPTS = 1` escalates on the second pass.

Observed end to end on a real run: two clean quality reviews (0 findings, 3 and 5 real touchpoints, a 10-line WALK each) delivered to a human as an incomplete review. The spec reviewer in the same run passed only by luck — its last narration happened to end `Reply below.\n\n`.

## Fix

Normalise a heading that *ends* its line but does not *start* it onto its own line before splitting:

```ts
const GLUED_HEADING = /^(.*[^\s#])(#{1,6}[ \t]*(?:TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)[ \t]*:?[ \t]*)$/gim;
...
const normalized = text.replace(GLUED_HEADING, "$1\n$2");
```

Three guards, each load-bearing:

| Guard | Keeps out | Cost if relaxed |
|---|---|---|
| `\s` in `[^\s#]` | prose (`marked ## FINDINGS`) — the join never leaves a space, prose always does | the Problem line becomes a heading, flushing the finding so its `Fix:` is silently dropped |
| `#` in `[^\s#]` | a well-formed `## TOUCHPOINTS` | rewritten to `#` + `# TOUCHPOINTS`, breaking the case that already worked |
| `$` | a section word quoted mid-sentence | prose mentions become headings |

`parseDispositions` needs nothing — it scans every line for `DISPOSITION` and never consults `HEADING`.

The join itself belongs to acpx, not nax, so the parser is the seam we own. Worth an upstream look separately; this fix stands on its own either way.

## Verification

- **TDD** — the glued-heading test went RED against the unmodified parser, using the literal text from the failed run.
- **Replay** — both captured production replies, run through the fixed parser *and* `auditGaps` against the real workdir: 3 and 5 touchpoints, **zero gaps**, route stays `clean`. The spec review is unchanged (3 touchpoints, 48-line WALK).
- **Mutation-tested** — the first commit's tests left the adjacency guard unpinned (`[^\s#]` → `[^#]` kept all 13 green while silently dropping a finding's `Fix:`). The second commit adds a case per guard; each now fails under its corresponding mutant.
- Full suite green (unit + integration + ui, 0 fail), lint, typecheck, and all 22 pre-commit gates pass.

### Known limit

`[^\s#]` → `[^ #]` (literal space) still passes. That mutant differs only on a tab immediately before `##`, which the message join never produces — noted rather than left silently untested.
