### PR TITLE
chore: release v0.81.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.80.1",
+  "version": "0.81.0-canary.1",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Canary release v0.81.0-canary.1.

## Why

Testing next cycle features.

## How

## Testing

- [ ] CI passes

## Notes

