### PR TITLE
fix(execution): make lock.ts stolen-lock restore path deterministically testable

### DIFF
--- a/scripts/baselines/coverage-per-file-baseline.json
+++ b/scripts/baselines/coverage-per-file-baseline.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-08-20T06:05:31.740Z",
+  "updatedAt": "2026-08-20T06:30:29.890Z",
   "byFile": {
     "src/acceptance/content-loader.ts": 0,
     "src/agents/acp/adapter-close-physical.ts": 0.0741,
@@ -54,7 +54,6 @@
     "src/execution/lifecycle/headless-formatter.ts": 0.7193,
     "src/execution/lifecycle/run-initialization.ts": 0.7481,
     "src/execution/lifecycle/run-setup.ts": 0.4852,
-    "src/execution/lock.ts": 0.6762,
     "src/execution/parallel-worker.ts": 0.7763,
     "src/execution/post-run.ts": 0.5685,
     "src/execution/progress.ts": 0.6667,

--- a/src/execution/helpers.ts
+++ b/src/execution/helpers.ts
@@ -36,4 +36,4 @@ export {
 } from "./story-context";
 
 // Lock management
-export { acquireLock, releaseLock } from "./lock";
+export { acquireLock, releaseLock, _lockDeps } from "./lock";

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -18,6 +18,7 @@ export {
   getAllReadyStories,
   acquireLock,
   releaseLock,
+  _lockDeps,
   formatProgress,
   type ExecutionResult,
   type StoryCounts,

--- a/src/execution/lock.ts
+++ b/src/execution/lock.ts
@@ -10,6 +10,16 @@ import path from "node:path";
 import { isProcessAlive } from "@/utils/process-alive";
 import { getLogger } from "../logger";
 
+/**
+ * Injectable seam for the stale-lock rename step, so tests can deterministically
+ * simulate the race window BUG-34 guards against (another racer replacing lockPath
+ * with a fresh live lock between our staleness read and our rename) instead of
+ * relying on real concurrent scheduling, which only exercises that branch sometimes.
+ */
+export const _lockDeps = {
+  rename: rename as typeof rename,
+};
+
 /** Safely get logger instance, returns null if not initialized */
 function getSafeLogger() {
   try {
@@ -101,7 +111,7 @@ export async function acquireLock(workdir: string): Promise<boolean> {
         // back off.
         const tombstonePath = `${lockPath}.stale.${process.pid}.${Date.now()}`;
         try {
-          await rename(lockPath, tombstonePath);
+          await _lockDeps.rename(lockPath, tombstonePath);
         } catch (renameError) {
           if ((renameError as NodeJS.ErrnoException).code === "ENOENT") {
             // Another process already claimed cleanup of this stale lock —

--- a/test/unit/execution/helpers.test.ts
+++ b/test/unit/execution/helpers.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
-import { acquireLock, formatProgress, releaseLock } from "@/execution";
+import { _lockDeps, acquireLock, formatProgress, releaseLock } from "@/execution";
 import type { StoryCounts } from "@/execution";
 import { spawn } from "bun";
 
@@ -343,5 +343,76 @@ describe("acquireLock and releaseLock", () => {
     expect(entries.some((e) => e.includes(".stale."))).toBe(false);
 
     await releaseLock(testDir);
+  });
+
+  describe("BUG-34: stolen-lock restore path (deterministic)", () => {
+    // The real BUG-07 concurrency test above only exercises this branch when
+    // real OS scheduling happens to interleave two racers a specific way —
+    // observed to make lock.ts's own line coverage bounce between runs
+    // (nax-gap-analysis-2026-08-20 §3). These tests force the race window
+    // deterministically via `_lockDeps.rename` instead of relying on luck.
+    let originalRename: typeof _lockDeps.rename;
+
+    beforeEach(() => {
+      originalRename = _lockDeps.rename;
+    });
+
+    afterEach(() => {
+      _lockDeps.rename = originalRename;
+    });
+
+    test("restores the stolen live lock when a racer's fresh lock appears mid-rename", async () => {
+      const stalePid = 999999;
+      await Bun.write(lockPath, JSON.stringify({ pid: stalePid, timestamp: Date.now() - 60000 }));
+
+      const freshPid = process.pid;
+      _lockDeps.rename = (async (src: string, dest: string) => {
+        // Simulate a second racer winning the O_CREAT|O_EXCL create at
+        // lockPath after our staleness read but before our rename lands.
+        await Bun.write(src as string, JSON.stringify({ pid: freshPid, timestamp: Date.now() }));
+        return originalRename(src, dest);
+      }) as typeof _lockDeps.rename;
+
+      const acquired = await acquireLock(testDir);
+      expect(acquired).toBe(false);
+
+      // The freshly-created live lock must be restored, untouched, at lockPath.
+      const lockData = JSON.parse(await Bun.file(lockPath).text());
+      expect(lockData.pid).toBe(freshPid);
+
+      // No leftover tombstone from the aborted steal.
+      const { readdirSync } = await import("node:fs");
+      const entries = readdirSync(testDir);
+      expect(entries.some((e) => e.includes(".stale."))).toBe(false);
+    });
+
+    test("drops the tombstone when the stolen lock cannot be restored (occupied by a third racer)", async () => {
+      const stalePid = 999999;
+      await Bun.write(lockPath, JSON.stringify({ pid: stalePid, timestamp: Date.now() - 60000 }));
+
+      const freshPid = process.pid;
+      const thirdRacerPid = 424242;
+      _lockDeps.rename = (async (src: string, dest: string) => {
+        // Simulate racer B's fresh live lock appearing...
+        await Bun.write(src as string, JSON.stringify({ pid: freshPid, timestamp: Date.now() }));
+        const result = await originalRename(src, dest);
+        // ...then racer D winning a brand-new create at lockPath before we
+        // get a chance to restore B's content — the restore must not clobber it.
+        await Bun.write(src as string, JSON.stringify({ pid: thirdRacerPid, timestamp: Date.now() }));
+        return result;
+      }) as typeof _lockDeps.rename;
+
+      const acquired = await acquireLock(testDir);
+      expect(acquired).toBe(false);
+
+      // Racer D's lock must survive untouched.
+      const lockData = JSON.parse(await Bun.file(lockPath).text());
+      expect(lockData.pid).toBe(thirdRacerPid);
+
+      // Our stolen tombstone must be dropped, not left behind.
+      const { readdirSync } = await import("node:fs");
+      const entries = readdirSync(testDir);
+      expect(entries.some((e) => e.includes(".stale."))).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `src/execution/lock.ts`'s own line coverage was bouncing between runs (79.05%/67.62%, flagged as a side finding in the 2026-08-20 gap analysis §3) because the BUG-34 stolen-lock restore branch was only ever exercised incidentally, when the BUG-07 concurrency test's 10 real racers happened to interleave a specific way.
- Adds an injectable `_lockDeps.rename` seam (same pattern as `_runnerDeps` etc.) and two deterministic tests that simulate the exact race window instead of relying on real scheduling luck.
- `lock.ts` coverage is now stable (~87%) across repeated runs and clears the 80% floor, so it's removed from the per-file coverage grandfather baseline.

## Test plan
- [x] `bun test test/unit/execution/helpers.test.ts` — 21 pass, 0 fail
- [x] `bun run test:coverage` repeated 6x — `lock.ts` line hits identical (92/108) every run, vs. previously bouncing 71–83/108
- [x] `bun run check:all` — all 22 gates green (typecheck ratchets unchanged: test-typecheck 2001/2001, as-unknown-as 815/815)
- [x] `bun run test` — full unit + integration + UI suites green