### PR TITLE
fix(nax-finish): stop sending reviewers two contradictory output contracts

### DIFF
--- a/flows/nax-finish/review-prompts.ts
+++ b/flows/nax-finish/review-prompts.ts
@@ -225,7 +225,39 @@ maintainability concern stated with its cost is worth surfacing even at moderate
 confidence.
 `;
 
-export const WORKER_PROTOCOL = `# Worker protocol (shared mechanics)
+/**
+ * The one place the finding block's shape is defined.
+ *
+ * Extracted so the flow's reply contract can embed it directly. It used to live
+ * only inside `WORKER_PROTOCOL`'s output-format section, so dropping that
+ * section from the assembled prompt (see `WORKER_PROTOCOL_MECHANICS`) would have
+ * taken the block template with it — `outputContract`'s `## FINDINGS` said only
+ * "the `[SEVERITY] …` blocks defined in the worker protocol above".
+ */
+export const FINDING_BLOCK_SHAPE = `\`\`\`
+[SEVERITY] <short title>
+  Problem: <what's wrong, with file/line and the concrete cost>
+  Fix: <the concrete change, or "note intentional deviation">
+\`\`\``;
+
+/**
+ * The worker protocol minus its output-format section: how to fetch the diff,
+ * what churn to ignore, which collaborators to read, and the severity table.
+ *
+ * This is what `buildReviewPrompt` assembles. The omitted section is a *second,
+ * contradictory* reply contract — it opens "Return **only your findings**,
+ * nothing else: … no `FINDINGS` divider" and closes by requiring the literal
+ * line `No findings.` as the reviewer's "entire final message", while
+ * `outputContract` below demands three headed sections. The negative
+ * instruction came first and was the more emphatic of the two.
+ *
+ * The clean review was the sharpest edge: "entire final message" forbids
+ * emitting `## TOUCHPOINTS` and `## WALK` at all when nothing was found, which
+ * `steps/review-audit.ts` then reads as an incomplete review. Every quality
+ * review recorded in `~/.nax/<project>/finish-audit/` came back
+ * `outcome: "unparseable"` on its first attempt.
+ */
+export const WORKER_PROTOCOL_MECHANICS = `# Worker protocol (shared mechanics)
 
 Self-contained mechanics for a post-impl-review **worker** (SPEC or QUALITY).
 Read this plus your dimension reference (\`spec-review.md\` or \`code-quality.md\`) —
@@ -277,17 +309,15 @@ reads to judge an integration-shaped defect.)
 | MEDIUM | Partial coverage — AC present but incomplete; minor drift affecting correctness; an integration gap reachable through a now-permitted input; a test-isolation defect that can cause false positives or flakiness under reordering/parallelism; a resource leak; a swallowed error on a real path; a concurrency/race or performance regression the diff introduces; or an accessibility defect on a new interactive UI element |
 | LOW | Minor naming deviation, style mismatch, dead/redundant/duplicated code, unused locals, a soft convention deviation, or other non-blocking gap |
 
-## Output format — return ONLY this
+`;
+
+const WORKER_PROTOCOL_OUTPUT_FORMAT = `## Output format — return ONLY this
 
 Return **only your findings**, nothing else: no \`Spec:\`/\`Base:\` header, no
 \`FINDINGS\` divider, no \`VERDICT\` line (the dispatcher adds those). Emit each
 finding as a block:
 
-\`\`\`
-[SEVERITY] <short title>
-  Problem: <what's wrong, with file/line and the concrete cost>
-  Fix: <the concrete change, or "note intentional deviation">
-\`\`\`
+${FINDING_BLOCK_SHAPE}
 
 If you found nothing in your group, return the literal line \`No findings.\` as
 your entire final message. That message is the only thing that travels back to
@@ -305,12 +335,14 @@ const CLASSIFIER = [
 /**
  * The reply contract.
  *
- * This supersedes the "Output format — return ONLY this" section of
- * `WORKER_PROTOCOL` above, which is kept verbatim so it stays diffable against
- * the skill's `references/worker-protocol.md`. Its `[SEVERITY]` blocks are
- * exactly this contract's `## FINDINGS` section; the two sections before it are
- * what the flow adds, because the flow — unlike the skill's dispatcher — has no
- * human reading the reply and so must be able to check the obligations itself.
+ * The flow's only reply contract. It used to *compete* with the "Output format
+ * — return ONLY this" section of `WORKER_PROTOCOL`, which the prompt also
+ * carried; that section is no longer assembled (see `WORKER_PROTOCOL_MECHANICS`)
+ * and its block template now lives in `FINDING_BLOCK_SHAPE`, embedded below.
+ *
+ * The two sections before `## FINDINGS` are what the flow adds, because the flow
+ * — unlike the skill's dispatcher — has no human reading the reply and so must
+ * be able to check the obligations itself.
  *
  * There is no JSON. A reply constrained to one JSON object has nowhere to put
  * the per-AC and per-function enumerations both dimension references depend on,
@@ -335,10 +367,13 @@ ${walk}. This is the enumeration your dimension reference requires. One line eac
 no prose. A missing or empty WALK section is an incomplete review.
 
 ## FINDINGS
-The \`[SEVERITY] …\` blocks defined in the worker protocol above — or the literal
-line \`No findings.\` if you found none. This section is the only thing that
-becomes a finding; the two above are the evidence that you were in a position to
-write it.`;
+One block per finding, in exactly this shape:
+
+${FINDING_BLOCK_SHAPE}
+
+Or the literal line \`No findings.\` if you found none. This section is the only
+thing that becomes a finding; the two above are the evidence that you were in a
+position to write it.`;
 }
 
 /**
@@ -386,7 +421,7 @@ export function buildReviewPrompt(
       `You are the ${phase.toUpperCase()} reviewer for a completed feature.`,
       `The spec/requirements source is: ${args.specPath}. Read it in full.`,
       `Fetch and review the diff: \`git diff ${args.base}...HEAD\` (also \`--name-only\` for the file list).`,
-      WORKER_PROTOCOL,
+      WORKER_PROTOCOL_MECHANICS,
       dims,
       CLASSIFIER,
       outputContract(phase),
@@ -404,7 +439,7 @@ export function buildReviewPrompt(
       "",
       `Read whatever files you need — the spec is at ${args.specPath} and the whole repo is available. Scope means *what you judge*, not *what you may read*.`,
     ].join("\n"),
-    WORKER_PROTOCOL,
+    WORKER_PROTOCOL_MECHANICS,
     dims,
     CLASSIFIER,
     outputContract(phase),
@@ -466,3 +501,11 @@ export function fixPrompt(
     ].join("\n"),
   ].join("\n\n");
 }
+
+/**
+ * The protocol as the post-impl-review skill ships it, kept whole and exported
+ * so it stays byte-diffable against that skill's
+ * `references/worker-protocol.md` — the reason it was inlined verbatim. Nothing
+ * in this flow assembles it; `buildReviewPrompt` uses the mechanics alone.
+ */
+export const WORKER_PROTOCOL = `${WORKER_PROTOCOL_MECHANICS}${WORKER_PROTOCOL_OUTPUT_FORMAT}`;

--- a/test/unit/flows/nax-finish/review-prompts.test.ts
+++ b/test/unit/flows/nax-finish/review-prompts.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  FINDING_BLOCK_SHAPE,
   QUALITY_REVIEW_DIMENSIONS,
   SPEC_REVIEW_DIMENSIONS,
+  WORKER_PROTOCOL,
+  WORKER_PROTOCOL_MECHANICS,
   buildReviewPrompt,
   fixPrompt,
 } from "@flows/nax-finish/review-prompts";
@@ -132,5 +135,90 @@ describe("buildReviewPrompt — incremental re-review", () => {
       expect(p).toContain("Confidence threshold");
       expect(p).toContain("## FINDINGS");
     }
+  });
+});
+
+// The assembled prompt used to carry two contradictory output contracts.
+// `WORKER_PROTOCOL` closes with "## Output format — return ONLY this" ("return
+// only your findings, nothing else: ... no `FINDINGS` divider"), and
+// `outputContract` then demands three headed sections. The negative instruction
+// came first and was the more emphatic of the two.
+//
+// The sharpest edge is the clean review: "return the literal line `No findings.`
+// as your entire final message" forbids emitting ## TOUCHPOINTS and ## WALK at
+// all when nothing was found — which is exactly what `steps/review-audit.ts`
+// treats as an incomplete review. Both quality reviews ever recorded came back
+// `outcome: "unparseable"` on their first attempt.
+describe("buildReviewPrompt — exactly one output contract", () => {
+  const CASES = [
+    { phase: "spec" as const, since: null },
+    { phase: "spec" as const, since: "abc123" },
+    { phase: "quality" as const, since: null },
+    { phase: "quality" as const, since: "abc123" },
+  ];
+
+  for (const { phase, since } of CASES) {
+    const label = `${phase} / ${since ? "re-review" : "first round"}`;
+
+    test(`${label}: the worker protocol's competing output format never reaches the prompt`, () => {
+      const p = buildReviewPrompt(phase, {
+        base: "origin/main",
+        specPath: "s.md",
+        since,
+        priorFindings: since ? [{ severity: "HIGH", title: "T", problem: "P", fix: "F" }] : undefined,
+      });
+      expect(p).not.toContain("## Output format");
+      expect(p).not.toContain("return ONLY this");
+      expect(p).not.toContain("nothing else");
+      expect(p).not.toContain("entire final message");
+      expect(p).not.toContain("no `FINDINGS` divider");
+    });
+
+    test(`${label}: the reply contract survives, block shape included`, () => {
+      const p = buildReviewPrompt(phase, {
+        base: "origin/main",
+        specPath: "s.md",
+        since,
+        priorFindings: since ? [{ severity: "HIGH", title: "T", problem: "P", fix: "F" }] : undefined,
+      });
+      expect(p).toContain("## TOUCHPOINTS");
+      expect(p).toContain("## WALK");
+      expect(p).toContain("## FINDINGS");
+      // Dropping the worker protocol's output section must not take the block
+      // template with it — `outputContract` used to just point at it.
+      expect(p).toContain("[SEVERITY] <short title>");
+      expect(p).toContain("Problem:");
+      expect(p).toContain("Fix:");
+      // A clean review still has a way to say so, from the reply contract.
+      expect(p).toContain("No findings.");
+    });
+
+    test(`${label}: the mechanics the worker still needs are all present`, () => {
+      const p = buildReviewPrompt(phase, {
+        base: "origin/main",
+        specPath: "s.md",
+        since,
+        priorFindings: since ? [{ severity: "HIGH", title: "T", problem: "P", fix: "F" }] : undefined,
+      });
+      expect(p).toContain("Worker protocol (shared mechanics)");
+      expect(p).toContain("## Filter noise");
+      expect(p).toContain("## Severity table");
+      expect(p).toContain("## Read the unchanged collaborators");
+    });
+  }
+
+  // The whole constant stays exported and byte-identical to the skill's
+  // references/worker-protocol.md, which is why it was inlined verbatim in the
+  // first place. Only what the *flow* assembles changes.
+  test("WORKER_PROTOCOL is still whole, and the mechanics are a strict prefix of it", () => {
+    expect(WORKER_PROTOCOL).toContain("## Output format — return ONLY this");
+    expect(WORKER_PROTOCOL).toContain("entire final message");
+    expect(WORKER_PROTOCOL.startsWith(WORKER_PROTOCOL_MECHANICS)).toBe(true);
+    expect(WORKER_PROTOCOL_MECHANICS).not.toContain("## Output format");
+  });
+
+  test("the finding block shape is its own constant, shared by both", () => {
+    expect(FINDING_BLOCK_SHAPE).toContain("[SEVERITY] <short title>");
+    expect(WORKER_PROTOCOL).toContain(FINDING_BLOCK_SHAPE);
   });
 });


### PR DESCRIPTION
## Problem

The assembled `nax-finish` review prompt carried **two contradictory output contracts**.

`WORKER_PROTOCOL` closes with:

> ## Output format — return ONLY this
> Return **only your findings**, nothing else: no `Spec:`/`Base:` header, no `FINDINGS` divider, no `VERDICT` line...

and `outputContract`, appended ~40 lines later, demands three headed sections — `## TOUCHPOINTS`, `## WALK`, `## FINDINGS`. The negative instruction came first and was the more emphatic of the two. The existing comment on `outputContract` acknowledged the overlap ("This supersedes the 'Output format' section... kept verbatim so it stays diffable against the skill's `references/worker-protocol.md`"), but both were still being sent to the model.

The sharpest edge is the **clean** review. `WORKER_PROTOCOL` requires the literal line `No findings.` as the reviewer's *"entire final message"*, which forbids emitting `## TOUCHPOINTS` and `## WALK` at all when nothing was found — precisely what `steps/review-audit.ts` then treats as an incomplete review, routing `incomplete` and burning a re-review.

A reviewer that obeys the first instruction emits no headings, so `parseReviewReport` finds nothing, the JSON fallback tier fails, and the verdict routes `reprompt`. With `MAX_REPROMPT_ATTEMPTS = 1`, the next miss escalates the run.

Every quality review recorded in `finish-audit` so far came back `outcome: "unparseable"` on its first attempt.

## Fix

Split the one constant into three:

- **`WORKER_PROTOCOL_MECHANICS`** — diff fetching, noise filter, collaborator reads, severity table. This is what `buildReviewPrompt` now assembles.
- **`FINDING_BLOCK_SHAPE`** — the `[SEVERITY] / Problem: / Fix:` template. Extracted because `outputContract`'s `## FINDINGS` previously said only *"the `[SEVERITY]` blocks defined in the worker protocol above"* — dropping that section wholesale would have taken the block template with it. It is now embedded directly in the reply contract.
- **`WORKER_PROTOCOL`** — unchanged in value, still exported.

The reviewer now receives exactly one contract, and it is the one `parseReviewReport` actually reads.

`references/worker-protocol.md` in the skills repo is deliberately **not** touched: its dispatcher genuinely wants "return only findings", because it adds the surrounding sections itself. The contradiction was specific to this flow's assembly.

## Test plan

- [x] New `describe("buildReviewPrompt — exactly one output contract")` covers both phases across both the first-round and re-review branches: asserts the competing instructions are absent, the three-section contract and the block shape are present, and the mechanics the worker still needs survive.
- [x] Confirmed **RED before GREEN** — the assertions fail against the previous assembly, so they are not tautological.
- [x] `WORKER_PROTOCOL` proven **byte-identical** to its previous value by evaluating the old literal from `git show HEAD` and comparing at runtime. The byte-diffability against the skill reference — the reason it was inlined verbatim — is preserved.
- [x] `bun test test/unit/flows/` — 555 pass, 0 fail across 29 files.
- [x] `bun x tsc --noEmit` and `bun run lint` clean.

Prompt size drops slightly as a side effect: spec 12,983 → 12,582 chars, quality 10,191 → 9,790.

## Note

This is a prompt change, so the unit tests only lock in that the contradiction cannot return. The real signal is the next finish run: a quality round with no `outcome: "unparseable"` on attempt 1.
