### PR TITLE
fix: suppress story.start for attempts refused by the tier pre-check (#1653)

### DIFF
--- a/scripts/baselines/file-sizes-baseline.json
+++ b/scripts/baselines/file-sizes-baseline.json
@@ -1,8 +1,8 @@
 {
-  "updatedAt": "2026-08-16T15:49:00.054Z",
+  "updatedAt": "2026-08-21T02:06:18.666Z",
   "byFile": {
     "src/agents/manager.ts": 789,
-    "src/execution/unified-executor.ts": 768,
+    "src/execution/unified-executor.ts": 764,
     "src/prd/schema.ts": 628,
     "src/prompts/builders/rectifier-builder.ts": 902,
     "src/session/manager.ts": 708,

--- a/src/execution/story-announce.ts
+++ b/src/execution/story-announce.ts
@@ -1,0 +1,51 @@
+/**
+ * story.start announcement — the human-readable log line emitted when a story
+ * is dispatched.
+ *
+ * Extracted from the executor so the three dispatch paths (parallel batch,
+ * single-story batch fallback, sequential) share one shape. Callers must emit
+ * this only AFTER `preIterationTierCheck` has cleared the attempt to run
+ * (#1653): before that point the attempt may still be refused for an exhausted
+ * tier ladder, and a story.start line for it reads as a fresh attempt the agent
+ * abandoned instantly.
+ *
+ * The `story:started` bus event is deliberately NOT emitted here — it stays at
+ * the pre-check call sites, because tier-escalation's BUG-5 branch pairs it with
+ * a compensating `story:failed`, and reporters, the events file, the TUI, and
+ * the max-retries trigger all depend on that pairing.
+ */
+
+import { getSafeLogger } from "../logger";
+import type { PRD, UserStory } from "../prd/types";
+
+/** Tier/agent/complexity the story will actually run as, resolved by the caller. */
+export interface StoryStartAnnouncement {
+  complexity: string;
+  modelTier: string;
+  agent: string;
+}
+
+/**
+ * A story's number is its ordinal in the PRD, not a progress counter (#1653).
+ * The previous derivation (`total - pending + 1`) moved as *other* stories
+ * finished, so the same story was logged under a different number on each
+ * attempt. Returns 0 for a story absent from the PRD — defensive only; every
+ * dispatch path selects from `prd.userStories`.
+ */
+export function storyOrdinal(prd: PRD, storyId: string): number {
+  return prd.userStories.findIndex((s) => s.id === storyId) + 1;
+}
+
+/** Emit the `story.start` log line for a story that is about to be dispatched. */
+export function logStoryStart(prd: PRD, story: UserStory, announcement: StoryStartAnnouncement): void {
+  getSafeLogger()?.info("story.start", `${story.title}`, {
+    storyId: story.id,
+    storyTitle: story.title,
+    complexity: announcement.complexity,
+    modelTier: announcement.modelTier,
+    agent: announcement.agent,
+    storyNumber: storyOrdinal(prd, story.id),
+    storyTotal: prd.userStories.length,
+    attempt: story.attempts + 1,
+  });
+}

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -31,6 +31,7 @@ import { runIteration } from "./iteration-runner";
 import type { RunParallelBatchOptions, RunParallelBatchResult } from "./parallel-batch";
 import { handlePipelineFailure } from "./pipeline-result-handler";
 import { closeStorySessions } from "./session-manager-runtime";
+import { logStoryStart } from "./story-announce";
 import { resolveRetryCandidate, selectIndependentBatch, selectNextStories } from "./story-selector";
 
 export type { SequentialExecutionContext, SequentialExecutionResult } from "./executor-types";
@@ -256,13 +257,17 @@ export async function executeUnified(
         const selectBatch = _unifiedExecutorDeps.selectIndependentBatch;
         const batch = retryStory ? [retryStory] : selectBatch(readyStories, ctx.parallelCount as number);
         if (batch.length > 1) {
-          // Emit story:started for each batch story before dispatch (AC-5)
-          const batchCounts = countStories(prd);
-          const batchBaseDone = batchCounts.total - batchCounts.pending;
-          for (const [batchIndex, story] of batch.entries()) {
-            // #1575: announce the tier/agent the story will actually run as.
+          // Emit story:started for each batch story before dispatch (AC-5). The
+          // event stays here even for a story the pre-check will refuse — see
+          // story-announce.ts for why the story.start LOG does not (#1653).
+          // #1575: announce the tier/agent the story will actually run as. Recorded
+          // per story and reused by the story.start log below, so the log line can
+          // never disagree with the event it accompanies.
+          const batchAnnouncements = new Map<string, { modelTier: string; agent: string }>();
+          for (const story of batch) {
             const modelTier = buildPreviewRouting(story, ctx.config).modelTier;
             const batchAgent = agentFor(story, ctx);
+            batchAnnouncements.set(story.id, { modelTier, agent: batchAgent });
             pipelineEventBus.emit({
               type: "story:started",
               storyId: story.id,
@@ -271,16 +276,6 @@ export async function executeUnified(
               modelTier,
               agent: batchAgent,
               iteration: iterations,
-            });
-            logger?.info("story.start", `${story.title}`, {
-              storyId: story.id,
-              storyTitle: story.title,
-              complexity: story.routing?.complexity ?? "unknown",
-              modelTier,
-              agent: batchAgent,
-              storyNumber: batchBaseDone + batchIndex + 1,
-              storyTotal: batchCounts.total,
-              attempt: story.attempts + 1,
             });
           }
 
@@ -304,6 +299,15 @@ export async function executeUnified(
           if (batchPreCheck.prdDirty) prdDirty = true;
           if (batchPreCheck.dispatchable.length === 0) {
             continue;
+          }
+          // #1653: announce only the stories that actually dispatch.
+          for (const story of batchPreCheck.dispatchable) {
+            const announcement = batchAnnouncements.get(story.id);
+            logStoryStart(batchPreCheck.prd, story, {
+              complexity: story.routing?.complexity ?? "unknown",
+              modelTier: announcement?.modelTier ?? buildPreviewRouting(story, ctx.config).modelTier,
+              agent: announcement?.agent ?? agentFor(story, ctx),
+            });
           }
           const batchResult = await _unifiedExecutorDeps.runParallelBatch({
             stories: batchPreCheck.dispatchable,
@@ -481,7 +485,6 @@ export async function executeUnified(
 
           const modelTier = singleSelection.routing.modelTier;
           const singleAgent = agentFor(singleStory, ctx);
-          const singleCounts = countStories(prd);
           pipelineEventBus.emit({
             type: "story:started",
             storyId: singleStory.id,
@@ -495,16 +498,6 @@ export async function executeUnified(
             modelTier,
             agent: singleAgent,
             iteration: iterations,
-          });
-          logger?.info("story.start", `${singleStory.title}`, {
-            storyId: singleStory.id,
-            storyTitle: singleStory.title,
-            complexity: singleSelection.routing.complexity ?? "unknown",
-            modelTier,
-            agent: singleAgent,
-            storyNumber: singleCounts.total - singleCounts.pending + 1,
-            storyTotal: singleCounts.total,
-            attempt: singleStory.attempts + 1,
           });
           const singlePre = await _unifiedExecutorDeps.preIterationTierCheck(
             singleStory,
@@ -524,6 +517,13 @@ export async function executeUnified(
             prdDirty = singlePre.prdDirty;
             continue;
           }
+
+          // #1653: announced only after the pre-check clears the attempt to run.
+          logStoryStart(prd, singleStory, {
+            complexity: singleSelection.routing.complexity ?? "unknown",
+            modelTier,
+            agent: singleAgent,
+          });
 
           const singleIter = await _unifiedExecutorDeps.runIteration(
             ctx,
@@ -589,7 +589,6 @@ export async function executeUnified(
 
       const modelTier = selection.routing.modelTier;
       const seqAgent = agentFor(selection.story, ctx);
-      const seqCounts = countStories(prd);
       pipelineEventBus.emit({
         type: "story:started",
         storyId: selection.story.id,
@@ -603,16 +602,6 @@ export async function executeUnified(
         modelTier,
         agent: seqAgent,
         iteration: iterations,
-      });
-      logger?.info("story.start", `${selection.story.title}`, {
-        storyId: selection.story.id,
-        storyTitle: selection.story.title,
-        complexity: selection.routing.complexity ?? "unknown",
-        modelTier,
-        agent: seqAgent,
-        storyNumber: seqCounts.total - seqCounts.pending + 1,
-        storyTotal: seqCounts.total,
-        attempt: selection.story.attempts + 1,
       });
       const seqPre = await _unifiedExecutorDeps.preIterationTierCheck(
         selection.story,
@@ -632,6 +621,13 @@ export async function executeUnified(
         prdDirty = seqPre.prdDirty;
         continue;
       }
+
+      // #1653: announced only after the pre-check clears the attempt to run.
+      logStoryStart(prd, selection.story, {
+        complexity: selection.routing.complexity ?? "unknown",
+        modelTier,
+        agent: seqAgent,
+      });
 
       const iter = await _unifiedExecutorDeps.runIteration(ctx, prd, selection, iterations, totalCost, allStoryMetrics);
       await pipelineEventBus.drain();

--- a/test/unit/execution/unified-executor-logging.test.ts
+++ b/test/unit/execution/unified-executor-logging.test.ts
@@ -7,8 +7,38 @@
  *   story.start logging — sequential (single-story) dispatch
  */
 
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type { Logger } from "@/logger";
 import * as loggerModule from "@/logger";
+
+/** One `logger.info` call captured by `installStoryLogSpy`. */
+interface CapturedLog {
+  stage: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Install a `getSafeLogger` spy and return the array its `info` calls land in.
+ * The mock is typed as `Partial<Logger>` so the narrowing cast is a plain
+ * widening rather than a double cast.
+ */
+function installStoryLogSpy(): { calls: CapturedLog[]; restore: () => void } {
+  const calls: CapturedLog[] = [];
+  const logger: Partial<Logger> = {
+    info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+      calls.push({ stage, message, data });
+    }),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+  };
+  const spy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as Logger);
+  return { calls, restore: () => spy.mockRestore() };
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test fixture helpers
@@ -48,7 +78,12 @@ function makeProfileStory(id: string) {
   });
 }
 
-function makePrd(stories: ReturnType<typeof makePendingStory>[]) {
+/** A story the run has already completed — `makePendingStory` pins status to "pending". */
+function makePassedStory(id: string) {
+  return { ...makePendingStory(id), status: "passed" as const, passes: true };
+}
+
+function makePrd(stories: Array<ReturnType<typeof makePendingStory> | ReturnType<typeof makePassedStory>>) {
   return {
     project: "test-project",
     feature: "test-feature",
@@ -422,5 +457,232 @@ describe("story.start announcement — profile-assigned stories (#1575)", () => 
     // A story with no profile still falls back to the run's default agent.
     const plainCall = infoCalls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-002");
     expect(plainCall?.data?.agent).not.toBe("pi");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1653: story.start must not be logged for an attempt that never runs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("story.start suppression when the tier ladder is exhausted (#1653)", () => {
+  let deps: Record<string, unknown>;
+  let origRunIteration: unknown;
+  let origSelectIndependentBatch: unknown;
+  let origPreIterationTierCheck: unknown;
+  let spy: ReturnType<typeof installStoryLogSpy>;
+
+  beforeEach(async () => {
+    const mod = await import("@/execution/unified-executor");
+    deps = (mod as Record<string, unknown>)._unifiedExecutorDeps as Record<string, unknown>;
+    origRunIteration = deps.runIteration;
+    origSelectIndependentBatch = deps.selectIndependentBatch;
+    origPreIterationTierCheck = deps.preIterationTierCheck;
+    spy = installStoryLogSpy();
+  });
+
+  afterEach(() => {
+    if (deps) {
+      deps.runIteration = origRunIteration;
+      deps.selectIndependentBatch = origSelectIndependentBatch;
+      deps.preIterationTierCheck = origPreIterationTierCheck;
+    }
+    spy?.restore();
+    mock.restore();
+  });
+
+  test("single-story dispatch logs no story.start when the pre-iteration check skips the story", async () => {
+    const story = makePendingStory("US-001");
+    const prd = makePrd([story]);
+
+    deps.selectIndependentBatch = mock(() => [story]);
+    deps.preIterationTierCheck = mock(async () => ({ shouldSkipIteration: true, prdDirty: false, prd }));
+    deps.runIteration = mock(async () => {
+      throw new Error("runIteration must not be reached for a skipped story");
+    });
+
+    const { executeUnified } = await import("@/execution/unified-executor");
+    await executeUnified(makeCtx({ parallelCount: 2 }) as never, prd as never).catch(() => {});
+
+    expect(spy.calls.filter((c) => c.stage === "story.start")).toHaveLength(0);
+  });
+
+  test("sequential dispatch logs no story.start when the pre-iteration check skips the story", async () => {
+    const story = makePendingStory("US-001");
+    const prd = makePrd([story]);
+
+    // No parallelCount — dispatch falls through to the sequential path.
+    deps.preIterationTierCheck = mock(async () => ({ shouldSkipIteration: true, prdDirty: false, prd }));
+    deps.runIteration = mock(async () => {
+      throw new Error("runIteration must not be reached for a skipped story");
+    });
+
+    const { executeUnified } = await import("@/execution/unified-executor");
+    await executeUnified(makeCtx() as never, prd as never).catch(() => {});
+
+    expect(spy.calls.filter((c) => c.stage === "story.start")).toHaveLength(0);
+  });
+
+  test("story.start is still logged when the pre-iteration check lets the story run", async () => {
+    const story = makePendingStory("US-001");
+    const prd = makePrd([story]);
+
+    deps.preIterationTierCheck = mock(async () => ({ shouldSkipIteration: false, prdDirty: false, prd }));
+    deps.runIteration = mock(async () => ({
+      prd: makePrd([]),
+      storiesCompletedDelta: 1,
+      costDelta: 0,
+      prdDirty: false,
+    }));
+
+    const { executeUnified } = await import("@/execution/unified-executor");
+    await executeUnified(makeCtx() as never, prd as never).catch(() => {});
+
+    const calls = spy.calls.filter((c) => c.stage === "story.start");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].data?.storyId).toBe("US-001");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1653: the parallel batch announces only the stories that survive the pre-check
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("story.start suppression in a parallel batch (#1653)", () => {
+  let deps: Record<string, unknown>;
+  let origRunParallelBatch: unknown;
+  let origSelectIndependentBatch: unknown;
+  let origPreIterationTierCheck: unknown;
+  let spy: ReturnType<typeof installStoryLogSpy>;
+  let prdPath: string;
+
+  beforeEach(async () => {
+    const mod = await import("@/execution/unified-executor");
+    deps = (mod as Record<string, unknown>)._unifiedExecutorDeps as Record<string, unknown>;
+    origRunParallelBatch = deps.runParallelBatch;
+    origSelectIndependentBatch = deps.selectIndependentBatch;
+    origPreIterationTierCheck = deps.preIterationTierCheck;
+    spy = installStoryLogSpy();
+  });
+
+  afterEach(async () => {
+    if (deps) {
+      deps.runParallelBatch = origRunParallelBatch;
+      deps.selectIndependentBatch = origSelectIndependentBatch;
+      deps.preIterationTierCheck = origPreIterationTierCheck;
+    }
+    spy?.restore();
+    mock.restore();
+    if (prdPath) await rm(prdPath, { force: true });
+  });
+
+  test("a batch story refused by the pre-iteration check is never announced", async () => {
+    const kept = makePendingStory("US-001");
+    const refused = makePendingStory("US-002");
+    const prd = makePrd([kept, refused]);
+
+    // runBatchPreChecks reloads the PRD from disk whenever a story is skipped,
+    // so the fixture needs a real file behind ctx.prdPath.
+    prdPath = join(tmpdir(), `nax-1653-batch-${process.pid}.json`);
+    await Bun.write(prdPath, JSON.stringify(prd));
+
+    deps.selectIndependentBatch = mock(() => [kept, refused]);
+    deps.preIterationTierCheck = mock(async (story: { id: string }) => ({
+      shouldSkipIteration: story.id === "US-002",
+      prdDirty: false,
+      prd,
+    }));
+    deps.runParallelBatch = mock(async () => ({
+      completed: [kept],
+      failed: [],
+      mergeConflicts: [],
+      storyCosts: new Map([[kept.id, 0]]),
+      totalCost: 0,
+    }));
+
+    const { executeUnified } = await import("@/execution/unified-executor");
+    const ctx = { ...makeCtx({ parallelCount: 2 }), prdPath };
+    await executeUnified(ctx as never, prd as never).catch(() => {});
+
+    const announced = spy.calls.filter((c) => c.stage === "story.start").map((c) => c.data?.storyId);
+    expect(announced).toEqual(["US-001"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1653: storyNumber is the story's PRD ordinal, not a progress counter
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("story.start storyNumber is the story's PRD ordinal (#1653)", () => {
+  let deps: Record<string, unknown>;
+  let origRunIteration: unknown;
+  let origSelectIndependentBatch: unknown;
+  let origPreIterationTierCheck: unknown;
+  let spy: ReturnType<typeof installStoryLogSpy>;
+
+  beforeEach(async () => {
+    const mod = await import("@/execution/unified-executor");
+    deps = (mod as Record<string, unknown>)._unifiedExecutorDeps as Record<string, unknown>;
+    origRunIteration = deps.runIteration;
+    origSelectIndependentBatch = deps.selectIndependentBatch;
+    origPreIterationTierCheck = deps.preIterationTierCheck;
+    spy = installStoryLogSpy();
+  });
+
+  afterEach(() => {
+    if (deps) {
+      deps.runIteration = origRunIteration;
+      deps.selectIndependentBatch = origSelectIndependentBatch;
+      deps.preIterationTierCheck = origPreIterationTierCheck;
+    }
+    spy?.restore();
+    mock.restore();
+  });
+
+  test("a story keeps its own ordinal regardless of how many siblings have finished", async () => {
+    // US-002 finished; US-003 is the third story in the PRD and must be announced
+    // as 3/3. The old pending-count derivation (total - pending + 1) reported 2
+    // here, because it counted completed siblings rather than the story's place.
+    const first = makePendingStory("US-001");
+    const done = makePassedStory("US-002");
+    const story = makePendingStory("US-003");
+    const prd = makePrd([first, done, story]);
+
+    deps.selectIndependentBatch = mock(() => [story]);
+    deps.preIterationTierCheck = mock(async () => ({ shouldSkipIteration: false, prdDirty: false, prd }));
+    deps.runIteration = mock(async () => ({
+      prd: makePrd([first, done]),
+      storiesCompletedDelta: 1,
+      costDelta: 0,
+      prdDirty: false,
+    }));
+
+    const { executeUnified } = await import("@/execution/unified-executor");
+    await executeUnified(makeCtx({ parallelCount: 2 }) as never, prd as never).catch(() => {});
+
+    const call = spy.calls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-003");
+    expect(call?.data).toMatchObject({ storyNumber: 3, storyTotal: 3 });
+  });
+
+  test("the first story in the PRD stays number 1 after a later sibling has passed", async () => {
+    // The old derivation counted US-002's completion against US-001 and announced
+    // it as 2/2 even though it is the first story in the PRD.
+    const story = makePendingStory("US-001");
+    const done = makePassedStory("US-002");
+    const prd = makePrd([story, done]);
+
+    deps.selectIndependentBatch = mock(() => [story]);
+    deps.preIterationTierCheck = mock(async () => ({ shouldSkipIteration: false, prdDirty: false, prd }));
+    deps.runIteration = mock(async () => ({
+      prd: makePrd([done]),
+      storiesCompletedDelta: 1,
+      costDelta: 0,
+      prdDirty: false,
+    }));
+
+    const { executeUnified } = await import("@/execution/unified-executor");
+    await executeUnified(makeCtx({ parallelCount: 2 }) as never, prd as never).catch(() => {});
+
+    const call = spy.calls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-001");
+    expect(call?.data).toMatchObject({ storyNumber: 1, storyTotal: 2 });
   });
 });


### PR DESCRIPTION
Closes #1653.

## Problem

All three dispatch paths in `unified-executor.ts` logged `story.start` *before* calling `preIterationTierCheck`. When a story had no next tier left, the refusal followed ~1 ms later:

```
00:42:03.289  info  story.start  {"storyId":"US-003","modelTier":"powerful","attempt":2,...}
00:42:03.290  error execution    Story failed - all tiers exhausted  {"storyId":"US-003","attempts":1}
```

No session, no phase, no cost between the two lines — but the log reads as a fresh top-tier attempt the model abandoned instantly, which sends the reader after the agent instead of the ladder. Cosmetic, but it is misleading exactly when run logs get read.

A second bug in the same line: `storyNumber` was derived as `total - pending + 1`, so a story's number moved as *other* stories finished — the same story was announced as 3 on two attempts and 4 on the third.

## Fix

- The `story.start` log now emits only after `preIterationTierCheck` returns `shouldSkipIteration: false`. The parallel-batch path announces only `batchPreCheck.dispatchable`.
- `storyNumber` is the story's ordinal in `prd.userStories` — which is what the formatter's `Story: 3/5` line (`src/log-format/formatter.ts:173`) has always claimed to show.
- The announcement moves to a new `src/execution/story-announce.ts` so all three paths share one shape.
- The batch path resolves each story's tier/agent once and reuses it for both the `story:started` event and the log, so the two can never disagree.

## Deliberate deviation from the issue

The issue suggests also moving the `story:started` emit and retiring the BUG-5 compensation in `tier-escalation.ts`. **The compensation is kept.** The story does reach a terminal state, and `events-writer`, `hooks`, the TUI, and the max-retries interaction trigger all subscribe to `story:failed`; retiring it would silently drop terminal-state signalling for every tier exhaustion. Only the human-readable log line moved. A comment at the emit site records why.

## Tests

5 new tests in `test/unit/execution/unified-executor-logging.test.ts`, one per affected path plus the ordinal behaviour:

- single-story and sequential dispatch log no `story.start` when the pre-check skips the story
- `story.start` is still logged when the pre-check clears the story
- a batch story refused by the pre-check is never announced
- a story keeps its own ordinal regardless of how many siblings have finished (2 cases)

All 5 fail against the unfixed source and pass with the fix (verified by stashing the `src/` changes and re-running).

## Verification

- `bun run test` — all phases pass (unit, integration, ui)
- `bun run typecheck` — clean
- `bun run lint` — all 23 static gates pass
- test-typecheck and `as unknown as` ratchets both at baseline (the new tests type the logger mock as `Partial<Logger>` and use a `makePassedStory` factory rather than spending ratchet budget)
- `unified-executor.ts` 768 → 764 lines; file-size baseline lowered to match

## Follow-up (not in this PR)

`unified-executor-logging.test.ts` still has five copies of an inline logger-spy block predating this change. This PR adds a shared `installStoryLogSpy()` helper and uses it for the new describes; consolidating the older five would drop the file's five baseline typecheck errors to zero, but is unrelated churn.