### PR TITLE
fix(scripts): resolve .js import specifiers in report-dead-tests

### DIFF
--- a/scripts/report-dead-tests.ts
+++ b/scripts/report-dead-tests.ts
@@ -79,26 +79,25 @@ export function parseTestFile(content: string, filePath: string): TestInfo {
 }
 
 /**
- * Check if an import path exists on disk (handles both .ts and .tsx variants)
+ * Check if an import path exists on disk (handles both .ts and .tsx variants).
+ *
+ * TypeScript's ESM convention writes the specifier with the extension of the
+ * EMITTED file (`./foo.js`) while the file on disk is `./foo.ts`. Probing only the
+ * literal specifier means `foo.js` is tested as `foo.js.ts` and a live module is
+ * reported dead — a false positive that has already cost this repo five real test
+ * files (98b27affe). Both the literal and the extension-stripped form are tried, so
+ * a genuine `foo.js.ts` on disk still resolves too.
  */
 function importExists(importPath: string, baseDir: string): boolean {
-  // Try with .ts
-  const tsPath = join(baseDir, `${importPath}.ts`);
-  if (existsSync(tsPath)) return true;
+  const candidates = [importPath];
+  const stripped = importPath.replace(/\.(js|jsx|mjs|cjs)$/, "");
+  if (stripped !== importPath) candidates.push(stripped);
 
-  // Try with .tsx
-  const tsxPath = join(baseDir, `${importPath}.tsx`);
-  if (existsSync(tsxPath)) return true;
-
-  // Try as directory with index.ts
-  const indexPath = join(baseDir, importPath, "index.ts");
-  if (existsSync(indexPath)) return true;
-
-  // Try as directory with index.tsx
-  const indexTsxPath = join(baseDir, importPath, "index.tsx");
-  if (existsSync(indexTsxPath)) return true;
-
-  return false;
+  return candidates.some((candidate) =>
+    [`${candidate}.ts`, `${candidate}.tsx`, join(candidate, "index.ts"), join(candidate, "index.tsx")].some((rel) =>
+      existsSync(join(baseDir, rel)),
+    ),
+  );
 }
 
 /**

--- a/test/unit/scripts/report-dead-tests.test.ts
+++ b/test/unit/scripts/report-dead-tests.test.ts
@@ -101,6 +101,71 @@ describe("findDeadImports", () => {
     expect(deadImports).not.toContain("src/config/loader");
   });
 
+  // The repo's own TypeScript convention writes runtime-relative specifiers with a
+  // `.js` extension that resolves to a `.ts` file on disk. importExists() used to
+  // append `.ts` without stripping that suffix, probing `<path>.js.ts` and reporting
+  // a live module as dead. That false positive caused 98b27affe to delete five real
+  // test files, including all 24 RuleBasedOptimizer tests. Every pre-existing test in
+  // this block used extensionless specifiers, so none of them could catch it.
+  test("resolves a .js specifier to its .ts file on disk", () => {
+    const testInfo = {
+      path: "test/unit/example.test.ts",
+      imports: ["src/config/loader.js"],
+      testNames: [],
+      describes: [],
+    };
+
+    expect(findDeadImports(testInfo, tempDir)).toEqual([]);
+  });
+
+  test("resolves a .jsx specifier to its .tsx file on disk", () => {
+    writeFileSync(join(tempDir, "src", "config", "panel.tsx"), "export const panel = {};");
+    const testInfo = {
+      path: "test/unit/example.test.ts",
+      imports: ["src/config/panel.jsx"],
+      testNames: [],
+      describes: [],
+    };
+
+    expect(findDeadImports(testInfo, tempDir)).toEqual([]);
+  });
+
+  test("resolves a .js specifier pointing at a directory barrel", () => {
+    writeFileSync(join(tempDir, "src", "pipeline", "index.ts"), "export const p = {};");
+    const testInfo = {
+      path: "test/unit/example.test.ts",
+      imports: ["src/pipeline/index.js"],
+      testNames: [],
+      describes: [],
+    };
+
+    expect(findDeadImports(testInfo, tempDir)).toEqual([]);
+  });
+
+  test("still flags a .js specifier whose module genuinely does not exist", () => {
+    const testInfo = {
+      path: "test/unit/example.test.ts",
+      imports: ["src/config/missing.js"],
+      testNames: [],
+      describes: [],
+    };
+
+    expect(findDeadImports(testInfo, tempDir)).toContain("src/config/missing.js");
+  });
+
+  test("does not strip .js from a module whose real filename ends in .js", () => {
+    // A literal `foo.js.ts` on disk must still resolve via the unstripped path.
+    writeFileSync(join(tempDir, "src", "config", "legacy.js.ts"), "export const legacy = {};");
+    const testInfo = {
+      path: "test/unit/example.test.ts",
+      imports: ["src/config/legacy.js"],
+      testNames: [],
+      describes: [],
+    };
+
+    expect(findDeadImports(testInfo, tempDir)).toEqual([]);
+  });
+
   test("checks both .ts and .ts extensions", () => {
     const testInfo = {
       path: "test/unit/example.test.ts",


### PR DESCRIPTION
## Summary

`scripts/report-dead-tests.ts` reported live modules as dead whenever a test imported them with a `.js` specifier. One-line class of fix in `importExists()`, plus the five test cases that can actually reproduce it.

## The bug

TypeScript's ESM convention writes the specifier with the extension of the **emitted** file (`./foo.js`) while the file on disk is `./foo.ts` — the convention `src/` uses throughout. `importExists()` appended `.ts`/`.tsx` to the literal specifier without stripping that suffix, so `foo.js` was probed as `foo.js.ts` and came back missing.

Demonstrated against the real exported `findDeadImports` before the fix:

```
file on disk: true
with .js  -> ["src/optimizer/rule-based.optimizer.js"]   <- false positive
without   -> []
```

## Why it matters

`98b27affe` ("chore(test): delete dead test files with broken imports", 2026-03-10) deleted **five real test files totalling 2,498 lines** on the strength of this false positive:

| File | Lines |
|---|---|
| `test/unit/optimizer/rule-based.optimizer.test.ts` | 358 (24 tests) |
| `test/unit/optimizer/noop.optimizer.test.ts` | 125 |
| `test/unit/formatters.test.ts` | 468 |
| `test/unit/logging/formatter.test.ts` | 456 |
| `test/e2e/plan-analyze-run.test.ts` | 902 |

`git ls-tree 98b27affe^ src/optimizer/` shows the sources were present the whole time. The optimizer pair had shipped green 15 days earlier in `a3963d48d`.

## Scope and honesty note

**The bug is currently latent, not active.** No test file imports `src/` with a `.js` specifier today (0 of 1,914 src-relative test imports), so the generated report is byte-identical before and after — only its timestamp moves, which is why `docs/dead-tests-report.md` is deliberately left unregenerated here. This fix removes a landmine rather than correcting a live misreport: any new test written with the `.js` convention that `src/` already uses would trip it again.

## Why it stayed invisible

Every pre-existing `findDeadImports` test used **extensionless** specifiers — the one input shape that cannot reproduce the defect. The five added tests cover `.js` → `.ts`, `.jsx` → `.tsx`, a `.js` directory barrel, a genuinely-missing `.js` module (must still be flagged), and a module whose real filename is `foo.js.ts` (must still resolve via the unstripped path). Three of the five fail against the old code.

## Follow-up (not in this PR)

Recovering the three non-optimizer files listed above. The optimizer pair is superseded — `test/unit/optimizer/` is restored in #1642, which removes the module those tests covered.

## Gates

`check:all` (22 gates), typecheck, and `bun test test/unit/` (13,761 pass / 0 fail) all green. No baselines raised.