### PR TITLE
fix(finish): restore the glued-heading split and fix the quality WALK contradiction

### DIFF
--- a/src/finish/review/parse.ts
+++ b/src/finish/review/parse.ts
@@ -17,18 +17,39 @@ type Section = "touchpoints" | "walk" | "findings";
 /** Headings are matched loosely — any level, any case, optional trailing colon. */
 const HEADING = /^\s*#{1,6}\s*(TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)\s*:?\s*$/i;
 /**
- * The old acpx flow (`flows/nax-finish/findings-parse.ts`) joined the agent's
- * message stream with no separator, so a heading could land mid-line — for
- * example `…confidence bar.## TOUCHPOINTS` — whenever the preceding narration
- * message did not itself end in a newline. That required a `GLUED_HEADING`
- * regex here to re-insert the missing newline before parsing.
+ * Re-insert the newline a glued heading is missing, so `HEADING` can see it.
  *
- * In-process, `extractOutput` in `src/agents/acp/adapter-output.ts` builds the
- * reply by joining assistant messages with `"\n"` (`.join("\n")`), so a
- * heading can never land mid-line: every message boundary is already a
- * newline boundary. The glued-heading case this guarded against cannot arise
- * here — do not restore the regex.
+ * The old acpx flow (`flows/nax-finish/findings-parse.ts`) carried this regex
+ * because it joined the agent's message stream with no separator, letting a
+ * heading land mid-line — `…the report now.## TOUCHPOINTS` — whenever the
+ * preceding narration did not itself end in a newline.
+ *
+ * The port dropped it, on the reasoning that `extractOutput`
+ * (`src/agents/acp/adapter-output.ts`) joins assistant messages with `"\n"`,
+ * so every message boundary is already a newline boundary. That reasoning is
+ * wrong, and a real run disproved it: the ACP wire path never produces more
+ * than one assistant message per turn. `handleAcpEvent` accumulates every
+ * `agent_message_chunk` into a single buffer with `state.text += text`
+ * (`src/agents/acp/parser.ts`), and the session client wraps that one buffer
+ * as one `{ role: "assistant" }` message (`src/agents/acp/spawn-client-session.ts`),
+ * so `join("\n")` has nothing to join and chunk boundaries stay glued exactly
+ * as they were under acpx. On a live finish run the quality reviewer's reply opened
+ * `I have enough to write the report now.## TOUCHPOINTS`; the section was read
+ * as prose, its six touchpoints were dropped, and `auditGaps` failed a review
+ * that had in fact done the reading. With `MAX_INCOMPLETE_ATTEMPTS = 1` a
+ * second such reply escalates the run.
+ *
+ * Deliberately narrow — it splits only where the heading is *directly*
+ * adjacent to the prose before it and *ends* the line:
+ *
+ * - `([^\s#])` — a preceding non-space, non-`#` character. Whitespace before
+ *   the `#` means the reviewer is talking about a section (`the block marked
+ *   ## FINDINGS`), not opening one; excluding `#` stops a well-formed
+ *   `## WALK` from being split at its own second hash.
+ * - `(?=[ \t]*(?:\r?\n|$))` — nothing but the heading to end of line. Trailing
+ *   content (`as noted.## FINDINGS below`) is prose too.
  */
+const GLUED_HEADING = /([^\s#])(#{1,6}[ \t]*(?:TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)[ \t]*:?)(?=[ \t]*(?:\r?\n|$))/gi;
 const BLOCK = /^\s*\[(CRITICAL|HIGH|MEDIUM|LOW)\]\s+(.+?)\s*$/;
 const FIELD = /^\s*(Problem|Fix|Judgment)\s*:\s*(.*)$/i;
 const NO_FINDINGS = /^\s*no findings\.?\s*$/i;
@@ -76,6 +97,7 @@ export function parseReviewReport(text: string): ReviewReport {
   let section: Section = "findings";
   let current: Finding | null = null;
   let lastField: "problem" | "fix" | null = null;
+  const normalized = text.replace(GLUED_HEADING, "$1\n$2");
 
   const flush = () => {
     if (current) report.findings.push(current);
@@ -83,7 +105,7 @@ export function parseReviewReport(text: string): ReviewReport {
     lastField = null;
   };
 
-  for (const line of text.split("\n")) {
+  for (const line of normalized.split("\n")) {
     const heading = HEADING.exec(line);
     if (heading) {
       flush();

--- a/src/finish/review/prompts.gen.ts
+++ b/src/finish/review/prompts.gen.ts
@@ -163,12 +163,17 @@ test code — and judge each changed function on its own merits.
 
 ## Forcing function — enumerate before you conclude
 
-Before reporting, walk **every function/method the diff adds or changes** and
-write yourself a one-line verdict for each: *earns its place* or *concern: …*.
-This enumeration is a thinking tool — it does not go in the final report, only
-the resulting findings do. Skipping it is how real maintainability issues get
-missed: an agent that pattern-matches a few obvious smells and stops will always
-under-report. Look at each changed function deliberately.
+Before reporting, walk **every function/method the diff adds or changes — in
+test files as well as production ones** — and write yourself a one-line verdict
+for each: *earns its place* or *concern: …*. Skipping it is how real
+maintainability issues get missed: an agent that pattern-matches a few obvious
+smells and stops will always under-report. Look at each changed function
+deliberately.
+
+This enumeration goes in your reply, as the \`## WALK\` section the reply contract
+requires — one line per changed function, no prose. It is the evidence that you
+were in a position to write the findings below it; a reply without it is treated
+as an incomplete review and sent back.
 
 ## What to look for
 

--- a/src/finish/review/references/code-quality.md
+++ b/src/finish/review/references/code-quality.md
@@ -7,12 +7,17 @@ test code — and judge each changed function on its own merits.
 
 ## Forcing function — enumerate before you conclude
 
-Before reporting, walk **every function/method the diff adds or changes** and
-write yourself a one-line verdict for each: *earns its place* or *concern: …*.
-This enumeration is a thinking tool — it does not go in the final report, only
-the resulting findings do. Skipping it is how real maintainability issues get
-missed: an agent that pattern-matches a few obvious smells and stops will always
-under-report. Look at each changed function deliberately.
+Before reporting, walk **every function/method the diff adds or changes — in
+test files as well as production ones** — and write yourself a one-line verdict
+for each: *earns its place* or *concern: …*. Skipping it is how real
+maintainability issues get missed: an agent that pattern-matches a few obvious
+smells and stops will always under-report. Look at each changed function
+deliberately.
+
+This enumeration goes in your reply, as the `## WALK` section the reply contract
+requires — one line per changed function, no prose. It is the evidence that you
+were in a position to write the findings below it; a reply without it is treated
+as an incomplete review and sent back.
 
 ## What to look for
 

--- a/test/unit/finish/review-parse.test.ts
+++ b/test/unit/finish/review-parse.test.ts
@@ -84,13 +84,10 @@ describe("parseReviewReport", () => {
     expect(r.walk).toHaveLength(2);
   });
 
-  // The three guards below used to pin GLUED_HEADING's three regex clauses in
-  // the ported acpx flow. That regex is gone here (D3.3): in-process, message
-  // assembly always joins with "\n" (see src/agents/acp/adapter-output.ts),
-  // so a heading can no longer land mid-line and there is nothing left to
-  // guard against. These now pass trivially — HEADING never matches inside
-  // these lines regardless of adjacency or trailing content — and are kept to
-  // prove the deletion changed no other behaviour.
+  // The three guards below pin GLUED_HEADING's clauses: it splits only where
+  // the heading is directly adjacent to the prose before it AND ends the line.
+  // Whitespace between the two, or trailing content after the heading word,
+  // means the reviewer is talking *about* a section rather than opening one.
 
   test("does not split when whitespace separates the prose from the #", () => {
     const r = parseReviewReport(
@@ -140,15 +137,34 @@ describe("parseReviewReport", () => {
     expect(r.sawNoFindings).toBe(true);
   });
 
-  test("reads a literally glued heading as a missing section, not a split one", () => {
-    // In-process this input cannot arise from message joining (adapter-output
-    // always joins with "\n"), so treating it as unparsed prose — rather than
-    // splitting it into a heading — is correct, not a regression.
+  test("splits a heading glued to the narration before it", () => {
+    // The real shape observed on a live finish run (quality attempt 1): the
+    // ACP wire path accumulates every message
+    // chunk into ONE assistant message, so the reviewer's closing narration
+    // and its first heading arrive with nothing between them. Read as prose,
+    // the whole TOUCHPOINTS section disappears and `auditGaps` fails a review
+    // that in fact discharged its obligations.
     const r = parseReviewReport(
-      "No defects cleared the confidence bar.## TOUCHPOINTS\n- a.ts:sym — why\n\n## WALK\nb.ts:fn — earns its place\n\n## FINDINGS\nNo findings.\n",
+      "I have enough to write the report now.## TOUCHPOINTS\n- a.ts:sym — why\n\n## WALK\nb.ts:fn — earns its place\n\n## FINDINGS\nNo findings.\n",
     );
-    expect(r.sawTouchpointsSection).toBe(false);
-    expect(r.touchpoints).toEqual([]);
+    expect(r.sawTouchpointsSection).toBe(true);
+    expect(r.touchpoints).toEqual([{ path: "a.ts", symbol: "sym", note: "why" }]);
+    expect(r.walk).toEqual(["b.ts:fn — earns its place"]);
+    expect(r.sawNoFindings).toBe(true);
+  });
+
+  test("splits a glued heading at any level, case, and trailing colon", () => {
+    const r = parseReviewReport("done.# touchpoints:\n- a.ts:sym — why\n");
+    expect(r.sawTouchpointsSection).toBe(true);
+    expect(r.touchpoints).toEqual([{ path: "a.ts", symbol: "sym", note: "why" }]);
+  });
+
+  test("splits a glued DISPOSITIONS heading, closing the section before it", () => {
+    const r = parseReviewReport("## WALK\nAC-1 Covered\nall four handled.## DISPOSITIONS\n- a.ts:sym — why\n");
+    // DISPOSITIONS resets the section to findings, so the bullet below it is
+    // not swept into the walk enumeration. The narration the heading was glued
+    // to stays in the walk section it was actually written in.
+    expect(r.walk).toEqual(["AC-1 Covered", "all four handled."]);
   });
 });
 


### PR DESCRIPTION
## What changed

Two defects in the native finish phase's review layer, both found by auditing a live finish run's artifacts rather than by the phase failing.

### 1. A glued heading blanked a whole evidence section

`parse.ts` dropped the acpx flow's `GLUED_HEADING` regex, on this reasoning:

> In-process, `extractOutput` in `src/agents/acp/adapter-output.ts` builds the reply by joining assistant messages with `"\n"`, so a heading can never land mid-line: every message boundary is already a newline boundary. The glued-heading case this guarded against cannot arise here — do not restore the regex.

That is wrong. The ACP wire path never produces more than one assistant message per turn: `handleAcpEvent` accumulates every `agent_message_chunk` into a single buffer with `state.text += text` (`src/agents/acp/parser.ts`), and the session client wraps that one buffer as one `{ role: "assistant" }` message (`src/agents/acp/spawn-client-session.ts`). `join("\n")` has nothing to join, so chunk boundaries stay glued exactly as they were under acpx.

On a live finish run the quality reviewer's reply opened:

```
I have enough to write the report now.## TOUCHPOINTS
```

`HEADING` anchors on `^\s*#{1,6}`, so that is not a heading. `sawTouchpointsSection` stayed false, the six touchpoint bullets were parsed in the default `findings` section and silently discarded, and `auditGaps` failed a review that had in fact done the reading — costing a full re-review round. With `MAX_INCOMPLETE_ATTEMPTS = 1`, a second such reply escalates the run to a human.

The restored regex is deliberately narrower than the acpx original. It splits only where the heading is **directly adjacent** to the prose before it **and ends the line**:

```
/([^\s#])(#{1,6}[ \t]*(?:TOUCHPOINTS|WALK|FINDINGS|DISPOSITIONS)[ \t]*:?)(?=[ \t]*(?:\r?\n|$))/gi
```

- `[^\s#]` — whitespace before the `#` means the reviewer is talking *about* a section (`the block marked ## FINDINGS`), not opening one; excluding `#` stops a well-formed `## WALK` being split at its own second hash.
- the lookahead — trailing content (`as noted.## FINDINGS below`) is prose too.

Those are exactly the three cases the existing guard tests pin. They were annotated as passing trivially after the deletion; they are load-bearing again, and their comment says so.

### 2. `code-quality.md` contradicted the reply contract

The dimension reference told the quality reviewer its per-function enumeration "does not go in the final report, only the resulting findings do" — while the reply contract requires that enumeration as the `## WALK` section and `auditGaps` fails any reply without one. A reviewer following the dimension file literally gets marked incomplete for obeying it.

The forcing-function section now states that the enumeration *is* the `## WALK` section, and scopes it explicitly to test files as well as production ones (the defect list already leads with test isolation, but the walk instruction did not say so).

## Not fixed here

The same run surfaced a third problem, filed as #1635: `auditGaps` checks the WALK's *shape*, not its *coverage* of the diff, so a WALK naming 4 of the diff's changed functions passes exactly like one naming all of them. That needs a design call and is out of scope for this PR — with both fixes above landed, the gate still cannot tell a thorough WALK from a token one.

## Test plan

- [x] `bun test test/unit/finish` — 359 pass, 0 fail. Three new cases in `review-parse.test.ts`: the literal glued shape from the run, a lowercase single-`#` heading with a trailing colon, and a glued `## DISPOSITIONS` closing the section before it. The test that asserted the old behaviour (`reads a literally glued heading as a missing section`) is inverted.
- [x] All three glued-heading guard tests still pass, now for the right reason.
- [x] `bun test test/unit/finish test/unit/operations` — 1553 pass, 0 fail.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean, all ratchets at baseline, `check:review-prompts-generated` confirms `prompts.gen.ts` matches the `.md` sources.
