### PR TITLE
fix(init): stop ignoring every file in a feature directory

### DIFF
--- a/src/precheck/checks-warnings.ts
+++ b/src/precheck/checks-warnings.ts
@@ -164,7 +164,11 @@ export async function checkGitignoreCoversNax(workdir: string): Promise<Check> {
     "**/.nax-acceptance*",
     "**/_nax_acceptance_test.py",
     "**/_nax_suggested_test.py",
-    `**/${PROJECT_FEATURES_DIR}/*/`,
+    // Substring-matched, so this also passes for the `**/`-prefixed form
+    // `nax init` writes. Never assert the bare feature directory here: a
+    // blanket `<features>/*/` rule ignores the committed `spec.md` and
+    // `prd.json` alongside the run artifacts.
+    `${PROJECT_FEATURES_DIR}/*/fragments/`,
   ];
   const missing = patterns.filter((pattern) => !content.includes(pattern));
   const passed = missing.length === 0;

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -15,31 +15,50 @@
 
 import { PROJECT_FEATURES_DIR } from "@/config";
 
+/**
+ * Run artifacts written inside `<features>/<name>/`.
+ *
+ * Each is listed individually rather than ignoring the feature directory
+ * wholesale: `spec.md`, `prd.json`, `prd-fidelity-report.md`,
+ * `acceptance-meta.json` and the planning notes beside them are the feature's
+ * source of truth and belong in version control. A rule that ignores the
+ * whole `<features>/<name>` directory hides those too — silently, since git
+ * never reports an ignored file.
+ *
+ * Each is prefixed with a `**` path segment so the rule also covers a monorepo
+ * package's own `.nax/`, which is where nax writes when a story carries a
+ * `workdir`.
+ */
+const FEATURE_RUN_ARTIFACTS = [
+  "runs/",
+  "plan/",
+  "sessions/",
+  "stories/",
+  // Per-story context fragments, rewritten by every run. Kept in sync with
+  // `fragmentPath()` in src/context/fragments/store.ts.
+  "fragments/",
+  "interactions/",
+  "semantic-verdicts/",
+  "status.json",
+  "checkpoint.jsonl",
+  "progress.txt",
+  "acp-sessions.json",
+  "acceptance-refined.json",
+  // Backups the LLM-recovery path drops beside the file it rewrote.
+  "*.bak",
+].map((artifact) => `**/${PROJECT_FEATURES_DIR}/*/${artifact}`);
+
 export const NAX_GITIGNORE_ENTRIES = [
   ".nax-verifier-verdict.json",
   "nax.lock",
   ".nax/**/runs/",
   ".nax/metrics.json",
-  `${PROJECT_FEATURES_DIR}/*/status.json`,
-  `${PROJECT_FEATURES_DIR}/*/plan/`,
-  // Per-story context fragments, rewritten by every run. Like the sibling
-  // feature-tree entries above and below, this is subsumed by the blanket
-  // `**/<features>/*/` rule further down — it is listed explicitly because a
-  // repo that narrows that blanket rule to keep `prd.json` / `spec.md` under
-  // version control (as the nax repo itself does) must not silently start
-  // committing run artifacts. Kept in sync with `fragmentPath()` in
-  // src/context/fragments/store.ts.
-  `${PROJECT_FEATURES_DIR}/*/fragments/`,
-  `${PROJECT_FEATURES_DIR}/*/acp-sessions.json`,
-  `${PROJECT_FEATURES_DIR}/*/interactions/`,
-  `${PROJECT_FEATURES_DIR}/*/progress.txt`,
-  `${PROJECT_FEATURES_DIR}/*/acceptance-refined.json`,
+  ...FEATURE_RUN_ARTIFACTS,
   ".nax-pids",
   ".nax-wt/",
   "**/.nax-acceptance*",
   "**/_nax_acceptance_test.py",
   "**/_nax_suggested_test.py",
-  `**/${PROJECT_FEATURES_DIR}/*/`,
   ".nax/prompt-audit/",
   // Only reached when a run has no outputDir — nax-finish normally writes its
   // audit under `~/.nax/<project>/finish-audit/`. It still must be ignored:

--- a/test/unit/precheck/checks-warnings.test.ts
+++ b/test/unit/precheck/checks-warnings.test.ts
@@ -134,7 +134,7 @@ describe("checkGitignoreCoversNax", () => {
       "**/.nax-acceptance*",
       "**/_nax_acceptance_test.py",
       "**/_nax_suggested_test.py",
-      "**/.nax/features/*/",
+      "**/.nax/features/*/fragments/",
     ].join("\n");
     writeFileSync(join(workdir, ".gitignore"), gitignoreContent);
 
@@ -153,7 +153,7 @@ describe("checkGitignoreCoversNax", () => {
       "**/.nax-acceptance*",
       "**/_nax_acceptance_test.py",
       "**/_nax_suggested_test.py",
-      "**/.nax/features/*/",
+      "**/.nax/features/*/fragments/",
     ].join("\n");
     writeFileSync(join(workdir, ".gitignore"), gitignoreContent);
 

--- a/test/unit/precheck/precheck-checks-tier2-warnings.test.ts
+++ b/test/unit/precheck/precheck-checks-tier2-warnings.test.ts
@@ -252,7 +252,7 @@ nax.lock
 **/.nax-acceptance*
 **/_nax_acceptance_test.py
 **/_nax_suggested_test.py
-**/.nax/features/*/
+**/.nax/features/*/fragments/
 `.trim(),
     );
 

--- a/test/unit/utils/gitignore.test.ts
+++ b/test/unit/utils/gitignore.test.ts
@@ -37,7 +37,9 @@ describe("NAX_GITIGNORE_ENTRIES", () => {
     expect(ignored).toBeDefined();
 
     const produced = dirname(fragmentPath("/repo", "my-feature", "US-001"));
-    const expanded = ignored?.replace("*", "my-feature").replace(/\/$/, "") ?? "";
+    // The `**/` prefix makes the rule reach a monorepo package's own .nax/;
+    // strip it to compare against the repo-root path fragmentPath produces.
+    const expanded = (ignored ?? "").replace(/^\*\*\//, "").replace("*", "my-feature").replace(/\/$/, "");
 
     expect(produced).toBe(join("/repo", expanded));
   });
@@ -50,6 +52,33 @@ describe("NAX_GITIGNORE_ENTRIES", () => {
 
   test("no duplicate entries", () => {
     expect(new Set(NAX_GITIGNORE_ENTRIES).size).toBe(NAX_GITIGNORE_ENTRIES.length);
+  });
+
+  test("git ignores a feature's run artifacts but not its committed spec and prd", async () => {
+    // Asked of git itself rather than of the list, because the failure this
+    // pins was invisible in the list: a blanket `<features>/*/` entry reads as
+    // one more artifact rule, and only git reveals that it also swallows
+    // spec.md and prd.json — silently, since git never reports ignored files.
+    await withTempDir(async (dir) => {
+      Bun.spawnSync(["git", "init", "-q", dir], { cwd: dir });
+      await Bun.write(join(dir, ".gitignore"), `${NAX_GITIGNORE_ENTRIES.join("\n")}\n`);
+
+      const isIgnored = (path: string) =>
+        Bun.spawnSync(["git", "check-ignore", "-q", path], { cwd: dir }).exitCode === 0;
+
+      const feature = ".nax/features/my-feature";
+      for (const committed of ["spec.md", "prd.json", "prd-fidelity-report.md", "acceptance-meta.json"]) {
+        expect(`${committed}: ${isIgnored(`${feature}/${committed}`)}`).toBe(`${committed}: false`);
+      }
+      for (const artifact of ["status.json", "progress.txt", "plan/x.jsonl", "fragments/US-001.md", "prd.json.bak"]) {
+        expect(`${artifact}: ${isIgnored(`${feature}/${artifact}`)}`).toBe(`${artifact}: true`);
+      }
+
+      // Same rules must hold for a monorepo package's own .nax/, which is
+      // where nax writes when a story carries a workdir.
+      expect(isIgnored(`packages/api/${feature}/spec.md`)).toBe(false);
+      expect(isIgnored(`packages/api/${feature}/status.json`)).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

`NAX_GITIGNORE_ENTRIES` ended with a blanket `**/.nax/features/*/`. In gitignore
syntax that ignores **every file** under each feature directory — including
`spec.md` and `prd.json`, the two artifacts meant to be committed. Git never
reports an ignored file, so a repo initialised by `nax init` loses them silently.

Reproduced on a throwaway repo carrying only the generated entries:

```
.gitignore:5:**/.nax/features/*/	.nax/features/foo/spec.md
.gitignore:5:**/.nax/features/*/	.nax/features/foo/prd.json
```

The entry landed in #80 to keep the generated acceptance test out of git when nax
writes to `packageDir/.nax/features/<name>/`. The dedicated `**/.nax-acceptance*`,
`**/_nax_acceptance_test.py` and `**/_nax_suggested_test.py` entries cover that
today, so it is redundant — and it subsumed every specific feature-tree rule
above it, leaving those doing no work.

## Fix

Replace it with one entry per run artifact, each carrying the `**` prefix so the
rules also reach a monorepo package's own `.nax/` — the one thing the blanket
rule got right that the specific rules lacked:

```
runs/  plan/  sessions/  stories/  fragments/  interactions/
semantic-verdicts/  status.json  checkpoint.jsonl  progress.txt
acp-sessions.json  acceptance-refined.json  *.bak
```

`spec.md`, `prd.json`, `prd-fidelity-report.md` and `acceptance-meta.json` stay
committable. The artifact list was derived by enumerating every distinct entry
that actually appears under a feature directory across two long-lived repos.

`checkGitignoreCoversNax` duplicated the same blanket pattern, so it warned
against repos for *not* having the broken rule. It now asserts
`.nax/features/*/fragments/`, a substring of the `**`-prefixed form `nax init`
writes — so it passes for freshly initialised repos and for existing ones whose
`.gitignore` predates the prefix.

## Testing

- New regression test asks git itself via `git check-ignore` against a temp repo,
  rather than inspecting the list — the defect was invisible at list level, since
  a blanket entry reads as one more artifact rule. Verified it fails against the
  old code (`spec.md: true` where `false` expected) and passes with the fix.
- Fragments-pinning test now strips the `**/` prefix before expanding.
- Full suite: 14930 pass. The 4 failures (2 ADR-024 e2e, 1 full-suite-rectify
  e2e, 1 profile `$VAR`) reproduce identically on unmodified `main`.
- `bun run typecheck` and `bun run lint` clean; all pre-commit gates green.

## Note for existing repos

`patchIgnoreFile` is additive-only by design, so it will never remove the line
from a `.gitignore` that already has it. Repos initialised since #80 need the
`**/.nax/features/*/` line deleted by hand. Already-tracked files are unaffected
(gitignore does not apply to tracked paths) — the loss only hits feature
directories created after the line landed.