### PR TITLE
feat(finish): PR and escalation layer for native nax-finish

### DIFF
--- a/docs/20260819-review-finish-pr-escalate.md
+++ b/docs/20260819-review-finish-pr-escalate.md
@@ -1,0 +1,155 @@
+> **Update 2026-08-19:** Every finding below except ENH-6 has been fixed (see
+> "Resolution" note per finding). ENH-6 was investigated and found to be
+> parity with `flows/nax-finish/nax-finish.flow.ts`, which drops `channel`
+> from the persisted result too — not a port-fidelity defect, so left as-is
+> pending a real plan-5 decision on whether to add the field at all.
+> `tsc`/`lint`/ratchets/tests all still pass after the fixes.
+
+# Deep Code Review: finish PR/escalation layer (`feat/finish-pr-escalate`)
+
+**Date:** 2026-08-19
+**Reviewer:** Claude (AI)
+**Branch:** `feat/finish-pr-escalate` vs `main`
+**Plan:** `docs/superpowers/plans/2026-08-19-finish-pr-escalate.md`
+**Files:** 23 changed (~2000 LOC `src/`, ~1500 LOC `test/`)
+**Gates:** `bun x tsc --noEmit` PASS · `bun run lint` PASS (all ratchets unchanged: `test-as-unknown-as` 830/830, `test-typecheck` 2014/2014) · `bun test test/unit/finish test/unit/forge test/unit/plugins` — 1026 pass / 0 fail
+
+---
+
+## Overall Grade: A- (86/100)
+
+The port is faithful to the plan's architecture to an unusually high degree: the template merger is provably byte-identical to the `flows/` original (confirmed by diff and by the required drift-guard test), `machine.ts`'s diff is exactly the one mandated `state.gatesRan = gates.ran` assignment, `flows/` is completely untouched, and the four throw/no-throw contracts (D4.3–D4.6) are implemented with the right asymmetry in the right places. The residual risk is narrow and concentrated at the fail-open/fatal boundary in the PR-composition path — one real HIGH bug and a couple of MEDIUM gaps, all one try/catch or one test away from closed.
+
+---
+
+## Findings
+
+### 🟠 HIGH
+
+#### BUG-1: `openDraftFinishPr` can throw despite its "never throws" contract
+**Severity:** HIGH | **Category:** Bug
+**File:** `src/finish/pr/open.ts:134-139`
+
+`hasOpenPr` is wrapped in try/catch, but the subsequent `openPr(...)` call is not. `openPr` only converts a *non-zero exit* into `success: false` — a rejecting `deps.run` (e.g. `gh` not installed, or the wall-clock-timeout path throwing) propagates straight out of `openDraftFinishPr` → `ops.openDraftPr` → the machine's outer catch, escalating an otherwise healthy run at step 3.
+
+**Risk:** Violates D4.5, which explicitly lists "a forge CLI that could not answer" as a return-null case. On any machine without a working `gh`/`glab` binary, every finish run would escalate at the draft-open step instead of just skipping the draft.
+
+**Fix:** Wrap the `openPr(...)` call (or the whole function body) in the same try/catch that already guards `hasOpenPr`, returning `null` on any throw.
+
+**Resolution:** Fixed — `openDraftFinishPr` now wraps its whole body in one try/catch. `ops-impl.ts`'s `openDraftPr` was also hardened the same way for the ctx-load/render step above it, and a regression test (`openDraftPr returns null rather than throwing when the forge cannot be spawned, per D4.5`) was added.
+
+---
+
+### 🟡 MEDIUM
+
+#### BUG-2: `promotePr` treats a body-render failure as fatal, not just a push failure
+**Severity:** MEDIUM | **Category:** Bug
+**File:** `src/finish/ops-impl.ts:136-148`
+
+D4.6 deliberately makes `commitAndPush` and `openOrPromotePr` fatal. But `loadFinishPrContext` / `buildFinishBody` sit between them, uncaught — a render-time throw (e.g. a `Finding` shape `escapeTableCell` can't handle) escalates a run whose branch is already pushed and whose gates are all green. This is the exact "already-promoted green run rewritten to escalated" failure D4.4 exists to prevent for `narrate`, one call earlier in the same terminal path.
+
+**Fix:** Either wrap the context-load/render step in try/catch with a minimal title/body fallback, or confirm (and document) that the loader's fail-open guarantees make this unreachable in practice — currently that guarantee is asserted, not tested at this call site.
+
+**Resolution:** Fixed — added `buildPrContentOrFallback` in `ops-impl.ts`, which wraps the load+render step and falls back to a generic `fix(<feature>): nax-finish automated fixes` title and an explanatory body on any throw. `promotePr` now always calls `openOrPromotePr`, never aborting on a render failure once the push has already succeeded.
+
+#### BUG-3: `escalate` drops the D4.7 sync note on the no-forge path
+**Severity:** MEDIUM | **Category:** Bug
+**File:** `src/finish/ops-impl.ts:152-159`
+
+`syncNote` is computed from a failed `commitAndPush`, then the function immediately returns `{ deliveryError: "no forge detected" }`, discarding it. The one case where a human most needs "the partial fixes were never pushed either" is exactly the case where that information is silently lost.
+
+**Fix:** Fold `syncNote` into the `deliveryError` string (or a structured field) before returning on the no-forge branch.
+
+**Resolution:** Fixed — `escalate` now tracks `pushError` separately and folds it into the no-forge `deliveryError` string (`"no forge detected; partial fixes could not be pushed either: ..."`). A regression test asserts the sync note reaches the posted comment on the forge-present path.
+
+#### ENH-4: D4.7's sync-note behaviour is untested
+**Severity:** MEDIUM | **Category:** Enhancement (test coverage)
+**File:** `test/unit/finish/ops-impl.test.ts:147-159`
+
+The only escalate-push test asserts the wip commit message, not that a `commitAndPush` failure appends `> Note: nax-finish could not push its partial fixes` to the comment — the actual locked decision. Also untested: D4.6's "push failure is fatal" for `promotePr`, `escalate` returning `{ url }` on success, and `openDraftPr` returning `null` when `forgeKind` is null.
+
+**Fix:** Add the missing assertions; these are exactly the paths BUG-1/BUG-3 would have been caught by.
+
+**Resolution:** Fixed — added `promotePr rejects when the push fails, per D4.6`, `escalate appends a sync note to the comment when the partial-fix push fails, per D4.7`, and `escalate returns the delivered url on a successful comment` to `ops-impl.test.ts`.
+
+#### ENH-5: D4.12's own stated test criterion — "the field survives to the rendered body" — isn't actually checked end-to-end
+**Severity:** MEDIUM | **Category:** Enhancement (test coverage)
+**File:** `test/unit/finish/machine-end-to-end.test.ts:262`
+
+Coverage of `gatesRan` is split across three disjoint unit tests (machine sets it, loader reads it, renderer emits it), but the end-to-end green-path test only asserts `## Verification` is present, not a `- Gates:` line. The plan's own rationale for D4.12 is that a dropped wire renders as *no line at all* and would go unnoticed — which is precisely the scenario this gap leaves unguarded.
+
+**Fix:** Add `expect(lastEditBody).toContain("- Gates: ...")` to the green-path e2e test.
+
+**Resolution:** Fixed — `machine-end-to-end.test.ts`'s green-path test now asserts `lastEditBody` contains `"- Gates: test"` (the fixture's configured gate command).
+
+---
+
+### 🟢 LOW
+
+#### ENH-6: `EscalationOutcome.channel` is computed then discarded
+**File:** `src/finish/ops-impl.ts:165`
+`postEscalation` returns which channel was used (`"telegram" | "pr-comment"`), but the adapter drops it and `FinishResult` has no field for it. Per `escalate.ts`'s own comment, the plugin needs to read this from the result file to know whether it should still send a Telegram message. Likely intended for plan 5, but worth flagging now since the value is thrown away here.
+
+**Resolution:** Not changed. `flows/nax-finish/nax-finish.flow.ts:462-475` computes the identical `channel` value at its escalate node and *also* never persists it onto `FinishResult` (`flows/nax-finish/types.ts:226-252` has no `channel` field either) — the native port is exact parity with the flow, not a regression introduced by this plan. Adding a `channel` field to `FinishResult` would be new scope beyond what any of D4.1-D4.12 calls for, and the plan explicitly reserves config/plugin wiring for plan 5. Left as a flagged gap for that plan rather than fixed here.
+
+#### STYLE-7: `src/forge/deps.ts` comments are stale after the lift
+**File:** `src/forge/deps.ts:23-24, 47`
+Points at a nonexistent path (`src/plugins/builtin/nax-finish/index.ts:66-97`), references a test seam (`_autoPrDeps`) this module doesn't have, and the hardcoded timeout message (`"[auto-pr] command killed..."`) will misattribute a wedged `git push` during a finish run to auto-PR in the escalation comment. D4.11 mandated a verbatim lift of the *code*, not comments only true at the old call site.
+
+**Resolution:** Fixed — the header comment now points at the real `defaultRun` source (`src/plugins/builtin/auto-pr/index.ts`) and describes the actual test-seam split (auto-pr keeps `_autoPrDeps`, this module's callers inject `ForgeDeps` directly). The timeout stderr tag was changed from `[auto-pr]` to `[forge]` so a wedged subprocess during a finish run doesn't misattribute itself to auto-PR; confirmed no test asserts the old string.
+
+#### STYLE-8: `updatePrBody` bypasses the module's own injectable warn seam
+**File:** `src/finish/pr/open.ts:103, 108`
+Calls `process.emitWarning` directly instead of routing through `_finishPrDeps.warn` like its sibling `context.ts` does for the identical concern. Consequence: the failure-path tests can only assert "did not throw," not that a warning fired, and the test run prints unsuppressable stack traces.
+
+**Resolution:** Fixed — added a module-local `_openDeps.warn` seam in `open.ts` (mirroring `_finishPrDeps.warn`'s shape, since `ForgeDeps` itself has no `warn` method and adding one would ripple beyond this module) and routed both `updatePrBody` failure branches through it. The `process.emitWarning` calls in the test output are unchanged in the two `updatePrBody` tests, since those still exercise the real default — this is a testability seam, not a behavior change.
+
+#### STYLE-9: Inconsistent error stringification within one function
+**File:** `src/finish/ops-impl.ts:156` (`String(err)`) vs `:167` (`errorMessage(err)`)
+`String(naxError)` yields `"NaxError: <msg>"`, differing from every other error surface in the module. Faithful to the original flow's behavior, so low priority, but worth normalizing since `errorMessage` is imported two lines away.
+
+**Resolution:** Fixed as part of the BUG-3 change — `escalate` now uses `errorMessage(err)` for the push failure too, consistently with the rest of the module.
+
+#### BUG-10: `fix` spreads `callCtx` without clearing `sessionOverride`
+**File:** `src/finish/ops-impl.ts:117`
+`{ ...callCtx }` inherits any `sessionOverride` already present on the caller's context. Inert today (nothing wires a context with one yet), but once plan 5 does, a fix call could silently inherit a reviewer role. Pass `callCtx` unchanged or explicitly clear the field to make intent unambiguous.
+
+**Resolution:** Fixed — `fix()` now spreads `{ ...callCtx, sessionOverride: undefined }`, explicitly clearing any inherited role.
+
+#### STYLE-11: New test files fail `biome check` (pre-existing pattern, not a regression)
+`test/unit/finish/{escalate,machine-end-to-end,machine-loops,ops-impl,pr-context}.test.ts`, `test/unit/forge/template-merge.test.ts` have import-order/formatting violations. `bun run lint` doesn't run biome over `test/`, and existing files (`test/unit/finish/route.test.ts`) fail identically, so this doesn't block the ratchets — noted only so it isn't mistaken for a clean biome pass.
+
+---
+
+## Priority Fix Order
+
+| Priority | ID | Effort | Description |
+|:---|:---|:---|:---|
+| P0 | BUG-1 | S | `openDraftFinishPr`: wrap `openPr` call so it never throws (D4.5) |
+| P1 | BUG-3 | S | `escalate`: fold sync note into the no-forge return |
+| P1 | ENH-4 | S | Add tests for D4.6/D4.7 fatal-push and sync-note paths |
+| P1 | ENH-5 | S | Assert `- Gates:` line survives in the e2e green path |
+| P2 | BUG-2 | M | Decide/implement fail-open behavior for body-render failure in `promotePr` |
+| P2 | BUG-10 | S | Clear `sessionOverride` when building the fix call context |
+| P3 | ENH-6, STYLE-7/8/9 | S | Wire `channel` through, fix stale comments, use `_finishPrDeps.warn`, normalize error stringification |
+
+---
+
+## Locked-Decision Compliance (D4.1–D4.12)
+
+All confirmed compliant except the narrow gaps above (D4.5 partially violated by BUG-1; D4.6/D4.7 correctly implemented but under-tested):
+
+- **D4.1** — `flows/` untouched (`git diff main...HEAD -- flows/` empty); `src/forge/template-merge.ts` byte-identical to the original apart from the mandated header swap; drift-guard equivalence test present.
+- **D4.2** — context/body/open/index split matches exactly.
+- **D4.3** — `postEscalation` throws `NaxError`s with correct codes; adapter catches and returns `{ deliveryError }`.
+- **D4.4** — `narrate`'s full body is wrapped, not just the LLM call.
+- **D4.5** — mostly correct; see BUG-1.
+- **D4.6** — push-then-promote, both fatal, correctly implemented; see BUG-2 for the render-step gap between them.
+- **D4.7** — best-effort push implemented; see BUG-3 for the dropped note on one branch.
+- **D4.8** — `prBody` is a factory option using the existing `FinishPrBodySettings` type; no new type declared.
+- **D4.9** — `_finishOpsDeps = { callOp }` seam present and exported from `@/finish`.
+- **D4.10** — `sessionOverride.role` set to `"finish-review-spec"` / `"finish-review-quality"`, no new resolver field.
+- **D4.11** — `defaultForgeDeps` is a straight lift including the timeout mapping; auto-PR's own copy untouched.
+- **D4.12** — `machine.ts` diff is exactly the one assignment; see ENH-5 for the missing e2e assertion.
+
+Import discipline, file-size caps, `as unknown as` ratchet, and the no-emoji rule all hold with no violations found.

--- a/docs/superpowers/plans/2026-08-19-finish-pr-escalate.md
+++ b/docs/superpowers/plans/2026-08-19-finish-pr-escalate.md
@@ -1,0 +1,1253 @@
+# Finish PR, Escalation and the Concrete `FinishOps` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `src/finish/` the two halves it still lacks — everything that talks to a forge (PR context, body, title, draft-open, push-and-promote, escalation delivery) and the concrete `FinishOps` object that binds those plus plan 3's three `RunOperation`s to the state machine — so that after this plan `runFinishMachine` can be driven end to end with nothing stubbed but the process boundary.
+
+**Architecture:** The PR body stays a deterministic string join over artifacts on disk: a loader (`pr/context.ts`) assembles a `FinishPrContext` from `prd.json`, `status.json`, the audit trail, a diffstat and the repo template; a pure renderer (`pr/body.ts`) turns it into markdown merged into the repo's own PR template. Forge traffic goes through `@/forge`, which already owns detection, `openPr`, `hasOpenPr`, `viewArgv`, `extractUrl` and `findPrTemplate` — this plan adds only what `src/forge/` does not have (promote-to-ready, body edit) and moves the one shared module still living under `flows/`. `ops-impl.ts` is a factory: it closes over a `CallContext`, per-phase model selections and forge deps, and returns a `FinishOps` whose LLM methods are `callOp` calls with a per-phase `sessionOverride.role` and whose forge methods are the modules below. Nothing is wired into the runner; `flows/nax-finish/` keeps running untouched.
+
+**Tech Stack:** TypeScript, Bun (test runner and toolchain), Biome (format/lint).
+
+**Spec:** `docs/superpowers/specs/2026-08-18-native-nax-finish-design.md` — this plan implements the PR/escalation half of **cutover step 2**. Read sections 4.2 (module decomposition), 4.5 (operations) and 4.7 (the draft-PR lifecycle, D7) before starting.
+
+**Predecessors:**
+- `docs/superpowers/plans/2026-08-18-forge-shared-module.md` — PR #1626. `src/forge/` exists.
+- `docs/superpowers/plans/2026-08-18-finish-core.md` — PR #1627. `src/finish/` core exists.
+- `docs/superpowers/plans/2026-08-18-finish-review-ops.md` — PR #1628. The review layer and the three `RunOperation`s exist.
+
+**Read before starting, in this order:** `src/finish/ops.ts` (the contract this plan fills), `src/finish/machine.ts` (its only consumer — every call site and every "must not throw" claim below is stated there), `src/forge/index.ts` (what you must not re-port), `src/finish/operations/index.ts` (what plan 3 already gives you).
+
+## Global Constraints
+
+Unchanged from plans 2 and 3; repeated because they are the ones a worker trips over.
+
+- Runtime is **Bun**. `src/` is Bun-native. **This plan does not delete anything under `flows/`** — it is still the live implementation until plan 5. The single exception is Task 1, which *moves* one file that `src/` already imports.
+- **Duplication with `flows/nax-finish/` is expected for the whole of this plan.** Both trees exist; only one is wired. Do not edit `flows/` (Task 1's deletion aside) and do not import from `flows/` in new code.
+- **File size caps:** 600 lines for `src/`, 800 for `test/` (`scripts/check-file-sizes.ts`). `wc -l` every file before you add to it.
+- **No emojis** in code, comments, or documentation.
+- **Imports:** `@/` alias for other modules, **relative inside `src/finish/`** (`./types`, `../route`) and inside `src/forge/`, because both have a barrel and `scripts/check-alias-internals.ts` flags a value import reaching past one. `@/forge`, `@/config`, `@/operations`, `@/errors` — never their subpaths from outside.
+- `scripts/check-deep-relatives.ts` has a frozen baseline — **new tests import `@/finish`, `@/forge` and `@test/helpers`**, never `../../../src/...` or `../../helpers`. Copy the style of `test/unit/finish/gates-quality.test.ts`. If the baseline must move, use `bun run check:deep-relatives:update` and say so in the commit.
+- **Temp directories in tests:** `makeTempDir` / `cleanupTempDir` / `withTempDir` from `test/helpers/temp.ts`. `.nax/rules/forbidden-patterns-tests.md` forbids hand-rolled `rm -rf` cleanup.
+- **Errors:** `NaxError` from `src/errors.ts` with a `FINISH_*` / `FORGE_*` code. `scripts/check-nax-error.ts` has a baseline — do not add violations.
+- **Commits:** conventional commits. Attribution is disabled globally; no co-author trailers.
+- **Branch:** `feat/finish-pr-escalate`, created from `main` (already created alongside this plan).
+- **Gates before every commit:** `bun x tsc --noEmit`, `bun run lint`, and the task's own tests. A pre-commit hook runs the full static-check suite and will reject the commit if anything fails.
+
+---
+
+## Locked Decisions
+
+Read these before Task 1. They were settled against the real code; do not re-derive them.
+
+**D4.1 — `pr-template-merge.ts` moves to `src/forge/template-merge.ts`.** It is the one module under `flows/` that `src/` already imports (`src/plugins/builtin/auto-pr/pr-body.ts:16`, via the `@flows/*` tsconfig alias). Finish's native body builder needs it too, and plan 5 deletes `flows/`, so it must move now rather than acquire a second consumer of a doomed path. It lands in `src/forge/` and not `src/finish/` because auto-pr must not import `@/finish` internals, and `src/forge/` is already the shared home for the sibling concern (`findPrTemplate`). The `flows/` copy is **left in place** — `flows/` cannot import `src/` and the flow still runs — and dies with the rest of `flows/` in plan 5. The now-unused `@flows/*` alias in `tsconfig.json` also stays until then.
+
+**D4.2 — the PR subtree is `src/finish/pr/{context,body,open,index}.ts`.** `flows/nax-finish/steps/pr-body.ts` is 462 lines doing two jobs (load artifacts, render markdown). Split at that seam: the loader is I/O and fail-open policy, the renderer is pure and is where every future body change lands. Both stay well under the 600-line cap, and the renderer being pure is what lets its tests run with no disk at all.
+
+**D4.3 — `postEscalation` may throw; `FinishOps.escalate` may not.** The ported `postEscalation` keeps its `FinishError` throws (a comment that could not be posted and a draft that could not be opened are different failures and the message says which). The *adapter* in `ops-impl.ts` wraps it in try/catch and returns `{ deliveryError }`, which is what `src/finish/ops.ts` documents and what `machine.ts`'s `doEscalate` expects. Do not soften `postEscalation` into a non-throwing function; do not let the adapter propagate.
+
+**D4.4 — `narrate` must swallow everything.** `machine.ts`'s `finishTerminal` calls `ops.narrate` *after* `ops.promotePr`, inside the outer try. A throw there sends an already-promoted green run to `doEscalate` and rewrites its status to `escalated`. `finishNarrativeOp` already has `recover` for an empty reply, but `detectForge`, the context load and the body edit can all still throw, so the whole `narrate` body is wrapped in try/catch and warns — the same reasoning `flows/nax-finish/steps/pr-narrative.ts` states for `amendPrBodyNode`.
+
+**D4.5 — a draft that cannot be opened is skipped, not fatal.** `openDraftPr` returns `null` on every unhappy path: no forge detected, `hasOpenPr` throwing (`FORGE_PR_LIST_FAILED` — BUG-8 made it throw precisely so the caller decides, and the safe decision here is "do not open a second one"), or `openPr` returning `success: false`. The draft is a convenience; the terminal `promotePr` creates the PR when none exists. Failing the run at step 3 for it would throw away work that is otherwise fine.
+
+**D4.6 — `promotePr` pushes first, and a push failure is fatal.** Faithful to `open_pr` in `flows/nax-finish/nax-finish.flow.ts`: `commitAndPush(workdir, branch, "fix(<feature>): nax-finish automated fixes")` then open-or-promote. Both throw on failure, and both *should* — a branch that will not push has no PR to promote, and `machine.ts`'s outer catch turns the throw into an escalation, which is the #1399 requirement that a dead end always reaches a human. `commitAndPush` and `PUSH_TIMEOUT_MS` already exist in `src/finish/commit.ts` and are currently called by nothing; this is their consumer.
+
+**D4.7 — escalation pushes partial fixes best-effort.** Also faithful to the flow: the escalate path tries `commitAndPush` so a human sees the partial work, and on failure appends a `syncNote` to the comment rather than losing the escalation itself. The push is inside its own try/catch, never outside.
+
+**D4.8 — template mode and section map are factory options, not config reads.** They live at `finish.autoFlow.prBody` today, and `autoFlow` is the plugin-shaped block plan 5 reshapes. `createFinishOps` takes `prBody?: { template?: TemplateMode; sectionMap?: Record<string, string> }` defaulting to `{ template: "merge", sectionMap: {} }`, and plan 5 supplies it from config. Same for the four model selections and `preferTelegram`. This plan reads no config for PR composition.
+
+**D4.9 — `callOp` is injected through `_finishOpsDeps`.** `src/finish/ops-impl.ts` exports `export const _finishOpsDeps = { callOp }` and calls `_finishOpsDeps.callOp(...)`, matching `_callOpDeps` / `_autoPrDeps` / `_finishGitDeps`. Without it, every test of the factory needs a `NaxRuntime`. The seam is exported from `@/finish` so tests reach it without a deep relative.
+
+**D4.11 — the default `ForgeDeps` implementation moves into `src/forge/`.** `ForgeDeps` is `src/forge/`'s own contract but the module ships no default implementation, so the only one in the repo is `defaultRun` / `defaultReadText` inside `src/plugins/builtin/auto-pr/index.ts`. `src/finish/` must not import from `@/plugins` — that inverts the layering, and the plugin's copy is wrapped in a test seam (`_autoPrDeps`) with its own baseline of tests. Task 1 therefore adds `src/forge/deps.ts` exporting `defaultForgeDeps: ForgeDeps`, a straight lift of those two functions including the wall-clock cap (a wedged `gh` must not hang a run's completion phase). Auto-PR keeps its own copy for now; converging it is a plan 5 opportunity, not this plan's scope.
+
+**D4.10 — per-phase reviewer role goes through `sessionOverride.role`.** `finishReviewOp.session.role` is the static default `"finish-review-spec"`; the factory passes `{ ...ctx, sessionOverride: { role: phase === "spec" ? "finish-review-spec" : "finish-review-quality" } }`. This is settled in plan 3's header comment and matches `src/plan/critic.ts`. Do not add a resolver field to `RunOperation`.
+
+---
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+| --- | --- |
+| `src/forge/template-merge.ts` | Moved from `flows/nax-finish/pr-template-merge.ts`. `mergeTemplate`, `BodySection`, `TemplateMode`, `MergeOptions`, `DEFAULT_SECTION_ALIASES`. |
+| `src/forge/deps.ts` | `defaultForgeDeps` — the default `ForgeDeps` implementation (D4.11). |
+| `src/finish/pr/context.ts` | `loadFinishPrContext`, `FinishPrContext`, `FinishPrStory`, `_finishPrDeps`. Artifact reads, diffstat, template load. All fail-open. |
+| `src/finish/pr/body.ts` | `buildFinishBody`, `buildFinishTitle`. Pure renderers over `FinishPrContext`. |
+| `src/finish/pr/open.ts` | `openDraftFinishPr`, `openOrPromotePr`, `updatePrBody`, `parseView`. |
+| `src/finish/pr/index.ts` | Barrel for the PR subtree. |
+| `src/finish/escalate.ts` | `buildEscalationComment`, `postEscalation`, `EscalationOutcome`. |
+| `src/finish/ops-impl.ts` | `createFinishOps`, `FinishOpsDeps`, `_finishOpsDeps`. |
+| `test/unit/forge/template-merge.test.ts` | Ported from `test/unit/flows/nax-finish/pr-template-merge.test.ts`. |
+| `test/unit/finish/pr-context.test.ts` | Loader: artifact parsing, fail-open paths, diffstat pathspec. |
+| `test/unit/finish/pr-body.test.ts` | Renderer, ported from `test/unit/flows/nax-finish/pr-body.test.ts`. |
+| `test/unit/finish/pr-open.test.ts` | Draft open, promote, body edit, `parseView`. |
+| `test/unit/finish/escalate.test.ts` | Comment shape, channel selection, failure modes. |
+| `test/unit/finish/ops-impl.test.ts` | The factory: role overrides, non-throwing contracts, adapter shapes. |
+| `test/unit/finish/machine-end-to-end.test.ts` | `runFinishMachine` driven by a real `createFinishOps` over fake process/disk boundaries. |
+
+**Modified:**
+
+| File | Change |
+| --- | --- |
+| `src/plugins/builtin/auto-pr/pr-body.ts` | Import `mergeTemplate` from `@/forge`, not `@flows/nax-finish/pr-template-merge`. |
+| `src/forge/index.ts` | Export the template-merge surface. |
+| `src/finish/index.ts` | Export the PR subtree, escalation and the ops factory. |
+
+**Deleted:**
+
+| File | Why |
+| --- | --- |
+| `flows/nax-finish/pr-template-merge.ts` | Moved to `src/forge/` (D4.1). Nothing under `flows/` imports it — verify with the grep in Task 1 Step 1 before deleting. |
+| `test/unit/flows/nax-finish/pr-template-merge.test.ts` | Moves with it. |
+
+---
+
+### Task 1: Move the template merger into `src/forge/`
+
+**Files:**
+- Create: `src/forge/template-merge.ts` (moved content)
+- Modify: `src/forge/index.ts`, `src/plugins/builtin/auto-pr/pr-body.ts:16`
+- Delete: `flows/nax-finish/pr-template-merge.ts`, `test/unit/flows/nax-finish/pr-template-merge.test.ts`
+- Test: `test/unit/forge/template-merge.test.ts` (moved content)
+
+**Interfaces:**
+- Produces: `mergeTemplate(template: string | null | undefined, sections: BodySection[], opts?: MergeOptions): string`; `interface BodySection { key: string; heading: string; body: string }`; `type TemplateMode = "merge" | "strict" | "ignore"`; `interface MergeOptions { mode?: TemplateMode; sectionMap?: Record<string, string> }`; `DEFAULT_SECTION_ALIASES: Record<string, string>`. Tasks 3 and 6 consume these; `src/plugins/builtin/auto-pr/pr-body.ts` already does.
+
+- [ ] **Step 1: Confirm nothing under `flows/` still imports it**
+
+```bash
+grep -rn "pr-template-merge" flows/ src/ test/ scripts/ tsconfig.json
+```
+
+Expected: exactly three importers — `flows/nax-finish/steps/pr-body.ts`, `src/plugins/builtin/auto-pr/pr-body.ts`, and the two test files. **If `flows/nax-finish/steps/pr-body.ts` imports it, the file cannot be deleted yet** (`flows/` cannot import `src/`): in that case copy it to `src/forge/template-merge.ts`, leave the `flows/` copy and its test alone, and note in the commit that the duplicate dies in plan 5. Everything else in this task is unchanged.
+
+- [ ] **Step 2: Move the file and its test**
+
+```bash
+git mv flows/nax-finish/pr-template-merge.ts src/forge/template-merge.ts
+git mv test/unit/flows/nax-finish/pr-template-merge.test.ts test/unit/forge/template-merge.test.ts
+```
+
+Then in `src/forge/template-merge.ts` replace the "Lives under `flows/` ... because `flows/` is the more constrained runtime" paragraph of the header comment with:
+
+```
+ * Lives in `src/forge/` because both consumers are here: the auto-PR plugin's
+ * body builder and `src/finish/pr/body.ts`. It was under `flows/` while the
+ * finish flow was the only other caller; `flows/` cannot import `src/`, so the
+ * flow keeps its own copy until plan 5 deletes that tree.
+```
+
+Leave every other line of the module byte-identical — the alias table and the merge semantics are settled behaviour (nax#1504, nax#1477) and this task changes neither.
+
+- [ ] **Step 3: Repoint the two importers**
+
+`src/forge/index.ts`, appended to the existing exports:
+
+```ts
+export type { BodySection, MergeOptions, TemplateMode } from "./template-merge";
+export { DEFAULT_SECTION_ALIASES, mergeTemplate } from "./template-merge";
+```
+
+`src/plugins/builtin/auto-pr/pr-body.ts:16`:
+
+```ts
+import { type BodySection, type MergeOptions, mergeTemplate } from "@/forge";
+```
+
+In `test/unit/forge/template-merge.test.ts`, change the import to `@/forge` (it is a new file in a directory whose sibling tests already use the alias).
+
+- [ ] **Step 4: Add the default `ForgeDeps` implementation (D4.11)**
+
+Create `src/forge/deps.ts`:
+
+```ts
+/**
+ * The default `ForgeDeps`: subprocess execution and file reads for every
+ * function in this module.
+ *
+ * Lifted from `defaultRun` / `defaultReadText` in
+ * `src/plugins/builtin/auto-pr/index.ts`, which was the only implementation of
+ * this module's own contract. `src/finish/` needs one too and must not import
+ * from `@/plugins`, so it lives with the contract instead. stdout and stderr
+ * are read concurrently with `proc.exited` so non-trivial output cannot
+ * deadlock, under a wall-clock cap so a wedged `gh` / `glab` / `git push`
+ * cannot hang a run's completion phase.
+ */
+```
+
+Copy `defaultRun`, `defaultReadText` and the `DEFAULT_SUBPROCESS_TIMEOUT_MS` constant from `src/plugins/builtin/auto-pr/index.ts` verbatim — including the `exitCode === 0 ? 124 : exitCode` timeout mapping — and export:
+
+```ts
+export const defaultForgeDeps: ForgeDeps = { run: defaultRun, readText: defaultReadText };
+```
+
+Add to `src/forge/index.ts`: `export { defaultForgeDeps } from "./deps";`. Do not modify the auto-PR plugin's copy in this task.
+
+- [ ] **Step 5: Run the moved test plus every consumer's test**
+
+Run: `bun test test/unit/forge/ test/unit/plugins/auto-pr* test/unit/flows/nax-finish/pr-body.test.ts`
+Expected: PASS, with no change to any assertion. The flow's own `pr-body.test.ts` still passes because the `flows/` copy is untouched (or, if Step 1 found the flow importing it, because the copy stayed).
+
+- [ ] **Step 6: Static checks and commit**
+
+```bash
+bun x tsc --noEmit && bun run lint && bun test test/unit/forge/
+git add -A
+git commit -m "refactor(forge): move the PR template merger and default deps into src/forge"
+```
+
+---
+
+### Task 2: The PR context loader
+
+**Files:**
+- Create: `src/finish/pr/context.ts`
+- Test: `test/unit/finish/pr-context.test.ts`
+
+**Interfaces:**
+- Consumes: `readRounds` and `AuditTarget` from `../audit`; `readSpecSummary`, `resolveNarrative`, `resolveTitle` from `../operations`; `findPrTemplate` and `ForgeKind` from `@/forge`; `TemplateMode` from `@/forge`; `featureDir` from `@/config`.
+- Produces:
+
+```ts
+export interface FinishPrStory { id: string; title: string; acCount: number }
+
+export interface FinishPrContext {
+  feature: string;
+  stories: FinishPrStory[];
+  outOfScope: string[];
+  acceptance?: string;
+  regression?: string;
+  gatesRan: string[];
+  diffstat?: string;
+  artifactSummary?: string;
+  template?: string;
+  templateMode?: TemplateMode;
+  templateSectionMap?: Record<string, string>;
+  narrative?: string;
+  title: string;
+  rounds: FinishRound[];
+  run: { durationMs?: number; storiesPassed?: number; storiesTotal?: number };
+}
+
+export interface LoadPrContextArgs {
+  state: FinishState;
+  audit: AuditTarget;
+  gatesRan: string[];
+  forge?: ForgeKind;
+  narrative?: string;
+  title?: string;
+  prBody?: { template?: TemplateMode; sectionMap?: Record<string, string> };
+}
+
+export async function loadFinishPrContext(args: LoadPrContextArgs): Promise<FinishPrContext>;
+export const _finishPrDeps: {
+  run(cmd: string[], opts: { cwd: string }): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  readText(path: string): Promise<string | null>;
+  warn(message: string, details: { path: string; error: unknown }): void;
+};
+```
+
+Task 3 consumes `FinishPrContext`; Task 6 calls `loadFinishPrContext`.
+
+**Port notes.** This is `loadFinishPrContext` from `flows/nax-finish/steps/pr-body.ts:217-268` plus its private helpers `readJson`, `storiesFrom`, `runGitDiff`, `runDiffstat`, `loadTemplate` and the `NAX_ARTIFACT_PATHSPEC` constant, with four substitutions:
+
+1. Input is a `FinishState` + `AuditTarget`, not a `FinishInput`. `feature`, `workdir`, `base` and `specPath` are already fields of `FinishState`; `readRounds` takes the `AuditTarget`.
+2. The PRD path is `join(featureDir(state.workdir, state.feature), "prd.json")` and status is its sibling `status.json`. The flow took a caller-supplied `prdPath` because acpx handed it one; in-process `featureDir` is the SSOT (`src/config/paths.ts:117`) and open-coding `.nax` is what shipped the stray-directory bug it warns about.
+3. `findPrTemplate(workdir, forge, deps)` comes from `@/forge` and takes `ForgeKind`, not the flow's `Forge`.
+4. `templateMode` / `templateSectionMap` come from `args.prBody` (D4.8), not from a config read.
+
+Everything else is a faithful port, **including every fail-open path and the comments explaining them**: `readJson` warns and returns `undefined` on a genuine read failure but is silent on ENOENT; `runDiffstat` returns `{}` on an empty `base` and `undefined` on any non-zero exit or throw; `loadTemplate` returns `undefined` when the forge is unknown or the read throws. The `NAX_ARTIFACT_PATHSPEC = "**/.nax/**"` glob and both `:(glob...)` pathspecs are load-bearing — copy them exactly, comment included.
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/unit/finish/pr-context.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { _finishPrDeps, createFinishState, loadFinishPrContext } from "@/finish";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+const originalDeps = { ..._finishPrDeps };
+let dir: string;
+
+function stateFor(workdir: string) {
+  return createFinishState({
+    feature: "demo",
+    workdir,
+    branch: "feat/demo",
+    runId: "run-1",
+    base: "origin/main",
+    specPath: ".nax/features/demo/spec.md",
+  });
+}
+
+beforeEach(async () => {
+  dir = await makeTempDir("pr-context");
+});
+
+afterEach(async () => {
+  Object.assign(_finishPrDeps, originalDeps);
+  await cleanupTempDir(dir);
+});
+
+describe("loadFinishPrContext", () => {
+  test("reads stories and out-of-scope from the feature's prd.json", async () => {
+    const featureDirPath = join(dir, ".nax", "features", "demo");
+    await mkdir(featureDirPath, { recursive: true });
+    await writeFile(
+      join(featureDirPath, "prd.json"),
+      JSON.stringify({
+        userStories: [{ id: "US-001", title: "First", acceptanceCriteria: [1, 2, 3] }],
+        outOfScope: ["not this"],
+      }),
+    );
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+      gatesRan: ["lint"],
+    });
+
+    expect(ctx.stories).toEqual([{ id: "US-001", title: "First", acCount: 3 }]);
+    expect(ctx.outOfScope).toEqual(["not this"]);
+    expect(ctx.gatesRan).toEqual(["lint"]);
+  });
+
+  test("drops a story row whose id or title is not a string", async () => {
+    const featureDirPath = join(dir, ".nax", "features", "demo");
+    await mkdir(featureDirPath, { recursive: true });
+    await writeFile(
+      join(featureDirPath, "prd.json"),
+      JSON.stringify({ userStories: [{ id: 7, title: "Bad" }, { id: "US-002", title: "Good" }] }),
+    );
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+      gatesRan: [],
+    });
+
+    expect(ctx.stories.map((s) => s.id)).toEqual(["US-002"]);
+  });
+
+  test("splits the diffstat from the nax-artifact summary using a glob pathspec", async () => {
+    const calls: string[][] = [];
+    _finishPrDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--shortstat")
+        ? { exitCode: 0, stdout: " 1 file changed, 5 insertions(+)\n", stderr: "" }
+        : { exitCode: 0, stdout: " src/a.ts | 2 +-\n", stderr: "" };
+    };
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+      gatesRan: [],
+    });
+
+    expect(ctx.diffstat).toContain("src/a.ts");
+    expect(ctx.artifactSummary).toBe("1 file changed, 5 insertions(+)");
+    const stat = calls.find((c) => c.includes("--stat"));
+    expect(stat).toContain(":(glob,exclude)**/.nax/**");
+    const shortstat = calls.find((c) => c.includes("--shortstat"));
+    expect(shortstat).toContain(":(glob)**/.nax/**");
+  });
+
+  test("skips the diffstat entirely when base is empty", async () => {
+    let ran = false;
+    _finishPrDeps.run = async () => {
+      ran = true;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const state = stateFor(dir);
+    state.base = "";
+
+    const ctx = await loadFinishPrContext({
+      state,
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+      gatesRan: [],
+    });
+
+    expect(ran).toBe(false);
+    expect(ctx.diffstat).toBeUndefined();
+  });
+
+  test("falls back to feat: <feature> when no title was produced", async () => {
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+      gatesRan: [],
+    });
+
+    expect(ctx.title).toBe("feat: demo");
+  });
+
+  test("carries the caller's template mode and section map", async () => {
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+      gatesRan: [],
+      prBody: { template: "strict", sectionMap: { notes: "narrative" } },
+    });
+
+    expect(ctx.templateMode).toBe("strict");
+    expect(ctx.templateSectionMap).toEqual({ notes: "narrative" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test test/unit/finish/pr-context.test.ts`
+Expected: FAIL — `loadFinishPrContext` is not exported from `@/finish`.
+
+- [ ] **Step 3: Port the loader**
+
+Create `src/finish/pr/context.ts` following the port notes above. The shape of the module, with the parts that must be copied verbatim from `flows/nax-finish/steps/pr-body.ts` marked:
+
+```ts
+/**
+ * Assembles a `FinishPrContext` from the artifacts a finish run leaves on disk.
+ *
+ * Ported from `flows/nax-finish/steps/pr-body.ts` (read-only reference, never
+ * imported — `flows/` runs in acpx's own Node process). Every read here is
+ * fail-open: the PR body is useful without any one section, and a finish that
+ * reached this point has already done all of its real work. Losing the PR to a
+ * permissions error on a file most repos do not have is the failure this
+ * policy exists to prevent.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { featureDir } from "@/config";
+import { findPrTemplate } from "@/forge";
+import type { ForgeKind, TemplateMode } from "@/forge";
+import type { AuditTarget } from "../audit";
+import { readRounds } from "../audit";
+import { readSpecSummary, resolveNarrative, resolveTitle } from "../operations";
+import type { FinishState } from "../state";
+import type { FinishRound } from "../types";
+
+// ... interfaces exactly as in the Interfaces block above ...
+
+export const _finishPrDeps = {
+  // D4.11 — the shared default, so a finish and an auto-PR spawn subprocesses
+  // identically. Never a second local spawner.
+  run: defaultForgeDeps.run,
+  readText: async (path: string) => {
+    try {
+      return await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  },
+  warn: (message: string, details: { path: string; error: unknown }) =>
+    process.emitWarning(message, { detail: `${details.path}: ${String(details.error)}` }),
+};
+```
+
+`_finishPrDeps` takes `run` from `defaultForgeDeps` (Task 1, D4.11) — do not write a second spawner — but keeps its own `readText`. The difference is deliberate: this one returns `null` for a missing file and **throws** on a genuine I/O failure, which is what lets `readJson` tell "no `status.json` yet" (routine, silent) from "the mount is broken" (warn). `defaultForgeDeps.readText` collapses both into `null`, which is right for template discovery and wrong here.
+
+Port `readJson`, `storiesFrom`, `runGitDiff`, `runDiffstat`, `loadTemplate` and `loadFinishPrContext` with their comments. The `Promise.all` in the loader keeps all six reads parallel — do not serialize it.
+
+- [ ] **Step 4: Export from the barrels and run the tests**
+
+Create `src/finish/pr/index.ts` with the context exports, and add to `src/finish/index.ts`:
+
+```ts
+export { _finishPrDeps, loadFinishPrContext } from "./pr";
+export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./pr";
+```
+
+Run: `bun test test/unit/finish/pr-context.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Static checks and commit**
+
+```bash
+bun x tsc --noEmit && bun run lint && bun test test/unit/finish/
+git add src/finish/pr/ src/finish/index.ts test/unit/finish/pr-context.test.ts
+git commit -m "feat(finish): load the PR body context from run artifacts"
+```
+
+---
+
+### Task 3: The PR body and title renderers
+
+**Files:**
+- Create: `src/finish/pr/body.ts`
+- Modify: `src/finish/pr/index.ts`, `src/finish/index.ts`
+- Test: `test/unit/finish/pr-body.test.ts`
+
+**Interfaces:**
+- Consumes: `FinishPrContext` (Task 2); `mergeTemplate`, `BodySection` from `@/forge` (Task 1).
+- Produces: `buildFinishTitle(ctx: FinishPrContext): string`, `buildFinishBody(ctx: FinishPrContext): string`. Task 6 calls both.
+
+**Port notes.** Lines 275-462 of `flows/nax-finish/steps/pr-body.ts`, verbatim apart from the `mergeTemplate` import path: `buildFinishTitle`, `escapeTableCell`, `formatDuration`, `buildStoriesSection`, `buildVerificationSection`, `buildRoundHeading`, `EMPTY_ROUND_NOTE`, `buildRoundBlock`, `buildRoundsSection`, `renderFinding`, `renderRejected`, `buildNarrativeSection`, `buildOutOfScopeSection`, `buildFooter`, `buildBodySections`, `buildFinishBody`, and the `SECONDS_PER_MINUTE` / `MS_PER_SECOND` / `SHORT_SHA_LEN` constants. Keep every comment: `EMPTY_ROUND_NOTE`'s six-way distinction is issue #1507, the null-body filtering is #1477, and the escape order in `escapeTableCell` (backslashes first) is load-bearing.
+
+Do not "improve" anything here. Divergence from the flow's rendering is what makes a native finish PR unrecognisable next to the ones already in history.
+
+- [ ] **Step 1: Port the existing test suite**
+
+```bash
+cp test/unit/flows/nax-finish/pr-body.test.ts test/unit/finish/pr-body.test.ts
+```
+
+Then, in the copy: delete every test that exercises `loadFinishPrContext` (those belong to Task 2 and are already covered there), point the import at `@/finish`, and keep every rendering assertion untouched. The flow's file is 18.3K — the renderer half should land near the 800-line test cap, so check with `wc -l` and split into `pr-body.test.ts` (sections) and `pr-body-rounds.test.ts` (the rounds/dispositions table) if it exceeds it.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test test/unit/finish/pr-body.test.ts`
+Expected: FAIL — `buildFinishBody` is not exported from `@/finish`.
+
+- [ ] **Step 3: Port the renderer**
+
+Create `src/finish/pr/body.ts` with the functions listed above. Its header comment:
+
+```ts
+/**
+ * The finish PR title and body: a pure deterministic builder over
+ * `FinishPrContext`.
+ *
+ * Pure on purpose. Every fact in a finish body — gate results, story counts,
+ * diffstat, review rounds — is a string join over artifacts, which is what
+ * keeps a finish PR greppable in history. The only model-authored fields
+ * (`narrative`, `title`) arrive already resolved, each with a deterministic
+ * fallback, so the body never waits on a reviewer.
+ *
+ * Ported from `flows/nax-finish/steps/pr-body.ts`; the rendering is settled
+ * behaviour (nax#1477, nax#1504, nax#1507) and must not drift.
+ */
+```
+
+- [ ] **Step 4: Export and run**
+
+Add to `src/finish/pr/index.ts` and `src/finish/index.ts`:
+
+```ts
+export { buildFinishBody, buildFinishTitle } from "./body";
+```
+
+Run: `bun test test/unit/finish/pr-body.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Prove the port is faithful**
+
+Run a one-off comparison (scratch file, not committed): build one `FinishPrContext` fixture, render it through `src/finish/pr/body.ts`'s `buildFinishBody` and through `flows/nax-finish/steps/pr-body.ts`'s, and assert the two strings are identical. Report the result in the commit message. A fixture that exercises all six sections plus one rejected disposition is enough.
+
+- [ ] **Step 6: Static checks and commit**
+
+```bash
+bun x tsc --noEmit && bun run lint && bun test test/unit/finish/
+git add src/finish/pr/ src/finish/index.ts test/unit/finish/pr-body*.test.ts
+git commit -m "feat(finish): render the PR title and body natively"
+```
+
+---
+
+### Task 4: Draft open, promote and body edit
+
+**Files:**
+- Create: `src/finish/pr/open.ts`
+- Modify: `src/finish/pr/index.ts`, `src/finish/index.ts`
+- Test: `test/unit/finish/pr-open.test.ts`
+
+**Interfaces:**
+- Consumes: `detectForge`, `hasOpenPr`, `openPr`, `viewArgv`, `extractUrl`, `ForgeDeps`, `ForgeKind` from `@/forge`; `commitAndPush` from `../commit`.
+- Produces:
+
+```ts
+export function parseView(stdout: string, forge: ForgeKind): { isDraft: boolean; url?: string };
+
+export async function openDraftFinishPr(
+  args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
+  deps: ForgeDeps,
+): Promise<{ url: string } | null>;
+
+export async function openOrPromotePr(
+  args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
+  deps: ForgeDeps,
+): Promise<{ status: "opened" | "promoted" | "already-ready"; url?: string }>;
+
+export async function updatePrBody(
+  args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
+  deps: ForgeDeps,
+): Promise<void>;
+```
+
+Task 6 calls all three async functions.
+
+**Port notes.** `openOrPromotePr`, `updatePrBody` and `parseView` are `flows/nax-finish/steps/pr.ts`, restructured so the forge is a required argument (the flow's `knownForge?` fallback existed because the flow had two independent detection sites; the native caller detects once) and so I/O arrives as `ForgeDeps` rather than a module-level `_prDeps`. Keep both `FinishError` throws as `NaxError` with the same codes — `FINISH_PR_CREATE_FAILED`, `FINISH_PR_PROMOTE_FAILED` — and keep `updatePrBody` non-fatal (it warns and returns; a failed metadata write must not invalidate a PR that exists).
+
+`openDraftFinishPr` is new (D7): `hasOpenPr` first, then `openPr(forge, { title, body, branch, draft: true }, deps, workdir)`. Per D4.5 it returns `null` rather than throwing on every unhappy path — including a `hasOpenPr` throw, which it catches.
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/unit/finish/pr-open.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { openDraftFinishPr, openOrPromotePr, parseView, updatePrBody } from "@/finish";
+import type { ForgeDeps } from "@/forge";
+
+function depsFor(handler: (cmd: string[]) => { exitCode: number; stdout?: string; stderr?: string }): {
+  deps: ForgeDeps;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const deps: ForgeDeps = {
+    run: async (cmd) => {
+      calls.push(cmd);
+      const r = handler(cmd);
+      return { exitCode: r.exitCode, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+    },
+    readText: async () => null,
+  };
+  return { deps, calls };
+}
+
+const args = {
+  workdir: "/repo",
+  branch: "feat/demo",
+  title: "feat: demo",
+  body: "body",
+  forge: "github" as const,
+};
+
+describe("parseView", () => {
+  test("reads isDraft and url from GitHub JSON", () => {
+    expect(parseView('{"isDraft":true,"url":"https://x/1"}', "github")).toEqual({
+      isDraft: true,
+      url: "https://x/1",
+    });
+  });
+
+  test("treats an unparseable reply as ready, not draft", () => {
+    expect(parseView("not json https://x/2", "github")).toEqual({ isDraft: false, url: "https://x/2" });
+  });
+
+  test("accepts any of GitLab's draft field spellings", () => {
+    expect(parseView('{"work_in_progress":true,"web_url":"https://x/3"}', "gitlab").isDraft).toBe(true);
+  });
+});
+
+describe("openDraftFinishPr", () => {
+  test("opens a draft when the branch has no open PR", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("list") ? { exitCode: 0, stdout: "[]" } : { exitCode: 0, stdout: "https://x/9" },
+    );
+    await expect(openDraftFinishPr(args, deps)).resolves.toEqual({ url: "https://x/9" });
+    expect(calls.at(-1)).toContain("--draft");
+  });
+
+  test("returns null when a PR is already open", async () => {
+    const { deps, calls } = depsFor(() => ({ exitCode: 0, stdout: '[{"number":1}]' }));
+    await expect(openDraftFinishPr(args, deps)).resolves.toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("returns null rather than throwing when the PR list call fails", async () => {
+    const { deps } = depsFor(() => ({ exitCode: 1, stderr: "auth required" }));
+    await expect(openDraftFinishPr(args, deps)).resolves.toBeNull();
+  });
+
+  test("returns null when creation fails", async () => {
+    const { deps } = depsFor((cmd) =>
+      cmd.includes("list") ? { exitCode: 0, stdout: "[]" } : { exitCode: 1, stderr: "rate limited" },
+    );
+    await expect(openDraftFinishPr(args, deps)).resolves.toBeNull();
+  });
+});
+
+describe("openOrPromotePr", () => {
+  test("creates the PR when view fails, and reports opened", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 1 } : { exitCode: 0, stdout: "https://x/10" },
+    );
+    await expect(openOrPromotePr(args, deps)).resolves.toEqual({ status: "opened", url: "https://x/10" });
+    expect(calls.at(-1)).not.toContain("--draft");
+  });
+
+  test("promotes a draft and then writes the body", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: '{"isDraft":true,"url":"https://x/11"}' } : { exitCode: 0 },
+    );
+    await expect(openOrPromotePr(args, deps)).resolves.toEqual({ status: "promoted", url: "https://x/11" });
+    expect(calls.map((c) => c[2])).toEqual(["view", "ready", "edit"]);
+  });
+
+  test("writes the body on an already-ready PR without promoting", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: '{"isDraft":false,"url":"https://x/12"}' } : { exitCode: 0 },
+    );
+    await expect(openOrPromotePr(args, deps)).resolves.toEqual({ status: "already-ready", url: "https://x/12" });
+    expect(calls.map((c) => c[2])).toEqual(["view", "edit"]);
+  });
+
+  test("throws FINISH_PR_CREATE_FAILED when creation fails", async () => {
+    const { deps } = depsFor((cmd) => (cmd.includes("view") ? { exitCode: 1 } : { exitCode: 1, stderr: "boom" }));
+    await expect(openOrPromotePr(args, deps)).rejects.toThrow(/boom/);
+  });
+
+  test("throws FINISH_PR_PROMOTE_FAILED when promotion fails", async () => {
+    const { deps } = depsFor((cmd) => {
+      if (cmd.includes("view")) return { exitCode: 0, stdout: '{"isDraft":true}' };
+      return cmd.includes("ready") ? { exitCode: 1, stderr: "denied" } : { exitCode: 0 };
+    });
+    await expect(openOrPromotePr(args, deps)).rejects.toThrow(/denied/);
+  });
+});
+
+describe("updatePrBody", () => {
+  test("never throws when the edit fails", async () => {
+    const { deps } = depsFor(() => ({ exitCode: 1, stderr: "nope" }));
+    await expect(updatePrBody(args, deps)).resolves.toBeUndefined();
+  });
+
+  test("never throws when the run itself rejects", async () => {
+    const deps: ForgeDeps = {
+      run: async () => {
+        throw new Error("spawn failed");
+      },
+      readText: async () => null,
+    };
+    await expect(updatePrBody(args, deps)).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test test/unit/finish/pr-open.test.ts`
+Expected: FAIL — none of the four symbols are exported.
+
+- [ ] **Step 3: Implement**
+
+Create `src/finish/pr/open.ts`. `parseView` and the two ported functions come from `flows/nax-finish/steps/pr.ts` with the substitutions in the port notes. `openDraftFinishPr`:
+
+```ts
+/**
+ * Open the draft PR the finish run holds its work in (D7).
+ *
+ * Returns null on every unhappy path — no open-PR check, a create that
+ * failed, a forge CLI that could not answer. The draft is a convenience: the
+ * terminal promote creates the PR when none exists, so failing the run here
+ * would discard work that is otherwise fine. `hasOpenPr` throws on a non-zero
+ * exit by design (a `gh` auth failure must not read as "no PR"); the safe
+ * decision at this call site is to skip.
+ */
+export async function openDraftFinishPr(
+  args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
+  deps: ForgeDeps,
+): Promise<{ url: string } | null> {
+  let alreadyOpen: boolean;
+  try {
+    alreadyOpen = await hasOpenPr(args.forge, args.branch, deps, args.workdir);
+  } catch {
+    return null;
+  }
+  if (alreadyOpen) return null;
+
+  const result = await openPr(
+    args.forge,
+    { title: args.title, body: args.body, branch: args.branch, draft: true },
+    deps,
+    args.workdir,
+  );
+  return result.success && result.url ? { url: result.url } : null;
+}
+```
+
+- [ ] **Step 4: Export and run**
+
+Add `export { openDraftFinishPr, openOrPromotePr, parseView, updatePrBody } from "./open";` to `src/finish/pr/index.ts` and re-export from `src/finish/index.ts`.
+
+Run: `bun test test/unit/finish/pr-open.test.ts`
+Expected: PASS (12 tests).
+
+- [ ] **Step 5: Static checks and commit**
+
+```bash
+bun x tsc --noEmit && bun run lint && bun test test/unit/finish/
+git add src/finish/pr/ src/finish/index.ts test/unit/finish/pr-open.test.ts
+git commit -m "feat(finish): open, promote and update the finish PR natively"
+```
+
+---
+
+### Task 5: Escalation delivery
+
+**Files:**
+- Create: `src/finish/escalate.ts`
+- Modify: `src/finish/index.ts`
+- Test: `test/unit/finish/escalate.test.ts`
+
+**Interfaces:**
+- Consumes: `detectForge`, `viewArgv`, `extractUrl`, `ForgeDeps`, `ForgeKind` from `@/forge`; `Finding` from `./types`.
+- Produces:
+
+```ts
+export function buildEscalationComment(feature: string, escalationReason: string, findings: Finding[]): string;
+
+export interface EscalationOutcome {
+  url?: string;
+  channel: "telegram" | "pr-comment";
+}
+
+export async function postEscalation(
+  args: { workdir: string; branch: string; comment: string; forge: ForgeKind; preferTelegram?: boolean },
+  deps: ForgeDeps,
+): Promise<EscalationOutcome>;
+```
+
+Task 6 calls both.
+
+**Port notes.** `flows/nax-finish/steps/escalate.ts`, with the forge passed in rather than detected inside, `ForgeDeps` in place of `_escalateDeps`, and `NaxError` in place of `FinishError` keeping the codes `FINISH_ESCALATION_COMMENT_FAILED` and `FINISH_ESCALATION_DRAFT_FAILED`. The comment text is byte-identical to the flow's — it is what a human reads and there is no reason for the two to differ.
+
+`preferTelegram` still short-circuits after the read-only view lookup: Telegram becomes the sole channel, no comment is posted and no draft is opened to hold one. The view is still read so the notification can carry a link.
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/unit/finish/escalate.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { buildEscalationComment, postEscalation } from "@/finish";
+import type { ForgeDeps } from "@/forge";
+import type { Finding } from "@/finish";
+
+const finding: Finding = {
+  severity: "HIGH",
+  title: "Missing rollback",
+  problem: "The migration has no down path.",
+  fix: "Add a reversible migration.",
+} as Finding;
+
+function depsFor(handler: (cmd: string[]) => { exitCode: number; stdout?: string; stderr?: string }): {
+  deps: ForgeDeps;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  return {
+    calls,
+    deps: {
+      run: async (cmd) => {
+        calls.push(cmd);
+        const r = handler(cmd);
+        return { exitCode: r.exitCode, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+      },
+      readText: async () => null,
+    },
+  };
+}
+
+const args = { workdir: "/repo", branch: "feat/demo", comment: "escalation", forge: "github" as const };
+
+describe("buildEscalationComment", () => {
+  test("names the feature, the reason and every finding", () => {
+    const text = buildEscalationComment("demo", "Two reviewers disagree", [finding]);
+    expect(text).toContain("nax-finish escalation");
+    expect(text).toContain("demo");
+    expect(text).toContain("Two reviewers disagree");
+    expect(text).toContain("Missing rollback");
+    expect(text).toContain("Add a reversible migration.");
+  });
+
+  test("renders with no findings at all", () => {
+    expect(buildEscalationComment("demo", "Context could not be resolved", [])).toContain("### Findings");
+  });
+});
+
+describe("postEscalation", () => {
+  test("comments on an existing PR", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: '{"url":"https://x/1"}' } : { exitCode: 0 },
+    );
+    await expect(postEscalation(args, deps)).resolves.toEqual({ url: "https://x/1", channel: "pr-comment" });
+    expect(calls.at(-1)).toContain("comment");
+  });
+
+  test("opens a draft to hold the comment when no PR exists", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 1 } : { exitCode: 0, stdout: "https://x/2" },
+    );
+    await expect(postEscalation(args, deps)).resolves.toEqual({ url: "https://x/2", channel: "pr-comment" });
+    expect(calls.at(-1)).toContain("--draft");
+  });
+
+  test("posts nothing and opens nothing when Telegram is preferred", async () => {
+    const { deps, calls } = depsFor(() => ({ exitCode: 0, stdout: '{"url":"https://x/3"}' }));
+    await expect(postEscalation({ ...args, preferTelegram: true }, deps)).resolves.toEqual({
+      url: "https://x/3",
+      channel: "telegram",
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("still reports the channel when Telegram is preferred and no PR exists", async () => {
+    const { deps } = depsFor(() => ({ exitCode: 1 }));
+    await expect(postEscalation({ ...args, preferTelegram: true }, deps)).resolves.toEqual({
+      url: undefined,
+      channel: "telegram",
+    });
+  });
+
+  test("throws when the comment cannot be posted", async () => {
+    const { deps } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: "{}" } : { exitCode: 1, stderr: "forbidden" },
+    );
+    await expect(postEscalation(args, deps)).rejects.toThrow(/forbidden/);
+  });
+
+  test("throws when the holding draft cannot be opened", async () => {
+    const { deps } = depsFor((cmd) => (cmd.includes("view") ? { exitCode: 1 } : { exitCode: 1, stderr: "denied" }));
+    await expect(postEscalation(args, deps)).rejects.toThrow(/denied/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test test/unit/finish/escalate.test.ts`
+Expected: FAIL — neither symbol is exported.
+
+- [ ] **Step 3: Implement, export and run**
+
+Create `src/finish/escalate.ts` per the port notes; add `export { buildEscalationComment, postEscalation } from "./escalate";` and `export type { EscalationOutcome } from "./escalate";` to `src/finish/index.ts`.
+
+Run: `bun test test/unit/finish/escalate.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 4: Static checks and commit**
+
+```bash
+bun x tsc --noEmit && bun run lint && bun test test/unit/finish/
+git add src/finish/escalate.ts src/finish/index.ts test/unit/finish/escalate.test.ts
+git commit -m "feat(finish): deliver escalations through the forge natively"
+```
+
+---
+
+### Task 6: The concrete `FinishOps` factory
+
+**Files:**
+- Create: `src/finish/ops-impl.ts`
+- Modify: `src/finish/index.ts`
+- Test: `test/unit/finish/ops-impl.test.ts`
+
+**Interfaces:**
+- Consumes: everything above, plus `finishReviewOp`, `finishFixOp`, `finishNarrativeOp` from `../operations`; `callOp` and `CallContext` from `@/operations`; `commitAndPush` from `../commit`; `ConfiguredModel` from `@/config`.
+- Produces:
+
+```ts
+export interface FinishOpsDeps {
+  /** The call context every LLM op runs under. Its `sessionOverride` is replaced per phase. */
+  callCtx: CallContext;
+  /** Subprocess and file I/O for every forge call. */
+  forge: ForgeDeps;
+  /** Resolved once by the caller; null disables every forge interaction. */
+  forgeKind: ForgeKind | null;
+  audit: AuditTarget;
+  /** Per-step model selection. Absent falls through to callOp's own default. */
+  models?: {
+    reviewSpec?: ConfiguredModel;
+    reviewQuality?: ConfiguredModel;
+    fix?: ConfiguredModel;
+    narrative?: ConfiguredModel;
+  };
+  timeouts?: { reviewMs?: number; fixMs?: number; narrativeMs?: number };
+  prBody?: { template?: TemplateMode; sectionMap?: Record<string, string> };
+  /** Telegram is the sole escalation channel when true (D4.3 in the flow's terms). */
+  preferTelegram?: boolean;
+  /** Gate names the body's Verification section reports. Mutated by the caller as gates run. */
+  gatesRan?: () => string[];
+  /** Narrative is opt-out: when false, `narrate` is omitted from the returned object. */
+  narrative?: boolean;
+  warn?: (message: string, details: Record<string, unknown>) => void;
+}
+
+export const _finishOpsDeps: { callOp: typeof callOp };
+
+export function createFinishOps(deps: FinishOpsDeps): FinishOps;
+```
+
+Plan 5 calls `createFinishOps` and hands the result to `runFinishMachine`.
+
+**Implementation notes.**
+
+- `review(phase, req)` calls `_finishOpsDeps.callOp({ ...deps.callCtx, sessionOverride: { role: phase === "spec" ? "finish-review-spec" : "finish-review-quality" } }, finishReviewOp, { phase, base: state.base, specPath: state.specPath, workdir: state.workdir, since: state.phases[phase].reviewSince, gaps: state.phases[phase].reviewGaps, priorFindings: state.findings, model, timeoutMs })`. It returns `{ findings, gaps }` unchanged — `FinishReviewOutput` is structurally a superset of `ReviewOutcome`, so no adapter. It does **not** catch: a review that cannot run must reach the machine's catch and escalate.
+- `fix(phase, req)` calls `finishFixOp` with `{ phase, workdir: state.workdir, findings, failing, gateOutput, acceptanceOutput, model, timeoutMs }` and returns its `FixOutcome` unchanged. No catch, same reason.
+- `openDraftPr(state)` returns `null` immediately when `forgeKind` is null; otherwise loads the context (`loadFinishPrContext` with `forge: forgeKind`, `gatesRan: deps.gatesRan?.() ?? []`, `prBody`), renders title and body, and calls `openDraftFinishPr`.
+- `promotePr(state)` runs `commitAndPush(state.workdir, state.branch, \`fix(${state.feature}): nax-finish automated fixes\`)` **first** (D4.6), then — when `forgeKind` is non-null — loads context, renders, and calls `openOrPromotePr`. With a null forge it returns `{ status: "already-ready" }` after the push, because there is nothing to promote and the branch is still pushed. Neither call is caught.
+- `narrate(state)` is present on the returned object only when `deps.narrative !== false`. Its entire body is inside one try/catch (D4.4): call `finishNarrativeOp` under `sessionOverride: { role: "finish-narrative" }` with `{ base: state.base, model, timeoutMs }`, then re-load the PR context passing the resulting `narrative` and `title`, render, and `updatePrBody`. On any throw, `warn` and return.
+- `escalate(state, reason, findings)` never throws (D4.3). It: (1) tries `commitAndPush` for the partial fixes and, on failure, records a `syncNote` string (D4.7); (2) builds the comment with `buildEscalationComment(state.feature, reason, findings) + syncNote`; (3) calls `postEscalation` when `forgeKind` is non-null, returning `{ url }`; (4) catches everything and returns `{ deliveryError: errorMessage(err) }`. With a null forge it returns `{ deliveryError: "no forge detected" }` — the escalation still needs somewhere to say it went nowhere.
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/unit/finish/ops-impl.test.ts` — the seven behaviours that matter. Use a fake `callOp` through `_finishOpsDeps` and a `ForgeDeps` whose `run` records commands. A minimal `callCtx` cast (`{} as CallContext`) is sufficient: nothing in the factory reads it except to spread it.
+
+```ts
+import { afterEach, describe, expect, test } from "bun:test";
+import { _finishOpsDeps, createFinishOps, createFinishState } from "@/finish";
+import type { ForgeDeps } from "@/forge";
+import type { CallContext } from "@/operations";
+
+const original = { ..._finishOpsDeps };
+afterEach(() => Object.assign(_finishOpsDeps, original));
+
+function baseDeps(overrides: Partial<Parameters<typeof createFinishOps>[0]> = {}) {
+  const calls: string[][] = [];
+  const forge: ForgeDeps = {
+    run: async (cmd) => {
+      calls.push(cmd);
+      return { exitCode: 0, stdout: "https://x/1", stderr: "" };
+    },
+    readText: async () => null,
+  };
+  return {
+    calls,
+    deps: {
+      callCtx: {} as CallContext,
+      forge,
+      forgeKind: "github" as const,
+      audit: { auditDir: "/tmp/audit", runId: "run-1" },
+      ...overrides,
+    },
+  };
+}
+
+const state = createFinishState({
+  feature: "demo",
+  workdir: "/repo",
+  branch: "feat/demo",
+  runId: "run-1",
+  base: "origin/main",
+  specPath: "spec.md",
+});
+
+test("review runs the spec phase under the finish-review-spec role", async () => {
+  let seenRole: string | undefined;
+  _finishOpsDeps.callOp = (async (ctx: CallContext) => {
+    seenRole = ctx.sessionOverride?.role;
+    return { findings: [], gaps: [], touchpoints: [], walk: [] };
+  }) as typeof _finishOpsDeps.callOp;
+  const { deps } = baseDeps();
+  await createFinishOps(deps).review("spec", { state });
+  expect(seenRole).toBe("finish-review-spec");
+});
+
+test("review runs the quality phase under the finish-review-quality role", async () => {
+  let seenRole: string | undefined;
+  _finishOpsDeps.callOp = (async (ctx: CallContext) => {
+    seenRole = ctx.sessionOverride?.role;
+    return { findings: [], gaps: [], touchpoints: [], walk: [] };
+  }) as typeof _finishOpsDeps.callOp;
+  const { deps } = baseDeps();
+  await createFinishOps(deps).review("quality", { state });
+  expect(seenRole).toBe("finish-review-quality");
+});
+
+test("review passes the phase's re-review window and gap notice through", async () => {
+  let seenInput: { since?: string; gaps?: string[] } | undefined;
+  _finishOpsDeps.callOp = (async (_ctx: CallContext, _op: unknown, input: { since?: string; gaps?: string[] }) => {
+    seenInput = input;
+    return { findings: [], gaps: [], touchpoints: [], walk: [] };
+  }) as typeof _finishOpsDeps.callOp;
+  const windowed = createFinishState({ ...state });
+  windowed.phases.spec.reviewSince = "abc123";
+  windowed.phases.spec.reviewGaps = ["did not read src/a.ts"];
+  const { deps } = baseDeps();
+  await createFinishOps(deps).review("spec", { state: windowed });
+  expect(seenInput?.since).toBe("abc123");
+  expect(seenInput?.gaps).toEqual(["did not read src/a.ts"]);
+});
+
+test("review propagates a throw instead of swallowing it", async () => {
+  _finishOpsDeps.callOp = (async () => {
+    throw new Error("agent died");
+  }) as typeof _finishOpsDeps.callOp;
+  const { deps } = baseDeps();
+  await expect(createFinishOps(deps).review("spec", { state })).rejects.toThrow("agent died");
+});
+
+test("narrate swallows a throw so a promoted run is not re-escalated", async () => {
+  _finishOpsDeps.callOp = (async () => {
+    throw new Error("narrator died");
+  }) as typeof _finishOpsDeps.callOp;
+  const { deps } = baseDeps();
+  const ops = createFinishOps(deps);
+  await expect(ops.narrate?.(state)).resolves.toBeUndefined();
+});
+
+test("narrate is absent when narrative is disabled", () => {
+  const { deps } = baseDeps({ narrative: false });
+  expect(createFinishOps(deps).narrate).toBeUndefined();
+});
+
+test("escalate reports a delivery failure rather than throwing", async () => {
+  const forge: ForgeDeps = {
+    run: async () => {
+      throw new Error("gh missing");
+    },
+    readText: async () => null,
+  };
+  const { deps } = baseDeps({ forge });
+  await expect(createFinishOps(deps).escalate(state, "needs a human", [])).resolves.toMatchObject({
+    deliveryError: expect.stringContaining("gh missing"),
+  });
+});
+
+test("escalate reports no forge as a delivery error", async () => {
+  const { deps } = baseDeps({ forgeKind: null });
+  const outcome = await createFinishOps(deps).escalate(state, "needs a human", []);
+  expect(outcome.deliveryError).toBeTruthy();
+});
+
+test("promotePr pushes before it talks to the forge", async () => {
+  const { deps, calls } = baseDeps();
+  await createFinishOps(deps).promotePr(state);
+  const pushIndex = calls.findIndex((c) => c.includes("push"));
+  const forgeIndex = calls.findIndex((c) => c[0] === "gh");
+  expect(pushIndex).toBeGreaterThanOrEqual(0);
+  expect(pushIndex).toBeLessThan(forgeIndex);
+});
+```
+
+The push assertion needs `commitAndPush`'s git seam stubbed too — `_finishGitDeps.git`, exported from `@/finish`. Stub it in that test to record its argv into the same `calls` array and return `{ exitCode: 0, stdout: "", stderr: "" }`, and restore it in `afterEach`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test test/unit/finish/ops-impl.test.ts`
+Expected: FAIL — `createFinishOps` is not exported.
+
+- [ ] **Step 3: Implement the factory**
+
+Create `src/finish/ops-impl.ts` per the implementation notes. Header comment:
+
+```ts
+/**
+ * The concrete `FinishOps` the state machine runs against.
+ *
+ * A factory rather than a module of free functions: every method needs the
+ * same closed-over `CallContext`, forge deps and model selections, and the
+ * machine's contract (`./ops`) is an object. Two of the contract's clauses are
+ * load-bearing and are implemented here, not in the modules below:
+ *
+ * - `escalate` must not throw. Its whole body is wrapped, and a delivery
+ *   failure is returned as `deliveryError` — `machine.ts`'s `doEscalate` is
+ *   the only caller and it has no other way to record that the human was
+ *   never told.
+ * - `narrate` must not throw. The machine calls it *after* `promotePr`,
+ *   inside its one try, so a throw rewrites an already-promoted green run to
+ *   `escalated`.
+ *
+ * `review` and `fix` deliberately do neither: a reviewer or fixer that cannot
+ * run is exactly the case the machine's catch exists for.
+ */
+```
+
+- [ ] **Step 4: Export and run**
+
+Add to `src/finish/index.ts`:
+
+```ts
+export { _finishOpsDeps, createFinishOps } from "./ops-impl";
+export type { FinishOpsDeps } from "./ops-impl";
+```
+
+Run: `bun test test/unit/finish/ops-impl.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Static checks and commit**
+
+```bash
+bun x tsc --noEmit && bun run lint && bun test test/unit/finish/
+git add src/finish/ops-impl.ts src/finish/index.ts test/unit/finish/ops-impl.test.ts
+git commit -m "feat(finish): assemble the concrete FinishOps object"
+```
+
+---
+
+### Task 7: End-to-end machine test over the real ops
+
+**Files:**
+- Test: `test/unit/finish/machine-end-to-end.test.ts`
+
+**Interfaces:**
+- Consumes: `runFinishMachine`, `createFinishOps`, `createFinishState`, `_finishOpsDeps`, `_finishGitDeps`, `_finishPrDeps`, `_acceptanceGateDeps`, `_qualityGateDeps` — all from `@/finish`.
+
+This is the task that proves the plan. Every prior test stubs one module; this one drives `runFinishMachine` with a real `createFinishOps` and fakes only the three process boundaries (git, forge subprocesses, the LLM call). If the pieces disagree about a shape, it fails here rather than in plan 5's wiring.
+
+- [ ] **Step 1: Write the green-path test**
+
+```ts
+test("a clean run reaches promoted with a PR body built from artifacts", async () => {
+  // acceptance passes, both reviewers return no findings, gates green
+  // _finishOpsDeps.callOp returns { findings: [], gaps: [], ... } for review,
+  //   { dispositions: [] } for fix, and a narrative for narrate
+  // forge run: view -> draft, ready -> ok, edit -> ok
+  // Expect: result.status === "promoted", and the `gh pr edit` argv carries a
+  // body containing "## Verification" and the story table.
+});
+```
+
+Assert three things and no more: the terminal status is `promoted`; `gh pr create --draft` ran exactly once (the draft is opened at step 3 and never re-opened); the body handed to `gh pr edit` contains the rendered Stories and Verification sections.
+
+- [ ] **Step 2: Write the escalation-path test**
+
+```ts
+test("a review that throws escalates with a comment and a written result file", async () => {
+  // _finishOpsDeps.callOp throws on the spec review
+  // Expect: result.status === "escalated", result.escalationReason names the
+  // throw, `gh pr comment` ran with the escalation comment, and the result
+  // file on disk has status "escalated".
+});
+```
+
+- [ ] **Step 3: Write the narrate-cannot-break-a-green-run test**
+
+```ts
+test("a narrator failure leaves the run promoted", async () => {
+  // Everything green, but the narrative call throws.
+  // Expect: result.status === "promoted" and no escalation comment was posted.
+});
+```
+
+This is the regression test for D4.4 — the one defect that would otherwise only show up in production, on a run that had already succeeded.
+
+- [ ] **Step 4: Run the whole finish suite**
+
+Run: `bun test test/unit/finish/`
+Expected: PASS, all files.
+
+- [ ] **Step 5: Full gates and commit**
+
+```bash
+bun x tsc --noEmit && bun run lint && bun test
+git add test/unit/finish/machine-end-to-end.test.ts
+git commit -m "test(finish): drive the machine end to end over the real ops"
+```
+
+- [ ] **Step 6: Confirm the module is still unwired**
+
+```bash
+grep -rn "from \"@/finish\"\|from \"./finish\"" src/ --include="*.ts" | grep -v "^src/finish/"
+```
+
+Expected: no output. `src/finish/` is complete but wired to nothing; plan 5 wires it. If this prints anything, the plan's scope was exceeded — revert that import.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage.** Design section 4.2's module list is now fully realised except `phase.ts` (plan 5). Section 4.7's draft lifecycle is Task 4 plus `openDraftPr`/`promotePr` in Task 6. Section 4.5's operations were plan 3; this plan only binds them.
+- **Out of scope, deliberately.** Wiring `"finish"` into `PostRunPhase` (three sites: the type, `status-writer.ts:118-120`, `usePipelineBusEvents.ts:243`), the cost-aggregator delta, the config reshape from `finish.autoFlow`, the Telegram send itself, and deleting `flows/` — all plan 5. The `@flows/*` tsconfig alias also stays until then.
+- **Known duplication after this plan.** `flows/nax-finish/steps/{pr,pr-body,pr-narrative,escalate}.ts` still exist and still run. That is expected and is not a defect to file.

--- a/docs/superpowers/plans/2026-08-19-finish-pr-escalate.md
+++ b/docs/superpowers/plans/2026-08-19-finish-pr-escalate.md
@@ -29,6 +29,8 @@ Unchanged from plans 2 and 3; repeated because they are the ones a worker trips 
 - `scripts/check-deep-relatives.ts` has a frozen baseline — **new tests import `@/finish`, `@/forge` and `@test/helpers`**, never `../../../src/...` or `../../helpers`. Copy the style of `test/unit/finish/gates-quality.test.ts`. If the baseline must move, use `bun run check:deep-relatives:update` and say so in the commit.
 - **Temp directories in tests:** `makeTempDir` / `cleanupTempDir` / `withTempDir` from `test/helpers/temp.ts`. `.nax/rules/forbidden-patterns-tests.md` forbids hand-rolled `rm -rf` cleanup.
 - **Errors:** `NaxError` from `src/errors.ts` with a `FINISH_*` / `FORGE_*` code. `scripts/check-nax-error.ts` has a baseline — do not add violations.
+- **Test ratchets** (`.claude/rules/test-ratchets.md`), all in `bun run lint`'s chain: `check:test-typecheck` counts type errors under `tsconfig.test.json` and `check:test-as-unknown-as` counts `as unknown as` casts — **neither may grow**. Every cast in this plan's tests is a single `as` (`{} as CallContext`, `as Finding`), which is fine; never reach for `as unknown as` to silence a type error, fix the fixture instead. `check:test-mocks --strict` bans inline `IAgentManager` / `AgentAdapter` mocks and local `makeConfig()` / `makeStory()` factories — the local `depsFor()` / `baseDeps()` helpers below are neither, so they pass.
+- **`check:feature-dir-ssot`** enforces that `.nax/features/<name>` is never open-coded. Task 2 must build the PRD path with `featureDir()` for this reason, not just for tidiness.
 - **Commits:** conventional commits. Attribution is disabled globally; no co-author trailers.
 - **Branch:** `feat/finish-pr-escalate`, created from `main` (already created alongside this plan).
 - **Gates before every commit:** `bun x tsc --noEmit`, `bun run lint`, and the task's own tests. A pre-commit hook runs the full static-check suite and will reject the commit if anything fails.
@@ -39,7 +41,9 @@ Unchanged from plans 2 and 3; repeated because they are the ones a worker trips 
 
 Read these before Task 1. They were settled against the real code; do not re-derive them.
 
-**D4.1 — `pr-template-merge.ts` moves to `src/forge/template-merge.ts`.** It is the one module under `flows/` that `src/` already imports (`src/plugins/builtin/auto-pr/pr-body.ts:16`, via the `@flows/*` tsconfig alias). Finish's native body builder needs it too, and plan 5 deletes `flows/`, so it must move now rather than acquire a second consumer of a doomed path. It lands in `src/forge/` and not `src/finish/` because auto-pr must not import `@/finish` internals, and `src/forge/` is already the shared home for the sibling concern (`findPrTemplate`). The `flows/` copy is **left in place** — `flows/` cannot import `src/` and the flow still runs — and dies with the rest of `flows/` in plan 5. The now-unused `@flows/*` alias in `tsconfig.json` also stays until then.
+**D4.1 — `pr-template-merge.ts` is COPIED to `src/forge/template-merge.ts`, not moved.** It is the one module under `flows/` that `src/` already imports (`src/plugins/builtin/auto-pr/pr-body.ts:16`, via the `@flows/*` tsconfig alias). Finish's native body builder needs it too, and plan 5 deletes `flows/`, so a `src/` copy has to exist now rather than let a second consumer depend on a doomed path. It lands in `src/forge/` and not `src/finish/` because auto-pr must not import `@/finish` internals, and `src/forge/` is already the shared home for the sibling concern (`findPrTemplate`).
+
+The `flows/` original **cannot be deleted in this plan**: `flows/nax-finish/steps/pr-body.ts:26` and `flows/nax-finish/types.ts:1` both import it, and `flows/` cannot import `src/`. Both copies exist until plan 5 deletes the tree. **Its test stays too** — `test/unit/flows/nax-finish/pr-template-merge.test.ts` guards the implementation that is still live, and deleting it to avoid a duplicate would drop coverage from running code. The new `test/unit/forge/template-merge.test.ts` is a copy, and Task 1 adds one cheap equivalence test so the two cannot silently diverge while both exist. The `@flows/*` alias in `tsconfig.json` also stays until plan 5.
 
 **D4.2 — the PR subtree is `src/finish/pr/{context,body,open,index}.ts`.** `flows/nax-finish/steps/pr-body.ts` is 462 lines doing two jobs (load artifacts, render markdown). Split at that seam: the loader is I/O and fail-open policy, the renderer is pure and is where every future body change lands. Both stay well under the 600-line cap, and the renderer being pure is what lets its tests run with no disk at all.
 
@@ -53,13 +57,19 @@ Read these before Task 1. They were settled against the real code; do not re-der
 
 **D4.7 — escalation pushes partial fixes best-effort.** Also faithful to the flow: the escalate path tries `commitAndPush` so a human sees the partial work, and on failure appends a `syncNote` to the comment rather than losing the escalation itself. The push is inside its own try/catch, never outside.
 
-**D4.8 — template mode and section map are factory options, not config reads.** They live at `finish.autoFlow.prBody` today, and `autoFlow` is the plugin-shaped block plan 5 reshapes. `createFinishOps` takes `prBody?: { template?: TemplateMode; sectionMap?: Record<string, string> }` defaulting to `{ template: "merge", sectionMap: {} }`, and plan 5 supplies it from config. Same for the four model selections and `preferTelegram`. This plan reads no config for PR composition.
+**D4.8 — template mode and section map are factory options, not config reads, and their type already exists.** They live at `finish.autoFlow.prBody` today, and `autoFlow` is the plugin-shaped block plan 5 reshapes. `createFinishOps` takes `prBody?: FinishPrBodySettings` defaulting to `{ template: "merge", sectionMap: {} }`, and plan 5 supplies it from config. Same for the four model selections and `preferTelegram`. This plan reads no config for PR composition.
+
+**Use the existing type. Do not declare a new one.** `src/finish/types.ts` already exports `FinishPrBodySettings { template?: TemplateMode; sectionMap?: Record<string, string> }` and a local `TemplateMode`, both placed there by plan 2 as placeholders for exactly this moment — its header comment even says "Plan 3 moves the real `pr-template-merge.ts` and re-points this" (it slipped to plan 4). Nothing in `src/finish/` references either type yet, so this plan is their first consumer. Task 1 re-points `TemplateMode` at `@/forge` so there is one definition, not two.
 
 **D4.9 — `callOp` is injected through `_finishOpsDeps`.** `src/finish/ops-impl.ts` exports `export const _finishOpsDeps = { callOp }` and calls `_finishOpsDeps.callOp(...)`, matching `_callOpDeps` / `_autoPrDeps` / `_finishGitDeps`. Without it, every test of the factory needs a `NaxRuntime`. The seam is exported from `@/finish` so tests reach it without a deep relative.
 
 **D4.11 — the default `ForgeDeps` implementation moves into `src/forge/`.** `ForgeDeps` is `src/forge/`'s own contract but the module ships no default implementation, so the only one in the repo is `defaultRun` / `defaultReadText` inside `src/plugins/builtin/auto-pr/index.ts`. `src/finish/` must not import from `@/plugins` — that inverts the layering, and the plugin's copy is wrapped in a test seam (`_autoPrDeps`) with its own baseline of tests. Task 1 therefore adds `src/forge/deps.ts` exporting `defaultForgeDeps: ForgeDeps`, a straight lift of those two functions including the wall-clock cap (a wedged `gh` must not hang a run's completion phase). Auto-PR keeps its own copy for now; converging it is a plan 5 opportunity, not this plan's scope.
 
 **D4.10 — per-phase reviewer role goes through `sessionOverride.role`.** `finishReviewOp.session.role` is the static default `"finish-review-spec"`; the factory passes `{ ...ctx, sessionOverride: { role: phase === "spec" ? "finish-review-spec" : "finish-review-quality" } }`. This is settled in plan 3's header comment and matches `src/plan/critic.ts`. Do not add a resolver field to `RunOperation`.
+
+**D4.12 — the machine records which gates ran on `FinishState`.** The body's Verification section reports `- Gates: <names>`, which the flow sourced from its gate node's output (`gateOutputs(ctx).ran`). In the native machine `runQualityGates` returns `ran` to `runQualityGatesLoop` and nowhere else — `FinishOps` never sees it, so a factory option or a thunk would render an empty gate line on every PR and nobody would notice, because an empty list renders as *no line at all*. Task 6 therefore adds `gatesRan?: string[]` to `FinishState` and one assignment in `runQualityGatesLoop` (`state.gatesRan = gates.ran`) after each `runGateZeroAndRepoGates`; `loadFinishPrContext` reads `state.gatesRan ?? []`. This is the only change to `machine.ts` in this plan and it needs a test asserting the field survives to the rendered body.
+
+The draft opened at step 3 legitimately has no gate line — gates have not run yet. That matches the flow, which only ever built a body at the end.
 
 ---
 
@@ -69,7 +79,7 @@ Read these before Task 1. They were settled against the real code; do not re-der
 
 | File | Responsibility |
 | --- | --- |
-| `src/forge/template-merge.ts` | Moved from `flows/nax-finish/pr-template-merge.ts`. `mergeTemplate`, `BodySection`, `TemplateMode`, `MergeOptions`, `DEFAULT_SECTION_ALIASES`. |
+| `src/forge/template-merge.ts` | Copied from `flows/nax-finish/pr-template-merge.ts` (the original stays — D4.1). `mergeTemplate`, `BodySection`, `TemplateMode`, `MergeOptions`, `DEFAULT_SECTION_ALIASES`. |
 | `src/forge/deps.ts` | `defaultForgeDeps` — the default `ForgeDeps` implementation (D4.11). |
 | `src/finish/pr/context.ts` | `loadFinishPrContext`, `FinishPrContext`, `FinishPrStory`, `_finishPrDeps`. Artifact reads, diffstat, template load. All fail-open. |
 | `src/finish/pr/body.ts` | `buildFinishBody`, `buildFinishTitle`. Pure renderers over `FinishPrContext`. |
@@ -77,7 +87,7 @@ Read these before Task 1. They were settled against the real code; do not re-der
 | `src/finish/pr/index.ts` | Barrel for the PR subtree. |
 | `src/finish/escalate.ts` | `buildEscalationComment`, `postEscalation`, `EscalationOutcome`. |
 | `src/finish/ops-impl.ts` | `createFinishOps`, `FinishOpsDeps`, `_finishOpsDeps`. |
-| `test/unit/forge/template-merge.test.ts` | Ported from `test/unit/flows/nax-finish/pr-template-merge.test.ts`. |
+| `test/unit/forge/template-merge.test.ts` | Copied from `test/unit/flows/nax-finish/pr-template-merge.test.ts`, plus one equivalence test against the `flows/` copy. |
 | `test/unit/finish/pr-context.test.ts` | Loader: artifact parsing, fail-open paths, diffstat pathspec. |
 | `test/unit/finish/pr-body.test.ts` | Renderer, ported from `test/unit/flows/nax-finish/pr-body.test.ts`. |
 | `test/unit/finish/pr-open.test.ts` | Draft open, promote, body edit, `parseView`. |
@@ -90,51 +100,51 @@ Read these before Task 1. They were settled against the real code; do not re-der
 | File | Change |
 | --- | --- |
 | `src/plugins/builtin/auto-pr/pr-body.ts` | Import `mergeTemplate` from `@/forge`, not `@flows/nax-finish/pr-template-merge`. |
-| `src/forge/index.ts` | Export the template-merge surface. |
+| `src/forge/index.ts` | Export the template-merge surface and `defaultForgeDeps`. |
+| `src/finish/types.ts` | Re-point `TemplateMode` at `@/forge`; drop the stale "Plan 3 moves..." comment. Add `gatesRan?: string[]` reference in `FinishState` (declared in `state.ts`). |
+| `src/finish/state.ts` | Add `gatesRan?: string[]` to `FinishState` (D4.12). |
+| `src/finish/machine.ts` | One assignment: `state.gatesRan = gates.ran` in `runQualityGatesLoop` (D4.12). |
 | `src/finish/index.ts` | Export the PR subtree, escalation and the ops factory. |
 
-**Deleted:**
-
-| File | Why |
-| --- | --- |
-| `flows/nax-finish/pr-template-merge.ts` | Moved to `src/forge/` (D4.1). Nothing under `flows/` imports it — verify with the grep in Task 1 Step 1 before deleting. |
-| `test/unit/flows/nax-finish/pr-template-merge.test.ts` | Moves with it. |
+**Deleted:** nothing. Everything under `flows/` stays until plan 5 (D4.1).
 
 ---
 
-### Task 1: Move the template merger into `src/forge/`
+### Task 1: Copy the template merger and default deps into `src/forge/`
 
 **Files:**
-- Create: `src/forge/template-merge.ts` (moved content)
-- Modify: `src/forge/index.ts`, `src/plugins/builtin/auto-pr/pr-body.ts:16`
-- Delete: `flows/nax-finish/pr-template-merge.ts`, `test/unit/flows/nax-finish/pr-template-merge.test.ts`
-- Test: `test/unit/forge/template-merge.test.ts` (moved content)
+- Create: `src/forge/template-merge.ts` (copied content), `src/forge/deps.ts`
+- Modify: `src/forge/index.ts`, `src/plugins/builtin/auto-pr/pr-body.ts:16`, `src/finish/types.ts`
+- Test: `test/unit/forge/template-merge.test.ts` (copied content plus one equivalence test)
+- Unchanged: `flows/nax-finish/pr-template-merge.ts` and its test both stay (D4.1)
 
 **Interfaces:**
 - Produces: `mergeTemplate(template: string | null | undefined, sections: BodySection[], opts?: MergeOptions): string`; `interface BodySection { key: string; heading: string; body: string }`; `type TemplateMode = "merge" | "strict" | "ignore"`; `interface MergeOptions { mode?: TemplateMode; sectionMap?: Record<string, string> }`; `DEFAULT_SECTION_ALIASES: Record<string, string>`. Tasks 3 and 6 consume these; `src/plugins/builtin/auto-pr/pr-body.ts` already does.
 
-- [ ] **Step 1: Confirm nothing under `flows/` still imports it**
+- [ ] **Step 1: Confirm the importers, and that the original must stay**
 
 ```bash
 grep -rn "pr-template-merge" flows/ src/ test/ scripts/ tsconfig.json
 ```
 
-Expected: exactly three importers — `flows/nax-finish/steps/pr-body.ts`, `src/plugins/builtin/auto-pr/pr-body.ts`, and the two test files. **If `flows/nax-finish/steps/pr-body.ts` imports it, the file cannot be deleted yet** (`flows/` cannot import `src/`): in that case copy it to `src/forge/template-merge.ts`, leave the `flows/` copy and its test alone, and note in the commit that the duplicate dies in plan 5. Everything else in this task is unchanged.
+Expected, and already verified while writing this plan: `flows/nax-finish/steps/pr-body.ts:26` and `flows/nax-finish/types.ts:1` import it from inside `flows/`, `src/plugins/builtin/auto-pr/pr-body.ts:16` imports it through the `@flows/*` alias, and each tree has a test. The two `flows/` importers are why this is a **copy, not a move** — `flows/` cannot import `src/`, so deleting the original breaks the live flow. Do not delete anything in this task.
 
-- [ ] **Step 2: Move the file and its test**
+- [ ] **Step 2: Copy the file and its test**
 
 ```bash
-git mv flows/nax-finish/pr-template-merge.ts src/forge/template-merge.ts
-git mv test/unit/flows/nax-finish/pr-template-merge.test.ts test/unit/forge/template-merge.test.ts
+cp flows/nax-finish/pr-template-merge.ts src/forge/template-merge.ts
+cp test/unit/flows/nax-finish/pr-template-merge.test.ts test/unit/forge/template-merge.test.ts
 ```
 
 Then in `src/forge/template-merge.ts` replace the "Lives under `flows/` ... because `flows/` is the more constrained runtime" paragraph of the header comment with:
 
 ```
  * Lives in `src/forge/` because both consumers are here: the auto-PR plugin's
- * body builder and `src/finish/pr/body.ts`. It was under `flows/` while the
- * finish flow was the only other caller; `flows/` cannot import `src/`, so the
- * flow keeps its own copy until plan 5 deletes that tree.
+ * body builder and `src/finish/pr/body.ts`. `flows/nax-finish/` keeps a
+ * byte-identical copy because it cannot import `src/`; that copy and this
+ * comment both go when plan 5 deletes the flow. Until then, edit neither
+ * without editing the other — `test/unit/forge/template-merge.test.ts` has an
+ * equivalence test that fails if they drift.
 ```
 
 Leave every other line of the module byte-identical — the alias table and the merge semantics are settled behaviour (nax#1504, nax#1477) and this task changes neither.
@@ -154,7 +164,25 @@ export { DEFAULT_SECTION_ALIASES, mergeTemplate } from "./template-merge";
 import { type BodySection, type MergeOptions, mergeTemplate } from "@/forge";
 ```
 
-In `test/unit/forge/template-merge.test.ts`, change the import to `@/forge` (it is a new file in a directory whose sibling tests already use the alias).
+In `test/unit/forge/template-merge.test.ts`, change the import to `@/forge` (it is a new file in a directory whose sibling tests already use the alias), and append the drift guard that justifies keeping two copies:
+
+```ts
+import { mergeTemplate as flowMergeTemplate } from "@flows/nax-finish/pr-template-merge";
+
+test("stays byte-identical to the flows copy that is still live", () => {
+  const template = "## Summary\n\n<!-- what changed -->\n\n## Testing\n\n- [ ] tests pass\n";
+  const sections = [
+    { key: "narrative", heading: "What changed", body: "Ported the merger." },
+    { key: "verification", heading: "Verification", body: "- Gates: lint, test" },
+    { key: "footer", heading: "", body: "3/3 stories" },
+  ];
+  for (const mode of ["merge", "strict", "ignore"] as const) {
+    expect(mergeTemplate(template, sections, { mode })).toBe(flowMergeTemplate(template, sections, { mode }));
+  }
+});
+```
+
+This test is deleted in plan 5 along with the `flows/` copy it compares against.
 
 - [ ] **Step 4: Add the default `ForgeDeps` implementation (D4.11)**
 
@@ -183,17 +211,29 @@ export const defaultForgeDeps: ForgeDeps = { run: defaultRun, readText: defaultR
 
 Add to `src/forge/index.ts`: `export { defaultForgeDeps } from "./deps";`. Do not modify the auto-PR plugin's copy in this task.
 
-- [ ] **Step 5: Run the moved test plus every consumer's test**
+- [ ] **Step 5: Re-point `src/finish/types.ts`'s placeholder `TemplateMode` (D4.8)**
 
-Run: `bun test test/unit/forge/ test/unit/plugins/auto-pr* test/unit/flows/nax-finish/pr-body.test.ts`
-Expected: PASS, with no change to any assertion. The flow's own `pr-body.test.ts` still passes because the `flows/` copy is untouched (or, if Step 1 found the flow importing it, because the copy stayed).
+`src/finish/types.ts` opens with a locally declared `TemplateMode` whose comment says a later plan will re-point it. This is that plan. Replace the declaration and its comment with a re-export so there is exactly one definition:
 
-- [ ] **Step 6: Static checks and commit**
+```ts
+import type { TemplateMode } from "@/forge";
+
+export type { TemplateMode };
+```
+
+Leave `FinishPrBodySettings` exactly as it is — it already has the shape Tasks 2 and 6 need, and it is now typed against the real `TemplateMode`. Run `bun x tsc --noEmit` here specifically: if anything in `src/finish/` was silently relying on the local declaration, this is where it surfaces (nothing should — nothing referenced it before this plan).
+
+- [ ] **Step 6: Run the copied test plus every consumer's test**
+
+Run: `bun test test/unit/forge/ test/unit/plugins/auto-pr* test/unit/flows/nax-finish/`
+Expected: PASS, with no change to any assertion. Every `flows/` test still passes because nothing under `flows/` was touched, and the new equivalence test proves the copy is faithful.
+
+- [ ] **Step 7: Static checks and commit**
 
 ```bash
 bun x tsc --noEmit && bun run lint && bun test test/unit/forge/
 git add -A
-git commit -m "refactor(forge): move the PR template merger and default deps into src/forge"
+git commit -m "refactor(forge): add the PR template merger and default deps to src/forge"
 ```
 
 ---
@@ -205,7 +245,7 @@ git commit -m "refactor(forge): move the PR template merger and default deps int
 - Test: `test/unit/finish/pr-context.test.ts`
 
 **Interfaces:**
-- Consumes: `readRounds` and `AuditTarget` from `../audit`; `readSpecSummary`, `resolveNarrative`, `resolveTitle` from `../operations`; `findPrTemplate` and `ForgeKind` from `@/forge`; `TemplateMode` from `@/forge`; `featureDir` from `@/config`.
+- Consumes: `readRounds` and `AuditTarget` from `../audit`; `readSpecSummary`, `resolveNarrative`, `resolveTitle` from `../operations`; `findPrTemplate`, `defaultForgeDeps` and `ForgeKind` from `@/forge`; `TemplateMode` and `FinishPrBodySettings` from `../types`; `featureDir` from `@/config`.
 - Produces:
 
 ```ts
@@ -232,11 +272,11 @@ export interface FinishPrContext {
 export interface LoadPrContextArgs {
   state: FinishState;
   audit: AuditTarget;
-  gatesRan: string[];
   forge?: ForgeKind;
   narrative?: string;
   title?: string;
-  prBody?: { template?: TemplateMode; sectionMap?: Record<string, string> };
+  /** `FinishPrBodySettings` from `../types` — do not redeclare the shape (D4.8). */
+  prBody?: FinishPrBodySettings;
 }
 
 export async function loadFinishPrContext(args: LoadPrContextArgs): Promise<FinishPrContext>;
@@ -254,7 +294,8 @@ Task 3 consumes `FinishPrContext`; Task 6 calls `loadFinishPrContext`.
 1. Input is a `FinishState` + `AuditTarget`, not a `FinishInput`. `feature`, `workdir`, `base` and `specPath` are already fields of `FinishState`; `readRounds` takes the `AuditTarget`.
 2. The PRD path is `join(featureDir(state.workdir, state.feature), "prd.json")` and status is its sibling `status.json`. The flow took a caller-supplied `prdPath` because acpx handed it one; in-process `featureDir` is the SSOT (`src/config/paths.ts:117`) and open-coding `.nax` is what shipped the stray-directory bug it warns about.
 3. `findPrTemplate(workdir, forge, deps)` comes from `@/forge` and takes `ForgeKind`, not the flow's `Forge`.
-4. `templateMode` / `templateSectionMap` come from `args.prBody` (D4.8), not from a config read.
+4. `templateMode` / `templateSectionMap` come from `args.prBody` (D4.8), typed as the existing `FinishPrBodySettings` from `../types` — do not declare a second inline shape.
+5. `gatesRan` is read off `state.gatesRan ?? []` (D4.12), not passed in. The machine is the only thing that knows which gates ran, and Task 6 is where it starts recording them; until then this renders as no gate line, which is the correct output for a body built before the gates run.
 
 Everything else is a faithful port, **including every fail-open path and the comments explaining them**: `readJson` warns and returns `undefined` on a genuine read failure but is silent on ENOENT; `runDiffstat` returns `{}` on an empty `base` and `undefined` on any non-zero exit or throw; `loadTemplate` returns `undefined` when the forge is unknown or the read throws. The `NAX_ARTIFACT_PATHSPEC = "**/.nax/**"` glob and both `:(glob...)` pathspecs are load-bearing — copy them exactly, comment included.
 
@@ -308,12 +349,10 @@ describe("loadFinishPrContext", () => {
     const ctx = await loadFinishPrContext({
       state: stateFor(dir),
       audit: { auditDir: join(dir, "audit"), runId: "run-1" },
-      gatesRan: ["lint"],
     });
 
     expect(ctx.stories).toEqual([{ id: "US-001", title: "First", acCount: 3 }]);
     expect(ctx.outOfScope).toEqual(["not this"]);
-    expect(ctx.gatesRan).toEqual(["lint"]);
   });
 
   test("drops a story row whose id or title is not a string", async () => {
@@ -328,7 +367,6 @@ describe("loadFinishPrContext", () => {
     const ctx = await loadFinishPrContext({
       state: stateFor(dir),
       audit: { auditDir: join(dir, "audit"), runId: "run-1" },
-      gatesRan: [],
     });
 
     expect(ctx.stories.map((s) => s.id)).toEqual(["US-002"]);
@@ -346,7 +384,6 @@ describe("loadFinishPrContext", () => {
     const ctx = await loadFinishPrContext({
       state: stateFor(dir),
       audit: { auditDir: join(dir, "audit"), runId: "run-1" },
-      gatesRan: [],
     });
 
     expect(ctx.diffstat).toContain("src/a.ts");
@@ -369,7 +406,6 @@ describe("loadFinishPrContext", () => {
     const ctx = await loadFinishPrContext({
       state,
       audit: { auditDir: join(dir, "audit"), runId: "run-1" },
-      gatesRan: [],
     });
 
     expect(ran).toBe(false);
@@ -382,10 +418,22 @@ describe("loadFinishPrContext", () => {
     const ctx = await loadFinishPrContext({
       state: stateFor(dir),
       audit: { auditDir: join(dir, "audit"), runId: "run-1" },
-      gatesRan: [],
     });
 
     expect(ctx.title).toBe("feat: demo");
+  });
+
+  test("reports the gate names the machine recorded on state", async () => {
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+    const withGates = stateFor(dir);
+    withGates.gatesRan = ["lint", "typecheck"];
+
+    const ctx = await loadFinishPrContext({
+      state: withGates,
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+    });
+
+    expect(ctx.gatesRan).toEqual(["lint", "typecheck"]);
   });
 
   test("carries the caller's template mode and section map", async () => {
@@ -394,7 +442,6 @@ describe("loadFinishPrContext", () => {
     const ctx = await loadFinishPrContext({
       state: stateFor(dir),
       audit: { auditDir: join(dir, "audit"), runId: "run-1" },
-      gatesRan: [],
       prBody: { template: "strict", sectionMap: { notes: "narrative" } },
     });
 
@@ -427,13 +474,15 @@ Create `src/finish/pr/context.ts` following the port notes above. The shape of t
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { featureDir } from "@/config";
-import { findPrTemplate } from "@/forge";
-import type { ForgeKind, TemplateMode } from "@/forge";
+import { defaultForgeDeps, findPrTemplate } from "@/forge";
+import type { ForgeKind } from "@/forge";
 import type { AuditTarget } from "../audit";
 import { readRounds } from "../audit";
 import { readSpecSummary, resolveNarrative, resolveTitle } from "../operations";
 import type { FinishState } from "../state";
-import type { FinishRound } from "../types";
+// TemplateMode is re-exported by ../types from @/forge (Task 1, D4.8) --
+// import it from ../types like every other finish-side type, not from @/forge.
+import type { FinishPrBodySettings, FinishRound, TemplateMode } from "../types";
 
 // ... interfaces exactly as in the Interfaces block above ...
 
@@ -468,7 +517,7 @@ export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./pr";
 ```
 
 Run: `bun test test/unit/finish/pr-context.test.ts`
-Expected: PASS (6 tests).
+Expected: PASS (7 tests).
 
 - [ ] **Step 5: Static checks and commit**
 
@@ -561,7 +610,7 @@ git commit -m "feat(finish): render the PR title and body natively"
 - Test: `test/unit/finish/pr-open.test.ts`
 
 **Interfaces:**
-- Consumes: `detectForge`, `hasOpenPr`, `openPr`, `viewArgv`, `extractUrl`, `ForgeDeps`, `ForgeKind` from `@/forge`; `commitAndPush` from `../commit`.
+- Consumes: `hasOpenPr`, `openPr`, `viewArgv`, `extractUrl`, `ForgeDeps`, `ForgeKind` from `@/forge`. Note it does NOT call `detectForge` — the forge is resolved once by the caller and passed in, which is what stops the body and the create command from disagreeing about it.
 - Produces:
 
 ```ts
@@ -791,7 +840,7 @@ git commit -m "feat(finish): open, promote and update the finish PR natively"
 - Test: `test/unit/finish/escalate.test.ts`
 
 **Interfaces:**
-- Consumes: `detectForge`, `viewArgv`, `extractUrl`, `ForgeDeps`, `ForgeKind` from `@/forge`; `Finding` from `./types`.
+- Consumes: `viewArgv`, `extractUrl`, `ForgeDeps`, `ForgeKind` from `@/forge`; `Finding` from `./types`. As in Task 4, the forge arrives resolved; this module never detects it.
 - Produces:
 
 ```ts
@@ -940,8 +989,8 @@ git commit -m "feat(finish): deliver escalations through the forge natively"
 
 **Files:**
 - Create: `src/finish/ops-impl.ts`
-- Modify: `src/finish/index.ts`
-- Test: `test/unit/finish/ops-impl.test.ts`
+- Modify: `src/finish/index.ts`, `src/finish/state.ts` (D4.12), `src/finish/machine.ts` (D4.12, one line)
+- Test: `test/unit/finish/ops-impl.test.ts`, `test/unit/finish/machine-loops.test.ts` (one added test)
 
 **Interfaces:**
 - Consumes: everything above, plus `finishReviewOp`, `finishFixOp`, `finishNarrativeOp` from `../operations`; `callOp` and `CallContext` from `@/operations`; `commitAndPush` from `../commit`; `ConfiguredModel` from `@/config`.
@@ -964,11 +1013,10 @@ export interface FinishOpsDeps {
     narrative?: ConfiguredModel;
   };
   timeouts?: { reviewMs?: number; fixMs?: number; narrativeMs?: number };
-  prBody?: { template?: TemplateMode; sectionMap?: Record<string, string> };
-  /** Telegram is the sole escalation channel when true (D4.3 in the flow's terms). */
+  /** The existing `FinishPrBodySettings` from `./types` (D4.8). */
+  prBody?: FinishPrBodySettings;
+  /** Telegram is the sole escalation channel when true. */
   preferTelegram?: boolean;
-  /** Gate names the body's Verification section reports. Mutated by the caller as gates run. */
-  gatesRan?: () => string[];
   /** Narrative is opt-out: when false, `narrate` is omitted from the returned object. */
   narrative?: boolean;
   warn?: (message: string, details: Record<string, unknown>) => void;
@@ -985,14 +1033,40 @@ Plan 5 calls `createFinishOps` and hands the result to `runFinishMachine`.
 
 - `review(phase, req)` calls `_finishOpsDeps.callOp({ ...deps.callCtx, sessionOverride: { role: phase === "spec" ? "finish-review-spec" : "finish-review-quality" } }, finishReviewOp, { phase, base: state.base, specPath: state.specPath, workdir: state.workdir, since: state.phases[phase].reviewSince, gaps: state.phases[phase].reviewGaps, priorFindings: state.findings, model, timeoutMs })`. It returns `{ findings, gaps }` unchanged — `FinishReviewOutput` is structurally a superset of `ReviewOutcome`, so no adapter. It does **not** catch: a review that cannot run must reach the machine's catch and escalate.
 - `fix(phase, req)` calls `finishFixOp` with `{ phase, workdir: state.workdir, findings, failing, gateOutput, acceptanceOutput, model, timeoutMs }` and returns its `FixOutcome` unchanged. No catch, same reason.
-- `openDraftPr(state)` returns `null` immediately when `forgeKind` is null; otherwise loads the context (`loadFinishPrContext` with `forge: forgeKind`, `gatesRan: deps.gatesRan?.() ?? []`, `prBody`), renders title and body, and calls `openDraftFinishPr`.
+- `openDraftPr(state)` returns `null` immediately when `forgeKind` is null; otherwise loads the context (`loadFinishPrContext` with `forge: forgeKind`, `prBody`), renders title and body, and calls `openDraftFinishPr`.
 - `promotePr(state)` runs `commitAndPush(state.workdir, state.branch, \`fix(${state.feature}): nax-finish automated fixes\`)` **first** (D4.6), then — when `forgeKind` is non-null — loads context, renders, and calls `openOrPromotePr`. With a null forge it returns `{ status: "already-ready" }` after the push, because there is nothing to promote and the branch is still pushed. Neither call is caught.
 - `narrate(state)` is present on the returned object only when `deps.narrative !== false`. Its entire body is inside one try/catch (D4.4): call `finishNarrativeOp` under `sessionOverride: { role: "finish-narrative" }` with `{ base: state.base, model, timeoutMs }`, then re-load the PR context passing the resulting `narrative` and `title`, render, and `updatePrBody`. On any throw, `warn` and return.
 - `escalate(state, reason, findings)` never throws (D4.3). It: (1) tries `commitAndPush` for the partial fixes and, on failure, records a `syncNote` string (D4.7); (2) builds the comment with `buildEscalationComment(state.feature, reason, findings) + syncNote`; (3) calls `postEscalation` when `forgeKind` is non-null, returning `{ url }`; (4) catches everything and returns `{ deliveryError: errorMessage(err) }`. With a null forge it returns `{ deliveryError: "no forge detected" }` — the escalation still needs somewhere to say it went nowhere.
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Record the gate names on `FinishState` (D4.12)**
 
-`test/unit/finish/ops-impl.test.ts` — the seven behaviours that matter. Use a fake `callOp` through `_finishOpsDeps` and a `ForgeDeps` whose `run` records commands. A minimal `callCtx` cast (`{} as CallContext`) is sufficient: nothing in the factory reads it except to spread it.
+This comes first because the body builder already reads the field. In `src/finish/state.ts`, add to `FinishState`:
+
+```ts
+  /**
+   * Gate names the last quality-gate pass ran, for the PR body's Verification
+   * section. Recorded here because `runQualityGates`'s result is otherwise
+   * local to the machine's loop, and `FinishOps` — which builds the body —
+   * never sees it. An absent or empty list renders no gate line at all, which
+   * is why a silently-unset field would have gone unnoticed.
+   */
+  gatesRan?: string[];
+```
+
+In `src/finish/machine.ts`'s `runQualityGatesLoop`, immediately after `const gates = await runGateZeroAndRepoGates(state, deps);`:
+
+```ts
+    state.gatesRan = gates.ran;
+```
+
+Add one test to `test/unit/finish/machine-loops.test.ts` asserting that after a green gate pass `state.gatesRan` equals the gate names the stubbed `runQualityGates` reported. Copy the stubbing style already in that file (`_qualityGateDeps`).
+
+Run: `bun test test/unit/finish/machine-loops.test.ts`
+Expected: PASS.
+
+- [ ] **Step 2: Write the failing tests for the factory**
+
+`test/unit/finish/ops-impl.test.ts` — the nine behaviours that matter. Use a fake `callOp` through `_finishOpsDeps` and a `ForgeDeps` whose `run` records commands. A minimal `callCtx` cast (`{} as CallContext`) is sufficient: nothing in the factory reads it except to spread it.
 
 ```ts
 import { afterEach, describe, expect, test } from "bun:test";
@@ -1121,14 +1195,19 @@ test("promotePr pushes before it talks to the forge", async () => {
 });
 ```
 
-The push assertion needs `commitAndPush`'s git seam stubbed too — `_finishGitDeps.git`, exported from `@/finish`. Stub it in that test to record its argv into the same `calls` array and return `{ exitCode: 0, stdout: "", stderr: "" }`, and restore it in `afterEach`.
+The push assertion needs `commitAndPush`'s git seam stubbed too — `_finishGitDeps.git`, exported from `@/finish`. Stub it to record its argv into the same `calls` array and return `{ exitCode: 0, stdout: "", stderr: "" }`, and restore it in `afterEach`.
 
-- [ ] **Step 2: Run to verify failure**
+Two mechanics of that stub matter, both verified against `src/finish/commit.ts`:
+
+- `_finishGitDeps.git` is `gitWithTimeout`, which **prepends `"git"` itself**, so the recorded argv is `["push", "--set-upstream", "origin", "feat/demo"]` — no leading `"git"` to match on.
+- `commitAndPush` calls `commitFixes` first, which runs `git status --porcelain`. An empty stdout reads as a clean tree, so it returns `{ committed: false }` without an `add`/`commit`, and the push still runs unconditionally (`commit.ts` documents why: the branch can be ahead of its remote with nothing new to commit). Returning empty stdout is therefore the simplest correct stub — do not make it return dirty output unless the test is specifically about committing.
+
+- [ ] **Step 3: Run to verify failure**
 
 Run: `bun test test/unit/finish/ops-impl.test.ts`
 Expected: FAIL — `createFinishOps` is not exported.
 
-- [ ] **Step 3: Implement the factory**
+- [ ] **Step 4: Implement the factory**
 
 Create `src/finish/ops-impl.ts` per the implementation notes. Header comment:
 
@@ -1154,7 +1233,7 @@ Create `src/finish/ops-impl.ts` per the implementation notes. Header comment:
  */
 ```
 
-- [ ] **Step 4: Export and run**
+- [ ] **Step 5: Export and run**
 
 Add to `src/finish/index.ts`:
 
@@ -1164,13 +1243,13 @@ export type { FinishOpsDeps } from "./ops-impl";
 ```
 
 Run: `bun test test/unit/finish/ops-impl.test.ts`
-Expected: PASS (9 tests).
+Expected: PASS (9 tests in ops-impl.test.ts, plus the machine-loops test from Step 1).
 
-- [ ] **Step 5: Static checks and commit**
+- [ ] **Step 6: Static checks and commit**
 
 ```bash
 bun x tsc --noEmit && bun run lint && bun test test/unit/finish/
-git add src/finish/ops-impl.ts src/finish/index.ts test/unit/finish/ops-impl.test.ts
+git add src/finish/ops-impl.ts src/finish/index.ts src/finish/state.ts src/finish/machine.ts test/unit/finish/ops-impl.test.ts test/unit/finish/machine-loops.test.ts
 git commit -m "feat(finish): assemble the concrete FinishOps object"
 ```
 
@@ -1249,5 +1328,5 @@ Expected: no output. `src/finish/` is complete but wired to nothing; plan 5 wire
 ## Self-Review Notes
 
 - **Spec coverage.** Design section 4.2's module list is now fully realised except `phase.ts` (plan 5). Section 4.7's draft lifecycle is Task 4 plus `openDraftPr`/`promotePr` in Task 6. Section 4.5's operations were plan 3; this plan only binds them.
-- **Out of scope, deliberately.** Wiring `"finish"` into `PostRunPhase` (three sites: the type, `status-writer.ts:118-120`, `usePipelineBusEvents.ts:243`), the cost-aggregator delta, the config reshape from `finish.autoFlow`, the Telegram send itself, and deleting `flows/` — all plan 5. The `@flows/*` tsconfig alias also stays until then.
+- **Out of scope, deliberately.** Wiring `"finish"` into `PostRunPhase` (three sites: the type, `src/execution/status-writer.ts`'s `setPostRunPhase` overloads at ~117-119, and `src/tui/hooks/usePipelineBusEvents.ts`'s phase map at ~69-72 — re-locate both by symbol, the line numbers drift), the cost-aggregator delta, the config reshape from `finish.autoFlow`, the Telegram send itself, and deleting `flows/` — all plan 5. The `@flows/*` tsconfig alias also stays until then.
 - **Known duplication after this plan.** `flows/nax-finish/steps/{pr,pr-body,pr-narrative,escalate}.ts` still exist and still run. That is expected and is not a defect to file.

--- a/src/finish/escalate.ts
+++ b/src/finish/escalate.ts
@@ -1,0 +1,110 @@
+/**
+ * Delivering an escalation to its channel: a comment on the existing PR/MR, or
+ * a draft opened to hold it, or nothing at all when Telegram is preferred.
+ *
+ * Ported from `flows/nax-finish/steps/escalate.ts` (read-only reference, never
+ * imported). Restructured so the forge is a required argument rather than
+ * detected inside, and so I/O arrives as `ForgeDeps` rather than a
+ * module-level `_escalateDeps` seam. The comment text is byte-identical to the
+ * flow's — it is what a human reads and there is no reason for the two to
+ * differ.
+ */
+import { NaxError } from "@/errors";
+import { extractUrl, viewArgv } from "@/forge";
+import type { ForgeDeps, ForgeKind } from "@/forge";
+import type { Finding } from "./types";
+
+export function buildEscalationComment(feature: string, escalationReason: string, findings: Finding[]): string {
+  const lines = [
+    `## nax-finish escalation — \`${feature}\``,
+    "",
+    "This feature needs human judgment before it can ship. nax-finish stopped rather than guess.",
+    "",
+    `**Needs judgment:** ${escalationReason}`,
+    "",
+    "### Findings",
+    ...findings.map((f) => `- **[${f.severity}] ${f.title}** — ${f.problem}\n  - Suggested: ${f.fix}`),
+  ];
+  return lines.join("\n");
+}
+
+export interface EscalationOutcome {
+  url?: string;
+  /** Where the "needs judgment" message was delivered. */
+  channel: "telegram" | "pr-comment";
+}
+
+/**
+ * Deliver an escalation.
+ *
+ * `preferTelegram` (set by the plugin only when Telegram is both enabled and
+ * credentialed) makes Telegram the sole channel: the flow posts no comment and
+ * — critically — opens no draft PR to hold one, matching the design's
+ * "prefer Telegram when configured, else fall back to a PR/MR comment". The
+ * plugin sends the message itself after reading the result file. It still reads
+ * any existing PR/MR so the notification can carry a link, which is a read-only
+ * lookup with no side effect.
+ */
+export async function postEscalation(
+  args: { workdir: string; branch: string; comment: string; forge: ForgeKind; preferTelegram?: boolean },
+  deps: ForgeDeps,
+): Promise<EscalationOutcome> {
+  const view = await deps.run(viewArgv(args.forge, args.branch, "url"), { cwd: args.workdir });
+  const existingUrl = view.exitCode === 0 ? extractUrl(view.stdout) : undefined;
+
+  if (args.preferTelegram) {
+    return { url: existingUrl, channel: "telegram" };
+  }
+
+  if (view.exitCode === 0) {
+    const commentCmd =
+      args.forge === "github"
+        ? ["gh", "pr", "comment", args.branch, "--body", args.comment]
+        : ["glab", "mr", "note", args.branch, "--message", args.comment];
+    const commented = await deps.run(commentCmd, { cwd: args.workdir });
+    if (commented.exitCode !== 0) {
+      throw new NaxError(
+        `Failed to post escalation comment on "${args.branch}": ${commented.stderr.trim() || `exit ${commented.exitCode}`}`,
+        "FINISH_ESCALATION_COMMENT_FAILED",
+        { stage: "finish-escalate", branch: args.branch },
+      );
+    }
+    return { url: existingUrl, channel: "pr-comment" };
+  }
+
+  const createCmd =
+    args.forge === "github"
+      ? [
+          "gh",
+          "pr",
+          "create",
+          "--draft",
+          "--title",
+          `nax-finish: ${args.branch}`,
+          "--body",
+          args.comment,
+          "--head",
+          args.branch,
+        ]
+      : [
+          "glab",
+          "mr",
+          "create",
+          "--draft",
+          "--title",
+          `nax-finish: ${args.branch}`,
+          "--description",
+          args.comment,
+          "--source-branch",
+          args.branch,
+        ];
+  const create = await deps.run(createCmd, { cwd: args.workdir });
+  if (create.exitCode !== 0) {
+    throw new NaxError(
+      `Failed to open a draft to hold the escalation for "${args.branch}": ${create.stderr.trim() || `exit ${create.exitCode}`}`,
+      "FINISH_ESCALATION_DRAFT_FAILED",
+      { stage: "finish-escalate", branch: args.branch },
+    );
+  }
+  return { url: extractUrl(create.stdout), channel: "pr-comment" };
+}

--- a/src/finish/index.ts
+++ b/src/finish/index.ts
@@ -54,6 +54,8 @@ export type {
   FinishReviewInput,
   FinishReviewOutput,
 } from "./operations";
+export { _finishPrDeps, loadFinishPrContext } from "./pr";
+export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./pr";
 export {
   gateCommitRoute,
   MAX_FIX_ATTEMPTS,

--- a/src/finish/index.ts
+++ b/src/finish/index.ts
@@ -58,6 +58,8 @@ export { _finishPrDeps, loadFinishPrContext } from "./pr";
 export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./pr";
 export { buildFinishBody, buildFinishTitle } from "./pr";
 export { openDraftFinishPr, openOrPromotePr, parseView, updatePrBody } from "./pr";
+export { buildEscalationComment, postEscalation } from "./escalate";
+export type { EscalationOutcome } from "./escalate";
 export {
   gateCommitRoute,
   MAX_FIX_ATTEMPTS,

--- a/src/finish/index.ts
+++ b/src/finish/index.ts
@@ -56,6 +56,7 @@ export type {
 } from "./operations";
 export { _finishPrDeps, loadFinishPrContext } from "./pr";
 export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./pr";
+export { buildFinishBody, buildFinishTitle } from "./pr";
 export {
   gateCommitRoute,
   MAX_FIX_ATTEMPTS,

--- a/src/finish/index.ts
+++ b/src/finish/index.ts
@@ -57,6 +57,7 @@ export type {
 export { _finishPrDeps, loadFinishPrContext } from "./pr";
 export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./pr";
 export { buildFinishBody, buildFinishTitle } from "./pr";
+export { openDraftFinishPr, openOrPromotePr, parseView, updatePrBody } from "./pr";
 export {
   gateCommitRoute,
   MAX_FIX_ATTEMPTS,

--- a/src/finish/index.ts
+++ b/src/finish/index.ts
@@ -30,6 +30,8 @@ export { _qualityGateDeps, resolveGateCommands, runQualityGates } from "./gates/
 export { runFinishMachine } from "./machine";
 export type { FinishMachineDeps } from "./machine";
 export type { FinishOps, FixOutcome, FixRequest, ReviewRequest } from "./ops";
+export { _finishOpsDeps, createFinishOps } from "./ops-impl";
+export type { FinishOpsDeps } from "./ops-impl";
 export {
   buildNarrativePrompt,
   finishFixOp,

--- a/src/finish/machine.ts
+++ b/src/finish/machine.ts
@@ -306,6 +306,7 @@ async function runQualityGatesLoop(state: FinishState, deps: FinishMachineDeps):
   for (;;) {
     assertNotAborted(deps);
     const gates = await runGateZeroAndRepoGates(state, deps);
+    state.gatesRan = gates.ran;
     const routed = routeQualityGates(gates, state.phases.gate);
 
     if (routed.route === "green") {

--- a/src/finish/ops-impl.ts
+++ b/src/finish/ops-impl.ts
@@ -74,6 +74,34 @@ const PROMOTE_MESSAGE = (feature: string): string => `fix(${feature}): nax-finis
 const ESCALATION_PUSH_MESSAGE = (feature: string): string =>
   `wip(${feature}): nax-finish partial fixes before escalation`;
 
+/**
+ * Load the PR context and render it, falling back to a minimal title/body on
+ * any failure rather than propagating.
+ *
+ * `loadFinishPrContext` is itself fail-open per artifact, but the pure
+ * renderers (`buildFinishTitle` / `buildFinishBody`) are not guarded, and a
+ * throw here must not undo work `promotePr`'s already-fatal push just did —
+ * the branch is pushed and the gates are green by the time this runs, so
+ * losing that to an unrenderable PR body would be strictly worse than a
+ * generic one.
+ */
+async function buildPrContentOrFallback(
+  state: FinishState,
+  audit: AuditTarget,
+  forgeKind: ForgeKind,
+  prBody: FinishPrBodySettings | undefined,
+): Promise<{ title: string; body: string }> {
+  try {
+    const ctx = await loadFinishPrContext({ state, audit, forge: forgeKind, prBody });
+    return { title: buildFinishTitle(ctx), body: buildFinishBody(ctx) };
+  } catch (err) {
+    return {
+      title: `fix(${state.feature}): nax-finish automated fixes`,
+      body: `PR body could not be generated: ${errorMessage(err)}`,
+    };
+  }
+}
+
 export function createFinishOps(deps: FinishOpsDeps): FinishOps {
   const { callCtx, forge, forgeKind, audit, models, timeouts, prBody, preferTelegram, warn } = deps;
 
@@ -114,20 +142,26 @@ export function createFinishOps(deps: FinishOpsDeps): FinishOps {
         model: models?.fix,
         timeoutMs: timeouts?.fixMs,
       };
-      return _finishOpsDeps.callOp({ ...callCtx }, finishFixOp, input);
+      // Not `callCtx` alone — an explicit `sessionOverride: undefined` makes sure a
+      // context the caller built with one set (e.g. for a review call reused here)
+      // doesn't leak a reviewer role into the fixer once a caller starts wiring one in.
+      return _finishOpsDeps.callOp({ ...callCtx, sessionOverride: undefined }, finishFixOp, input);
     },
 
     async openDraftPr(state: FinishState) {
       if (forgeKind === null) return null;
-      const ctx = await loadFinishPrContext({ state, audit, forge: forgeKind, prBody });
+      // A context-load or render failure here must not surface as a throw: the
+      // draft is a convenience (D4.5) and the safe response to any failure in
+      // producing its content is the same as to any failure opening it — skip.
+      let content: { title: string; body: string };
+      try {
+        const ctx = await loadFinishPrContext({ state, audit, forge: forgeKind, prBody });
+        content = { title: buildFinishTitle(ctx), body: buildFinishBody(ctx) };
+      } catch {
+        return null;
+      }
       return openDraftFinishPr(
-        {
-          workdir: state.workdir,
-          branch: state.branch,
-          title: buildFinishTitle(ctx),
-          body: buildFinishBody(ctx),
-          forge: forgeKind,
-        },
+        { workdir: state.workdir, branch: state.branch, title: content.title, body: content.body, forge: forgeKind },
         forge,
       );
     },
@@ -135,28 +169,32 @@ export function createFinishOps(deps: FinishOpsDeps): FinishOps {
     async promotePr(state: FinishState) {
       await commitAndPush(state.workdir, state.branch, PROMOTE_MESSAGE(state.feature));
       if (forgeKind === null) return { status: "already-ready" };
-      const ctx = await loadFinishPrContext({ state, audit, forge: forgeKind, prBody });
+      const content = await buildPrContentOrFallback(state, audit, forgeKind, prBody);
       return openOrPromotePr(
-        {
-          workdir: state.workdir,
-          branch: state.branch,
-          title: buildFinishTitle(ctx),
-          body: buildFinishBody(ctx),
-          forge: forgeKind,
-        },
+        { workdir: state.workdir, branch: state.branch, title: content.title, body: content.body, forge: forgeKind },
         forge,
       );
     },
 
     async escalate(state: FinishState, reason: string, findings: Finding[]) {
-      let syncNote = "";
+      let pushError: string | undefined;
       try {
         await commitAndPush(state.workdir, state.branch, ESCALATION_PUSH_MESSAGE(state.feature));
       } catch (err) {
-        syncNote = `\n\n> Note: nax-finish could not push its partial fixes — ${String(err)}`;
+        pushError = errorMessage(err);
       }
+      const syncNote = pushError ? `\n\n> Note: nax-finish could not push its partial fixes — ${pushError}` : "";
       try {
-        if (forgeKind === null) return { deliveryError: "no forge detected" };
+        if (forgeKind === null) {
+          // The push failure would otherwise be lost here — this is the one
+          // branch that never reaches `buildEscalationComment`, so it has to
+          // carry `pushError` itself rather than via `syncNote`.
+          return {
+            deliveryError: pushError
+              ? `no forge detected; partial fixes could not be pushed either: ${pushError}`
+              : "no forge detected",
+          };
+        }
         const comment = buildEscalationComment(state.feature, reason, findings) + syncNote;
         const outcome = await postEscalation(
           { workdir: state.workdir, branch: state.branch, comment, forge: forgeKind, preferTelegram },

--- a/src/finish/ops-impl.ts
+++ b/src/finish/ops-impl.ts
@@ -1,0 +1,207 @@
+/**
+ * The concrete `FinishOps` the state machine runs against.
+ *
+ * A factory rather than a module of free functions: every method needs the
+ * same closed-over `CallContext`, forge deps and model selections, and the
+ * machine's contract (`./ops`) is an object. Two of the contract's clauses are
+ * load-bearing and are implemented here, not in the modules below:
+ *
+ * - `escalate` must not throw. Its whole body is wrapped, and a delivery
+ *   failure is returned as `deliveryError` — `machine.ts`'s `doEscalate` is
+ *   the only caller and it has no other way to record that the human was
+ *   never told.
+ * - `narrate` must not throw. The machine calls it *after* `promotePr`,
+ *   inside its one try, so a throw rewrites an already-promoted green run to
+ *   `escalated`.
+ *
+ * `review` and `fix` deliberately do neither: a reviewer or fixer that cannot
+ * run is exactly the case the machine's catch exists for.
+ */
+import type { ConfiguredModel } from "@/config";
+import type { ForgeDeps, ForgeKind } from "@/forge";
+import { callOp } from "@/operations";
+import type { CallContext } from "@/operations";
+import { errorMessage } from "../utils/errors";
+import type { AuditTarget } from "./audit";
+import { commitAndPush } from "./commit";
+import { buildEscalationComment, postEscalation } from "./escalate";
+import { finishFixOp, finishNarrativeOp, finishReviewOp } from "./operations";
+import type { FinishFixInput, FinishNarrativeInput, FinishReviewInput } from "./operations";
+import type { FinishOps, FixRequest, ReviewRequest } from "./ops";
+import {
+  buildFinishBody,
+  buildFinishTitle,
+  loadFinishPrContext,
+  openDraftFinishPr,
+  openOrPromotePr,
+  updatePrBody,
+} from "./pr";
+import type { FinishState } from "./state";
+import type { FinishPrBodySettings } from "./types";
+import type { Finding, FinishPhase } from "./types";
+
+export interface FinishOpsDeps {
+  /** The call context every LLM op runs under. Its `sessionOverride` is replaced per phase. */
+  callCtx: CallContext;
+  /** Subprocess and file I/O for every forge call. */
+  forge: ForgeDeps;
+  /** Resolved once by the caller; null disables every forge interaction. */
+  forgeKind: ForgeKind | null;
+  audit: AuditTarget;
+  /** Per-step model selection. Absent falls through to callOp's own default. */
+  models?: {
+    reviewSpec?: ConfiguredModel;
+    reviewQuality?: ConfiguredModel;
+    fix?: ConfiguredModel;
+    narrative?: ConfiguredModel;
+  };
+  timeouts?: { reviewMs?: number; fixMs?: number; narrativeMs?: number };
+  /** The existing `FinishPrBodySettings` from `./types` (D4.8). */
+  prBody?: FinishPrBodySettings;
+  /** Telegram is the sole escalation channel when true. */
+  preferTelegram?: boolean;
+  /** Narrative is opt-out: when false, `narrate` is omitted from the returned object. */
+  narrative?: boolean;
+  warn?: (message: string, details: Record<string, unknown>) => void;
+}
+
+export const _finishOpsDeps: { callOp: typeof callOp } = { callOp };
+
+/** The commit both the promote and the escalation paths push before touching the forge. */
+const PARTIAL_FIX_MESSAGE = (feature: string): string => `fix(${feature}): nax-finish automated fixes`;
+
+export function createFinishOps(deps: FinishOpsDeps): FinishOps {
+  const { callCtx, forge, forgeKind, audit, models, timeouts, prBody, preferTelegram, warn } = deps;
+
+  const ops: FinishOps = {
+    async review(phase: "spec" | "quality", req: ReviewRequest) {
+      const { state } = req;
+      const phaseState = state.phases[phase];
+      const input: FinishReviewInput = {
+        phase,
+        base: state.base,
+        specPath: state.specPath,
+        workdir: state.workdir,
+        since: phaseState.reviewSince,
+        gaps: phaseState.reviewGaps,
+        priorFindings: state.findings,
+        model: phase === "spec" ? models?.reviewSpec : models?.reviewQuality,
+        timeoutMs: timeouts?.reviewMs,
+      };
+      return _finishOpsDeps.callOp(
+        {
+          ...callCtx,
+          sessionOverride: { role: phase === "spec" ? "finish-review-spec" : "finish-review-quality" },
+        },
+        finishReviewOp,
+        input,
+      );
+    },
+
+    async fix(phase: FinishPhase, req: FixRequest) {
+      const { state, findings, failing, gateOutput, acceptanceOutput } = req;
+      const input: FinishFixInput = {
+        phase,
+        workdir: state.workdir,
+        findings,
+        failing,
+        gateOutput,
+        acceptanceOutput,
+        model: models?.fix,
+        timeoutMs: timeouts?.fixMs,
+      };
+      return _finishOpsDeps.callOp({ ...callCtx }, finishFixOp, input);
+    },
+
+    async openDraftPr(state: FinishState) {
+      if (forgeKind === null) return null;
+      const ctx = await loadFinishPrContext({ state, audit, forge: forgeKind, prBody });
+      return openDraftFinishPr(
+        {
+          workdir: state.workdir,
+          branch: state.branch,
+          title: buildFinishTitle(ctx),
+          body: buildFinishBody(ctx),
+          forge: forgeKind,
+        },
+        forge,
+      );
+    },
+
+    async promotePr(state: FinishState) {
+      await commitAndPush(state.workdir, state.branch, PARTIAL_FIX_MESSAGE(state.feature));
+      if (forgeKind === null) return { status: "already-ready" };
+      const ctx = await loadFinishPrContext({ state, audit, forge: forgeKind, prBody });
+      return openOrPromotePr(
+        {
+          workdir: state.workdir,
+          branch: state.branch,
+          title: buildFinishTitle(ctx),
+          body: buildFinishBody(ctx),
+          forge: forgeKind,
+        },
+        forge,
+      );
+    },
+
+    async escalate(state: FinishState, reason: string, findings: Finding[]) {
+      let syncNote = "";
+      try {
+        await commitAndPush(state.workdir, state.branch, PARTIAL_FIX_MESSAGE(state.feature));
+      } catch (err) {
+        syncNote = `\n\n> Automated fixes could not be pushed: ${errorMessage(err)}`;
+      }
+      try {
+        if (forgeKind === null) return { deliveryError: "no forge detected" };
+        const comment = buildEscalationComment(state.feature, reason, findings) + syncNote;
+        const outcome = await postEscalation(
+          { workdir: state.workdir, branch: state.branch, comment, forge: forgeKind, preferTelegram },
+          forge,
+        );
+        return outcome.url ? { url: outcome.url } : {};
+      } catch (err) {
+        return { deliveryError: errorMessage(err) };
+      }
+    },
+  };
+
+  if (deps.narrative !== false) {
+    ops.narrate = async (state: FinishState) => {
+      try {
+        if (forgeKind === null) return;
+        const input: FinishNarrativeInput = {
+          base: state.base,
+          model: models?.narrative,
+          timeoutMs: timeouts?.narrativeMs,
+        };
+        const outcome = await _finishOpsDeps.callOp(
+          { ...callCtx, sessionOverride: { role: "finish-narrative" } },
+          finishNarrativeOp,
+          input,
+        );
+        const ctx = await loadFinishPrContext({
+          state,
+          audit,
+          forge: forgeKind,
+          prBody,
+          narrative: outcome.narrative,
+          title: outcome.title,
+        });
+        await updatePrBody(
+          {
+            workdir: state.workdir,
+            branch: state.branch,
+            title: buildFinishTitle(ctx),
+            body: buildFinishBody(ctx),
+            forge: forgeKind,
+          },
+          forge,
+        );
+      } catch (err) {
+        warn?.("nax-finish could not write the PR narrative", { error: err });
+      }
+    };
+  }
+
+  return ops;
+}

--- a/src/finish/ops-impl.ts
+++ b/src/finish/ops-impl.ts
@@ -67,8 +67,12 @@ export interface FinishOpsDeps {
 
 export const _finishOpsDeps: { callOp: typeof callOp } = { callOp };
 
-/** The commit both the promote and the escalation paths push before touching the forge. */
-const PARTIAL_FIX_MESSAGE = (feature: string): string => `fix(${feature}): nax-finish automated fixes`;
+/** The commit the promote path pushes before touching the forge (matches the flow, line 344). */
+const PROMOTE_MESSAGE = (feature: string): string => `fix(${feature}): nax-finish automated fixes`;
+
+/** The commit the escalate path pushes so the escalation describes state a human can see (flow line 441). */
+const ESCALATION_PUSH_MESSAGE = (feature: string): string =>
+  `wip(${feature}): nax-finish partial fixes before escalation`;
 
 export function createFinishOps(deps: FinishOpsDeps): FinishOps {
   const { callCtx, forge, forgeKind, audit, models, timeouts, prBody, preferTelegram, warn } = deps;
@@ -129,7 +133,7 @@ export function createFinishOps(deps: FinishOpsDeps): FinishOps {
     },
 
     async promotePr(state: FinishState) {
-      await commitAndPush(state.workdir, state.branch, PARTIAL_FIX_MESSAGE(state.feature));
+      await commitAndPush(state.workdir, state.branch, PROMOTE_MESSAGE(state.feature));
       if (forgeKind === null) return { status: "already-ready" };
       const ctx = await loadFinishPrContext({ state, audit, forge: forgeKind, prBody });
       return openOrPromotePr(
@@ -147,9 +151,9 @@ export function createFinishOps(deps: FinishOpsDeps): FinishOps {
     async escalate(state: FinishState, reason: string, findings: Finding[]) {
       let syncNote = "";
       try {
-        await commitAndPush(state.workdir, state.branch, PARTIAL_FIX_MESSAGE(state.feature));
+        await commitAndPush(state.workdir, state.branch, ESCALATION_PUSH_MESSAGE(state.feature));
       } catch (err) {
-        syncNote = `\n\n> Automated fixes could not be pushed: ${errorMessage(err)}`;
+        syncNote = `\n\n> Note: nax-finish could not push its partial fixes — ${String(err)}`;
       }
       try {
         if (forgeKind === null) return { deliveryError: "no forge detected" };

--- a/src/finish/pr/body.ts
+++ b/src/finish/pr/body.ts
@@ -1,0 +1,223 @@
+/**
+ * The finish PR title and body: a pure deterministic builder over
+ * `FinishPrContext`.
+ *
+ * Pure on purpose. Every fact in a finish body — gate results, story counts,
+ * diffstat, review rounds — is a string join over artifacts, which is what
+ * keeps a finish PR greppable in history. The only model-authored fields
+ * (`narrative`, `title`) arrive already resolved, each with a deterministic
+ * fallback, so the body never waits on a reviewer.
+ *
+ * Ported from `flows/nax-finish/steps/pr-body.ts`; the rendering is settled
+ * behaviour (nax#1477, nax#1504, nax#1507) and must not drift.
+ */
+import { mergeTemplate } from "@/forge";
+import type { BodySection } from "@/forge";
+import type { Finding, FindingDisposition, FinishRound } from "../types";
+import type { FinishPrContext, FinishPrStory } from "./context";
+
+const SECONDS_PER_MINUTE = 60;
+const MS_PER_SECOND = 1000;
+
+/** Six hex + one — the abbreviated form used everywhere in PR bodies and logs. */
+const SHORT_SHA_LEN = 7;
+
+/**
+ * The PR title: the narrative node's conventional-commit subject when it
+ * produced one, else `feat: <feature>`.
+ *
+ * That fallback is what this returned unconditionally, and is still what
+ * `buildTitle` in `src/plugins/builtin/auto-pr/pr-body.ts` opens with — so a
+ * finish run that reaches `open_pr` before the narrative node has spoken still
+ * reads identically to an auto-PR-opened one in a list view. The two diverge
+ * only once there is something better to say: `feat: schema-drift-gate` names
+ * the run, not the change.
+ */
+export function buildFinishTitle(ctx: FinishPrContext): string {
+  return ctx.title;
+}
+
+/**
+ * Escape a string for safe inclusion in a single markdown table cell.
+ *
+ * Mirrors `escapeTableCell` in `src/plugins/builtin/auto-pr/pr-body.ts`,
+ * trimmed to the cases the finish body actually needs: pipes (which break
+ * the column boundary) and newlines (which create new rows). Backslashes are
+ * escaped first so the pipe escape survives a literal backslash in a title.
+ */
+function escapeTableCell(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function formatDuration(durationMs: number): string {
+  // `Math.max(0, NaN)` returns NaN, and `Math.floor(Infinity / 1000)` returns
+  // Infinity — both would render as `"NaNm NaNs"` / `"Infinitym Infinitys"`.
+  // A non-finite duration is a corrupted artifact (status.json is hand-editable),
+  // so fall back to zero rather than let it leak into the PR body verbatim.
+  if (!Number.isFinite(durationMs)) return "0m 00s";
+  const clampedMs = Math.max(0, Math.round(durationMs));
+  const totalSeconds = Math.floor(clampedMs / MS_PER_SECOND);
+  const minutes = Math.floor(totalSeconds / SECONDS_PER_MINUTE);
+  const seconds = totalSeconds % SECONDS_PER_MINUTE;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}
+
+function buildStoriesSection(stories: FinishPrStory[]): string {
+  const lines: string[] = [];
+  lines.push("| Story | Title | ACs |");
+  lines.push("|-------|-------|-----|");
+  for (const story of stories) {
+    lines.push(`| ${escapeTableCell(story.id)} | ${escapeTableCell(story.title)} | ${story.acCount} |`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Takes the whole context rather than the five fields it reads: the section
+ * grew past the three-positional-parameter cap in the coding standards, and
+ * every field it wants is already on `FinishPrContext`.
+ */
+function buildVerificationSection(ctx: FinishPrContext): string | null {
+  const { acceptance, regression, gatesRan, diffstat, artifactSummary } = ctx;
+  const lines: string[] = [];
+  if (acceptance !== undefined) lines.push(`- Acceptance: ${acceptance}`);
+  if (regression !== undefined) lines.push(`- Regression: ${regression}`);
+  if (gatesRan.length > 0) lines.push(`- Gates: ${gatesRan.join(", ")}`);
+  if (diffstat !== undefined && diffstat.length > 0) lines.push(`- Diffstat:\n\n\`\`\`\n${diffstat}\n\`\`\``);
+  // Stated even though the files are excluded above: a reviewer who diffs the
+  // branch themselves sees more than the diffstat quotes, and an unexplained
+  // mismatch reads as a stale body.
+  if (artifactSummary !== undefined && artifactSummary.length > 0) {
+    lines.push(`- Excluded from diffstat — nax run artifacts: ${artifactSummary}`);
+  }
+  if (lines.length === 0) return null;
+  return lines.join("\n");
+}
+
+function buildRoundHeading(round: FinishRound): string {
+  const base = `### ${round.phase} attempt ${round.attempt}`;
+  if (!round.committed || !round.sha) return base;
+  const short = round.sha.slice(0, SHORT_SHA_LEN);
+  return `${base} (${short})`;
+}
+
+/**
+ * What an empty finding list means, in the reader's terms.
+ *
+ * Four different things used to render identically as "_no findings_", which a
+ * human reads as "a reviewer looked at this and approved it" (#1507). Only
+ * `passed` means that. `no-reviewer` is the one that actively misleads: the
+ * gate phase has no reviewer node at all, so its empty list is the absence of a
+ * review, not the result of one.
+ *
+ * `fixed` and the legacy `undefined` both fall through to "_no findings_":
+ * rounds written before `outcome` existed carry no field to read, and claiming
+ * anything more specific about them would be inventing detail.
+ */
+const EMPTY_ROUND_NOTE: Record<string, string> = {
+  passed: "- _no findings_",
+  "no-reviewer": "- _no reviewer for this phase_",
+  unparseable: "- _reviewer output could not be parsed_",
+  escalated: "- _escalated for human review_",
+  "review-skipped": "- _re-review skipped: this fix touched test files only_",
+  incomplete: "- _review sent back: required evidence sections missing_",
+};
+
+function buildRoundBlock(round: FinishRound): string {
+  const lines: string[] = [buildRoundHeading(round)];
+  if (round.findings.length === 0) {
+    lines.push(EMPTY_ROUND_NOTE[round.outcome ?? ""] ?? "- _no findings_");
+  } else {
+    if (round.outcome === "incomplete") {
+      lines.push("- _not acted on — the review was sent back for missing evidence sections_");
+    }
+    for (const [i, finding] of round.findings.entries()) {
+      const d = round.dispositions?.find((x) => x.index === i + 1);
+      lines.push(d?.disposition === "rejected" ? renderRejected(finding, d) : renderFinding(finding));
+    }
+  }
+  return lines.join("\n");
+}
+
+function buildRoundsSection(rounds: FinishRound[]): string | null {
+  if (rounds.length === 0) return null;
+  return rounds.map(buildRoundBlock).join("\n\n");
+}
+
+function renderFinding(finding: Finding): string {
+  return `- [${finding.severity}] ${finding.title}`;
+}
+
+/**
+ * A waived finding, shown as waived.
+ *
+ * The alternative — dropping it — would make a rejection indistinguishable from
+ * a fix in the only artifact a human reads, which is the failure this whole
+ * mechanism exists to avoid.
+ */
+function renderRejected(finding: Finding, d: FindingDisposition): string {
+  const evidence = d.evidence ? `\`${d.evidence}\`` : "_no evidence cited_";
+  const caveat = d.evidenceMissing ? " — **evidence path not found**" : "";
+  return `- [${finding.severity}] ${finding.title} — _rejected_: ${evidence}${caveat}`;
+}
+
+/**
+ * Body only — the heading is attached by `buildFinishBody`, which drops any
+ * section whose body is null. "No text" therefore cannot render a bare
+ * `## What changed` heading, the empty-heading case #1477 forbids.
+ */
+function buildNarrativeSection(narrative: string | undefined): string | null {
+  return narrative?.trim() || null;
+}
+
+function buildOutOfScopeSection(outOfScope: string[]): string | null {
+  if (outOfScope.length === 0) return null;
+  return outOfScope.map((item) => `- ${item}`).join("\n");
+}
+
+function buildFooter(run: FinishPrContext["run"]): string | null {
+  const { storiesPassed, storiesTotal, durationMs } = run;
+  if (storiesPassed === undefined && storiesTotal === undefined && durationMs === undefined) return null;
+  const counts =
+    storiesPassed !== undefined && storiesTotal !== undefined ? `${storiesPassed}/${storiesTotal} stories` : null;
+  const timing = durationMs !== undefined ? formatDuration(durationMs) : null;
+  const parts = [counts, timing].filter((p): p is string => p !== null);
+  if (parts.length === 0) return null;
+  return parts.join(" · ");
+}
+
+/**
+ * The nax-authored sections, in canonical order — the order they appear in
+ * when the repo has no template, and the order the leftovers are appended in
+ * when it has one. `key` is what `mergeTemplate` matches against the repo's
+ * headings; the run footer carries an empty heading so it stays unmatchable
+ * and last.
+ */
+function buildBodySections(ctx: FinishPrContext): BodySection[] {
+  const candidates: { key: string; heading: string; body: string | null }[] = [
+    { key: "narrative", heading: "What changed", body: buildNarrativeSection(ctx.narrative) },
+    { key: "stories", heading: "Stories", body: ctx.stories.length > 0 ? buildStoriesSection(ctx.stories) : null },
+    { key: "verification", heading: "Verification", body: buildVerificationSection(ctx) },
+    { key: "rounds", heading: "Review rounds", body: buildRoundsSection(ctx.rounds) },
+    { key: "outOfScope", heading: "Out of scope", body: buildOutOfScopeSection(ctx.outOfScope) },
+    { key: "footer", heading: "", body: buildFooter(ctx.run) },
+  ];
+  return candidates
+    .filter((c): c is { key: string; heading: string; body: string } => c.body !== null)
+    .map(({ key, heading, body }) => ({ key, heading, body }));
+}
+
+/**
+ * Assemble the body, merged into the repo's own PR template when it has one.
+ *
+ * The template supplies the *shape* (which headings, in what order) and these
+ * sections supply the *content* — see `pr-template-merge.ts` for why appending
+ * it verbatim, which is what this used to do, shipped a blank form under a
+ * filled one (nax#1504).
+ */
+export function buildFinishBody(ctx: FinishPrContext): string {
+  return mergeTemplate(ctx.template, buildBodySections(ctx), {
+    mode: ctx.templateMode,
+    sectionMap: ctx.templateSectionMap,
+  });
+}

--- a/src/finish/pr/context.ts
+++ b/src/finish/pr/context.ts
@@ -1,0 +1,264 @@
+/**
+ * Assembles a `FinishPrContext` from the artifacts a finish run leaves on disk.
+ *
+ * Ported from `flows/nax-finish/steps/pr-body.ts` (read-only reference, never
+ * imported — `flows/` runs in acpx's own Node process). Every read here is
+ * fail-open: the PR body is useful without any one section, and a finish that
+ * reached this point has already done all of its real work. Losing the PR to a
+ * permissions error on a file most repos do not have is the failure this
+ * policy exists to prevent.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { featureDir } from "@/config";
+import { defaultForgeDeps, findPrTemplate } from "@/forge";
+import type { ForgeKind } from "@/forge";
+import type { AuditTarget } from "../audit";
+import { readRounds } from "../audit";
+import { readSpecSummary, resolveNarrative, resolveTitle } from "../operations";
+import type { FinishState } from "../state";
+// TemplateMode is re-exported by ../types from @/forge (Task 1, D4.8) --
+// import it from ../types like every other finish-side type, not from @/forge.
+import type { FinishPrBodySettings, FinishRound, TemplateMode } from "../types";
+
+/** One row in the Stories table. */
+export interface FinishPrStory {
+  id: string;
+  title: string;
+  acCount: number;
+}
+
+/** Everything the PR body renders, sourced from finish-audit artifacts. */
+export interface FinishPrContext {
+  feature: string;
+  stories: FinishPrStory[];
+  outOfScope: string[];
+  acceptance?: string;
+  regression?: string;
+  gatesRan: string[];
+  diffstat?: string;
+  /**
+   * `--shortstat` for the nax artifacts held out of `diffstat`. Absent when the
+   * branch touched none, so a repo that gitignores them renders nothing.
+   */
+  artifactSummary?: string;
+  /** Repository PR/MR template, verbatim. Absent when none resolves. */
+  template?: string;
+  /** How `template` is honoured. Absent → `merge`. See `pr-template-merge.ts`. */
+  templateMode?: TemplateMode;
+  /** Repo overrides for the template-heading → section-key table. */
+  templateSectionMap?: Record<string, string>;
+  /** Resolved "What changed" prose. Absent when neither source produced text. */
+  narrative?: string;
+  /**
+   * Resolved conventional-commit PR title. Always set — `resolveTitle` falls
+   * back to `feat: <feature>` when the narrative node produced nothing usable.
+   */
+  title: string;
+  rounds: FinishRound[];
+  run: {
+    durationMs?: number;
+    storiesPassed?: number;
+    storiesTotal?: number;
+  };
+}
+
+/** Everything `loadFinishPrContext` needs to assemble the context. */
+export interface LoadPrContextArgs {
+  state: FinishState;
+  /** Where this run's round trail lives. */
+  audit: AuditTarget;
+  /** The repo's forge, for template discovery. Absent → no template section. */
+  forge?: ForgeKind;
+  /** The narrative op's prose; falls back to the spec summary when absent. */
+  narrative?: string;
+  /** The narrative op's conventional-commit subject; falls back to `feat: <feature>`. */
+  title?: string;
+  /** `FinishPrBodySettings` from `../types` — do not redeclare the shape (D4.8). */
+  prBody?: FinishPrBodySettings;
+}
+
+export const _finishPrDeps: {
+  run(cmd: string[], opts: { cwd: string }): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  readText(path: string): Promise<string | null>;
+  warn(message: string, details: { path: string; error: unknown }): void;
+} = {
+  // D4.11 — the shared default, so a finish and an auto-PR spawn subprocesses
+  // identically. Never a second local spawner.
+  run: defaultForgeDeps.run,
+  // ENOENT is the routine case (status.json/prd.json not yet written) and must
+  // stay silent — mirrors `_qualityDeps.readText` in `steps/quality.ts`. Only a
+  // genuine I/O failure (permission denied, corrupted mount) should warn.
+  readText: async (path: string) => {
+    try {
+      return await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  },
+  warn: (message: string, details: { path: string; error: unknown }) =>
+    process.emitWarning(message, { detail: `${details.path}: ${String(details.error)}` }),
+};
+
+interface PrdArtifact {
+  userStories?: { id: string; title: string; acceptanceCriteria?: unknown[] }[];
+  outOfScope?: string[];
+}
+
+interface StatusArtifact {
+  postRun?: { acceptance?: { status?: string }; regression?: { status?: string } };
+  durationMs?: number;
+  progress?: { passed?: number; total?: number };
+}
+
+async function readJson(path: string): Promise<unknown> {
+  let text: string | null;
+  try {
+    text = await _finishPrDeps.readText(path);
+  } catch (error) {
+    _finishPrDeps.warn("[finish-pr] Failed to read PR context artifact", { path, error });
+    return undefined;
+  }
+  if (text === null) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    _finishPrDeps.warn("[finish-pr] Failed to parse PR context artifact", { path, error });
+    return undefined;
+  }
+}
+
+function storiesFrom(prd: PrdArtifact | undefined): FinishPrStory[] {
+  if (!Array.isArray(prd?.userStories)) return [];
+  // A hand-edited or older-schema PRD can carry a story with a missing/non-string
+  // `id`/`title` — drop only that row rather than letting `escapeTableCell` throw
+  // and take down the entire PR body (caught upstream by `open_pr`'s fallback).
+  return prd.userStories
+    .filter((story) => typeof story.id === "string" && typeof story.title === "string")
+    .map((story) => ({
+      id: story.id,
+      title: story.title,
+      acCount: Array.isArray(story.acceptanceCriteria) ? story.acceptanceCriteria.length : 0,
+    }));
+}
+
+/**
+ * Pathspec matching nax's own run artifacts, at any depth.
+ *
+ * `**` and the `glob` magic word are both load-bearing. nax writes artifacts
+ * to a repo-root `.nax/` *and* to a per-package `<pkg>/.nax/` — a root-anchored
+ * `:!.nax/**` silently keeps the per-package copy, which is routinely the
+ * largest file in the diff (587 of 2039 insertions on the run that motivated
+ * this). Without `glob`, git's default wildmatch lets `*` cross `/` and the
+ * two forms stop being distinguishable.
+ */
+const NAX_ARTIFACT_PATHSPEC = "**/.nax/**";
+
+/** The two halves of the branch's diff: what is under review, and what was held out. */
+interface DiffstatResult {
+  diffstat?: string;
+  artifactSummary?: string;
+}
+
+/** Run `git diff <...args>` under `workdir`, or `undefined` on any non-happy path. */
+async function runGitDiff(workdir: string, args: string[]): Promise<string | undefined> {
+  try {
+    const res = await _finishPrDeps.run(["git", "diff", ...args], { cwd: workdir });
+    if (res.exitCode !== 0) return undefined;
+    return res.stdout;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Diffstat of the branch, excluding nax's own artifacts.
+ *
+ * The artifacts (`spec.md`, `prd.json`, the generated acceptance test) are
+ * committed and real, but they are the run's exhaust rather than the change
+ * under review, and they dominate the totals — quoting them in the headline
+ * advertises a 2039-line change where 791 lines are reviewable code.
+ * `artifactSummary` keeps them accounted for rather than silently dropped, so
+ * the body still reconciles against `gh pr diff`.
+ *
+ * Fail-open on every non-happy path — a non-zero exit (no commits, divergent
+ * branch, base missing), a rejected run promise (forks too slow to start), or
+ * any thrown error — returning `undefined`. The PR's Verification block is
+ * optional, and a routine empty-branch finish must not lose `open_pr` to a
+ * throw that the body can simply skip.
+ */
+async function runDiffstat(workdir: string, base: string): Promise<DiffstatResult> {
+  // An empty `base` would interpolate to `...HEAD`, which git resolves as
+  // `HEAD...HEAD` — exit 0, empty stdout — masking the missing-base case as
+  // "no changes" instead of skipping explicitly.
+  if (!base) return {};
+  const range = `${base}...HEAD`;
+  const [diffstat, artifacts] = await Promise.all([
+    runGitDiff(workdir, ["--stat", range, "--", `:(glob,exclude)${NAX_ARTIFACT_PATHSPEC}`]),
+    runGitDiff(workdir, ["--shortstat", range, "--", `:(glob)${NAX_ARTIFACT_PATHSPEC}`]),
+  ]);
+  const summary = artifacts?.trim();
+  return { diffstat, artifactSummary: summary ? summary : undefined };
+}
+
+/**
+ * Resolve the repository's PR/MR template, fail-open.
+ *
+ * An absent template is the common case and never warns. A genuine read failure
+ * is swallowed too: the body is useful without this section, and `open_pr` must
+ * not lose a PR to a permissions error on a file most repos do not have.
+ */
+async function loadTemplate(workdir: string, forge: ForgeKind | undefined): Promise<string | undefined> {
+  if (forge === undefined) return undefined;
+  try {
+    return (
+      (await findPrTemplate(workdir, forge, { run: _finishPrDeps.run, readText: _finishPrDeps.readText })) ?? undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export async function loadFinishPrContext(args: LoadPrContextArgs): Promise<FinishPrContext> {
+  const featureDirPath = featureDir(args.state.workdir, args.state.feature);
+  // [US-004] The audit trail (`rounds`), the diffstat, and the spec summary
+  // are independent of the PRD/status reads — fetching them in parallel keeps
+  // the loader's wall clock at max(readRounds, readJson×2, diffstat, spec).
+  const [prd, status, rounds, stat, template, specSummary] = (await Promise.all([
+    readJson(join(featureDirPath, "prd.json")),
+    readJson(join(featureDirPath, "status.json")),
+    readRounds(args.audit),
+    runDiffstat(args.state.workdir, args.state.base),
+    loadTemplate(args.state.workdir, args.forge),
+    readSpecSummary(args.state.specPath, _finishPrDeps.readText),
+  ])) as [
+    PrdArtifact | undefined,
+    StatusArtifact | undefined,
+    FinishRound[],
+    DiffstatResult,
+    string | undefined,
+    string | null,
+  ];
+  return {
+    feature: args.state.feature,
+    stories: storiesFrom(prd),
+    outOfScope: Array.isArray(prd?.outOfScope) ? prd.outOfScope : [],
+    acceptance: status?.postRun?.acceptance?.status,
+    regression: status?.postRun?.regression?.status,
+    gatesRan: args.state.gatesRan ?? [],
+    rounds,
+    diffstat: stat.diffstat,
+    artifactSummary: stat.artifactSummary,
+    template,
+    ...(args.prBody?.template !== undefined ? { templateMode: args.prBody.template } : {}),
+    ...(args.prBody?.sectionMap !== undefined ? { templateSectionMap: args.prBody.sectionMap } : {}),
+    narrative: resolveNarrative(args.narrative, specSummary),
+    title: resolveTitle(args.title, args.state.feature),
+    run: {
+      durationMs: status?.durationMs,
+      storiesPassed: status?.progress?.passed,
+      storiesTotal: status?.progress?.total,
+    },
+  };
+}

--- a/src/finish/pr/index.ts
+++ b/src/finish/pr/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Barrel for `src/finish/pr/` — PR context assembly. Task 3 adds the body
+ * renderer here; consumers import from `src/finish/`'s barrel, never from
+ * this file directly.
+ */
+export { _finishPrDeps, loadFinishPrContext } from "./context";
+export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./context";

--- a/src/finish/pr/index.ts
+++ b/src/finish/pr/index.ts
@@ -5,3 +5,4 @@
  */
 export { _finishPrDeps, loadFinishPrContext } from "./context";
 export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./context";
+export { buildFinishBody, buildFinishTitle } from "./body";

--- a/src/finish/pr/index.ts
+++ b/src/finish/pr/index.ts
@@ -1,8 +1,9 @@
 /**
- * Barrel for `src/finish/pr/` — PR context assembly. Task 3 adds the body
- * renderer here; consumers import from `src/finish/`'s barrel, never from
- * this file directly.
+ * Barrel for `src/finish/pr/` — PR context assembly, body rendering, and the
+ * open/promote/edit operations. Consumers import from `src/finish/`'s barrel,
+ * never from this file directly.
  */
 export { _finishPrDeps, loadFinishPrContext } from "./context";
 export type { FinishPrContext, FinishPrStory, LoadPrContextArgs } from "./context";
 export { buildFinishBody, buildFinishTitle } from "./body";
+export { openDraftFinishPr, openOrPromotePr, parseView, updatePrBody } from "./open";

--- a/src/finish/pr/open.ts
+++ b/src/finish/pr/open.ts
@@ -1,0 +1,141 @@
+/**
+ * Opening and maintaining the finish PR: draft-first creation (D7), the
+ * terminal promote-or-create, and the non-fatal body write.
+ *
+ * Ported from `flows/nax-finish/steps/pr.ts` (read-only reference, never
+ * imported). Restructured so the forge is a required argument — the flow's
+ * `knownForge?` fallback existed because the flow had two independent
+ * detection sites; the caller detects once and passes it in, which stops the
+ * body and the create command from disagreeing about it — and so I/O arrives
+ * as `ForgeDeps` rather than a module-level `_prDeps` seam.
+ */
+import { NaxError } from "@/errors";
+import { extractUrl, hasOpenPr, openPr, viewArgv } from "@/forge";
+import type { ForgeDeps, ForgeKind } from "@/forge";
+
+/**
+ * Parse `gh pr view --json isDraft,url` / `glab mr view --output json` stdout.
+ *
+ * GitHub's schema is well-defined: `{ isDraft, url }`. GitLab's `glab mr view --output json`
+ * schema is not guaranteed to expose an equivalent boolean under a stable name across
+ * versions, so this is best-effort: it checks a few plausible field names for draft status
+ * and falls back to treating any successfully-parsed MR as ready (not draft) when none are
+ * found — per the task brief, "treat any successful view as already-ready unless you find
+ * clear evidence otherwise."
+ */
+export function parseView(stdout: string, forge: ForgeKind): { isDraft: boolean; url?: string } {
+  try {
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    if (forge === "github") {
+      return { isDraft: parsed.isDraft === true, url: typeof parsed.url === "string" ? parsed.url : undefined };
+    }
+    const isDraft = parsed.isDraft === true || parsed.draft === true || parsed.work_in_progress === true;
+    return { isDraft, url: extractUrl(stdout) };
+  } catch {
+    return { isDraft: false, url: extractUrl(stdout) };
+  }
+}
+
+/**
+ * Promote the finish's draft PR to ready, or create the PR when the branch
+ * has none (the view command failed or the branch's PR/MR is already closed).
+ */
+export async function openOrPromotePr(
+  args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
+  deps: ForgeDeps,
+): Promise<{ status: "opened" | "promoted" | "already-ready"; url?: string }> {
+  const view = await deps.run(viewArgv(args.forge, args.branch, "isDraft,url"), { cwd: args.workdir });
+
+  if (view.exitCode !== 0) {
+    const createCmd =
+      args.forge === "github"
+        ? ["gh", "pr", "create", "--title", args.title, "--body", args.body, "--head", args.branch]
+        : ["glab", "mr", "create", "--title", args.title, "--description", args.body, "--source-branch", args.branch];
+    const create = await deps.run(createCmd, { cwd: args.workdir });
+    if (create.exitCode !== 0) {
+      throw new NaxError(
+        `Failed to create PR/MR for "${args.branch}": ${create.stderr.trim() || `exit ${create.exitCode}`}`,
+        "FINISH_PR_CREATE_FAILED",
+        { stage: "finish-pr", branch: args.branch },
+      );
+    }
+    return { status: "opened", url: extractUrl(create.stdout) };
+  }
+
+  const { isDraft, url } = parseView(view.stdout, args.forge);
+  if (isDraft) {
+    const readyCmd =
+      args.forge === "github" ? ["gh", "pr", "ready", args.branch] : ["glab", "mr", "update", args.branch, "--ready"];
+    const ready = await deps.run(readyCmd, { cwd: args.workdir });
+    if (ready.exitCode !== 0) {
+      throw new NaxError(
+        `Failed to promote PR/MR "${args.branch}" to ready: ${ready.stderr.trim() || `exit ${ready.exitCode}`}`,
+        "FINISH_PR_PROMOTE_FAILED",
+        { stage: "finish-pr", branch: args.branch },
+      );
+    }
+    await updatePrBody(args, deps);
+    return { status: "promoted", url };
+  }
+
+  await updatePrBody(args, deps);
+  return { status: "already-ready", url };
+}
+
+/**
+ * Write the finish title/body onto an already-open PR/MR.
+ *
+ * Non-fatal by design: this runs after the PR exists, so a failed metadata
+ * write must not throw away that state — the caller's returned status/url
+ * stays valid either way.
+ */
+export async function updatePrBody(
+  args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
+  deps: ForgeDeps,
+): Promise<void> {
+  const editCmd =
+    args.forge === "github"
+      ? ["gh", "pr", "edit", args.branch, "--title", args.title, "--body", args.body]
+      : ["glab", "mr", "update", args.branch, "--title", args.title, "--description", args.body];
+  try {
+    const res = await deps.run(editCmd, { cwd: args.workdir });
+    if (res.exitCode !== 0) {
+      process.emitWarning("[finish-pr] Failed to write PR title/body", {
+        detail: `${args.branch}: ${res.stderr.trim()}`,
+      });
+    }
+  } catch (error) {
+    process.emitWarning("[finish-pr] Failed to write PR title/body", { detail: `${args.branch}: ${String(error)}` });
+  }
+}
+
+/**
+ * Open the draft PR the finish run holds its work in (D7).
+ *
+ * Returns null on every unhappy path — no open-PR check, a create that
+ * failed, a forge CLI that could not answer. The draft is a convenience: the
+ * terminal promote creates the PR when none exists, so failing the run here
+ * would discard work that is otherwise fine. `hasOpenPr` throws on a non-zero
+ * exit by design (a `gh` auth failure must not read as "no PR"); the safe
+ * decision at this call site is to skip.
+ */
+export async function openDraftFinishPr(
+  args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
+  deps: ForgeDeps,
+): Promise<{ url: string } | null> {
+  let alreadyOpen: boolean;
+  try {
+    alreadyOpen = await hasOpenPr(args.forge, args.branch, deps, args.workdir);
+  } catch {
+    return null;
+  }
+  if (alreadyOpen) return null;
+
+  const result = await openPr(
+    args.forge,
+    { title: args.title, body: args.body, branch: args.branch, draft: true },
+    deps,
+    args.workdir,
+  );
+  return result.success && result.url ? { url: result.url } : null;
+}

--- a/src/finish/pr/open.ts
+++ b/src/finish/pr/open.ts
@@ -13,6 +13,14 @@ import { NaxError } from "@/errors";
 import { extractUrl, hasOpenPr, openPr, viewArgv } from "@/forge";
 import type { ForgeDeps, ForgeKind } from "@/forge";
 
+/** `ForgeDeps` carries no `warn` — this is `updatePrBody`'s own injectable seam, so its
+ * non-fatal-failure tests can assert a warning fired instead of only "did not throw". */
+export const _openDeps = {
+  warn: (message: string, details: Record<string, unknown>): void => {
+    process.emitWarning(message, { detail: JSON.stringify(details) });
+  },
+};
+
 /**
  * Parse `gh pr view --json isDraft,url` / `glab mr view --output json` stdout.
  *
@@ -100,12 +108,10 @@ export async function updatePrBody(
   try {
     const res = await deps.run(editCmd, { cwd: args.workdir });
     if (res.exitCode !== 0) {
-      process.emitWarning("[finish-pr] Failed to write PR title/body", {
-        detail: `${args.branch}: ${res.stderr.trim()}`,
-      });
+      _openDeps.warn("[finish-pr] Failed to write PR title/body", { branch: args.branch, error: res.stderr.trim() });
     }
   } catch (error) {
-    process.emitWarning("[finish-pr] Failed to write PR title/body", { detail: `${args.branch}: ${String(error)}` });
+    _openDeps.warn("[finish-pr] Failed to write PR title/body", { branch: args.branch, error });
   }
 }
 
@@ -116,26 +122,26 @@ export async function updatePrBody(
  * failed, a forge CLI that could not answer. The draft is a convenience: the
  * terminal promote creates the PR when none exists, so failing the run here
  * would discard work that is otherwise fine. `hasOpenPr` throws on a non-zero
- * exit by design (a `gh` auth failure must not read as "no PR"); the safe
- * decision at this call site is to skip.
+ * exit by design (a `gh` auth failure must not read as "no PR"); `openPr`'s
+ * own `deps.run` can also reject outright (missing binary, a killed
+ * subprocess) rather than merely returning a non-zero exit — both are wrapped
+ * in the same try/catch so this function's "never throws" contract (D4.5)
+ * holds regardless of which step failed.
  */
 export async function openDraftFinishPr(
   args: { workdir: string; branch: string; title: string; body: string; forge: ForgeKind },
   deps: ForgeDeps,
 ): Promise<{ url: string } | null> {
-  let alreadyOpen: boolean;
   try {
-    alreadyOpen = await hasOpenPr(args.forge, args.branch, deps, args.workdir);
+    if (await hasOpenPr(args.forge, args.branch, deps, args.workdir)) return null;
+    const result = await openPr(
+      args.forge,
+      { title: args.title, body: args.body, branch: args.branch, draft: true },
+      deps,
+      args.workdir,
+    );
+    return result.success && result.url ? { url: result.url } : null;
   } catch {
     return null;
   }
-  if (alreadyOpen) return null;
-
-  const result = await openPr(
-    args.forge,
-    { title: args.title, body: args.body, branch: args.branch, draft: true },
-    deps,
-    args.workdir,
-  );
-  return result.success && result.url ? { url: result.url } : null;
 }

--- a/src/finish/state.ts
+++ b/src/finish/state.ts
@@ -67,6 +67,14 @@ export interface FinishState {
   phases: Record<FinishPhase, FinishPhaseState>;
   /** Findings the current phase's reviewer last reported; the fix step's input. */
   findings: Finding[];
+  /**
+   * Gate names the last quality-gate pass ran, for the PR body's Verification
+   * section. Recorded here because `runQualityGates`'s result is otherwise
+   * local to the machine's loop, and `FinishOps` — which builds the body —
+   * never sees it. An absent or empty list renders no gate line at all, which
+   * is why a silently-unset field would have gone unnoticed.
+   */
+  gatesRan?: string[];
   /** Set once the draft PR is open (D7), so promote is idempotent. */
   prUrl?: string;
   escalationReason?: string;

--- a/src/finish/types.ts
+++ b/src/finish/types.ts
@@ -1,11 +1,6 @@
-/**
- * How the repo's own PR/MR template is honoured when composing the body.
- * Local rather than imported from `flows/pr-template-merge.ts` — `flows/` is a
- * separate, live implementation on a different module system and must not be
- * imported into `src/`. Plan 3 moves the real `pr-template-merge.ts` and
- * re-points this.
- */
-export type TemplateMode = "merge" | "strict" | "ignore";
+import type { TemplateMode } from "@/forge";
+
+export type { TemplateMode };
 
 export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
 export interface Finding {

--- a/src/forge/deps.ts
+++ b/src/forge/deps.ts
@@ -1,0 +1,65 @@
+/**
+ * The default `ForgeDeps`: subprocess execution and file reads for every
+ * function in this module.
+ *
+ * Lifted from `defaultRun` / `defaultReadText` in
+ * `src/plugins/builtin/auto-pr/index.ts`, which was the only implementation of
+ * this module's own contract. `src/finish/` needs one too and must not import
+ * from `@/plugins`, so it lives with the contract instead. stdout and stderr
+ * are read concurrently with `proc.exited` so non-trivial output cannot
+ * deadlock, under a wall-clock cap so a wedged `gh` / `glab` / `git push`
+ * cannot hang a run's completion phase.
+ */
+
+import type { ForgeDeps } from "./types";
+
+/** Default wall-clock cap for any one subprocess (BUG-8). */
+export const DEFAULT_SUBPROCESS_TIMEOUT_MS = 30_000;
+
+/**
+ * Default subprocess runner — wraps Bun.spawn with concurrent stdout/stderr
+ * reads so non-trivial output does not deadlock, under a wall-clock cap so a
+ * wedged `git push` / `gh` / `glab` cannot hang the run's completion phase.
+ * Mirrors the nax-finish defaultRun pattern (`src/plugins/builtin/nax-finish/index.ts:66-97`).
+ * Tests override `_autoPrDeps.run`.
+ */
+export async function defaultRun(
+  cmd: string[],
+  opts: { cwd: string; timeoutMs?: number },
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(cmd, { cwd: opts.cwd, stdout: "pipe", stderr: "pipe" });
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_SUBPROCESS_TIMEOUT_MS;
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    return timedOut
+      ? {
+          exitCode: exitCode === 0 ? 124 : exitCode,
+          stdout,
+          stderr: `${stderr}\n[auto-pr] command killed after ${timeoutMs}ms timeout`,
+        }
+      : { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Default UTF-8 reader — returns `null` on missing files so callers can probe
+ * the candidate template paths without try/catch noise.
+ */
+async function defaultReadText(path: string): Promise<string | null> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
+  return file.text();
+}
+
+export const defaultForgeDeps: ForgeDeps = { run: defaultRun, readText: defaultReadText };

--- a/src/forge/deps.ts
+++ b/src/forge/deps.ts
@@ -20,8 +20,9 @@ export const DEFAULT_SUBPROCESS_TIMEOUT_MS = 30_000;
  * Default subprocess runner — wraps Bun.spawn with concurrent stdout/stderr
  * reads so non-trivial output does not deadlock, under a wall-clock cap so a
  * wedged `git push` / `gh` / `glab` cannot hang the run's completion phase.
- * Mirrors the nax-finish defaultRun pattern (`src/plugins/builtin/nax-finish/index.ts:66-97`).
- * Tests override `_autoPrDeps.run`.
+ * Lifted verbatim from `defaultRun` in `src/plugins/builtin/auto-pr/index.ts`
+ * (D4.11) — that module keeps its own copy and overrides `_autoPrDeps.run` in
+ * its tests; callers here inject a `ForgeDeps` directly instead of a seam.
  */
 export async function defaultRun(
   cmd: string[],
@@ -44,7 +45,7 @@ export async function defaultRun(
       ? {
           exitCode: exitCode === 0 ? 124 : exitCode,
           stdout,
-          stderr: `${stderr}\n[auto-pr] command killed after ${timeoutMs}ms timeout`,
+          stderr: `${stderr}\n[forge] command killed after ${timeoutMs}ms timeout`,
         }
       : { exitCode, stdout, stderr };
   } finally {

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -9,3 +9,6 @@ export { detectForge, forgeFromRemoteUrl, remoteHost } from "./detect";
 export type { OpenPrInput, OpenPrResult } from "./pr";
 export { extractUrl, hasOpenPr, openPr, viewArgv } from "./pr";
 export { findPrTemplate } from "./template";
+export { defaultForgeDeps } from "./deps";
+export type { BodySection, MergeOptions, TemplateMode } from "./template-merge";
+export { DEFAULT_SECTION_ALIASES, mergeTemplate } from "./template-merge";

--- a/src/forge/template-merge.ts
+++ b/src/forge/template-merge.ts
@@ -1,0 +1,255 @@
+/**
+ * Merge nax's generated PR/MR body into the repository's own PR template.
+ *
+ * ## Why this exists
+ *
+ * `gh pr create --body` / `glab mr create --description` suppress the repo's
+ * template, so a generated body has to account for it. The first attempt
+ * appended the template verbatim after the generated content, which shipped a
+ * *blank form* below a filled one: placeholder comments, a dangling `Closes #`,
+ * duplicated headings, and an unchecked "`bun test` passes" box sitting under a
+ * Verification section that already said the gates were green (nax#1504).
+ *
+ * A PR template is an input form, not decoration. So the template is treated as
+ * **shape** and nax's content as **fill**:
+ *
+ * - a template heading nax can fill  → keep the heading, replace its body
+ * - a template heading nax cannot    → drop it (`merge`) or empty it (`strict`)
+ * - nax content with no home         → append under nax's own heading
+ *
+ * The governing invariant is **never emit a field that was not filled**. That
+ * is the same rule `buildFinishBody` already followed for its own sections
+ * (nax#1477 forbids a bare heading with nothing under it); this module extends
+ * it to template-derived text. `strict` mode is the one deliberate exception,
+ * for repos whose CI asserts a set of headings exists.
+ *
+ * ## Why deterministic
+ *
+ * Placement is decided by a heading-alias table, not by a model. The facts in
+ * the body — gate results, story counts, diffstat, review rounds — stay a pure
+ * string join, which is what keeps a finish body greppable in PR history. A
+ * repo whose headings the table does not know loses nothing: its sections are
+ * dropped and nax's own headings are used instead, and `sectionMap` pins the
+ * mapping explicitly when a team wants its headings honoured.
+ *
+ * Lives in `src/forge/` because both consumers are here: the auto-PR plugin's
+ * body builder and `src/finish/pr/body.ts`. `flows/nax-finish/` keeps a
+ * byte-identical copy because it cannot import `src/`; that copy and this
+ * comment both go when plan 5 deletes the flow. Until then, edit neither
+ * without editing the other — `test/unit/forge/template-merge.test.ts` has an
+ * equivalence test that fails if they drift.
+ */
+
+/** One nax-authored section of the body. */
+export interface BodySection {
+  /**
+   * Stable id matched against the alias table. Independent of `heading` so
+   * renaming nax's own heading does not silently break template matching.
+   */
+  key: string;
+  /**
+   * nax's H2 text, used when the section is appended rather than merged.
+   * Empty means headingless (the run footer) — such a section is rendered as
+   * bare text and is never matched to a template heading, so a stray alias
+   * cannot bury the footer under someone's `## Notes`.
+   */
+  heading: string;
+  /** Markdown body without its heading line. Callers omit empty sections. */
+  body: string;
+}
+
+/**
+ * - `merge`  — template headings nax cannot fill are dropped. Default.
+ * - `strict` — they are kept, empty, for repos with heading-checking CI.
+ * - `ignore` — the template is not consulted at all.
+ */
+export type TemplateMode = "merge" | "strict" | "ignore";
+
+export interface MergeOptions {
+  mode?: TemplateMode;
+  /**
+   * Normalised template heading → `BodySection.key`, layered over
+   * `DEFAULT_SECTION_ALIASES`. An empty value suppresses a default alias,
+   * which is how a repo says "do not put anything under this heading".
+   */
+  sectionMap?: Record<string, string>;
+}
+
+/**
+ * Normalised heading → section key.
+ *
+ * Deliberately partial. `why`, `notes`, `screenshots` and friends are absent
+ * because nax has nothing truthful to put under them — an alias that mapped
+ * them to some loosely-related section would reintroduce exactly the
+ * unfilled-field problem this module exists to remove.
+ */
+export const DEFAULT_SECTION_ALIASES: Record<string, string> = {
+  // → narrative
+  what: "narrative",
+  "what changed": "narrative",
+  "whats changed": "narrative",
+  summary: "narrative",
+  description: "narrative",
+  overview: "narrative",
+  changes: "narrative",
+  "what does this do": "narrative",
+  "what does this mr do and why": "narrative",
+  "what does this pr do": "narrative",
+  // → stories
+  how: "stories",
+  implementation: "stories",
+  "implementation details": "stories",
+  "changes made": "stories",
+  approach: "stories",
+  design: "stories",
+  // → verification
+  testing: "verification",
+  tests: "verification",
+  "test plan": "verification",
+  verification: "verification",
+  qa: "verification",
+  validation: "verification",
+  "how to test": "verification",
+  "how has this been tested": "verification",
+  "how to set up and validate locally": "verification",
+};
+
+const HEADING_RE = /^##[ \t]+(.+?)[ \t]*$/;
+const FRONTMATTER_RE = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/;
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+/** `Closes #`, `Fixes # (issue)` — an issue reference with no issue. */
+const DANGLING_ISSUE_RE = /^[ \t]*(?:closes?|fixe?s?|resolves?)[ \t]*:?[ \t]*#[ \t]*(?:\([^)]*\))?[ \t]*$/i;
+/** An unticked task-list item — an unfilled field wherever it appears. */
+const UNCHECKED_BOX_RE = /^[ \t]*[-*+][ \t]+\[[ \t]\]/;
+
+interface TemplateSection {
+  heading: string;
+  body: string;
+}
+
+interface ParsedTemplate {
+  frontmatter: string;
+  preamble: string;
+  sections: TemplateSection[];
+}
+
+/** Lowercase, drop punctuation, collapse whitespace — so `## Testing:` matches `testing`. */
+function normalizeHeading(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Strip placeholders from template-derived prose.
+ *
+ * Only ever applied to the preamble — the one template region that survives
+ * into the body. Text under a matched heading is replaced wholesale and text
+ * under an unmatched one is discarded, so a checklist or a stale `Closes #`
+ * *inside a section* never reaches this function, which is why there is no
+ * checkbox-versus-gate reconciliation anywhere in this module.
+ *
+ * The preamble is the exception, because a template may open with a
+ * contributor checklist before its first heading. An unticked box there is an
+ * unfilled field like any other, so it is dropped while the prose around it is
+ * kept.
+ */
+function cleanTemplateText(text: string): string {
+  return text
+    .replace(HTML_COMMENT_RE, "")
+    .split("\n")
+    .filter((line) => !DANGLING_ISSUE_RE.test(line) && !UNCHECKED_BOX_RE.test(line))
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+}
+
+function parseTemplate(rawText: string): ParsedTemplate {
+  // Normalised up front so a CRLF template (anything authored on Windows, or
+  // fetched through a forge web editor) cannot leak a stray carriage return
+  // into a heading this module re-emits.
+  const text = rawText.replace(/\r\n/g, "\n");
+  const frontmatterMatch = FRONTMATTER_RE.exec(text);
+  const frontmatter = frontmatterMatch ? frontmatterMatch[0].trimEnd() : "";
+  const rest = frontmatterMatch ? text.slice(frontmatterMatch[0].length) : text;
+
+  const preambleLines: string[] = [];
+  const sections: TemplateSection[] = [];
+  let current: { heading: string; lines: string[] } | null = null;
+
+  for (const line of rest.split("\n")) {
+    const heading = HEADING_RE.exec(line);
+    if (heading) {
+      if (current) sections.push({ heading: current.heading, body: current.lines.join("\n") });
+      current = { heading: heading[1], lines: [] };
+      continue;
+    }
+    if (current) current.lines.push(line);
+    else preambleLines.push(line);
+  }
+  if (current) sections.push({ heading: current.heading, body: current.lines.join("\n") });
+
+  return { frontmatter, preamble: preambleLines.join("\n"), sections };
+}
+
+function renderSection(heading: string, body: string): string {
+  if (heading.length === 0) return body;
+  return body.length === 0 ? `## ${heading}` : `## ${heading}\n\n${body}`;
+}
+
+/** Nax-only body: every section under its own heading, in the order given. */
+function renderSections(sections: BodySection[]): string {
+  return sections
+    .filter((s) => s.body.trim().length > 0)
+    .map((s) => renderSection(s.heading, s.body.trim()))
+    .join("\n\n")
+    .trim();
+}
+
+export function mergeTemplate(
+  template: string | null | undefined,
+  sections: BodySection[],
+  opts: MergeOptions = {},
+): string {
+  const mode = opts.mode ?? "merge";
+  if (mode === "ignore" || !template || template.trim().length === 0) return renderSections(sections);
+
+  const parsed = parseTemplate(template);
+  // No H2 anywhere: the template is prose, or nests everything under H1/H3.
+  // There is no shape to merge into, and appending it unparsed is the defect
+  // this module removes — so fall back to the body nax would have written.
+  if (parsed.sections.length === 0) return renderSections(sections);
+
+  // Override keys go through the same normalisation as the template headings
+  // they are matched against, so a repo pins a heading by pasting it —
+  // `"What does this MR do and why?"` — not by hand-normalising it first.
+  const aliases = { ...DEFAULT_SECTION_ALIASES };
+  for (const [heading, key] of Object.entries(opts.sectionMap ?? {})) aliases[normalizeHeading(heading)] = key;
+  const fillable = sections.filter((s) => s.heading.length > 0 && s.body.trim().length > 0);
+  const consumed = new Set<string>();
+  const parts: string[] = [];
+
+  if (parsed.frontmatter.length > 0) parts.push(parsed.frontmatter);
+  const preamble = cleanTemplateText(parsed.preamble);
+  if (preamble.length > 0) parts.push(preamble);
+
+  for (const templateSection of parsed.sections) {
+    const key = aliases[normalizeHeading(templateSection.heading)];
+    const match = key ? fillable.find((s) => s.key === key && !consumed.has(s.key)) : undefined;
+    if (match) {
+      consumed.add(match.key);
+      parts.push(renderSection(templateSection.heading, match.body.trim()));
+    } else if (mode === "strict") {
+      parts.push(renderSection(templateSection.heading, ""));
+    }
+  }
+
+  for (const section of sections) {
+    if (consumed.has(section.key) || section.body.trim().length === 0) continue;
+    parts.push(renderSection(section.heading, section.body.trim()));
+  }
+
+  return parts.join("\n\n").trim();
+}

--- a/src/plugins/builtin/auto-pr/pr-body.ts
+++ b/src/plugins/builtin/auto-pr/pr-body.ts
@@ -7,13 +7,12 @@
  * No I/O — these functions receive a `PrBodyContext` and return strings.
  */
 
+// Imported from `@/forge`, not re-implemented, so the draft body and the
+// nax-finish body compose a template identically. The merger now lives in
+// `src/forge/` — the `flows/nax-finish/` copy that this module used to import
+// from is the same code, kept byte-identical until the flow is retired.
+import { type BodySection, type MergeOptions, mergeTemplate } from "@/forge";
 import type { UserStory } from "@/prd/types";
-// Imported from `flows/`, not re-implemented, so the draft body and the
-// nax-finish body compose a template identically. `flows/` is the more
-// constrained runtime (acpx's Node process — no `Bun`, no `@/*`), so code that
-// lives there runs here too; the reverse is not true, which is why the other
-// shared helpers in this directory were ported the other way.
-import { type BodySection, type MergeOptions, mergeTemplate } from "@flows/nax-finish/pr-template-merge";
 
 const SECONDS_PER_MINUTE = 60;
 const MS_PER_SECOND = 1000;

--- a/test/unit/finish/escalate.test.ts
+++ b/test/unit/finish/escalate.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { buildEscalationComment, postEscalation } from "@/finish";
+import type { ForgeDeps } from "@/forge";
+import type { Finding } from "@/finish";
+
+const finding: Finding = {
+  severity: "HIGH",
+  title: "Missing rollback",
+  problem: "The migration has no down path.",
+  fix: "Add a reversible migration.",
+} as Finding;
+
+function depsFor(handler: (cmd: string[]) => { exitCode: number; stdout?: string; stderr?: string }): {
+  deps: ForgeDeps;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  return {
+    calls,
+    deps: {
+      run: async (cmd) => {
+        calls.push(cmd);
+        const r = handler(cmd);
+        return { exitCode: r.exitCode, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+      },
+      readText: async () => null,
+    },
+  };
+}
+
+const args = { workdir: "/repo", branch: "feat/demo", comment: "escalation", forge: "github" as const };
+
+describe("buildEscalationComment", () => {
+  test("names the feature, the reason and every finding", () => {
+    const text = buildEscalationComment("demo", "Two reviewers disagree", [finding]);
+    expect(text).toContain("nax-finish escalation");
+    expect(text).toContain("demo");
+    expect(text).toContain("Two reviewers disagree");
+    expect(text).toContain("Missing rollback");
+    expect(text).toContain("Add a reversible migration.");
+  });
+
+  test("renders with no findings at all", () => {
+    expect(buildEscalationComment("demo", "Context could not be resolved", [])).toContain("### Findings");
+  });
+});
+
+describe("postEscalation", () => {
+  test("comments on an existing PR", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: '{"url":"https://x/1"}' } : { exitCode: 0 },
+    );
+    await expect(postEscalation(args, deps)).resolves.toEqual({ url: "https://x/1", channel: "pr-comment" });
+    expect(calls.at(-1)).toContain("comment");
+  });
+
+  test("opens a draft to hold the comment when no PR exists", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 1 } : { exitCode: 0, stdout: "https://x/2" },
+    );
+    await expect(postEscalation(args, deps)).resolves.toEqual({ url: "https://x/2", channel: "pr-comment" });
+    expect(calls.at(-1)).toContain("--draft");
+  });
+
+  test("posts nothing and opens nothing when Telegram is preferred", async () => {
+    const { deps, calls } = depsFor(() => ({ exitCode: 0, stdout: '{"url":"https://x/3"}' }));
+    await expect(postEscalation({ ...args, preferTelegram: true }, deps)).resolves.toEqual({
+      url: "https://x/3",
+      channel: "telegram",
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("still reports the channel when Telegram is preferred and no PR exists", async () => {
+    const { deps } = depsFor(() => ({ exitCode: 1 }));
+    await expect(postEscalation({ ...args, preferTelegram: true }, deps)).resolves.toEqual({
+      url: undefined,
+      channel: "telegram",
+    });
+  });
+
+  test("throws when the comment cannot be posted", async () => {
+    const { deps } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: "{}" } : { exitCode: 1, stderr: "forbidden" },
+    );
+    await expect(postEscalation(args, deps)).rejects.toThrow(/forbidden/);
+  });
+
+  test("throws when the holding draft cannot be opened", async () => {
+    const { deps } = depsFor((cmd) => (cmd.includes("view") ? { exitCode: 1 } : { exitCode: 1, stderr: "denied" }));
+    await expect(postEscalation(args, deps)).rejects.toThrow(/denied/);
+  });
+});

--- a/test/unit/finish/machine-end-to-end.test.ts
+++ b/test/unit/finish/machine-end-to-end.test.ts
@@ -1,0 +1,294 @@
+/**
+ * The finish state machine driven end to end over the real `createFinishOps`.
+ *
+ * Every other finish test stubs a single module. This one wires the real ops
+ * factory into the real machine and fakes only the three process boundaries:
+ * the git subprocess (`_finishGitDeps.git`), the forge CLI (`forge.run`) and
+ * the LLM call (`_finishOpsDeps.callOp`). The artifacts the ops read —
+ * `prd.json`, `status.json`, `spec.md` — are written into a real temp dir and
+ * read through the untouched `_finishPrDeps.readText`, so the pr-body loader
+ * sees real files and the rendered PR body is built from them. If the machine,
+ * the ops and the body builder disagree about a shape, this suite is where it
+ * surfaces rather than in plan 5's wiring.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "@/config";
+import type { NaxConfig } from "@/config";
+import type { ForgeDeps } from "@/forge";
+import type { CallContext } from "@/operations";
+import {
+  _acceptanceGateDeps,
+  _finishGitDeps,
+  _finishOpsDeps,
+  _finishPrDeps,
+  _qualityGateDeps,
+  createFinishOps,
+  createFinishState,
+  resultPath,
+  runFinishMachine,
+} from "@/finish";
+import type { FinishContext, FinishMachineDeps, FinishState } from "@/finish";
+import { withTempDir } from "@test/helpers";
+
+const PR_URL = "https://forge.example/pr/1";
+const RUN_ID = "run-1";
+const FEATURE = "feat";
+
+const originalGit = _finishGitDeps.git;
+const originalAcceptanceRun = _acceptanceGateDeps.run;
+const originalQuality = { ..._qualityGateDeps };
+const originalOps = { ..._finishOpsDeps };
+const originalPrRun = _finishPrDeps.run;
+
+afterEach(() => {
+  _finishGitDeps.git = originalGit;
+  _acceptanceGateDeps.run = originalAcceptanceRun;
+  _qualityGateDeps.run = originalQuality.run;
+  _qualityGateDeps.loadConfig = originalQuality.loadConfig;
+  _qualityGateDeps.loadPackageOverride = originalQuality.loadPackageOverride;
+  Object.assign(_finishOpsDeps, originalOps);
+  _finishPrDeps.run = originalPrRun;
+});
+
+function configWithCommands(commands: NaxConfig["quality"]["commands"]): NaxConfig {
+  return { ...DEFAULT_CONFIG, quality: { ...DEFAULT_CONFIG.quality, commands } };
+}
+
+function baseContext(specPath: string): FinishContext {
+  return {
+    base: "origin/main",
+    specPath,
+    acceptanceStatus: "ok",
+    groups: [{ packageDir: "", testPath: "test/acceptance/feat.test.ts", exists: true, cwd: "" }],
+    testFileRegex: ["\\.test\\.ts$"],
+    commitsAhead: 3,
+    route: "proceed",
+  };
+}
+
+/** Clean git tree: `status --porcelain` empty, so no commit, but push still runs. */
+function installGitStub(): void {
+  _finishGitDeps.git = async (args: string[]) => {
+    const cmd = args[0];
+    if (cmd === "status") return { exitCode: 0, stdout: "", stderr: "" };
+    if (cmd === "rev-parse") return { exitCode: 0, stdout: "sha1", stderr: "" };
+    return { exitCode: 0, stdout: "", stderr: "" };
+  };
+}
+
+function installAcceptanceGateStub(): void {
+  _acceptanceGateDeps.run = async () => ({
+    commandName: "acceptance",
+    command: "bun test",
+    success: true,
+    exitCode: 0,
+    output: "acceptance ok",
+    durationMs: 1,
+    timedOut: false,
+  });
+}
+
+function installQualityGateStub(): void {
+  _qualityGateDeps.loadConfig = async () => configWithCommands({ test: "true" });
+  _qualityGateDeps.loadPackageOverride = async () => null;
+  _qualityGateDeps.run = async () => ({
+    commandName: "test",
+    command: "true",
+    success: true,
+    exitCode: 0,
+    output: "ok",
+    durationMs: 1,
+    timedOut: false,
+  });
+}
+
+/** The diffstat subprocesses `loadFinishPrContext` runs; everything else is unreachable. */
+function installPrRunStub(): void {
+  _finishPrDeps.run = async (cmd: string[]) => {
+    if (cmd.includes("--shortstat")) {
+      return { exitCode: 0, stdout: " 2 files changed, 40 insertions(+)\n", stderr: "" };
+    }
+    return { exitCode: 0, stdout: " src/a.ts | 5 ++++-\n src/b.ts | 2 +-\n", stderr: "" };
+  };
+}
+
+interface ForgeRecorder {
+  calls: string[][];
+  editBodies: string[];
+  commentBodies: string[];
+  draftCreates: number;
+}
+
+/**
+ * The forge CLI, routed by `gh pr <action>`. `view` always reports an open
+ * draft so the promote path goes list -> create(draft) -> ready -> edit, and
+ * `postEscalation` always finds an existing PR and posts a comment.
+ */
+function installForgeStub(): { forge: ForgeDeps; recorder: ForgeRecorder } {
+  const recorder: ForgeRecorder = { calls: [], editBodies: [], commentBodies: [], draftCreates: 0 };
+  const forge: ForgeDeps = {
+    run: async (cmd: string[]) => {
+      recorder.calls.push(cmd);
+      switch (cmd[2]) {
+        case "list":
+          return { exitCode: 0, stdout: "[]", stderr: "" };
+        case "view":
+          return { exitCode: 0, stdout: JSON.stringify({ isDraft: true, url: PR_URL }), stderr: "" };
+        case "create": {
+          if (cmd.includes("--draft")) recorder.draftCreates += 1;
+          return { exitCode: 0, stdout: PR_URL, stderr: "" };
+        }
+        case "ready":
+          return { exitCode: 0, stdout: "", stderr: "" };
+        case "edit": {
+          const body = cmd[cmd.indexOf("--body") + 1];
+          if (body !== undefined) recorder.editBodies.push(body);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        case "comment": {
+          const body = cmd[cmd.indexOf("--body") + 1];
+          if (body !== undefined) recorder.commentBodies.push(body);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        default:
+          return { exitCode: 0, stdout: "", stderr: "" };
+      }
+    },
+    readText: async () => null,
+  };
+  return { forge, recorder };
+}
+
+function installCallOpStub(opts: { specReviewThrows?: boolean; narrativeThrows?: boolean }): void {
+  _finishOpsDeps.callOp = (async (ctx: CallContext, op: { name: string }, _input: unknown) => {
+    if (op.name === "finish-review") {
+      if (opts.specReviewThrows && ctx.sessionOverride?.role === "finish-review-spec") {
+        throw new Error("spec review agent exploded");
+      }
+      return {
+        findings: [],
+        gaps: [],
+        touchpoints: [],
+        walk: [],
+        sawNoFindings: true,
+        sawTouchpointsSection: true,
+        sawWalkSection: true,
+      };
+    }
+    if (op.name === "finish-fix") return { dispositions: [] };
+    if (op.name === "finish-narrative") {
+      if (opts.narrativeThrows) throw new Error("narrator agent exploded");
+      return { narrative: "Implements the demo feature end to end.", title: "feat: demo" };
+    }
+    return {};
+  }) as typeof _finishOpsDeps.callOp;
+}
+
+/** Write the feature's run artifacts so the untouched `_finishPrDeps.readText` reads them. */
+async function writeArtifacts(dir: string): Promise<string> {
+  const featureDirPath = join(dir, ".nax", "features", FEATURE);
+  await mkdir(featureDirPath, { recursive: true });
+  await writeFile(
+    join(featureDirPath, "prd.json"),
+    JSON.stringify({
+      userStories: [{ id: "US-001", title: "First story", acceptanceCriteria: ["a", "b", "c"] }],
+      outOfScope: ["not in scope"],
+    }),
+  );
+  await writeFile(
+    join(featureDirPath, "status.json"),
+    JSON.stringify({
+      postRun: { acceptance: { status: "passed" }, regression: { status: "passed" } },
+      durationMs: 42_000,
+      progress: { passed: 3, total: 3 },
+    }),
+  );
+  const specPath = join(featureDirPath, "spec.md");
+  await writeFile(specPath, "## Summary\nShips the feature end to end.\n");
+  return specPath;
+}
+
+interface MakeMachineResult {
+  deps: FinishMachineDeps;
+  state: FinishState;
+  recorder: ForgeRecorder;
+}
+
+function makeMachine(
+  dir: string,
+  specPath: string,
+  opts: { specReviewThrows?: boolean; narrativeThrows?: boolean } = {},
+): MakeMachineResult {
+  installGitStub();
+  installAcceptanceGateStub();
+  installQualityGateStub();
+  installPrRunStub();
+  installCallOpStub(opts);
+  const { forge, recorder } = installForgeStub();
+  const audit = { auditDir: join(dir, "audit"), runId: RUN_ID };
+  const ops = createFinishOps({ callCtx: {} as CallContext, forge, forgeKind: "github" as const, audit });
+  let tick = 0;
+  const deps: FinishMachineDeps = {
+    context: baseContext(specPath),
+    ops,
+    audit,
+    now: () => `2026-08-19T00:00:${String(tick++).padStart(2, "0")}.000Z`,
+  };
+  const state = createFinishState({
+    feature: FEATURE,
+    workdir: dir,
+    branch: "feat/finish-pr-escalate",
+    runId: RUN_ID,
+    base: "origin/main",
+    specPath,
+  });
+  return { deps, state, recorder };
+}
+
+describe("machine-end-to-end", () => {
+  test("a clean run reaches promoted with a PR body built from artifacts", async () => {
+    await withTempDir(async (dir) => {
+      const specPath = await writeArtifacts(dir);
+      const { deps, state, recorder } = makeMachine(dir, specPath);
+
+      const result = await runFinishMachine(state, deps);
+
+      expect(result.status).toBe("promoted");
+      expect(recorder.draftCreates).toBe(1);
+      expect(recorder.editBodies.length).toBeGreaterThan(0);
+      const lastEditBody = recorder.editBodies[recorder.editBodies.length - 1];
+      expect(lastEditBody).toContain("## Verification");
+      expect(lastEditBody).toContain("| US-001 | First story | 3 |");
+    });
+  });
+
+  test("a review that throws escalates with a comment and a written result file", async () => {
+    await withTempDir(async (dir) => {
+      const specPath = await writeArtifacts(dir);
+      const { deps, state, recorder } = makeMachine(dir, specPath, { specReviewThrows: true });
+
+      const result = await runFinishMachine(state, deps);
+
+      expect(result.status).toBe("escalated");
+      expect(result.escalationReason).toContain("spec review agent exploded");
+      expect(recorder.commentBodies).toHaveLength(1);
+      expect(recorder.commentBodies[0]).toContain("nax-finish escalation");
+      const onDisk = JSON.parse(await readFile(resultPath(deps.audit), "utf8")) as { status?: string };
+      expect(onDisk.status).toBe("escalated");
+    });
+  });
+
+  test("a narrator failure leaves the run promoted", async () => {
+    await withTempDir(async (dir) => {
+      const specPath = await writeArtifacts(dir);
+      const { deps, state, recorder } = makeMachine(dir, specPath, { narrativeThrows: true });
+
+      const result = await runFinishMachine(state, deps);
+
+      expect(result.status).toBe("promoted");
+      expect(recorder.commentBodies).toHaveLength(0);
+    });
+  });
+});

--- a/test/unit/finish/machine-end-to-end.test.ts
+++ b/test/unit/finish/machine-end-to-end.test.ts
@@ -261,6 +261,9 @@ describe("machine-end-to-end", () => {
       const lastEditBody = recorder.editBodies[recorder.editBodies.length - 1];
       expect(lastEditBody).toContain("## Verification");
       expect(lastEditBody).toContain("| US-001 | First story | 3 |");
+      // D4.12 — the gates the machine actually ran must survive to the rendered
+      // body; an unwired `state.gatesRan` would silently render no line at all.
+      expect(lastEditBody).toContain("- Gates: test");
     });
   });
 

--- a/test/unit/finish/machine-loops.test.ts
+++ b/test/unit/finish/machine-loops.test.ts
@@ -218,6 +218,15 @@ describe("machine-loops", () => {
     });
   });
 
+  test("green gate pass records the gate names on state.gatesRan", async () => {
+    await withTempDir(async (dir) => {
+      const { deps } = makeDeps({ auditDir: dir });
+      const state = baseState();
+      await runFinishMachine(state, deps);
+      expect(state.gatesRan).toEqual(["test"]);
+    });
+  });
+
   test("incomplete route: re-reviews exactly once (MAX_INCOMPLETE_ATTEMPTS) then escalates", async () => {
     await withTempDir(async (dir) => {
       const { deps, trail } = makeDeps({

--- a/test/unit/finish/ops-impl.test.ts
+++ b/test/unit/finish/ops-impl.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The `FinishOps` factory's contract (Task 6): per-phase role selection for
+ * the review op, pass-through of the re-review window and gap notice, the
+ * must-not-throw clauses for `escalate` and `narrate`, and the forge/delivery
+ * interaction ordering. The three LLM ops are stubbed out through
+ * `_finishOpsDeps.callOp`; the forge and git seams are stubbed to record the
+ * commands they were handed.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { _finishGitDeps, _finishOpsDeps, createFinishOps, createFinishState } from "@/finish";
+import type { ForgeDeps } from "@/forge";
+import type { CallContext } from "@/operations";
+
+const originalOps = { ..._finishOpsDeps };
+const originalGit = _finishGitDeps.git;
+afterEach(() => {
+  Object.assign(_finishOpsDeps, originalOps);
+  _finishGitDeps.git = originalGit;
+});
+
+function baseDeps(overrides: Partial<Parameters<typeof createFinishOps>[0]> = {}) {
+  const calls: string[][] = [];
+  _finishGitDeps.git = async (args: string[]) => {
+    calls.push(args);
+    return { exitCode: 0, stdout: "", stderr: "" };
+  };
+  const forge: ForgeDeps = {
+    run: async (cmd) => {
+      calls.push(cmd);
+      return { exitCode: 0, stdout: "https://x/1", stderr: "" };
+    },
+    readText: async () => null,
+  };
+  return {
+    calls,
+    deps: {
+      callCtx: {} as CallContext,
+      forge,
+      forgeKind: "github" as const,
+      audit: { auditDir: "/tmp/audit", runId: "run-1" },
+      ...overrides,
+    },
+  };
+}
+
+const state = createFinishState({
+  feature: "demo",
+  workdir: "/repo",
+  branch: "feat/demo",
+  runId: "run-1",
+  base: "origin/main",
+  specPath: "spec.md",
+});
+
+describe("ops-impl", () => {
+  test("review runs the spec phase under the finish-review-spec role", async () => {
+    let seenRole: string | undefined;
+    _finishOpsDeps.callOp = (async (ctx: CallContext) => {
+      seenRole = ctx.sessionOverride?.role;
+      return { findings: [], gaps: [], touchpoints: [], walk: [] };
+    }) as typeof _finishOpsDeps.callOp;
+    const { deps } = baseDeps();
+    await createFinishOps(deps).review("spec", { state });
+    expect(seenRole).toBe("finish-review-spec");
+  });
+
+  test("review runs the quality phase under the finish-review-quality role", async () => {
+    let seenRole: string | undefined;
+    _finishOpsDeps.callOp = (async (ctx: CallContext) => {
+      seenRole = ctx.sessionOverride?.role;
+      return { findings: [], gaps: [], touchpoints: [], walk: [] };
+    }) as typeof _finishOpsDeps.callOp;
+    const { deps } = baseDeps();
+    await createFinishOps(deps).review("quality", { state });
+    expect(seenRole).toBe("finish-review-quality");
+  });
+
+  test("review passes the phase's re-review window and gap notice through", async () => {
+    let seenInput: { since?: string; gaps?: string[] } | undefined;
+    _finishOpsDeps.callOp = (async (
+      _ctx: CallContext,
+      _op: unknown,
+      input: { since?: string; gaps?: string[] },
+    ) => {
+      seenInput = input;
+      return { findings: [], gaps: [], touchpoints: [], walk: [] };
+    }) as typeof _finishOpsDeps.callOp;
+    const windowed = createFinishState({ ...state });
+    windowed.phases.spec.reviewSince = "abc123";
+    windowed.phases.spec.reviewGaps = ["did not read src/a.ts"];
+    const { deps } = baseDeps();
+    await createFinishOps(deps).review("spec", { state: windowed });
+    expect(seenInput?.since).toBe("abc123");
+    expect(seenInput?.gaps).toEqual(["did not read src/a.ts"]);
+  });
+
+  test("review propagates a throw instead of swallowing it", async () => {
+    _finishOpsDeps.callOp = (async () => {
+      throw new Error("agent died");
+    }) as typeof _finishOpsDeps.callOp;
+    const { deps } = baseDeps();
+    await expect(createFinishOps(deps).review("spec", { state })).rejects.toThrow("agent died");
+  });
+
+  test("narrate swallows a throw so a promoted run is not re-escalated", async () => {
+    _finishOpsDeps.callOp = (async () => {
+      throw new Error("narrator died");
+    }) as typeof _finishOpsDeps.callOp;
+    const { deps } = baseDeps();
+    const ops = createFinishOps(deps);
+    await expect(ops.narrate?.(state)).resolves.toBeUndefined();
+  });
+
+  test("narrate is absent when narrative is disabled", () => {
+    const { deps } = baseDeps({ narrative: false });
+    expect(createFinishOps(deps).narrate).toBeUndefined();
+  });
+
+  test("escalate reports a delivery failure rather than throwing", async () => {
+    const forge: ForgeDeps = {
+      run: async () => {
+        throw new Error("gh missing");
+      },
+      readText: async () => null,
+    };
+    const { deps } = baseDeps({ forge });
+    await expect(createFinishOps(deps).escalate(state, "needs a human", [])).resolves.toMatchObject({
+      deliveryError: expect.stringContaining("gh missing"),
+    });
+  });
+
+  test("escalate reports no forge as a delivery error", async () => {
+    const { deps } = baseDeps({ forgeKind: null });
+    const outcome = await createFinishOps(deps).escalate(state, "needs a human", []);
+    expect(outcome.deliveryError).toBeTruthy();
+  });
+
+  test("promotePr pushes before it talks to the forge", async () => {
+    const { deps, calls } = baseDeps();
+    await createFinishOps(deps).promotePr(state);
+    const pushIndex = calls.findIndex((c) => c.includes("push"));
+    const forgeIndex = calls.findIndex((c) => c[0] === "gh");
+    expect(pushIndex).toBeGreaterThanOrEqual(0);
+    expect(pushIndex).toBeLessThan(forgeIndex);
+  });
+});

--- a/test/unit/finish/ops-impl.test.ts
+++ b/test/unit/finish/ops-impl.test.ts
@@ -157,4 +157,53 @@ describe("ops-impl", () => {
     expect(commitArgv).toBeDefined();
     expect(commitArgv?.join(" ")).toContain("wip(demo): nax-finish partial fixes before escalation");
   });
+
+  test("promotePr rejects when the push fails, per D4.6", async () => {
+    const { deps } = baseDeps();
+    _finishGitDeps.git = async (args: string[]) => {
+      if (args[0] === "push") return { exitCode: 1, stdout: "", stderr: "remote rejected" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    await expect(createFinishOps(deps).promotePr(state)).rejects.toThrow(/remote rejected/);
+  });
+
+  test("escalate appends a sync note to the comment when the partial-fix push fails, per D4.7", async () => {
+    let comment: string | undefined;
+    const forge: ForgeDeps = {
+      run: async (cmd) => {
+        if (cmd.includes("view")) return { exitCode: 1, stdout: "", stderr: "" };
+        if (cmd.includes("create")) {
+          comment = cmd[cmd.indexOf("--body") + 1];
+          return { exitCode: 0, stdout: "https://x/1", stderr: "" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      readText: async () => null,
+    };
+    const { deps } = baseDeps({ forge });
+    _finishGitDeps.git = async (args: string[]) => {
+      if (args[0] === "push") return { exitCode: 1, stdout: "", stderr: "no upstream" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    await createFinishOps(deps).escalate(state, "needs a human", []);
+    expect(comment).toContain("nax-finish could not push its partial fixes");
+    expect(comment).toContain("no upstream");
+  });
+
+  test("escalate returns the delivered url on a successful comment", async () => {
+    const { deps } = baseDeps();
+    const outcome = await createFinishOps(deps).escalate(state, "needs a human", []);
+    expect(outcome).toEqual({ url: "https://x/1" });
+  });
+
+  test("openDraftPr returns null rather than throwing when the forge cannot be spawned, per D4.5", async () => {
+    const forge: ForgeDeps = {
+      run: async () => {
+        throw new Error("gh missing");
+      },
+      readText: async () => null,
+    };
+    const { deps } = baseDeps({ forge });
+    await expect(createFinishOps(deps).openDraftPr(state)).resolves.toBeNull();
+  });
 });

--- a/test/unit/finish/ops-impl.test.ts
+++ b/test/unit/finish/ops-impl.test.ts
@@ -143,4 +143,18 @@ describe("ops-impl", () => {
     expect(pushIndex).toBeGreaterThanOrEqual(0);
     expect(pushIndex).toBeLessThan(forgeIndex);
   });
+
+  test("escalate pushes partial fixes under the flow's wip commit message", async () => {
+    const gitCalls: string[][] = [];
+    const { deps } = baseDeps({ forgeKind: null });
+    _finishGitDeps.git = async (args: string[]) => {
+      gitCalls.push(args);
+      if (args[0] === "status") return { exitCode: 0, stdout: " M file.ts\n", stderr: "" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    await createFinishOps(deps).escalate(state, "needs a human", []);
+    const commitArgv = gitCalls.find((c) => c[0] === "commit");
+    expect(commitArgv).toBeDefined();
+    expect(commitArgv?.join(" ")).toContain("wip(demo): nax-finish partial fixes before escalation");
+  });
 });

--- a/test/unit/finish/pr-body.test.ts
+++ b/test/unit/finish/pr-body.test.ts
@@ -1,0 +1,389 @@
+/**
+ * US-002 — deterministic finish PR title and body.
+ *
+ * The body is assembled by deterministic string joins over on-disk artifacts —
+ * no model call. The renderer mirrors `escapeTableCell` so a `|` in a story
+ * title cannot break its row, and mirrors `buildTitle` so finish-opened and
+ * auto-PR-opened PRs read the same.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFinishBody, buildFinishTitle, resolveTitle } from "@/finish";
+import type { Finding, FinishPrContext, FinishPrStory, FinishRound } from "@/finish";
+
+const story = (over: Partial<FinishPrStory> = {}): FinishPrStory => ({
+  id: "US-001",
+  title: "Wire header",
+  acCount: 3,
+  ...over,
+});
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  severity: "HIGH",
+  title: "Spec mismatch",
+  problem: "p",
+  fix: "f",
+  ...over,
+});
+
+const committedRound = (over: Partial<FinishRound> & { sha?: string } = {}): FinishRound => ({
+  ts: "2026-01-01T00:00:00.000Z",
+  phase: "spec",
+  attempt: 1,
+  committed: true,
+  findings: [],
+  ...over,
+});
+
+const baseCtx = (over: Partial<FinishPrContext> = {}): FinishPrContext => ({
+  feature: "auto-pr-plugin",
+  stories: [],
+  outOfScope: [],
+  gatesRan: [],
+  rounds: [],
+  run: {},
+  title: "feat: auto-pr-plugin",
+  ...over,
+});
+
+describe("buildFinishTitle (US-002 AC1)", () => {
+  test("renders the resolved conventional-commit title", () => {
+    const ctx = baseCtx({ feature: "schema-drift-gate", title: "fix: make the Alembic drift gate able to fail" });
+    expect(buildFinishTitle(ctx)).toBe("fix: make the Alembic drift gate able to fail");
+  });
+
+  test("renders the 'feat: <feature>' fallback that resolveTitle supplies", () => {
+    // The floor is still the auto-PR plugin's shape, so a finish run whose
+    // narrative node never spoke reads the same as an auto-PR-opened one.
+    expect(buildFinishTitle(baseCtx({ title: resolveTitle(undefined, "pipeline-run-outcome") }))).toBe(
+      "feat: pipeline-run-outcome",
+    );
+  });
+});
+
+describe("buildFinishBody — Stories table (US-002 AC2, AC3)", () => {
+  test("renders one table row per story", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [
+          story({ id: "US-001", title: "Header", acCount: 2 }),
+          story({ id: "US-002", title: "Footer", acCount: 4 }),
+        ],
+      }),
+    );
+    expect(body).toContain("| US-001 | Header | 2 |");
+    expect(body).toContain("| US-002 | Footer | 4 |");
+  });
+
+  test("escapes '|' in story titles so the row remains three columns", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story({ id: "US-001", title: "Audit | stub rows", acCount: 1 })],
+      }),
+    );
+    expect(body).toContain("| US-001 | Audit \\| stub rows | 1 |");
+    // The literal unescaped form must NOT appear in the row.
+    expect(body).not.toMatch(/\|\s*Audit\s*\|\s*stub rows\s*\|\s*1\s*\|/);
+  });
+});
+
+describe("buildFinishBody — Verification block (US-002 AC4-AC7)", () => {
+  test("renders the acceptance Verification line when acceptance is present", () => {
+    const body = buildFinishBody(baseCtx({ acceptance: "all 12 acceptance tests passed" }));
+    expect(body).toContain("Verification");
+    expect(body).toContain("Acceptance: all 12 acceptance tests passed");
+  });
+
+  test("renders the regression Verification line when regression is present", () => {
+    const body = buildFinishBody(baseCtx({ regression: "regression suite green" }));
+    expect(body).toContain("Regression: regression suite green");
+  });
+
+  test("renders every gate name in a single Verification line", () => {
+    const body = buildFinishBody(baseCtx({ gatesRan: ["lint", "typecheck", "test"] }));
+    expect(body).toContain("Gates: lint, typecheck, test");
+  });
+
+  test("includes the diffstat text verbatim in Verification when present", () => {
+    const stat = " src/foo.ts | 12 ++++--\n 1 file changed, 9 insertions(+), 3 deletions(-)";
+    const body = buildFinishBody(baseCtx({ diffstat: stat }));
+    expect(body).toContain(stat);
+  });
+
+  test("accounts for the held-out nax artifacts so the body reconciles with the real diff", () => {
+    const body = buildFinishBody(baseCtx({ artifactSummary: "5 files changed, 1248 insertions(+)" }));
+    expect(body).toContain("Excluded from diffstat — nax run artifacts: 5 files changed, 1248 insertions(+)");
+  });
+
+  test("renders no exclusion line when the branch touched no artifacts", () => {
+    const body = buildFinishBody(baseCtx({ diffstat: " src/foo.ts | 1 +" }));
+    expect(body).not.toContain("Excluded from diffstat");
+  });
+});
+
+describe("buildFinishBody — Review rounds (US-002 AC8-AC12)", () => {
+  test("renders one heading per round naming phase and attempt", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        rounds: [committedRound({ phase: "spec", attempt: 1 }), committedRound({ phase: "quality", attempt: 2 })],
+      }),
+    );
+    expect(body).toContain("## Review rounds");
+    expect(body).toContain("### spec attempt 1");
+    expect(body).toContain("### quality attempt 2");
+  });
+
+  test("renders each finding as a bullet carrying severity and title", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        rounds: [
+          committedRound({
+            findings: [
+              finding({ severity: "CRITICAL", title: "Spec drift in test" }),
+              finding({ severity: "LOW", title: "Naming inconsistency" }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(body).toContain("- [CRITICAL] Spec drift in test");
+    expect(body).toContain("- [LOW] Naming inconsistency");
+  });
+
+  test("a rejected finding is rendered as waived, with its evidence", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        rounds: [
+          committedRound({
+            phase: "quality",
+            outcome: "fixed",
+            findings: [finding({ severity: "LOW", title: "Dead param" })],
+            dispositions: [{ index: 1, disposition: "rejected", evidence: "test/unit/a.test.ts:9" }],
+          }),
+        ],
+      }),
+    );
+    expect(body).toContain("_rejected_");
+    expect(body).toContain("test/unit/a.test.ts:9");
+  });
+
+  test("renders the abbreviated seven-character SHA in the round heading when committed", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        rounds: [committedRound({ sha: "abcdef1234567" })],
+      }),
+    );
+    expect(body).toContain("### spec attempt 1 (abcdef1)");
+  });
+
+  test("renders no SHA in the round heading when the round is uncommitted", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        rounds: [
+          {
+            ts: "2026-01-01T00:00:00.000Z",
+            phase: "spec",
+            attempt: 1,
+            committed: false,
+            findings: [],
+          },
+        ],
+      }),
+    );
+    expect(body).toContain("### spec attempt 1");
+    expect(body).not.toMatch(/### spec attempt 1 \([0-9a-f]{7}\)/);
+  });
+
+  test("renders no Review rounds heading when rounds is empty", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [] }));
+    expect(body).not.toContain("## Review rounds");
+  });
+});
+
+// #1507: an empty finding list means four different things, and the body used
+// to render all of them as "_no findings_" — which a human reads as "a reviewer
+// looked and approved this". Only `passed` means that.
+describe("buildFinishBody — what an empty round actually means", () => {
+  const emptyRound = (over: Partial<FinishRound> = {}): FinishRound => ({
+    ts: "2026-01-01T00:00:00.000Z",
+    phase: "quality",
+    attempt: 1,
+    committed: false,
+    findings: [],
+    ...over,
+  });
+
+  test("a passed review still reads as no findings", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ outcome: "passed" })] }));
+    expect(body).toContain("- _no findings_");
+  });
+
+  test("a gate round says no reviewer ran, NOT that a reviewer found nothing", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ phase: "gate", outcome: "no-reviewer" })] }));
+    expect(body).toContain("### gate attempt 1");
+    expect(body).toContain("no reviewer");
+    expect(body).not.toContain("- _no findings_");
+  });
+
+  // The reader has to be able to see the skip. A PR whose gate fix bypassed the
+  // re-review by policy looks, in every other respect, exactly like one that was
+  // re-reviewed and came back clean.
+  test("a skipped re-review is visible in the body, not disguised as a clean one", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ phase: "gate", outcome: "review-skipped" })] }));
+    expect(body).toContain("re-review skipped");
+    expect(body).not.toContain("- _no findings_");
+  });
+
+  test("an unparseable review is not rendered as a pass", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ outcome: "unparseable" })] }));
+    expect(body).toContain("could not be parsed");
+    expect(body).not.toContain("- _no findings_");
+  });
+
+  test("an escalated review is not rendered as a pass", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({ outcome: "escalated" })] }));
+    expect(body).toContain("escalated");
+    expect(body).not.toContain("- _no findings_");
+  });
+
+  // Rounds written before `outcome` existed carry no such field. The body must
+  // keep rendering them exactly as it did, rather than claiming they had no
+  // reviewer — it does not know that.
+  test("a legacy round with no outcome renders as before", () => {
+    const body = buildFinishBody(baseCtx({ rounds: [emptyRound({})] }));
+    expect(body).toContain("- _no findings_");
+  });
+});
+
+describe("buildFinishBody — Out of scope (US-002 AC13, AC14)", () => {
+  test("renders one bullet per out-of-scope entry, text unchanged", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        outOfScope: ["A model-written summary section", "Auto-PR template behaviour"],
+      }),
+    );
+    expect(body).toContain("## Out of scope");
+    expect(body).toContain("- A model-written summary section");
+    expect(body).toContain("- Auto-PR template behaviour");
+  });
+
+  test("renders no Out of scope heading when the list is empty", () => {
+    const body = buildFinishBody(baseCtx({ outOfScope: [] }));
+    expect(body).not.toContain("## Out of scope");
+  });
+});
+
+describe("buildFinishBody — Run summary footer (US-002 AC15)", () => {
+  test("renders story counts and duration in 'Nm SSs' format", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        run: { storiesPassed: 4, storiesTotal: 5, durationMs: 92_000 },
+      }),
+    );
+    // AC15: "<storiesPassed>/<storiesTotal> stories · <durationMs formatted as Nm SSs>"
+    // — one line, joined by ' · '. A regression that swaps the separator or
+    // breaks the line would survive `toContain` on each half independently.
+    expect(body).toContain("4/5 stories · 1m 32s");
+  });
+
+  test("omits the footer when duration is absent and reports only counts when duration is provided", () => {
+    expect(buildFinishBody(baseCtx({ run: { storiesPassed: 1, storiesTotal: 1 } }))).toContain("1/1 stories");
+    const body = buildFinishBody(baseCtx({ run: { durationMs: 65_000 } }));
+    expect(body).toContain("1m 05s");
+  });
+
+  test("non-finite duration formats as '0m 00s' instead of propagating NaN/Infinity into the body", () => {
+    // NaN/Infinity are valid TypeScript `number` values and `Math.max(0, NaN)`
+    // propagates NaN, so a guard is required to avoid `"NaNm NaNs"` in the PR.
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const body = buildFinishBody(baseCtx({ run: { storiesPassed: 1, storiesTotal: 1, durationMs: bad } }));
+      expect(body).toContain("1/1 stories · 0m 00s");
+    }
+  });
+});
+
+describe("buildFinishBody — repository template (#1478, merged per #1504)", () => {
+  // Superseded the original #1478 contract ("append the template verbatim
+  // last"), which shipped an unfilled form below a filled one — see
+  // `pr-template-merge.ts`. The template is now shape, not trailing content.
+  test("drops a template section nax cannot fill rather than shipping its blank checklist", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story({ id: "US-001", title: "Header", acCount: 2 })],
+        template: "## Checklist\n- [ ] docs updated",
+      }),
+    );
+    expect(body).not.toContain("## Checklist");
+    expect(body).not.toContain("- [ ] docs updated");
+    expect(body).toContain("| US-001 | Header | 2 |");
+  });
+
+  test("adopts a template heading it can fill, and puts nax's content under it", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story({ id: "US-001", title: "Header", acCount: 2 })],
+        narrative: "Replaced the widget cache.",
+        template: "## Summary\n\n<!-- describe -->\n\n## How\n\n<!-- details -->",
+      }),
+    );
+    expect(body).toContain("## Summary\n\nReplaced the widget cache.");
+    expect(body).toContain("## How\n\n| Story | Title | ACs |");
+    expect(body).not.toContain("## What changed");
+    expect(body).not.toContain("<!--");
+  });
+
+  test("keeps every unfillable heading, empty, under the strict mode a heading-checking CI needs", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story()],
+        template: "## Checklist\n- [ ] docs updated",
+        templateMode: "strict",
+      }),
+    );
+    expect(body).toContain("## Checklist");
+    expect(body).not.toContain("- [ ] docs updated");
+  });
+
+  test("honours a sectionMap override for a heading the default table does not know", () => {
+    const body = buildFinishBody(
+      baseCtx({
+        stories: [story({ id: "US-001", title: "Header", acCount: 2 })],
+        template: "## Werk\n\n<!-- x -->",
+        templateSectionMap: { werk: "stories" },
+      }),
+    );
+    expect(body).toContain("## Werk\n\n| Story | Title | ACs |");
+    expect(body).not.toContain("## Stories");
+  });
+
+  test("omits the template entirely when none resolved", () => {
+    const body = buildFinishBody(baseCtx({ stories: [story()] }));
+    expect(body).not.toContain("## Checklist");
+    expect(body.endsWith("\n\n")).toBe(false);
+  });
+
+  test("treats a whitespace-only template as absent", () => {
+    const body = buildFinishBody(baseCtx({ stories: [story()], template: "   \n  " }));
+    expect(body.trimEnd()).toBe(body);
+  });
+});
+
+describe("buildFinishBody — What changed section (#1477)", () => {
+  test("renders the narrative first, above the Stories table", () => {
+    const body = buildFinishBody(baseCtx({ stories: [story()], narrative: "Replaced the widget cache." }));
+    expect(body.indexOf("## What changed")).toBe(0);
+    expect(body).toContain("Replaced the widget cache.");
+    expect(body.indexOf("## What changed")).toBeLessThan(body.indexOf("## Stories"));
+  });
+
+  test("omits the heading entirely when there is no narrative", () => {
+    // #1477 forbids an empty heading. Heading and text are produced by one
+    // function so this is structural, not a rule someone has to remember.
+    const body = buildFinishBody(baseCtx({ stories: [story()] }));
+    expect(body).not.toContain("## What changed");
+  });
+
+  test("treats a whitespace-only narrative as absent", () => {
+    const body = buildFinishBody(baseCtx({ stories: [story()], narrative: "  \n " }));
+    expect(body).not.toContain("## What changed");
+  });
+});

--- a/test/unit/finish/pr-context.test.ts
+++ b/test/unit/finish/pr-context.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { _finishPrDeps, createFinishState, loadFinishPrContext } from "@/finish";
+import { cleanupTempDir, makeTempDir } from "@test/helpers";
+
+const originalDeps = { ..._finishPrDeps };
+let dir: string;
+
+function stateFor(workdir: string) {
+  return createFinishState({
+    feature: "demo",
+    workdir,
+    branch: "feat/demo",
+    runId: "run-1",
+    base: "origin/main",
+    specPath: ".nax/features/demo/spec.md",
+  });
+}
+
+beforeEach(async () => {
+  dir = await makeTempDir("pr-context");
+});
+
+afterEach(async () => {
+  Object.assign(_finishPrDeps, originalDeps);
+  await cleanupTempDir(dir);
+});
+
+describe("loadFinishPrContext", () => {
+  test("reads stories and out-of-scope from the feature's prd.json", async () => {
+    const featureDirPath = join(dir, ".nax", "features", "demo");
+    await mkdir(featureDirPath, { recursive: true });
+    await writeFile(
+      join(featureDirPath, "prd.json"),
+      JSON.stringify({
+        userStories: [{ id: "US-001", title: "First", acceptanceCriteria: [1, 2, 3] }],
+        outOfScope: ["not this"],
+      }),
+    );
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+    });
+
+    expect(ctx.stories).toEqual([{ id: "US-001", title: "First", acCount: 3 }]);
+    expect(ctx.outOfScope).toEqual(["not this"]);
+  });
+
+  test("drops a story row whose id or title is not a string", async () => {
+    const featureDirPath = join(dir, ".nax", "features", "demo");
+    await mkdir(featureDirPath, { recursive: true });
+    await writeFile(
+      join(featureDirPath, "prd.json"),
+      JSON.stringify({ userStories: [{ id: 7, title: "Bad" }, { id: "US-002", title: "Good" }] }),
+    );
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+    });
+
+    expect(ctx.stories.map((s) => s.id)).toEqual(["US-002"]);
+  });
+
+  test("splits the diffstat from the nax-artifact summary using a glob pathspec", async () => {
+    const calls: string[][] = [];
+    _finishPrDeps.run = async (cmd) => {
+      calls.push(cmd);
+      return cmd.includes("--shortstat")
+        ? { exitCode: 0, stdout: " 1 file changed, 5 insertions(+)\n", stderr: "" }
+        : { exitCode: 0, stdout: " src/a.ts | 2 +-\n", stderr: "" };
+    };
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+    });
+
+    expect(ctx.diffstat).toContain("src/a.ts");
+    expect(ctx.artifactSummary).toBe("1 file changed, 5 insertions(+)");
+    const stat = calls.find((c) => c.includes("--stat"));
+    expect(stat).toContain(":(glob,exclude)**/.nax/**");
+    const shortstat = calls.find((c) => c.includes("--shortstat"));
+    expect(shortstat).toContain(":(glob)**/.nax/**");
+  });
+
+  test("skips the diffstat entirely when base is empty", async () => {
+    let ran = false;
+    _finishPrDeps.run = async () => {
+      ran = true;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const state = stateFor(dir);
+    state.base = "";
+
+    const ctx = await loadFinishPrContext({
+      state,
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+    });
+
+    expect(ran).toBe(false);
+    expect(ctx.diffstat).toBeUndefined();
+  });
+
+  test("falls back to feat: <feature> when no title was produced", async () => {
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+    });
+
+    expect(ctx.title).toBe("feat: demo");
+  });
+
+  test("reports the gate names the machine recorded on state", async () => {
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+    const withGates = stateFor(dir);
+    withGates.gatesRan = ["lint", "typecheck"];
+
+    const ctx = await loadFinishPrContext({
+      state: withGates,
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+    });
+
+    expect(ctx.gatesRan).toEqual(["lint", "typecheck"]);
+  });
+
+  test("carries the caller's template mode and section map", async () => {
+    _finishPrDeps.run = async () => ({ exitCode: 1, stdout: "", stderr: "" });
+
+    const ctx = await loadFinishPrContext({
+      state: stateFor(dir),
+      audit: { auditDir: join(dir, "audit"), runId: "run-1" },
+      prBody: { template: "strict", sectionMap: { notes: "narrative" } },
+    });
+
+    expect(ctx.templateMode).toBe("strict");
+    expect(ctx.templateSectionMap).toEqual({ notes: "narrative" });
+  });
+});

--- a/test/unit/finish/pr-open.test.ts
+++ b/test/unit/finish/pr-open.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { openDraftFinishPr, openOrPromotePr, parseView, updatePrBody } from "@/finish";
+import type { ForgeDeps } from "@/forge";
+
+function depsFor(handler: (cmd: string[]) => { exitCode: number; stdout?: string; stderr?: string }): {
+  deps: ForgeDeps;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const deps: ForgeDeps = {
+    run: async (cmd) => {
+      calls.push(cmd);
+      const r = handler(cmd);
+      return { exitCode: r.exitCode, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+    },
+    readText: async () => null,
+  };
+  return { deps, calls };
+}
+
+const args = {
+  workdir: "/repo",
+  branch: "feat/demo",
+  title: "feat: demo",
+  body: "body",
+  forge: "github" as const,
+};
+
+describe("parseView", () => {
+  test("reads isDraft and url from GitHub JSON", () => {
+    expect(parseView('{"isDraft":true,"url":"https://x/1"}', "github")).toEqual({
+      isDraft: true,
+      url: "https://x/1",
+    });
+  });
+
+  test("treats an unparseable reply as ready, not draft", () => {
+    expect(parseView("not json https://x/2", "github")).toEqual({ isDraft: false, url: "https://x/2" });
+  });
+
+  test("accepts any of GitLab's draft field spellings", () => {
+    expect(parseView('{"work_in_progress":true,"web_url":"https://x/3"}', "gitlab").isDraft).toBe(true);
+  });
+});
+
+describe("openDraftFinishPr", () => {
+  test("opens a draft when the branch has no open PR", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("list") ? { exitCode: 0, stdout: "[]" } : { exitCode: 0, stdout: "https://x/9" },
+    );
+    await expect(openDraftFinishPr(args, deps)).resolves.toEqual({ url: "https://x/9" });
+    expect(calls.at(-1)).toContain("--draft");
+  });
+
+  test("returns null when a PR is already open", async () => {
+    const { deps, calls } = depsFor(() => ({ exitCode: 0, stdout: '[{"number":1}]' }));
+    await expect(openDraftFinishPr(args, deps)).resolves.toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("returns null rather than throwing when the PR list call fails", async () => {
+    const { deps } = depsFor(() => ({ exitCode: 1, stderr: "auth required" }));
+    await expect(openDraftFinishPr(args, deps)).resolves.toBeNull();
+  });
+
+  test("returns null when creation fails", async () => {
+    const { deps } = depsFor((cmd) =>
+      cmd.includes("list") ? { exitCode: 0, stdout: "[]" } : { exitCode: 1, stderr: "rate limited" },
+    );
+    await expect(openDraftFinishPr(args, deps)).resolves.toBeNull();
+  });
+});
+
+describe("openOrPromotePr", () => {
+  test("creates the PR when view fails, and reports opened", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 1 } : { exitCode: 0, stdout: "https://x/10" },
+    );
+    await expect(openOrPromotePr(args, deps)).resolves.toEqual({ status: "opened", url: "https://x/10" });
+    expect(calls.at(-1)).not.toContain("--draft");
+  });
+
+  test("promotes a draft and then writes the body", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: '{"isDraft":true,"url":"https://x/11"}' } : { exitCode: 0 },
+    );
+    await expect(openOrPromotePr(args, deps)).resolves.toEqual({ status: "promoted", url: "https://x/11" });
+    expect(calls.map((c) => c[2])).toEqual(["view", "ready", "edit"]);
+  });
+
+  test("writes the body on an already-ready PR without promoting", async () => {
+    const { deps, calls } = depsFor((cmd) =>
+      cmd.includes("view") ? { exitCode: 0, stdout: '{"isDraft":false,"url":"https://x/12"}' } : { exitCode: 0 },
+    );
+    await expect(openOrPromotePr(args, deps)).resolves.toEqual({ status: "already-ready", url: "https://x/12" });
+    expect(calls.map((c) => c[2])).toEqual(["view", "edit"]);
+  });
+
+  test("throws FINISH_PR_CREATE_FAILED when creation fails", async () => {
+    const { deps } = depsFor((cmd) => (cmd.includes("view") ? { exitCode: 1 } : { exitCode: 1, stderr: "boom" }));
+    await expect(openOrPromotePr(args, deps)).rejects.toThrow(/boom/);
+  });
+
+  test("throws FINISH_PR_PROMOTE_FAILED when promotion fails", async () => {
+    const { deps } = depsFor((cmd) => {
+      if (cmd.includes("view")) return { exitCode: 0, stdout: '{"isDraft":true}' };
+      return cmd.includes("ready") ? { exitCode: 1, stderr: "denied" } : { exitCode: 0 };
+    });
+    await expect(openOrPromotePr(args, deps)).rejects.toThrow(/denied/);
+  });
+});
+
+describe("updatePrBody", () => {
+  test("never throws when the edit fails", async () => {
+    const { deps } = depsFor(() => ({ exitCode: 1, stderr: "nope" }));
+    await expect(updatePrBody(args, deps)).resolves.toBeUndefined();
+  });
+
+  test("never throws when the run itself rejects", async () => {
+    const deps: ForgeDeps = {
+      run: async () => {
+        throw new Error("spawn failed");
+      },
+      readText: async () => null,
+    };
+    await expect(updatePrBody(args, deps)).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/forge/template-merge.test.ts
+++ b/test/unit/forge/template-merge.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_SECTION_ALIASES, type BodySection, mergeTemplate } from "@/forge";
+import { mergeTemplate as flowMergeTemplate } from "@flows/nax-finish/pr-template-merge";
+import { TEMPLATE_BY_NAME, TEMPLATE_FIXTURES, UNPARSEABLE_FIXTURE_NAMES } from "@test/fixtures/pr-templates";
+
+/**
+ * The nax-authored sections, in the canonical order `buildFinishBody` emits
+ * them. `footer` carries no heading, which is how a headingless trailing line
+ * is expressed — it must never be matched to a template heading.
+ */
+function sections(overrides: Partial<Record<string, string>> = {}): BodySection[] {
+  const all: BodySection[] = [
+    { key: "narrative", heading: "What changed", body: "Adds a description field." },
+    { key: "stories", heading: "Stories", body: "| Story | Title | ACs |\n|---|---|---|\n| US-001 | Carry it | 9 |" },
+    { key: "verification", heading: "Verification", body: "- Acceptance: passed\n- Gates: build, test" },
+    { key: "rounds", heading: "Review rounds", body: "### quality attempt 1\n- _no findings_" },
+    { key: "outOfScope", heading: "Out of scope", body: "- Making it required." },
+    { key: "footer", heading: "", body: "2/2 stories · 18m 24s" },
+  ];
+  return all
+    .map((s) => (overrides[s.key] !== undefined ? { ...s, body: overrides[s.key] as string } : s))
+    .filter((s) => s.body.length > 0);
+}
+
+/** Every H2 heading in a rendered body, in order. */
+function headings(body: string): string[] {
+  return body
+    .split("\n")
+    .filter((l) => /^##\s/.test(l))
+    .map((l) => l.replace(/^##\s+/, ""));
+}
+
+/** The text under a given H2, up to the next H2. */
+function bodyUnder(body: string, heading: string): string {
+  const lines = body.split("\n");
+  const start = lines.findIndex((l) => l.trim() === `## ${heading}`);
+  if (start === -1) return "";
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^##\s/.test(l));
+  return (end === -1 ? rest : rest.slice(0, end)).join("\n").trim();
+}
+
+describe("mergeTemplate — no template to merge", () => {
+  test("renders nax sections in canonical order when the template is absent", () => {
+    const out = mergeTemplate(undefined, sections());
+    expect(headings(out)).toEqual(["What changed", "Stories", "Verification", "Review rounds", "Out of scope"]);
+    expect(out.trimEnd().endsWith("2/2 stories · 18m 24s")).toBe(true);
+  });
+
+  test("treats a whitespace-only template as absent", () => {
+    expect(mergeTemplate("   \n\n  ", sections())).toBe(mergeTemplate(undefined, sections()));
+  });
+
+  test('mode "ignore" drops a perfectly parseable template', () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { mode: "ignore" });
+    expect(out).toBe(mergeTemplate(undefined, sections()));
+  });
+
+  test.each(UNPARSEABLE_FIXTURE_NAMES)("falls back to the nax body for the unparseable %s template", (name) => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME[name], sections());
+    expect(out).toBe(mergeTemplate(undefined, sections()));
+  });
+});
+
+describe("mergeTemplate — this repo's template (the #1504 defect)", () => {
+  const merged = mergeTemplate(TEMPLATE_BY_NAME.nax, sections());
+
+  test("adopts the template's headings and order for the sections it can fill", () => {
+    expect(headings(merged).slice(0, 3)).toEqual(["What", "How", "Testing"]);
+  });
+
+  test("fills each adopted heading with the matching nax content", () => {
+    expect(bodyUnder(merged, "What")).toBe("Adds a description field.");
+    expect(bodyUnder(merged, "How")).toContain("| US-001 | Carry it | 9 |");
+    expect(bodyUnder(merged, "Testing")).toBe("- Acceptance: passed\n- Gates: build, test");
+  });
+
+  test("drops template sections nax has nothing to say under", () => {
+    expect(headings(merged)).not.toContain("Why");
+    expect(headings(merged)).not.toContain("Notes");
+  });
+
+  test("appends nax sections the template has no home for, under nax's own headings", () => {
+    expect(headings(merged).slice(3)).toEqual(["Review rounds", "Out of scope"]);
+  });
+
+  test("emits no unchecked checkbox contradicting the verified gate list", () => {
+    expect(merged).not.toContain("- [ ]");
+    expect(bodyUnder(merged, "Testing")).toContain("Acceptance: passed");
+  });
+
+  test("emits no dangling issue reference", () => {
+    expect(merged).not.toMatch(/(closes|fixes|resolves)\s*#\s*$/im);
+  });
+});
+
+describe("mergeTemplate — corpus invariants", () => {
+  const parseable = TEMPLATE_FIXTURES.filter((f) => !UNPARSEABLE_FIXTURE_NAMES.includes(f.name));
+
+  test.each(TEMPLATE_FIXTURES.map((f) => f.name))("%s: never ships an HTML placeholder comment", (name) => {
+    expect(mergeTemplate(TEMPLATE_BY_NAME[name], sections())).not.toContain("<!--");
+  });
+
+  test.each(TEMPLATE_FIXTURES.map((f) => f.name))("%s: never ships an unchecked checkbox", (name) => {
+    expect(mergeTemplate(TEMPLATE_BY_NAME[name], sections())).not.toContain("- [ ]");
+  });
+
+  test.each(parseable.map((f) => f.name))("%s: never emits a heading with nothing under it", (name) => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME[name], sections());
+    for (const heading of headings(out)) expect(bodyUnder(out, heading)).not.toBe("");
+  });
+
+  test.each(TEMPLATE_FIXTURES.map((f) => f.name))("%s: carries every nax section through exactly once", (name) => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME[name], sections());
+    for (const s of sections()) {
+      const occurrences = out.split(s.body).length - 1;
+      expect(occurrences).toBe(1);
+    }
+  });
+});
+
+describe("mergeTemplate — heading matching", () => {
+  test("matches case-insensitively and ignores punctuation", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["github-community"], sections());
+    expect(bodyUnder(out, "How Has This Been Tested?")).toBe("- Acceptance: passed\n- Gates: build, test");
+    expect(bodyUnder(out, "Description")).toBe("Adds a description field.");
+  });
+
+  test("drops the unmatched sections of a third-party template", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["github-community"], sections());
+    expect(headings(out)).not.toContain("Type of change");
+    expect(headings(out)).not.toContain("Checklist:");
+  });
+
+  test("a sectionMap entry overrides the default alias table", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { sectionMap: { notes: "outOfScope" } });
+    expect(bodyUnder(out, "Notes")).toBe("- Making it required.");
+    expect(headings(out)).not.toContain("Out of scope");
+  });
+
+  test("a sectionMap entry can suppress a default alias by pointing it at no section", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { sectionMap: { what: "" } });
+    expect(headings(out)).not.toContain("What");
+    expect(headings(out)).toContain("What changed");
+  });
+
+  test("the first of two headings sharing a key consumes it; the second is dropped", () => {
+    const template = "## Summary\n\nx\n\n## Description\n\ny\n";
+    const out = mergeTemplate(template, sections());
+    expect(bodyUnder(out, "Summary")).toBe("Adds a description field.");
+    expect(headings(out)).not.toContain("Description");
+  });
+
+  test("the headingless footer is never matched to a template heading", () => {
+    const out = mergeTemplate("## Notes\n\n<!-- x -->\n", sections(), { sectionMap: { notes: "footer" } });
+    expect(headings(out)).not.toContain("Notes");
+    expect(out.trimEnd().endsWith("2/2 stories · 18m 24s")).toBe(true);
+  });
+
+  test("a sectionMap key is matched the same way a template heading is — raw, as a human writes it in config", () => {
+    // The config schema promises keys match "case- and punctuation-
+    // insensitively". A user pins GitLab's default heading by pasting it, not
+    // by pre-normalising it to `what does this mr do and why`.
+    const out = mergeTemplate(TEMPLATE_BY_NAME["gitlab-default"], sections(), {
+      sectionMap: { "Screenshots or screen recordings": "rounds" },
+    });
+    expect(bodyUnder(out, "Screenshots or screen recordings")).toContain("quality attempt 1");
+  });
+
+  test("the default alias table maps the headings the corpus actually uses", () => {
+    expect(DEFAULT_SECTION_ALIASES.what).toBe("narrative");
+    expect(DEFAULT_SECTION_ALIASES.testing).toBe("verification");
+    expect(DEFAULT_SECTION_ALIASES.why).toBeUndefined();
+  });
+});
+
+describe("mergeTemplate — preamble and frontmatter", () => {
+  test("preserves YAML frontmatter verbatim at the top", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["with-frontmatter"], sections());
+    expect(out.startsWith('---\nname: Standard change\nlabels: ["needs-review", "team/platform"]')).toBe(true);
+    expect(out).toContain("assignees: octocat\n---");
+  });
+
+  test("frontmatter precedes the first heading", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["with-frontmatter"], sections());
+    expect(out.indexOf("---")).toBeLessThan(out.indexOf("## Summary"));
+  });
+
+  test("keeps preamble prose that survives comment stripping", () => {
+    const out = mergeTemplate("Please read CONTRIBUTING.md.\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out.startsWith("Please read CONTRIBUTING.md.")).toBe(true);
+  });
+
+  test("drops a preamble that was only a placeholder comment", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["gitlab-default"], sections());
+    expect(out.startsWith("<!--")).toBe(false);
+    expect(out).not.toContain("Set the MR title");
+  });
+
+  test("drops a dangling issue reference left in the preamble", () => {
+    const out = mergeTemplate("Closes #\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).not.toContain("Closes #");
+  });
+
+  test("keeps a real issue reference in the preamble", () => {
+    const out = mergeTemplate("Closes #1504\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).toContain("Closes #1504");
+  });
+});
+
+describe('mergeTemplate — "strict" mode', () => {
+  const strict = mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { mode: "strict" });
+
+  test("keeps every template heading so a heading-checking bot still passes", () => {
+    expect(headings(strict).slice(0, 5)).toEqual(["What", "Why", "How", "Testing", "Notes"]);
+  });
+
+  test("leaves unfillable sections empty rather than shipping their placeholders", () => {
+    expect(bodyUnder(strict, "Why")).toBe("");
+    expect(bodyUnder(strict, "Notes")).toBe("");
+    expect(strict).not.toContain("<!--");
+    expect(strict).not.toContain("- [ ]");
+  });
+
+  test("still fills the sections it can match", () => {
+    expect(bodyUnder(strict, "What")).toBe("Adds a description field.");
+    expect(bodyUnder(strict, "Testing")).toBe("- Acceptance: passed\n- Gates: build, test");
+  });
+
+  test("still appends the nax sections the template has no home for", () => {
+    expect(headings(strict).slice(5)).toEqual(["Review rounds", "Out of scope"]);
+  });
+});
+
+describe("mergeTemplate — hostile template shapes", () => {
+  test("a CRLF template does not leak carriage returns into the body", () => {
+    const out = mergeTemplate("## What\r\n\r\n<!-- x -->\r\n\r\n## Testing\r\n\r\n- [ ] tests\r\n", sections());
+    expect(out).not.toContain("\r");
+    expect(bodyUnder(out, "What")).toBe("Adds a description field.");
+  });
+
+  test("strips an unchecked checkbox left in the preamble, above the first heading", () => {
+    // A real shape: repos that open with a contributor checklist and only then
+    // start their sections. Preamble text is the one template region that
+    // survives into the body, so the no-unfilled-field rule has to hold there.
+    const out = mergeTemplate("- [ ] I read CONTRIBUTING.md\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).not.toContain("- [ ]");
+  });
+
+  test("keeps preamble prose that sits alongside a stripped checkbox", () => {
+    const out = mergeTemplate("Please confirm:\n\n- [ ] I read CONTRIBUTING.md\n\n## What\n\n<!-- x -->\n", sections());
+    expect(out).toContain("Please confirm:");
+    expect(out).not.toContain("- [ ]");
+  });
+
+  test("does not mistake a leading horizontal rule for YAML frontmatter", () => {
+    const out = mergeTemplate("---\n\nRead the guide.\n\n---\n\n## What\n\n<!-- x -->\n", sections());
+    expect(bodyUnder(out, "What")).toBe("Adds a description field.");
+    expect(out).toContain("Read the guide.");
+  });
+});
+
+describe("mergeTemplate — degenerate inputs", () => {
+  test("renders the template's shape when nax produced no sections at all", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME.nax, []);
+    expect(out).toBe("");
+  });
+
+  test("does not leave a run of blank lines where a section was dropped", () => {
+    expect(mergeTemplate(TEMPLATE_BY_NAME.nax, sections())).not.toMatch(/\n{3,}/);
+  });
+
+  test("does not emit trailing whitespace on any line", () => {
+    const out = mergeTemplate(TEMPLATE_BY_NAME["github-community"], sections());
+    for (const line of out.split("\n")) expect(line).toBe(line.trimEnd());
+  });
+
+  test("a sectionMap does not leak into the default alias table on the next call", () => {
+    const baseline = mergeTemplate(TEMPLATE_BY_NAME.nax, sections());
+    mergeTemplate(TEMPLATE_BY_NAME.nax, sections(), { sectionMap: { notes: "outOfScope", what: "" } });
+    expect(mergeTemplate(TEMPLATE_BY_NAME.nax, sections())).toBe(baseline);
+  });
+});
+
+describe("mergeTemplate — src/forge copy vs the live flows copy", () => {
+  test("stays byte-identical to the flows copy that is still live", () => {
+    const template = "## Summary\n\n<!-- what changed -->\n\n## Testing\n\n- [ ] tests pass\n";
+    const sections: BodySection[] = [
+      { key: "narrative", heading: "What changed", body: "Ported the merger." },
+      { key: "verification", heading: "Verification", body: "- Gates: lint, test" },
+      { key: "footer", heading: "", body: "3/3 stories" },
+    ];
+    for (const mode of ["merge", "strict", "ignore"] as const) {
+      expect(mergeTemplate(template, sections, { mode })).toBe(flowMergeTemplate(template, sections, { mode }));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the PR/escalation half of the native nax-finish cutover (plan 4): `src/forge/template-merge.ts` + `defaultForgeDeps`, `src/finish/pr/{context,body,open}.ts`, `src/finish/escalate.ts`, and the concrete `createFinishOps` factory binding the three `RunOperation`s (plan 3) and the forge modules to the state machine.
- `runFinishMachine` can now be driven end to end with nothing stubbed but the process boundary (git, forge subprocesses, the LLM call) — proven by the new machine end-to-end test (promoted / escalated / narrator-fails paths).
- `src/finish/` is complete but intentionally unwired; `flows/nax-finish/` stays live until plan 5. Duplication with `flows/` is expected and guarded (template-merger equivalence test).

## Test Plan
- [x] `bun x tsc --noEmit`
- [x] `bun run lint` (full static-check chain, ratchets unmoved)
- [x] `bun test test/unit/finish/` (375 pass)
- [x] `bun run test` (full canonical suite: unit + integration + ui)