### PR TITLE
fix(finish): five escalation-path defects from the native nax-finish port review

### DIFF
--- a/src/finish/machine.ts
+++ b/src/finish/machine.ts
@@ -15,6 +15,7 @@
  * recorded at the point routing decided that. Each is recorded exactly once.
  */
 import { NaxError } from "../errors";
+import { getSafeLogger } from "../logger";
 import { errorMessage } from "../utils/errors";
 import { type AuditTarget, recordRound, writeResult } from "./audit";
 import { buildCommitRound, commitFixes, filesInCommit } from "./commit";
@@ -32,6 +33,18 @@ export interface FinishMachineDeps {
   ops: FinishOps;
   audit: AuditTarget;
   signal?: AbortSignal;
+  /**
+   * The *run's* signal, distinct from `signal` (which also carries the phase's
+   * own `flowMs` deadline).
+   *
+   * `doEscalate` delivers an escalation for every failure path except one: a
+   * run the user cancelled. Delivery pushes a `wip(...)` commit and writes to
+   * the forge, and doing that while tearing down a Ctrl-C is a side effect
+   * nobody asked for. A `flowMs` deadline is the opposite case — finish ran
+   * too long and a human genuinely needs telling — so the two signals cannot
+   * be collapsed into one check.
+   */
+  runSignal?: AbortSignal;
   /** Injected so tests can assert round ordering deterministically. */
   now: () => string;
   timeouts?: FinishTimeouts;
@@ -79,6 +92,28 @@ async function doEscalate(
   state.status = "escalated";
   state.escalationReason = reason;
   state.findings = findings;
+
+  const base: FinishResult = {
+    feature: state.feature,
+    status: "escalated",
+    escalationReason: reason,
+    findings,
+  };
+  // Written BEFORE delivery is attempted (#1399): "the one path whose job is
+  // to say a human is needed was the one path with no fallback". An external
+  // kill (Ctrl-C, OOM) part-way through delivery must still leave a result
+  // file behind, which writing it afterwards cannot guarantee.
+  await safeWriteResult(deps, base);
+
+  // A run the user cancelled is not an escalation to broadcast -- see
+  // `FinishMachineDeps.runSignal`. The result above is still on disk, so the
+  // run stays auditable; only the outward-facing half is skipped.
+  if (deps.runSignal?.aborted) {
+    const aborted: FinishResult = { ...base, deliveryError: "run aborted before the escalation was delivered" };
+    await safeWriteResult(deps, aborted);
+    return aborted;
+  }
+
   // ops.escalate is documented "must not throw" (./ops), but this is the
   // terminal safety net -- a violation here must still leave a result on
   // disk rather than propagate past the outer catch and skip writeResult.
@@ -90,15 +125,35 @@ async function doEscalate(
     deliveryError = errorMessage(err);
   }
   const result: FinishResult = {
-    feature: state.feature,
-    status: "escalated",
-    escalationReason: reason,
-    findings,
+    ...base,
     ...(url ? { url } : {}),
     ...(deliveryError ? { deliveryError } : {}),
   };
-  await writeResult(deps.audit, result);
+  // Only rewrite when delivery actually produced something to add -- the
+  // pre-delivery write above already carries everything else.
+  if (url || deliveryError) await safeWriteResult(deps, result);
   return result;
+}
+
+/**
+ * `writeResult`, with a failure downgraded to a warning.
+ *
+ * Unguarded, a throw from here escapes `doEscalate`, reaches
+ * `runFinishMachine`'s outer catch and lands in `doEscalate` a *second* time
+ * -- delivering the same escalation twice (a duplicate PR comment and a
+ * duplicate Telegram message) before failing anyway. The round trail and the
+ * phase's own status write already record that finish escalated, so a lost
+ * result file is worth strictly less than a duplicate page to a human.
+ */
+async function safeWriteResult(deps: FinishMachineDeps, result: FinishResult): Promise<void> {
+  try {
+    await writeResult(deps.audit, result);
+  } catch (err) {
+    getSafeLogger()?.warn("finish", "Finish result file could not be written", {
+      storyId: "_run",
+      error: errorMessage(err),
+    });
+  }
 }
 
 /** Step 1: the context-resolution route decided before the machine started. */

--- a/src/finish/operations/review-op.ts
+++ b/src/finish/operations/review-op.ts
@@ -48,6 +48,24 @@ export interface FinishReviewInput {
  */
 export type FinishReviewOutput = ReviewReport & { gaps: string[] };
 
+/**
+ * The gap the exhausted-retry fallback carries.
+ *
+ * Load-bearing, not decorative. `callOp` returns a captured `exhaustedFallback`
+ * directly — its `!rawOutput` branch and its parse-failure branch both `return`
+ * without going through `runPostParse`, which is the only caller of
+ * `op.verify`. `verify` is where this op's `gaps` normally come from
+ * (`auditGaps`), so on the exhausted path it never runs. A fallback with an
+ * empty `gaps` array therefore reaches `routeReview` as
+ * `{findings: [], gaps: []}` and routes **clean**: a reviewer that produced
+ * nothing at all would be recorded as a passing review and the PR promoted on
+ * the strength of it. Carrying the gap here is what makes `routeReview` treat
+ * it as no verdict — one re-review, then escalate — which is the behaviour the
+ * acpx flow had when its reprompt budget ran out.
+ */
+const NO_REPLY_GAP =
+  "the reviewer produced no usable reply after every retry — no `## TOUCHPOINTS`, `## WALK` or `## FINDINGS` section was received, so nothing reviewed this diff";
+
 const EMPTY_REVIEW_REPORT: FinishReviewOutput = {
   findings: [],
   touchpoints: [],
@@ -55,7 +73,7 @@ const EMPTY_REVIEW_REPORT: FinishReviewOutput = {
   sawNoFindings: false,
   sawTouchpointsSection: false,
   sawWalkSection: false,
-  gaps: [],
+  gaps: [NO_REPLY_GAP],
 };
 
 const FINDING_BLOCK_START = /^\s*\[(CRITICAL|HIGH|MEDIUM|LOW)\]/;
@@ -140,10 +158,13 @@ export const finishReviewOp: RunOperation<FinishReviewInput, FinishReviewOutput,
       invalid: () => INVALID_PROMPT,
       truncated: () => TRUNCATED_PROMPT,
     },
-    // Degrade to "no verdict" (routeReview escalates on this), not a throw.
-    // parseReviewReport never throws, so the only live trigger for this is
-    // genuinely empty output — an unreadable-but-present reply is handled
-    // by parse() returning an empty-but-valid report instead.
+    // Degrade to "no verdict", not a throw. The verdict-ness lives in
+    // EMPTY_REVIEW_REPORT's `gaps` (see NO_REPLY_GAP): callOp returns this
+    // object without ever calling op.verify, so it must arrive at routeReview
+    // already un-routable as clean. parseReviewReport never throws, so the
+    // live trigger is genuinely empty output — an unreadable-but-present reply
+    // is handled by parse() returning an empty-but-valid report, which does
+    // get its gaps from verify.
     exhaustedFallback: () => EMPTY_REVIEW_REPORT,
   }),
   // verify is the sanctioned disk-consulting hook (ADR-020 §D4); a non-null

--- a/src/finish/phase.ts
+++ b/src/finish/phase.ts
@@ -157,10 +157,15 @@ export async function runFinishPhase(ctx: FinishPhaseContext): Promise<FinishRes
         narrativeMs: settings.timeouts.stepMs ?? undefined,
       },
       prBody: settings.prBody,
-      // Telegram is the sole escalation channel only when it is both enabled
-      // and actually credentialed — enabled with no token would suppress the
-      // PR comment and then send nothing at all.
-      preferTelegram: settings.escalate.telegram && telegramCreds(ctx.config) !== null,
+      // Telegram is the sole escalation channel only when it is enabled,
+      // actually credentialed, AND notifications are not switched off —
+      // `preferTelegram` suppresses the PR comment, and `notify()` below
+      // sends nothing when `notify.mode` is "off", so dropping any one of
+      // these three conjuncts delivers the escalation precisely nowhere.
+      // The acpx plugin this replaced tested all three together; the port
+      // originally kept only two.
+      preferTelegram:
+        settings.notify.mode !== "off" && settings.escalate.telegram && telegramCreds(ctx.config) !== null,
       narrative: settings.narrative,
     });
     result = await _finishPhaseDeps.runFinishMachine(state, {
@@ -168,6 +173,10 @@ export async function runFinishPhase(ctx: FinishPhaseContext): Promise<FinishRes
       ops,
       audit,
       signal,
+      // The run's own signal, so the machine can tell a cancelled run (do not
+      // push or post) from a `flowMs` deadline (do escalate) — `signal` above
+      // carries both and cannot distinguish them.
+      runSignal: ctx.abortSignal,
       now: _finishPhaseDeps.now,
       timeouts: { acceptanceMs: settings.timeouts.acceptanceMs, gateMs: settings.timeouts.gateMs },
     });
@@ -185,7 +194,20 @@ export async function runFinishPhase(ctx: FinishPhaseContext): Promise<FinishRes
     ...(result ? { result: result.status } : {}),
     ...(result?.url ? { url: result.url } : {}),
     ...(result?.escalationReason ? { escalationReason: result.escalationReason } : {}),
+    ...(result?.deliveryError ? { deliveryError: result.deliveryError } : {}),
   });
+  // An escalation nobody received is the worst outcome this phase has: the run
+  // stopped for a human who was never told. The plugin this replaced logged it
+  // and failed its action; the phase cannot fail a run, so the log and the
+  // status entry above are the whole signal.
+  if (result?.deliveryError) {
+    getSafeLogger()?.warn("finish", "Finish escalated but the escalation was not delivered", {
+      storyId: "_run",
+      feature: result.feature,
+      error: result.deliveryError,
+      escalationReason: result.escalationReason,
+    });
+  }
   if (failure) {
     // NOT carried on the event: `RunPhaseDetails`
     // (`src/plugins/extensions.ts:391-395`) is a closed union of four shapes
@@ -216,5 +238,15 @@ async function notify(ctx: FinishPhaseContext, settings: FinishSettings, result:
     result.status === "escalated"
       ? buildEscalationMessage(result.feature, result.escalationReason ?? "", result.findings ?? [])
       : buildTerminalMessage({ feature: result.feature, status: result.status, url: result.url });
-  await _finishPhaseDeps.sendTelegramNotify(creds, text);
+  // The boolean matters: a `false` means Telegram rejected the message, and on
+  // an escalation Telegram is the ONLY channel (`preferTelegram` suppressed the
+  // PR comment). Discarding it turned a dropped page into silence.
+  const delivered = await _finishPhaseDeps.sendTelegramNotify(creds, text);
+  if (!delivered) {
+    getSafeLogger()?.warn("finish", "Finish Telegram notification was not delivered", {
+      storyId: "_run",
+      feature: result.feature,
+      status: result.status,
+    });
+  }
 }

--- a/test/unit/finish/escalation-delivery.test.ts
+++ b/test/unit/finish/escalation-delivery.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Regression tests for the escalation-delivery defects found reviewing the
+ * native finish port against `docs/superpowers/specs/2026-08-18-native-nax-finish-design.md`.
+ *
+ * Each test here fails against the code as merged in #1630 — they are written
+ * to pin behaviour the port lost relative to the acpx plugin it replaced, so a
+ * later change that reintroduces the loss is caught rather than shipped.
+ *
+ * - The result file must exist *before* delivery is attempted (#1399): the one
+ *   path whose job is to say a human is needed was the one path with no
+ *   fallback, and an external kill mid-delivery must not erase the trail.
+ * - An aborted run must not push a commit or post to the forge. Cancelling is
+ *   not an escalation; the trail is still written so the run is auditable.
+ * - A `writeResult` failure must not deliver the escalation twice.
+ */
+import { afterEach, expect, test } from "bun:test";
+import type { AcceptanceGroupResult } from "@/cli";
+import { DEFAULT_CONFIG } from "@/config";
+import { _acceptanceGateDeps, _finishGitDeps, _qualityGateDeps, createFinishState, runFinishMachine } from "@/finish";
+import type { AuditTarget, FinishContext, FinishMachineDeps, FinishOps, FinishState } from "@/finish";
+import { withTempDir } from "@test/helpers";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const originalGit = _finishGitDeps.git;
+const originalAcceptanceRun = _acceptanceGateDeps.run;
+const originalQuality = { ..._qualityGateDeps };
+afterEach(() => {
+  _finishGitDeps.git = originalGit;
+  _acceptanceGateDeps.run = originalAcceptanceRun;
+  _qualityGateDeps.run = originalQuality.run;
+  _qualityGateDeps.loadConfig = originalQuality.loadConfig;
+  _qualityGateDeps.loadPackageOverride = originalQuality.loadPackageOverride;
+});
+
+function baseContext(overrides: Partial<FinishContext> = {}): FinishContext {
+  const group: AcceptanceGroupResult = {
+    packageDir: "",
+    testPath: "test/acceptance/feat.test.ts",
+    exists: true,
+    cwd: "",
+  };
+  return {
+    base: "origin/main",
+    specPath: ".nax/features/feat/spec.md",
+    acceptanceStatus: "ok",
+    groups: [group],
+    testFileRegex: ["\\.test\\.ts$"],
+    commitsAhead: 3,
+    route: "proceed",
+    ...overrides,
+  };
+}
+
+function baseState(): FinishState {
+  return createFinishState({
+    feature: "feat",
+    workdir: "/repo",
+    branch: "feat/x",
+    runId: "run-1",
+    base: "origin/main",
+    specPath: ".nax/features/feat/spec.md",
+  });
+}
+
+function installStubs(trail: string[]): void {
+  _finishGitDeps.git = async (args: string[]) => {
+    if (args[0] === "rev-parse") return { stdout: "sha1", stderr: "", exitCode: 0 };
+    if (args[0] === "status") return { stdout: " M file.ts\n", stderr: "", exitCode: 0 };
+    if (args[0] === "commit") trail.push("commit");
+    if (args[0] === "push") trail.push("push");
+    return { stdout: "", stderr: "", exitCode: 0 };
+  };
+  _acceptanceGateDeps.run = async () => ({
+    commandName: "acceptance",
+    command: "bun test",
+    success: true,
+    exitCode: 0,
+    output: "ok",
+    durationMs: 1,
+    timedOut: false,
+  });
+  _qualityGateDeps.loadConfig = async () => DEFAULT_CONFIG;
+  _qualityGateDeps.loadPackageOverride = async () => null;
+}
+
+function makeOps(trail: string[], overrides: Partial<FinishOps> = {}): FinishOps {
+  return {
+    review: async (phase) => {
+      trail.push(`review:${phase}`);
+      return { findings: [], gaps: [] };
+    },
+    fix: async () => ({}),
+    openDraftPr: async () => null,
+    promotePr: async () => ({ status: "opened" as const }),
+    escalate: async () => {
+      trail.push("escalate");
+      return {};
+    },
+    ...overrides,
+  };
+}
+
+function makeDeps(opts: {
+  auditDir: string;
+  ops?: Partial<FinishOps>;
+  context?: Partial<FinishContext>;
+  signal?: AbortSignal;
+  runSignal?: AbortSignal;
+}): { deps: FinishMachineDeps; trail: string[] } {
+  const trail: string[] = [];
+  installStubs(trail);
+  const audit: AuditTarget = { auditDir: opts.auditDir, runId: "run-1" };
+  let tick = 0;
+  return {
+    trail,
+    deps: {
+      context: baseContext(opts.context),
+      ops: makeOps(trail, opts.ops),
+      audit,
+      signal: opts.signal,
+      runSignal: opts.runSignal,
+      now: () => {
+        tick += 1;
+        return `2026-08-20T00:00:${String(tick).padStart(2, "0")}.000Z`;
+      },
+    },
+  };
+}
+
+test("the escalation result file is written before delivery is attempted (#1399)", async () => {
+  await withTempDir(async (dir) => {
+    let resultOnDiskDuringDelivery: string | null = null;
+    const { deps } = makeDeps({
+      auditDir: dir,
+      context: { route: "escalate", reason: "context could not be resolved" },
+      ops: {
+        escalate: async () => {
+          resultOnDiskDuringDelivery = await readFile(join(dir, "run-1.result.json"), "utf8").catch(() => null);
+          return {};
+        },
+      },
+    });
+
+    const result = await runFinishMachine(baseState(), deps);
+
+    expect(result.status).toBe("escalated");
+    expect(resultOnDiskDuringDelivery).not.toBeNull();
+    expect(JSON.parse(resultOnDiskDuringDelivery ?? "{}").status).toBe("escalated");
+  });
+});
+
+test("the delivered url and deliveryError still land in the final result file", async () => {
+  await withTempDir(async (dir) => {
+    const { deps } = makeDeps({
+      auditDir: dir,
+      context: { route: "escalate", reason: "needs a human" },
+      ops: { escalate: async () => ({ url: "https://forge.example/pr/9", deliveryError: "comment rejected" }) },
+    });
+
+    const result = await runFinishMachine(baseState(), deps);
+
+    expect(result.url).toBe("https://forge.example/pr/9");
+    expect(result.deliveryError).toBe("comment rejected");
+    const onDisk = JSON.parse(await readFile(join(dir, "run-1.result.json"), "utf8"));
+    expect(onDisk.url).toBe("https://forge.example/pr/9");
+    expect(onDisk.deliveryError).toBe("comment rejected");
+  });
+});
+
+test("an aborted run records the escalation but never delivers it", async () => {
+  await withTempDir(async (dir) => {
+    const runController = new AbortController();
+    runController.abort();
+    const { deps, trail } = makeDeps({
+      auditDir: dir,
+      signal: runController.signal,
+      runSignal: runController.signal,
+    });
+
+    const result = await runFinishMachine(baseState(), deps);
+
+    expect(result.status).toBe("escalated");
+    // No delivery, and specifically no push and no forge write.
+    expect(trail).not.toContain("escalate");
+    expect(trail).not.toContain("push");
+    expect(result.deliveryError).toMatch(/abort/i);
+    // The trail still exists for a human to read.
+    const onDisk = JSON.parse(await readFile(join(dir, "run-1.result.json"), "utf8"));
+    expect(onDisk.status).toBe("escalated");
+  });
+});
+
+test("a phase-deadline abort still delivers — only a run abort suppresses delivery", async () => {
+  await withTempDir(async (dir) => {
+    const deadline = new AbortController();
+    deadline.abort();
+    const { deps, trail } = makeDeps({
+      auditDir: dir,
+      // The phase signal fired, but the run's own signal did not.
+      signal: deadline.signal,
+      runSignal: new AbortController().signal,
+    });
+
+    const result = await runFinishMachine(baseState(), deps);
+
+    expect(result.status).toBe("escalated");
+    expect(trail).toContain("escalate");
+  });
+});
+
+test("a writeResult failure does not deliver the escalation twice", async () => {
+  await withTempDir(async (dir) => {
+    let deliveries = 0;
+    const { deps } = makeDeps({
+      auditDir: join(dir, "audit"),
+      context: { route: "escalate", reason: "needs a human" },
+      ops: {
+        escalate: async () => {
+          deliveries += 1;
+          return {};
+        },
+      },
+    });
+    // A path that cannot be created: `file` is a regular file, so mkdir -p under
+    // it fails, and every writeResult in this run throws.
+    await Bun.write(join(dir, "audit"), "not a directory");
+
+    const result = await runFinishMachine(baseState(), deps);
+
+    expect(result.status).toBe("escalated");
+    expect(deliveries).toBe(1);
+  });
+});

--- a/test/unit/finish/op-review.test.ts
+++ b/test/unit/finish/op-review.test.ts
@@ -8,7 +8,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { ConfigSelector } from "@/config";
 import type { FinishConfig } from "@/config/selectors";
 import type { FinishReviewInput } from "@/finish";
-import { finishReviewOp } from "@/finish";
+import { finishReviewOp, MAX_INCOMPLETE_ATTEMPTS, routeReview } from "@/finish";
+import type { Finding } from "@/finish";
+import { ParseValidationError } from "@/agents/retry";
+import type { RetryStrategy } from "@/agents/retry";
 import type { NaxRuntime } from "@/runtime";
 import { makeTestRuntime, withTempDir } from "@test/helpers";
 
@@ -169,5 +172,58 @@ describe("finishReviewOp.verify()", () => {
       );
       expect(result).not.toBeNull();
     });
+  });
+});
+
+/**
+ * The exhausted-retry path.
+ *
+ * `callOp` returns a captured `exhaustedFallback` DIRECTLY (call.ts, the
+ * `!rawOutput` branch) without running `runPostParse` — the only caller of
+ * `op.verify`. `verify` is what fills `gaps` via `auditGaps`, so a fallback
+ * carrying `gaps: []` reaches `routeReview` as `{findings: [], gaps: []}` and
+ * routes **clean**: a review that never happened, recorded as a pass, and the
+ * PR promoted on the strength of it. The fallback must therefore carry its own
+ * gap rather than relying on a `verify` that will not run.
+ */
+describe("finishReviewOp exhausted-retry fallback", () => {
+  // `OperationBase.retry` is a union (preset | strategy | resolver). This op
+  // declares the strategy form via makeParseRetryStrategy, so the narrowing is
+  // safe — same single-cast pattern this file already uses for `op.config`.
+  const strategy = finishReviewOp.retry as RetryStrategy;
+
+  function retryCtx(lastOutput?: string) {
+    return { site: "run" as const, agentName: "claude", stage: "review" as const, lastOutput };
+  }
+
+  /** `RetryDecision` is a discriminated union; `fallback` only exists on the no-retry arm. */
+  function exhausted(attempt: number, lastOutput?: string): { findings: Finding[]; gaps: string[] } {
+    const decision = strategy.shouldRetry(new ParseValidationError("probe"), attempt, retryCtx(lastOutput));
+    if (decision.retry) throw new Error("expected the strategy to stop retrying");
+    return decision.fallback as { findings: Finding[]; gaps: string[] };
+  }
+
+  test("the empty-output fallback cannot be routed as a clean review", () => {
+    const fallback = exhausted(0);
+    expect(fallback.findings).toEqual([]);
+    // The load-bearing assertion: non-empty gaps are what stop routeReview
+    // returning "clean" for a reviewer that produced nothing.
+    expect(fallback.gaps.length).toBeGreaterThan(0);
+  });
+
+  test("routeReview escalates rather than passing on that fallback", () => {
+    const fallback = exhausted(0);
+    // Second time around (incompleteAttempts at the cap) it must escalate, not approve.
+    const routed = routeReview("quality", fallback, {
+      rounds: 0,
+      reviewAttempts: 1,
+      fixAttempts: 0,
+      incompleteAttempts: MAX_INCOMPLETE_ATTEMPTS,
+    });
+    expect(routed.route).toBe("escalate");
+  });
+
+  test("an exhausted retry on non-empty output also carries the gap", () => {
+    expect(exhausted(1, "waffle, no sections").gaps.length).toBeGreaterThan(0);
   });
 });

--- a/test/unit/finish/phase.test.ts
+++ b/test/unit/finish/phase.test.ts
@@ -247,3 +247,70 @@ describe("runFinishPhase", () => {
     }
   });
 });
+
+/**
+ * Escalation delivery must reach exactly one channel.
+ *
+ * `preferTelegram` suppresses the PR/MR comment and makes Telegram the sole
+ * channel; `notify()` sends nothing at all when `notify.mode` is "off". Both
+ * true at once delivers the escalation nowhere, with no `deliveryError` to
+ * show for it — which is what the acpx plugin's three-conjunct guard
+ * (`notify.mode !== "off" && escalate.telegram && creds !== null`) prevented.
+ */
+describe("escalation channel selection", () => {
+  function capturePreferTelegram(opts: {
+    telegram?: boolean;
+    notifyMode?: "escalation" | "always" | "off";
+  }): Promise<boolean | undefined> {
+    const restore = { ..._finishPhaseDeps };
+    let seen: boolean | undefined;
+    _finishPhaseDeps.loadFinishContext = async () => proceedContext();
+    _finishPhaseDeps.detectForge = async () => "github";
+    _finishPhaseDeps.createFinishOps = (deps) => {
+      seen = deps.preferTelegram;
+      return { review: async () => ({ findings: [], gaps: [] }), fix: async () => ({}), openDraftPr: async () => null, promotePr: async () => ({ status: "opened" as const }), escalate: async () => ({}) };
+    };
+    _finishPhaseDeps.runFinishMachine = async () => ({ feature: "f", status: "already-ready" });
+    return runFinishPhase(makeCtx(opts))
+      .then(() => seen)
+      .finally(() => Object.assign(_finishPhaseDeps, restore));
+  }
+
+  test("credentialed telegram is the sole channel under the default notify mode", async () => {
+    expect(await capturePreferTelegram({ telegram: true })).toBe(true);
+  });
+
+  test("notify.mode off must NOT suppress the PR comment", async () => {
+    // Otherwise: no comment (preferTelegram) and no Telegram (mode off) —
+    // the escalation is delivered nowhere and nothing records that.
+    expect(await capturePreferTelegram({ telegram: true, notifyMode: "off" })).toBe(false);
+  });
+});
+
+test("an undelivered escalation is surfaced on the finish status entry", async () => {
+  const restore = { ..._finishPhaseDeps };
+  const updates: Array<Record<string, unknown>> = [];
+  _finishPhaseDeps.loadFinishContext = async () => proceedContext();
+  _finishPhaseDeps.detectForge = async () => "github";
+  _finishPhaseDeps.runFinishMachine = async () => ({
+    feature: "f",
+    status: "escalated",
+    escalationReason: "needs a human",
+    deliveryError: "gh pr comment failed",
+  });
+  const ctx = {
+    ...makeCtx(),
+    statusWriter: {
+      setPostRunPhase: (_phase: "finish", update: Record<string, unknown>) => {
+        updates.push(update);
+      },
+    },
+  };
+  try {
+    await runFinishPhase(ctx);
+    const terminal = updates[updates.length - 1];
+    expect(terminal.deliveryError).toBe("gh pr comment failed");
+  } finally {
+    Object.assign(_finishPhaseDeps, restore);
+  }
+});


### PR DESCRIPTION
## What

Fixes two HIGH and three MEDIUM defects on the native finish phase's escalation path, found by a full post-implementation review of the port (#1626–#1630) against `docs/superpowers/specs/2026-08-18-native-nax-finish-design.md`.

Every one is a regression against the acpx plugin the port replaced, and all five sit on paths that only a live run exercises — which is why the 379 tests that shipped with the port did not catch them.

## Why

**HIGH — an escalation could be delivered nowhere.** `preferTelegram` was computed as `escalate.telegram && creds !== null`. The plugin used three conjuncts, including `notify.mode !== "off"`. With `notify.mode: "off"`, credentials present and `escalate.telegram` at its default `true`, `postEscalation` suppressed the PR comment and `notify()` then declined to send: nobody was told, and `deliveryError` was `undefined` so nothing recorded it.

**HIGH — an empty reviewer reply was recorded as a clean pass.** `finishReviewOp.exhaustedFallback` returned `gaps: []`. That reads as harmless because `gaps` is normally filled by `op.verify` (`auditGaps`) — but `callOp` returns a captured `exhaustedFallback` *directly*: both its `!rawOutput` branch and its parse-failure branch `return` without going through `runPostParse`, the only caller of `op.verify`. So on the exhausted path `verify` never runs, the fallback reaches `routeReview` as `{findings: [], gaps: []}`, and `routeReview` returns `clean`.

A reviewer that produced nothing at all was therefore recorded as a passing review, and the run promoted the PR on the strength of it — the "nothing ran is not a pass" failure I1 exists to prevent, and an inversion of the flow's behaviour, which escalated once its reprompt budget ran out.

Reachability is bounded: only genuinely empty output hits this. A non-empty malformed reply still parses to an empty-but-valid report, gets its gaps from `verify`, and already escalated correctly.

**MEDIUM — "escalated but undelivered" was unobservable.** `deliveryError` went to the result file and nowhere else: no log, no status entry. `sendTelegramNotify`'s boolean return was discarded, so a message Telegram rejected was silent. The plugin logged both and failed its action.

**MEDIUM — the result file was written after delivery**, inverting #1399 ("the one path whose job is to say a human is needed was the one path with no fallback"). An external kill mid-delivery left no result file where the flow's ordering survived it.

**MEDIUM — a cancelled run broadcast an escalation.** Ctrl-C threw `FINISH_ABORTED` into the outer catch, which escalated: pushing a `wip(...)` commit and posting to the forge while tearing down.

## How

- `preferTelegram` requires all three conjuncts again.
- The review op's exhausted fallback carries its own `NO_REPLY_GAP`, so it arrives at `routeReview` already un-routable as `clean` — one re-review, then escalate.
- `deliveryError` gets a warn log and a field on the finish status entry; `sendTelegramNotify`'s boolean is checked and warned on.
- `doEscalate` writes the result *before* delivery and updates it afterwards only when delivery produced a url or an error. Both writes go through a guarded helper, which also removes a duplicate-delivery path: an unguarded `writeResult` throw escaped `doEscalate` into `runFinishMachine`'s outer catch and landed in `doEscalate` a second time, sending the same escalation twice.
- `FinishMachineDeps` gains `runSignal` — the run's own signal, distinct from the combined phase signal — so a cancelled run records its result and skips delivery while a `flowMs` deadline still escalates as it should.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

New: `test/unit/finish/escalation-delivery.test.ts`, plus cases in `op-review.test.ts` and `phase.test.ts`. Each regression test was run against the pre-fix code and confirmed to fail there before being accepted — a test written after the fix otherwise passes trivially.

All ratchets remain at baseline (test-typecheck 2001, `as unknown as` 815, deep-relatives 2845); two of them caught this PR's own test code first and were fixed properly rather than re-baselined.

## Notes

Three LOW findings from the same review are deliberately left: `EscalationOutcome.channel` is computed then discarded in `ops-impl.ts`; `status.json` can stick at `"running"` if `snapshotCost`/`phaseSignal` throw, since both sit outside `phase.ts`'s try; and STYLE-7/8/9.

No behaviour change for a default config — `notify.mode` defaults to `"escalation"`, so the H1 path needs an explicit `"off"`.
