### PR TITLE
fix: dispatch a repo-scoped test fix when the story-scoped one gives up (#1654)

### DIFF
--- a/docs/architecture/story-orchestrator-flow.md
+++ b/docs/architecture/story-orchestrator-flow.md
@@ -214,6 +214,7 @@ That subset is the SSOT map **`STRATEGY_TO_REVALIDATION_PHASES`**
 | semantic-review | `semantic-review` | `autofix-implementer` | lint, typecheck, full-suite-gate, semantic, adversarial |
 | adversarial-review (source) | `adversarial-review`, `fixTarget: source` | `autofix-implementer` | lint, typecheck, full-suite-gate, semantic, adversarial |
 | adversarial-review (test) | `adversarial-review`, `fixTarget: test` | `autofix-test-writer` | lint, typecheck, full-suite-gate, adversarial — **excludes semantic & verifier** |
+| full-suite-gate | `test-runner` | `full-suite-rectify` → `repo-scoped-test-fix` | lint, typecheck, full-suite-gate, verifier, verify-scoped, semantic, adversarial |
 
 ```mermaid
 flowchart LR
@@ -245,6 +246,11 @@ flowchart LR
   `lint-check` re-runs (cheapest). `maxAttempts: 1`. (See the soundness assumption in §5.)
 - **Any agent-written code fix** (typecheck / semantic / adversarial-source) can break
   anything, so it re-runs the full downstream chain: style → types → tests → both reviews.
+- **Failing-test fixes** (`full-suite-rectify`, then `repo-scoped-test-fix`) re-run
+  everything downstream *including* the verifier: they may edit test code through the
+  declaration protocol, which legitimately changes the TDD-boundary verdict. Both share
+  one revalidation set (`FULL_SUITE_RECTIFY_REVALIDATION`) because they run the same op
+  — the second edits a wider set of *files*, not a different set of *phases*.
 - **Test rewrites** (`autofix-test-writer`) re-run tests + adversarial re-judgment, but:
   - skip `semantic-review` (semantic review judges *source*, not tests), and
   - skip `verifier` **by intent** — re-running the verifier is an extra agent session
@@ -265,6 +271,14 @@ over a safe default.
 - Exit reasons (`src/execution/story-orchestrator.ts:61`, `EXHAUSTED_EXIT_REASONS`):
   `max-attempts-total`, `max-attempts-per-strategy`, `no-strategy`, `agent-gave-up`,
   `validate-short-circuit`, `bail-when`.
+- **Give-up fallthrough (#1654)**: when every strategy in the dispatched group answers
+  `UNRESOLVED:`, the cycle exits `agent-gave-up` *only if no other claimant remains*.
+  If a non-retired strategy with attempts left still claims the findings, the cycle
+  dispatches it instead — without re-validating first, since nothing touched the tree.
+  This is what routes a failing test the story-scoped rectifier declined as
+  out-of-scope to the repo-scoped `repo-scoped-test-fix`, rather than deadlocking the
+  story on a test it was forbidden to touch. Gated by
+  `execution.rectification.repoScopedFallback` (default `true`).
 - **`agent-gave-up`** fires when a fix-op emits the `UNRESOLVED:` sentinel (the implementer
   signalling a contradiction it cannot resolve — e.g. `full-suite-rectify` and
   `autofix-implementer` both parse it). The sentinel's reason text is carried as

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -71,7 +71,7 @@ export interface RectificationConfig {
   rethinkAtAttempt: number;
   /** Per-strategy attempt number at which "final chance before escalation" urgency is added. (default: 3) */
   urgencyAtAttempt: number;
-  /** Register the repo-scoped `regression-fix` fallthrough claimant for failing
+  /** Register the repo-scoped `repo-scoped-test-fix` fallthrough claimant for failing
    * tests the story-scoped rectifier declines as out-of-scope (#1654). (default: true) */
   repoScopedFallback: boolean;
 }

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -71,6 +71,9 @@ export interface RectificationConfig {
   rethinkAtAttempt: number;
   /** Per-strategy attempt number at which "final chance before escalation" urgency is added. (default: 3) */
   urgencyAtAttempt: number;
+  /** Register the repo-scoped `regression-fix` fallthrough claimant for failing
+   * tests the story-scoped rectifier declines as out-of-scope (#1654). (default: true) */
+  repoScopedFallback: boolean;
 }
 
 /** Regression gate config (BUG-009, BUG-026) */

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -81,6 +81,14 @@ export const RectificationConfigSchema = z.object({
   // Under maxAttemptsPerStrategy=3: rethink on attempt 2, urgency on attempt 3 (final).
   rethinkAtAttempt: z.number().int().min(1).default(2),
   urgencyAtAttempt: z.number().int().min(1).default(3),
+  /** Register the repo-scoped `regression-fix` strategy as a fallthrough claimant
+   * for failing tests the story-scoped rectifier declines as out-of-scope (#1654).
+   * Without it, a test that is red for reasons outside the story deadlocks every
+   * story in the package: the rectifier is asked to fix a test it is forbidden to
+   * touch, answers UNRESOLVED, and the story burns the escalation ladder. The
+   * fallthrough gets a single attempt under its own session role. Turn off to
+   * restore the exit-on-give-up behaviour. (default: true) */
+  repoScopedFallback: z.boolean().default(true),
 });
 
 export const RegressionGateConfigSchema = z.object({

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -81,7 +81,7 @@ export const RectificationConfigSchema = z.object({
   // Under maxAttemptsPerStrategy=3: rethink on attempt 2, urgency on attempt 3 (final).
   rethinkAtAttempt: z.number().int().min(1).default(2),
   urgencyAtAttempt: z.number().int().min(1).default(3),
-  /** Register the repo-scoped `regression-fix` strategy as a fallthrough claimant
+  /** Register the repo-scoped `repo-scoped-test-fix` strategy as a fallthrough claimant
    * for failing tests the story-scoped rectifier declines as out-of-scope (#1654).
    * Without it, a test that is red for reasons outside the story deadlocks every
    * story in the package: the rectifier is asked to fix a test it is forbidden to

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -35,7 +35,7 @@ import {
 } from "../operations";
 import type { DeclarationDiagnostic, TestEditDeclaration } from "../operations";
 import { shouldRunRectification } from "../operations/execution-gates";
-import { makeFullSuiteRectifyStrategy } from "../operations/full-suite-rectify";
+import { makeFullSuiteRectifyStrategy, makeRegressionFixStrategy } from "../operations/full-suite-rectify";
 import type { CallContext } from "../operations/types";
 import type { UserStory } from "../prd/types";
 import { resolveTestFilePatterns } from "../test-runners";
@@ -269,6 +269,18 @@ export async function buildPlanForStrategy(
           unknown
         >,
       );
+      // #1654 — repo-scoped fallthrough, registered AFTER the story-scoped
+      // strategy so `selectExecutionGroup` (which takes the first exclusive
+      // claimant) always tries the scoped one first. It is reached only once the
+      // scoped strategy has declined these findings and been retired for them,
+      // which is what makes the ordering load-bearing rather than cosmetic.
+      //
+      // Registered on the blocking cycle only. The non-blocking cycle below does
+      // not deadlock a story on a finding it cannot fix, so the extra dispatch
+      // would buy nothing there.
+      if (config.execution.rectification.repoScopedFallback) {
+        strategies.push(makeRegressionFixStrategy(story, sink) as FixStrategy<Finding, unknown, unknown, unknown>);
+      }
     }
     if (config.quality.autofix?.enabled !== false) {
       // Single-session strategies (tdd-simple / test-after / no-test) have no

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -35,7 +35,7 @@ import {
 } from "../operations";
 import type { DeclarationDiagnostic, TestEditDeclaration } from "../operations";
 import { shouldRunRectification } from "../operations/execution-gates";
-import { makeFullSuiteRectifyStrategy, makeRegressionFixStrategy } from "../operations/full-suite-rectify";
+import { makeFullSuiteRectifyStrategy, makeRepoScopedTestFixStrategy } from "../operations/full-suite-rectify";
 import type { CallContext } from "../operations/types";
 import type { UserStory } from "../prd/types";
 import { resolveTestFilePatterns } from "../test-runners";
@@ -279,7 +279,7 @@ export async function buildPlanForStrategy(
       // not deadlock a story on a finding it cannot fix, so the extra dispatch
       // would buy nothing there.
       if (config.execution.rectification.repoScopedFallback) {
-        strategies.push(makeRegressionFixStrategy(story, sink) as FixStrategy<Finding, unknown, unknown, unknown>);
+        strategies.push(makeRepoScopedTestFixStrategy(story, sink) as FixStrategy<Finding, unknown, unknown, unknown>);
       }
     }
     if (config.quality.autofix?.enabled !== false) {

--- a/src/execution/story-orchestrator/no-progress-bail.ts
+++ b/src/execution/story-orchestrator/no-progress-bail.ts
@@ -4,6 +4,30 @@ import type { Finding, FixStrategy, Iteration } from "@/findings";
 // Uses the coarse recurrence key (not findingKey) so an LLM reviewer rewording
 // the same finding at the same file:line:rule still reads as "no progress"
 // instead of minting a new identity every iteration (nax#1581).
+/**
+ * True when every strategy dispatched in this iteration answered UNRESOLVED —
+ * nothing was attempted, so the working tree cannot have changed (#1654).
+ *
+ * Such an iteration used to terminate the cycle outright, so it could never sit
+ * inside a trailing window. `runFixCycle` now falls through to a repo-scoped
+ * claimant instead, which puts a no-op iteration mid-history. Counting it as
+ * "no progress" is a category error: nothing ran, so the iteration is evidence
+ * of nothing. Left in the window it bails the very cycle the fallthrough exists
+ * to continue — a story already stalled for two iterations would exit at the
+ * give-up and never reach the claimant.
+ *
+ * Carry-forward iterations (`fixesApplied: []`, recorded by review
+ * orchestrators) are NOT exempted: the fix ran outside the cycle, so the
+ * iteration does carry a result.
+ *
+ * `withIncreasingFailuresBail` needs no equivalent guard — its predicate
+ * requires `findingsAfter.length > findingsBefore.length`, which a no-op
+ * iteration cannot satisfy, so it can only suppress that bail, never trigger it.
+ */
+function everyFixDeclined(iteration: Iteration<Finding>): boolean {
+  return iteration.fixesApplied.length > 0 && iteration.fixesApplied.every((fa) => fa.unresolved !== undefined);
+}
+
 function madeNoProgress(iteration: Iteration<Finding>): boolean {
   if (iteration.findingsBefore.length === 0) return false;
   const after = new Set(iteration.findingsAfter.map(findingRecurrenceKey));
@@ -30,8 +54,12 @@ export function withNoProgressBail(
           const userReason = innerBail(iterations);
           if (userReason !== null) return userReason;
         }
-        if (iterations.length >= threshold) {
-          const trailing = iterations.slice(-threshold);
+        // Excluded, not counted as progress: a no-op iteration neither advances
+        // the streak nor resets it — the window closes over the iterations that
+        // actually dispatched something.
+        const attempted = iterations.filter((it) => !everyFixDeclined(it));
+        if (attempted.length >= threshold) {
+          const trailing = attempted.slice(-threshold);
           if (trailing.every(madeNoProgress)) {
             return `no finding resolved for ${threshold} consecutive iteration(s); ${trailing.at(-1)?.findingsBefore.length ?? 0} finding(s) persisted`;
           }

--- a/src/execution/story-orchestrator/types.ts
+++ b/src/execution/story-orchestrator/types.ts
@@ -177,6 +177,22 @@ export const PHASE_KIND_TO_STATE_KEY: Record<PhaseKind, keyof InternalBuildState
   "adversarial-review": "adversarialReview",
 };
 
+/**
+ * Shared by `full-suite-rectify` and `repo-scoped-test-fix` (#1654) — the two
+ * strategies that fix failing tests through `fullSuiteRectifyOp`. Named so the
+ * two cannot drift: they run the same op under the same declaration protocol,
+ * so a phase that goes stale for one goes stale for both.
+ */
+const FULL_SUITE_RECTIFY_REVALIDATION: readonly PhaseKind[] = [
+  "lint-check",
+  "typecheck-check",
+  "full-suite-gate",
+  "verifier",
+  "verify-scoped",
+  "semantic-review",
+  "adversarial-review",
+];
+
 export const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
   // Mechanical fixes are AST-preserving (import-sort, formatting, unused-var removal).
   // They cannot introduce semantic regressions, so only lint-check needs re-running.
@@ -197,15 +213,17 @@ export const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[
   // included because it specifically judges test quality/coverage: rewriting tests is
   // exactly when its prior verdict goes stale, so it must re-run rather than be read as
   // a pre-rectification pass by the post-rectification resume. (Audit #2.)
-  "full-suite-rectify": [
-    "lint-check",
-    "typecheck-check",
-    "full-suite-gate",
-    "verifier",
-    "verify-scoped",
-    "semantic-review",
-    "adversarial-review",
-  ],
+  "full-suite-rectify": FULL_SUITE_RECTIFY_REVALIDATION,
+  // #1654 — the repo-scoped fallthrough claimant for the same failing-test
+  // findings, through the same op and the same test-edit declaration protocol.
+  // It edits a wider set of FILES, but not a different set of PHASES: the
+  // verifier's verdict and both reviews go stale in exactly the same way.
+  //
+  // Declared rather than left to `phasesToRevalidate`'s unknown-strategy
+  // fallback, which returns ALL phases — and "all" includes `test-writer`,
+  // `greenfield-gate`, and `implementer`, so a strategy that only fixed a
+  // failing test would re-run the story's authoring sessions.
+  "repo-scoped-test-fix": FULL_SUITE_RECTIFY_REVALIDATION,
 };
 
 /**

--- a/src/findings/cycle-selection.ts
+++ b/src/findings/cycle-selection.ts
@@ -1,0 +1,86 @@
+/**
+ * runFixCycle — strategy selection and attempt counting.
+ *
+ * Extracted from cycle.ts (600-line source limit) when #1654 added the
+ * remaining-claimant check. These four helpers answer "which strategies run
+ * this iteration, and how many times have they run already?" — pure functions
+ * over the strategy list, findings, and iteration history.
+ *
+ * scope: repo-scoped (pure; no I/O, no config)
+ */
+
+import type { DeclineLedger } from "./cycle-retirement";
+import type { FixStrategy, Iteration } from "./cycle-types";
+import type { Finding } from "./types";
+
+// ─── Strategy selection ──────────────────────────────────────────────────────
+
+export function selectActiveStrategies<F extends Finding>(
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
+  strategies: FixStrategy<F, any, any, any>[],
+  findings: F[],
+  verdict: string | undefined,
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+): FixStrategy<F, any, any, any>[] {
+  if (findings.length > 0) {
+    return strategies.filter((s) => findings.some((f) => s.appliesTo(f)));
+  }
+  if (verdict !== undefined) {
+    return strategies.filter((s) => s.appliesToVerdict?.(verdict) ?? false);
+  }
+  return [];
+}
+
+export function selectExecutionGroup<F extends Finding>(
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
+  active: FixStrategy<F, any, any, any>[],
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+): FixStrategy<F, any, any, any>[] {
+  const exclusive = active.find((s) => !s.coRun || s.coRun === "exclusive");
+  if (exclusive) return [exclusive];
+  return active.filter((s) => s.coRun === "co-run-sequential");
+}
+
+/**
+ * Is there still a strategy that could be dispatched for `findings`?
+ *
+ * Asked only after every strategy in the executed group answered UNRESOLVED
+ * (#1654). Exiting `agent-gave-up` there is correct only when the group was the
+ * last claimant; when another strategy still claims the findings, has not been
+ * retired, and has attempts left, the cycle must dispatch it instead. The
+ * caller has already recorded the give-ups in `ledger`, so the strategies that
+ * just declined are excluded by `isRetiredFor` — this cannot re-select them and
+ * loop forever.
+ *
+ * The attempt check must stay in step with the `uncappedActive` filter at the
+ * top of the loop: a strategy at its cap is skipped there, so treating it as a
+ * viable target here would spin the loop without dispatching anything.
+ */
+export function hasRemainingClaimant<F extends Finding>(
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
+  strategies: readonly FixStrategy<F, any, any, any>[],
+  findings: readonly F[],
+  ledger: DeclineLedger<F>,
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+  attemptsOf: (strategy: FixStrategy<F, any, any, any>) => number,
+): boolean {
+  return strategies.some(
+    (s) => findings.some((f) => s.appliesTo(f)) && !ledger.isRetiredFor(s, findings) && attemptsOf(s) < s.maxAttempts,
+  );
+}
+
+// ─── Attempt counting ────────────────────────────────────────────────────────
+
+export function countStrategyAttempts<F extends Finding>(
+  iterations: readonly Iteration<F>[],
+  strategyName: string,
+): number {
+  return iterations.reduce(
+    (sum, iter) => sum + iter.fixesApplied.filter((fa) => fa.strategyName === strategyName).length,
+    0,
+  );
+}
+
+export function countTotalAttempts<F extends Finding>(iterations: readonly Iteration<F>[]): number {
+  return iterations.reduce((sum, iter) => sum + iter.fixesApplied.length, 0);
+}

--- a/src/findings/cycle-types.ts
+++ b/src/findings/cycle-types.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Operation } from "@/operations/types";
+import type { SessionRole } from "@/runtime/session-role";
 import type { Finding } from "./types";
 
 // ─── Iteration record ────────────────────────────────────────────────────────
@@ -195,6 +196,18 @@ export interface FixStrategy<
 
   /** Per-strategy attempt cap. Counted via fixesApplied[].strategyName. */
   maxAttempts: number;
+
+  /**
+   * Optional session role for this strategy's dispatches (#1654).
+   *
+   * `runFixCycle` forwards it as `CallContext.sessionOverride.role`, which
+   * `callOp` prefers over `op.session.role`. Because session resume is keyed on
+   * the role, a role no other strategy uses yields a session of its own — so two
+   * strategies can share one `fixOp` without sharing its conversation. Set this
+   * when the second dispatch must not inherit the first one's framing; leave it
+   * unset to keep the op's declared role and its normal reuse.
+   */
+  sessionRole?: SessionRole;
 
   /**
    * Co-run discipline. Default (undefined or "exclusive") means this strategy

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -15,6 +15,13 @@ import type { Operation } from "@/operations";
 import { errorMessage } from "@/utils/errors";
 import { recordIteration } from "./cycle-iteration-log";
 import { createDeclineLedger } from "./cycle-retirement";
+import {
+  countStrategyAttempts,
+  countTotalAttempts,
+  hasRemainingClaimant,
+  selectActiveStrategies,
+  selectExecutionGroup,
+} from "./cycle-selection";
 import type {
   FixApplied,
   FixCycle,
@@ -92,47 +99,6 @@ export function classifyOutcome<F extends Finding>(before: F[], after: F[]): Ite
   if (perSource.some((o) => o === "regressed")) return "regressed";
   if (perSource.every((o) => o === "unchanged")) return "unchanged";
   return "partial";
-}
-
-// ─── Strategy selection ───────────────────────────────────────────────────────
-
-function selectActiveStrategies<F extends Finding>(
-  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
-  strategies: FixStrategy<F, any, any, any>[],
-  findings: F[],
-  verdict: string | undefined,
-  // biome-ignore lint/suspicious/noExplicitAny: see above
-): FixStrategy<F, any, any, any>[] {
-  if (findings.length > 0) {
-    return strategies.filter((s) => findings.some((f) => s.appliesTo(f)));
-  }
-  if (verdict !== undefined) {
-    return strategies.filter((s) => s.appliesToVerdict?.(verdict) ?? false);
-  }
-  return [];
-}
-
-function selectExecutionGroup<F extends Finding>(
-  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
-  active: FixStrategy<F, any, any, any>[],
-  // biome-ignore lint/suspicious/noExplicitAny: see above
-): FixStrategy<F, any, any, any>[] {
-  const exclusive = active.find((s) => !s.coRun || s.coRun === "exclusive");
-  if (exclusive) return [exclusive];
-  return active.filter((s) => s.coRun === "co-run-sequential");
-}
-
-// ─── Attempt counting ────────────────────────────────────────────────────────
-
-function countStrategyAttempts<F extends Finding>(iterations: readonly Iteration<F>[], strategyName: string): number {
-  return iterations.reduce(
-    (sum, iter) => sum + iter.fixesApplied.filter((fa) => fa.strategyName === strategyName).length,
-    0,
-  );
-}
-
-function countTotalAttempts<F extends Finding>(iterations: readonly Iteration<F>[]): number {
-  return iterations.reduce((sum, iter) => sum + iter.fixesApplied.length, 0);
 }
 
 // ─── runFixCycle ─────────────────────────────────────────────────────────────
@@ -309,6 +275,11 @@ export async function runFixCycle<F extends Finding>(
       const fixCtx: FixCycleContext = {
         ...ctx,
         fixStrategy: { name: strategy.name, findingsBefore: findingsBefore.length },
+        // #1654: a strategy may run under its own session role, which gives it a
+        // session of its own rather than continuing the one the previous
+        // strategy used. `callOp` resolves `sessionOverride.role ?? op.session.role`,
+        // so this isolates the dispatch without the op having to be duplicated.
+        ...(strategy.sessionRole ? { sessionOverride: { role: strategy.sessionRole } } : {}),
       };
       const output = await doCallOp(fixCtx, strategy.fixOp, input);
       const extracted = await (strategy.extractApplied?.(output, input) ?? {});
@@ -377,6 +348,31 @@ export async function runFixCycle<F extends Finding>(
         // Every other exit accumulates the iteration's spend; this one used to
         // return before doing so, reporting costUsd: 0 for real spend (#1369).
         totalCostUsd += fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
+
+        // #1654: exiting here is right only when this group was the LAST claimant.
+        // Skipping validation stays right either way — nothing touched the tree —
+        // but when another strategy still claims these findings, has attempts
+        // left, and has not itself been retired, the answer to "nothing changed"
+        // is to dispatch that strategy, not to end the cycle. Without this, a
+        // story-scoped rectifier declining a failing test as out-of-scope
+        // deadlocks the story even though a repo-scoped strategy is registered
+        // and willing. `declines` already holds this group's give-ups, so the
+        // strategies that just declined cannot be re-selected and loop forever.
+        const historyAfter: readonly Iteration<F>[] = cycle.priorIterations
+          ? [...cycle.priorIterations, ...cycle.iterations]
+          : cycle.iterations;
+        const remains = hasRemainingClaimant(cycle.strategies, cycle.findings, declines, (s) =>
+          countStrategyAttempts(historyAfter, s.name),
+        );
+        if (remains) {
+          logger?.info("findings.cycle", "group gave up — falling through to a remaining claimant", {
+            ...logCtx,
+            strategyName: firstUnresolved.strategyName,
+            unresolvedDetail: firstUnresolved.unresolved,
+          });
+          continue;
+        }
+
         logger?.info("findings.cycle", "cycle exited — agent gave up", {
           ...logCtx,
           reason: "agent-gave-up",

--- a/src/operations/full-suite-rectify-op.ts
+++ b/src/operations/full-suite-rectify-op.ts
@@ -2,13 +2,22 @@ import { autofixConfigSelector } from "../config";
 import type { AutofixConfig } from "../config/selectors";
 import type { Finding } from "../findings/types";
 import type { UserStory } from "../prd";
-import { RectifierPromptBuilder } from "../prompts";
+import { RectifierPromptBuilder, repoScopedRectification } from "../prompts";
 import { type TestEditDeclaration, parseTestEditDeclarations } from "./test-edit-declaration";
 import type { RunOperation } from "./types";
 
 export interface FullSuiteRectifyInput {
   story: UserStory;
   findings: readonly Finding[];
+  /**
+   * Which mandate to send (#1654). `"story"` (the default) forbids touching
+   * anything outside the story; `"repo"` lifts that for the fallthrough
+   * dispatch after the story-scoped attempt declined the findings as
+   * out-of-scope. Only the prompt differs — the UNRESOLVED protocol and the
+   * declaration parser are shared, which is why this is a field rather than a
+   * second op.
+   */
+  scope?: "story" | "repo";
 }
 
 export interface FullSuiteRectifyOutput {
@@ -24,8 +33,15 @@ export const fullSuiteRectifyOp: RunOperation<FullSuiteRectifyInput, FullSuiteRe
   stage: "rectification",
   session: { role: "implementer", lifetime: "warm" },
   config: autofixConfigSelector,
+  // The repo-scoped dispatch runs under its own session role and gets a single
+  // attempt, so nothing resumes its session — keeping it warm would strand one.
+  // The story-scoped dispatch keeps the op's declared `warm` lifetime.
+  keepOpen: (input) => input.scope !== "repo",
   build(input, _ctx) {
-    const prompt = RectifierPromptBuilder.failingTestRectification(input.findings as Finding[], input.story);
+    const prompt =
+      input.scope === "repo"
+        ? repoScopedRectification(input.findings as Finding[], input.story)
+        : RectifierPromptBuilder.failingTestRectification(input.findings as Finding[], input.story);
     return {
       role: { id: "role", content: "", overridable: false },
       task: { id: "task", content: prompt, overridable: false },

--- a/src/operations/full-suite-rectify.ts
+++ b/src/operations/full-suite-rectify.ts
@@ -106,3 +106,59 @@ export function makeFullSuiteRectifyStrategy(
     coRun: "exclusive",
   };
 }
+
+/**
+ * Factory for the repo-scoped regression-fix strategy (#1654).
+ *
+ * Registered alongside `makeFullSuiteRectifyStrategy` as the fallthrough
+ * claimant for failing tests it declined. Both claim the same findings, but
+ * retirement and attempt caps are keyed on the strategy NAME, so the
+ * story-scoped give-up retires only that strategy and `runFixCycle` dispatches
+ * this one instead of exiting `agent-gave-up`.
+ *
+ * Three deliberate differences from the story-scoped strategy:
+ *   - `buildInput` sets `scope: "repo"`, which swaps the mandate for one that
+ *     permits editing files outside the story (the test-integrity rules and the
+ *     declaration protocol are unchanged — see `repoScopedRectification`).
+ *   - `sessionRole: "regression-fix"` gives the dispatch a session of its own.
+ *     Session resume is keyed on the role, so this does not continue the
+ *     implementer conversation that just answered UNRESOLVED — the agent is not
+ *     asked to reverse a refusal still sitting in its own context, and the
+ *     story-scoped framing that is now wrong does not carry over.
+ *   - `maxAttempts: 1`. This is the last claimant, not another escalation rung:
+ *     if it also gives up, the cycle exits `agent-gave-up` as before.
+ *
+ * Declarations go to the same `sink` as the story-scoped strategy — a test edit
+ * made here is subject to the same downstream handling as any other.
+ */
+export function makeRegressionFixStrategy(
+  story: UserStory,
+  sink: DeclarationSink,
+): FixStrategy<Finding, FullSuiteRectifyInput, FullSuiteRectifyOutput, AutofixConfig> {
+  return {
+    name: "regression-fix",
+    appliesTo: (finding: Finding): boolean =>
+      finding.source === "test-runner" &&
+      (finding.category === "failed-test" || finding.category === "execution-failed"),
+    fixOp: fullSuiteRectifyOp,
+    sessionRole: "regression-fix",
+    buildInput: (findings) => ({ story, findings, scope: "repo" as const }),
+    extractApplied: (output: FullSuiteRectifyOutput) => {
+      for (const d of output.testEditDeclarations) {
+        if (d.reason !== "mock_structure") sink.testEdits.push(d);
+      }
+      // No mock-structure handoff is offered at repo scope (the story's
+      // test-writer does not own tests outside the story), so unlike the
+      // story-scoped strategy there is no declaration that can suppress the
+      // give-up: UNRESOLVED here means the cycle is genuinely done.
+      const unresolved = output.unresolvedReason;
+      return {
+        targetFiles: [],
+        summary: unresolved ?? "Fixed failing tests (repo scope)",
+        ...(unresolved ? { unresolved } : {}),
+      };
+    },
+    maxAttempts: 1,
+    coRun: "exclusive",
+  };
+}

--- a/src/operations/full-suite-rectify.ts
+++ b/src/operations/full-suite-rectify.ts
@@ -108,7 +108,7 @@ export function makeFullSuiteRectifyStrategy(
 }
 
 /**
- * Factory for the repo-scoped regression-fix strategy (#1654).
+ * Factory for the repo-scoped test-fix strategy (#1654).
  *
  * Registered alongside `makeFullSuiteRectifyStrategy` as the fallthrough
  * claimant for failing tests it declined. Both claim the same findings, but
@@ -120,7 +120,7 @@ export function makeFullSuiteRectifyStrategy(
  *   - `buildInput` sets `scope: "repo"`, which swaps the mandate for one that
  *     permits editing files outside the story (the test-integrity rules and the
  *     declaration protocol are unchanged — see `repoScopedRectification`).
- *   - `sessionRole: "regression-fix"` gives the dispatch a session of its own.
+ *   - `sessionRole: "repo-scoped-test-fix"` gives the dispatch a session of its own.
  *     Session resume is keyed on the role, so this does not continue the
  *     implementer conversation that just answered UNRESOLVED — the agent is not
  *     asked to reverse a refusal still sitting in its own context, and the
@@ -131,17 +131,17 @@ export function makeFullSuiteRectifyStrategy(
  * Declarations go to the same `sink` as the story-scoped strategy — a test edit
  * made here is subject to the same downstream handling as any other.
  */
-export function makeRegressionFixStrategy(
+export function makeRepoScopedTestFixStrategy(
   story: UserStory,
   sink: DeclarationSink,
 ): FixStrategy<Finding, FullSuiteRectifyInput, FullSuiteRectifyOutput, AutofixConfig> {
   return {
-    name: "regression-fix",
+    name: "repo-scoped-test-fix",
     appliesTo: (finding: Finding): boolean =>
       finding.source === "test-runner" &&
       (finding.category === "failed-test" || finding.category === "execution-failed"),
     fixOp: fullSuiteRectifyOp,
-    sessionRole: "regression-fix",
+    sessionRole: "repo-scoped-test-fix",
     buildInput: (findings) => ({ story, findings, scope: "repo" as const }),
     extractApplied: (output: FullSuiteRectifyOutput) => {
       for (const d of output.testEditDeclarations) {

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -91,7 +91,7 @@ export type {
   FullSuiteGateStatus,
   FullSuiteGateDeps,
 } from "./full-suite-gate";
-export { makeFullSuiteRectifyStrategy } from "./full-suite-rectify";
+export { makeFullSuiteRectifyStrategy, makeRegressionFixStrategy } from "./full-suite-rectify";
 export { fullSuiteRectifyOp } from "./full-suite-rectify-op";
 export type { FullSuiteRectifyInput, FullSuiteRectifyOutput } from "./full-suite-rectify-op";
 export { makeAutofixImplementerStrategy } from "./autofix-implementer-strategy";

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -91,7 +91,7 @@ export type {
   FullSuiteGateStatus,
   FullSuiteGateDeps,
 } from "./full-suite-gate";
-export { makeFullSuiteRectifyStrategy, makeRegressionFixStrategy } from "./full-suite-rectify";
+export { makeFullSuiteRectifyStrategy, makeRepoScopedTestFixStrategy } from "./full-suite-rectify";
 export { fullSuiteRectifyOp } from "./full-suite-rectify-op";
 export type { FullSuiteRectifyInput, FullSuiteRectifyOutput } from "./full-suite-rectify-op";
 export { makeAutofixImplementerStrategy } from "./autofix-implementer-strategy";

--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -104,6 +104,13 @@ Rules:
 
 interface EscapeHatchOptions {
   includeMockHandoff: boolean;
+  /**
+   * Include Exception 3 (sibling spillover). Defaults to true. The repo-scoped
+   * rectification prompt (#1654) omits it: Exception 3 licenses declining an
+   * out-of-scope failure and continuing, which is the instruction that dispatch
+   * exists to override.
+   */
+  includeSiblingScope?: boolean;
 }
 
 /**
@@ -114,7 +121,8 @@ interface EscapeHatchOptions {
  * The intro count always matches the number of included exceptions.
  */
 export function buildEscapeHatch(opts: EscapeHatchOptions): string {
-  const exceptions: string[] = [EXCEPTION_1_LINT_ONLY, EXCEPTION_2_PRD_CONTRACT, EXCEPTION_3_SIBLING_SCOPE];
+  const exceptions: string[] = [EXCEPTION_1_LINT_ONLY, EXCEPTION_2_PRD_CONTRACT];
+  if (opts.includeSiblingScope !== false) exceptions.push(EXCEPTION_3_SIBLING_SCOPE);
   if (opts.includeMockHandoff) exceptions.push(EXCEPTION_4_MOCK_HANDOFF);
 
   const count = exceptions.length;
@@ -411,4 +419,54 @@ ${errors}
 ${scopeDirective}
 Do NOT add new features — only fix the quality check errors.
 After fixing, re-run the failing check(s) to verify they pass, then commit your changes.${scopeConstraint}${noTestIsolationBlock(story)}${escapeHatchFor(story)}`;
+}
+
+// ─── Repo-scoped rectification (#1654) ────────────────────────────────────────
+
+/**
+ * The mandate for the repo-scoped fallthrough dispatch.
+ *
+ * Reached only after a story-scoped rectifier answered UNRESOLVED on a failing
+ * test it judged out of scope. The story-scoped prompt asks the agent to fix a
+ * test while forbidding it from touching what is broken; UNRESOLVED is the
+ * agent correctly reporting that contradiction. This lifts the scope constraint
+ * and nothing else — an agent free to edit any file is exactly the one that must
+ * still be barred from making a red test green by weakening it.
+ */
+const REPO_SCOPE_MANDATE = `
+These tests are failing, and a previous story-scoped attempt declined them as outside
+this story's scope. That constraint is lifted: you MAY modify any file in the repository,
+including files this story did not otherwise touch, when that is what it takes to make
+these tests pass.
+
+The scope constraint is lifted. The test-integrity rules are NOT:
+- Fix the SOURCE. Never weaken, loosen, delete, or \`skip\` a test to make it pass.
+- Do not edit test files outside the declared exceptions below.
+- Make the smallest change that makes the test pass. This is not a refactor.
+- Re-run the test suite after each change to verify.
+
+If a test does not fail consistently, do NOT try to make it pass. Re-run it a few
+times in isolation first. A test that passes on some runs is flaky, and editing it to
+be green hides a real defect — emit UNRESOLVED naming the test and say it is flaky.
+
+"It was not caused by this story" is not a reason to decline. Whether the failure
+predates this story or was introduced by it, the remedy is the same and it is yours to
+apply. Emit UNRESOLVED only when these tests cannot be made to pass at all — they
+contradict each other, or they require infrastructure that does not exist and cannot be
+created here. Say which, specifically.`;
+
+/**
+ * Build the repo-scoped failing-test rectification prompt.
+ *
+ * Drops Exception 3 (sibling spillover) — it instructs the agent to declare
+ * `sibling_scope` and move on, which re-licenses the refusal this dispatch
+ * responds to — and Exception 4 (mock-structure handoff), whose target is the
+ * story's own test-writer and does not own tests outside the story.
+ */
+export function repoScopedRectification(findings: Finding[], story: UserStory): string {
+  if (implementerOwnsTests(story)) {
+    return [formatFailingTestsList(findings), REPO_SCOPE_MANDATE, SINGLE_SESSION_TEST_EDIT_POLICY].join("\n");
+  }
+  const hatch = buildEscapeHatch({ includeMockHandoff: false, includeSiblingScope: false });
+  return [formatFailingTestsList(findings), REPO_SCOPE_MANDATE, hatch].join("\n");
 }

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -41,6 +41,7 @@ export { fenceLangFor, formatTestOutputForFix } from "./builders/acceptance-buil
 
 // Rectifier prompt builder — cross-domain rectification for TDD, verify, and review triggers.
 export { RectifierPromptBuilder, CONTRADICTION_ESCAPE_HATCH } from "./builders/rectifier-builder";
+export { repoScopedRectification } from "./builders/rectifier-builder-helpers";
 export type { RectifierTrigger, FailureRecord, ReviewFinding } from "./builders/rectifier-builder";
 
 // Timeout-retry prompt builder — informed retry prompt conditioned on whether the

--- a/src/runtime/session-role.ts
+++ b/src/runtime/session-role.ts
@@ -10,6 +10,7 @@ export type CanonicalSessionRole =
   | "main"
   | "test-writer"
   | "implementer"
+  | "regression-fix"
   | "verifier"
   | "diagnose"
   | "source-fix"
@@ -41,6 +42,7 @@ export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
   "main",
   "test-writer",
   "implementer",
+  "regression-fix",
   "verifier",
   "diagnose",
   "source-fix",

--- a/src/runtime/session-role.ts
+++ b/src/runtime/session-role.ts
@@ -10,7 +10,7 @@ export type CanonicalSessionRole =
   | "main"
   | "test-writer"
   | "implementer"
-  | "regression-fix"
+  | "repo-scoped-test-fix"
   | "verifier"
   | "diagnose"
   | "source-fix"
@@ -42,7 +42,7 @@ export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
   "main",
   "test-writer",
   "implementer",
-  "regression-fix",
+  "repo-scoped-test-fix",
   "verifier",
   "diagnose",
   "source-fix",

--- a/test/e2e/exhaustion-edge.e2e.test.ts
+++ b/test/e2e/exhaustion-edge.e2e.test.ts
@@ -230,12 +230,18 @@ describe("E2E: exhaustion + edge", () => {
   });
 
   test("implementer UNRESOLVED on full-suite-rectify → agent-gave-up exhaustion carries unresolvedDetail (US-002)", async () => {
-    // The full-suite gate fails with a test-runner finding → full-suite-rectify is the
-    // sole matching strategy. On the rectification turn the implementer emits an
-    // `UNRESOLVED:` sentinel (the AC5/AC6 relative-URL contradiction). fullSuiteRectifyOp
-    // parses it → extractApplied returns { unresolved } (no test-edit declarations, so the
-    // declaration-priority guard does not suppress it) → the cycle exits "agent-gave-up"
-    // in round 1, threading unresolvedDetail through to StoryOrchestratorResult.
+    // The full-suite gate fails with a test-runner finding → full-suite-rectify claims it.
+    // On the rectification turn the implementer emits an `UNRESOLVED:` sentinel (the
+    // AC5/AC6 relative-URL contradiction). fullSuiteRectifyOp parses it → extractApplied
+    // returns { unresolved } (no test-edit declarations, so the declaration-priority guard
+    // does not suppress it).
+    //
+    // Since #1654 that give-up no longer ends the cycle on its own: `repo-scoped-test-fix`
+    // still claims the finding, so the cycle falls through to it. Here it ALSO gives up —
+    // the AC5/AC6 contradiction is genuinely unsatisfiable, repo scope or not — and only
+    // then, with no claimant left, does the cycle exit "agent-gave-up". `unresolvedDetail`
+    // carries the LAST refusal: the first one ("out of scope") has been superseded, and the
+    // terminal reason is what the escalated tier needs.
     //
     // This exercises the REAL producer→result chain (parse → extractApplied → cycle →
     // rectification spread → execution-plan), complementing the post-run unit test which
@@ -243,6 +249,7 @@ describe("E2E: exhaustion + edge", () => {
     // ran extra rounds, and the diagnosis never surfaced.
     const UNRESOLVED_REASON =
       "AC5/AC6 pass relative loginUrl '/login' to OAuthModule.registerAsync; the library rejects relative URLs (new URL('/login') throws)";
+    const REPO_SCOPED_REASON = "even with repo scope, AC5 and AC6 cannot both hold";
     const tw = () => ({ output: JSON.stringify({ filesChanged: ["test/a.test.ts"] }) });
     const verifier = () => ({ output: PASSING_VERDICT });
     // Per-role attempt counter: attempt 0 = main implementer phase (normal output);
@@ -258,6 +265,7 @@ describe("E2E: exhaustion + edge", () => {
         "test-writer": tw,
         implementer,
         verifier,
+        "repo-scoped-test-fix": () => ({ output: `UNRESOLVED: ${REPO_SCOPED_REASON}` }),
         "reviewer-semantic": PASS_REVIEW,
         "reviewer-adversarial": PASS_REVIEW,
       },
@@ -275,7 +283,7 @@ describe("E2E: exhaustion + edge", () => {
 
     expect(result.success).toBe(false);
     expect(result.rectificationExhausted).toBe(true);
-    // The implementer's diagnosis is threaded through verbatim so the escalated tier knows why.
-    expect(result.unresolvedDetail).toBe(UNRESOLVED_REASON);
+    // The diagnosis is threaded through verbatim so the escalated tier knows why.
+    expect(result.unresolvedDetail).toBe(REPO_SCOPED_REASON);
   });
 });

--- a/test/e2e/full-suite-rectify.e2e.test.ts
+++ b/test/e2e/full-suite-rectify.e2e.test.ts
@@ -102,3 +102,89 @@ describe("E2E: full-suite-rectify (success path)", () => {
     expect(result.rectificationExhausted).toBe(true);
   });
 });
+
+// ─── #1654: give-up falls through to the repo-scoped claimant ────────────────
+//
+// The deadlock this fixes: a test that is red for reasons outside the story is
+// handed to a rectifier whose mandate forbids touching what is broken, so it
+// answers UNRESOLVED, the cycle exits `agent-gave-up`, and every story in the
+// package hits the same wall. These lock the end-to-end route from that refusal
+// to a dispatch that is actually allowed to fix it.
+
+describe("E2E: repo-scoped test fix (#1654)", () => {
+  const verifier = () => ({ output: PASSING_VERDICT });
+  /** Story-scoped rectifier: declines the failing test as out of this story's scope. */
+  const decliningImplementer = (attempt: number) =>
+    attempt === 0
+      ? { output: JSON.stringify({ filesChanged: ["src/a.ts"] }) }
+      : { output: "UNRESOLVED: test/legacy/auth.spec.ts is outside this story's scope" };
+
+  test("dispatches repo-scoped-test-fix after the story-scoped rectifier declines", async () => {
+    let repoScopedDispatched = false;
+    const { result } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      agent: {
+        "test-writer": tw,
+        implementer: decliningImplementer,
+        verifier,
+        "repo-scoped-test-fix": () => {
+          repoScopedDispatched = true;
+          return { output: JSON.stringify({ filesChanged: ["src/legacy/auth.ts"] }) };
+        },
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+      // Red before the repo-scoped fix, green after it — the shape of a
+      // pre-existing failure nobody in story scope was allowed to touch.
+      gates: {
+        fullSuite: (attempt: number) =>
+          repoScopedDispatched
+            ? { passed: true, failed: 0 }
+            : {
+                passed: false,
+                failed: 1,
+                output: `attempt ${attempt}: legacy auth spec red`,
+                failures: [{ testName: "redirects to login", file: "test/legacy/auth.spec.ts", error: "Invalid URL" }],
+              },
+      },
+    });
+
+    // The dispatch is the discriminating assertion: before #1654 the cycle exited
+    // `agent-gave-up` at the refusal and this role was never opened.
+    expect(repoScopedDispatched).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  test("repoScopedFallback: false restores the deadlock", async () => {
+    // Same scenario with the gate off — proves the dispatch above is what changed,
+    // and that the escape hatch actually reaches the strategy registration.
+    let repoScopedDispatched = false;
+    const { result } = await runOrchestratorE2E({
+      strategy: "three-session-tdd",
+      config: { execution: { rectification: { repoScopedFallback: false } } } as Partial<NaxConfig>,
+      agent: {
+        "test-writer": tw,
+        implementer: decliningImplementer,
+        verifier,
+        "repo-scoped-test-fix": () => {
+          repoScopedDispatched = true;
+          return { output: JSON.stringify({ filesChanged: ["src/legacy/auth.ts"] }) };
+        },
+        "reviewer-semantic": PASS_REVIEW,
+        "reviewer-adversarial": PASS_REVIEW,
+      },
+      gates: {
+        fullSuite: () => ({
+          passed: false,
+          failed: 1,
+          output: "legacy auth spec red",
+          failures: [{ testName: "redirects to login", file: "test/legacy/auth.spec.ts", error: "Invalid URL" }],
+        }),
+      },
+    });
+
+    expect(repoScopedDispatched).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.rectificationExhausted).toBe(true);
+  });
+});

--- a/test/unit/execution/build-plan-for-strategy-fix-assembly.test.ts
+++ b/test/unit/execution/build-plan-for-strategy-fix-assembly.test.ts
@@ -203,6 +203,40 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     });
     const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     await plan.run();
+    // #1654 registers the repo-scoped fallthrough alongside the story-scoped
+    // strategy, and the ORDER is load-bearing: selectExecutionGroup takes the
+    // first exclusive claimant, so the scoped strategy must be tried first and
+    // the fallthrough reached only after it declines.
+    expect(capturedStrategyNames).toEqual(["full-suite-rectify", "regression-fix"]);
+  });
+
+  test("#1654: repoScopedFallback: false leaves the story-scoped strategy alone", async () => {
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "verify-scoped") {
+        return {
+          success: false,
+          findings: [
+            { source: "test-runner", severity: "error", category: "failed-test", message: "scoped test failed" },
+          ],
+        };
+      }
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const story = makeStory();
+    const config = makeNaxConfig({
+      quality: { commands: {}, autofix: { enabled: false } },
+      execution: {
+        rectification: { enabled: true, maxAttemptsTotal: 2, repoScopedFallback: false },
+      },
+    });
+    const ctx = makeCtxWithRuntime(config);
+    const inputs = makeNonTddInputs(story, {
+      verifyScoped: { workdir: "/tmp/test", storyId: story.id },
+      rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+    });
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    await plan.run();
     expect(capturedStrategyNames).toEqual(["full-suite-rectify"]);
   });
 

--- a/test/unit/execution/build-plan-for-strategy-fix-assembly.test.ts
+++ b/test/unit/execution/build-plan-for-strategy-fix-assembly.test.ts
@@ -207,7 +207,7 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     // strategy, and the ORDER is load-bearing: selectExecutionGroup takes the
     // first exclusive claimant, so the scoped strategy must be tried first and
     // the fallthrough reached only after it declines.
-    expect(capturedStrategyNames).toEqual(["full-suite-rectify", "regression-fix"]);
+    expect(capturedStrategyNames).toEqual(["full-suite-rectify", "repo-scoped-test-fix"]);
   });
 
   test("#1654: repoScopedFallback: false leaves the story-scoped strategy alone", async () => {

--- a/test/unit/execution/story-orchestrator-no-progress-bail.test.ts
+++ b/test/unit/execution/story-orchestrator-no-progress-bail.test.ts
@@ -57,6 +57,16 @@ function stalledIterations(findings: Finding[], count: number): Iteration<Findin
   return Array.from({ length: count }, (_, index) => iteration(findings, findings, index + 1));
 }
 
+/** An iteration in which every dispatched strategy answered UNRESOLVED — nothing ran. */
+function declinedIteration(findings: Finding[], iterationNum: number): Iteration<Finding> {
+  return {
+    ...iteration(findings, findings, iterationNum),
+    fixesApplied: [
+      { strategyName: "full-suite-rectify", op: "noop", targetFiles: [], summary: "", unresolved: "out of scope" },
+    ],
+  };
+}
+
 describe("withNoProgressBail — US-002", () => {
   test("US-002 AC1: returns a reason for three identical trailing iterations", () => {
     const same = finding("same");
@@ -285,5 +295,46 @@ describe("withNoProgressBail — US-002 AC-2.9/AC-2.10: driven through runRectif
     await runtime.close();
 
     expect(dispatches()).toBeGreaterThan(3);
+  });
+});
+
+// ─── Declined iterations are not evidence of no progress (#1654) ─────────────
+//
+// Before #1654 an all-declined iteration always terminated the cycle, so it
+// could never sit inside a trailing window. Now the cycle falls through to a
+// repo-scoped claimant instead, which put a fake no-progress signal in the
+// window: nothing was dispatched, so "no finding resolved" is trivially true
+// and says nothing about whether progress is possible. Left unhandled, a story
+// already stalled for two iterations bails at the give-up and the fallthrough
+// claimant — the whole point of #1654 — never runs.
+
+describe("withNoProgressBail — declined iterations (#1654)", () => {
+  test("does not count an all-declined iteration toward the no-progress streak", () => {
+    const same = finding("same");
+    const bail = bailWhen(withNoProgressBail([strategy()], true, 3));
+    const iterations = [...stalledIterations([same], 2), declinedIteration([same], 3)];
+    expect(bail(iterations)).toBeNull();
+  });
+
+  test("still bails once real attempts fill the window again", () => {
+    // The exemption must not disable the bail — an all-declined iteration is
+    // skipped, not credited as progress.
+    const same = finding("same");
+    const bail = bailWhen(withNoProgressBail([strategy()], true, 3));
+    const iterations = [...stalledIterations([same], 2), declinedIteration([same], 3), iteration([same], [same], 4)];
+    expect(bail(iterations)).not.toBeNull();
+  });
+
+  test("a partially-declined iteration still counts — a sibling did run", () => {
+    const same = finding("same");
+    const partial: Iteration<Finding> = {
+      ...iteration([same], [same], 3),
+      fixesApplied: [
+        { strategyName: "full-suite-rectify", op: "noop", targetFiles: [], summary: "", unresolved: "out of scope" },
+        { strategyName: "autofix-test-writer", op: "noop", targetFiles: [], summary: "wrote a test" },
+      ],
+    };
+    const bail = bailWhen(withNoProgressBail([strategy()], true, 3));
+    expect(bail([...stalledIterations([same], 2), partial])).not.toBeNull();
   });
 });

--- a/test/unit/execution/story-orchestrator-revalidation-repo-scope.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation-repo-scope.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Revalidation routing for the repo-scoped test-fix strategy (#1654).
+ *
+ * `phasesToRevalidate` falls back to re-running EVERY phase when it meets a
+ * strategy name absent from `STRATEGY_TO_REVALIDATION_PHASES`. That fallback is
+ * safe by design but wrong here: "every phase" includes `test-writer` and
+ * `implementer`, so a strategy that merely fixed a failing test would re-run the
+ * story's authoring sessions. The mapping has to be declared, not inherited.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { phasesToRevalidate } from "@/execution";
+import type { PhaseKind } from "@/execution";
+import { STRATEGY_TO_REVALIDATION_PHASES } from "@/execution/story-orchestrator";
+
+const ALL_PHASE_KINDS: PhaseKind[] = [
+  "test-writer",
+  "greenfield-gate",
+  "implementer",
+  "test-presence-gate",
+  "full-suite-gate",
+  "mutation-check",
+  "verifier",
+  "verify-scoped",
+  "lint-check",
+  "typecheck-check",
+  "semantic-review",
+  "adversarial-review",
+];
+
+// biome-ignore lint/suspicious/noExplicitAny: only `kind` is read by phasesToRevalidate
+const allPhases = ALL_PHASE_KINDS.map((kind) => ({ kind }) as any);
+
+describe("repo-scoped-test-fix revalidation mapping (#1654)", () => {
+  test("is declared in the SSOT map, not left to the unknown-strategy fallback", () => {
+    expect(STRATEGY_TO_REVALIDATION_PHASES["repo-scoped-test-fix"]).toBeDefined();
+  });
+
+  test("re-runs the same phases as full-suite-rectify", () => {
+    // It fixes failing tests through the same op and may edit tests via the same
+    // declaration protocol, so the verifier and both reviews go stale in exactly
+    // the same way. A wider file scope does not change which phases are affected.
+    expect(STRATEGY_TO_REVALIDATION_PHASES["repo-scoped-test-fix"]).toEqual(
+      STRATEGY_TO_REVALIDATION_PHASES["full-suite-rectify"],
+    );
+  });
+
+  test("does not re-run the story's authoring phases", () => {
+    const kinds = phasesToRevalidate(["repo-scoped-test-fix"], allPhases).map((p) => p.kind);
+    expect(kinds).not.toContain("test-writer");
+    expect(kinds).not.toContain("implementer");
+    expect(kinds).not.toContain("greenfield-gate");
+  });
+
+  test("re-runs the gate that produced the finding", () => {
+    const kinds = phasesToRevalidate(["repo-scoped-test-fix"], allPhases).map((p) => p.kind);
+    expect(kinds).toContain("full-suite-gate");
+  });
+
+  test("co-running with full-suite-rectify does not widen the set", () => {
+    const solo = phasesToRevalidate(["repo-scoped-test-fix"], allPhases).map((p) => p.kind);
+    const both = phasesToRevalidate(["full-suite-rectify", "repo-scoped-test-fix"], allPhases).map((p) => p.kind);
+    expect(both).toEqual(solo);
+  });
+});

--- a/test/unit/findings/_cycle-fixtures.ts
+++ b/test/unit/findings/_cycle-fixtures.ts
@@ -9,6 +9,7 @@
  */
 
 import { mock } from "bun:test";
+import type { CallOpFn } from "@/findings/cycle";
 import type { FixCycle, FixCycleContext, FixStrategy } from "@/findings";
 import type { Finding } from "@/findings";
 import { makeMockAgentManager, makeNaxConfig } from "@test/helpers";
@@ -79,4 +80,23 @@ export function makeCycle(
 
 export function makeCallOpMock(returnValue: unknown = {}): ReturnType<typeof mock> {
   return mock(async () => returnValue);
+}
+
+/**
+ * Typed `callOp` stub that records each dispatch's context and input.
+ *
+ * Prefer this over `makeCallOpMock()` in new tests: it satisfies `CallOpFn`
+ * directly, so call sites need no type assertion at all, and the
+ * recorded `ctx` is readable without reaching into bun's mock internals.
+ */
+export function makeCallOpSpy(returnValue: unknown = {}): {
+  fn: CallOpFn;
+  calls: Array<{ ctx: FixCycleContext; opName: string; input: unknown }>;
+} {
+  const calls: Array<{ ctx: FixCycleContext; opName: string; input: unknown }> = [];
+  const fn: CallOpFn = async (ctx, op, input) => {
+    calls.push({ ctx, opName: op.name, input });
+    return returnValue as never;
+  };
+  return { fn, calls };
 }

--- a/test/unit/findings/cycle-retirement.test.ts
+++ b/test/unit/findings/cycle-retirement.test.ts
@@ -313,11 +313,11 @@ describe("runFixCycle — give-up falls through to a remaining claimant (#1654)"
     const dispatched: string[] = [];
     const cycle = makeCycle(
       [lintA],
-      [scoped("full-suite-rectify", dispatched), unscoped("regression-fix", dispatched)],
+      [scoped("full-suite-rectify", dispatched), unscoped("repo-scoped-test-fix", dispatched)],
       async () => [],
     );
     const r = await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
-    expect(dispatched).toEqual(["full-suite-rectify", "regression-fix"]);
+    expect(dispatched).toEqual(["full-suite-rectify", "repo-scoped-test-fix"]);
     expect(r.exitReason).toBe("resolved");
   });
 
@@ -329,7 +329,7 @@ describe("runFixCycle — give-up falls through to a remaining claimant (#1654)"
     const dispatched: string[] = [];
     const cycle = makeCycle(
       [lintA],
-      [scoped("full-suite-rectify", dispatched), unscoped("regression-fix", dispatched)],
+      [scoped("full-suite-rectify", dispatched), unscoped("repo-scoped-test-fix", dispatched)],
       async () => {
         validateCallsBeforeFallthrough.push([...dispatched]);
         return [];
@@ -337,18 +337,18 @@ describe("runFixCycle — give-up falls through to a remaining claimant (#1654)"
     );
     await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
     // Exactly one validate, and it happened only after BOTH strategies ran.
-    expect(validateCallsBeforeFallthrough).toEqual([["full-suite-rectify", "regression-fix"]]);
+    expect(validateCallsBeforeFallthrough).toEqual([["full-suite-rectify", "repo-scoped-test-fix"]]);
   });
 
   test("exits agent-gave-up when the fallthrough claimant also gives up", async () => {
     const dispatched: string[] = [];
     const cycle = makeCycle(
       [lintA],
-      [scoped("full-suite-rectify", dispatched), unscoped("regression-fix", dispatched, "cannot fix this either")],
+      [scoped("full-suite-rectify", dispatched), unscoped("repo-scoped-test-fix", dispatched, "cannot fix this either")],
       async () => [lintA],
     );
     const r = await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
-    expect(dispatched).toEqual(["full-suite-rectify", "regression-fix"]);
+    expect(dispatched).toEqual(["full-suite-rectify", "repo-scoped-test-fix"]);
     expect(r.exitReason).toBe("agent-gave-up");
     expect(r.unresolvedDetail).toBe("cannot fix this either");
   });
@@ -358,11 +358,11 @@ describe("runFixCycle — give-up falls through to a remaining claimant (#1654)"
     // correct, and must not be turned into an infinite loop by the new check.
     const dispatched: string[] = [];
     const exhausted = makeStrategy({
-      name: "regression-fix",
+      name: "repo-scoped-test-fix",
       coRun: "exclusive",
       maxAttempts: 0,
       extractApplied: () => {
-        dispatched.push("regression-fix");
+        dispatched.push("repo-scoped-test-fix");
         return { summary: "" };
       },
     });
@@ -375,12 +375,12 @@ describe("runFixCycle — give-up falls through to a remaining claimant (#1654)"
   test("still exits agent-gave-up when the remaining claimant does not claim the findings", async () => {
     const dispatched: string[] = [];
     const otherSource = makeStrategy({
-      name: "regression-fix",
+      name: "repo-scoped-test-fix",
       coRun: "exclusive",
       maxAttempts: 1,
       appliesTo: (f: Finding) => f.source === "typecheck",
       extractApplied: () => {
-        dispatched.push("regression-fix");
+        dispatched.push("repo-scoped-test-fix");
         return { summary: "" };
       },
     });
@@ -398,11 +398,11 @@ describe("runFixCycle — strategy.sessionRole isolates the dispatch session", (
     const spy = makeCallOpSpy();
     const cycle = makeCycle(
       [lintA],
-      [makeStrategy({ name: "regression-fix", coRun: "exclusive", sessionRole: "regression-fix" })],
+      [makeStrategy({ name: "repo-scoped-test-fix", coRun: "exclusive", sessionRole: "repo-scoped-test-fix" })],
       async () => [],
     );
     await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: spy.fn });
-    expect(spy.calls[0]?.ctx.sessionOverride?.role).toBe("regression-fix");
+    expect(spy.calls[0]?.ctx.sessionOverride?.role).toBe("repo-scoped-test-fix");
   });
 
   test("leaves sessionOverride unset for a strategy that declares no sessionRole", async () => {

--- a/test/unit/findings/cycle-retirement.test.ts
+++ b/test/unit/findings/cycle-retirement.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, test } from "bun:test";
 import type { CallOpFn } from "@/findings/cycle";
 import { runFixCycle } from "@/findings";
 import type { Finding } from "@/findings";
-import { lintA, lintB, makeCallOpMock, makeCtx, makeCycle, makeFinding, makeStrategy, typecheckC } from "./_cycle-fixtures";
+import { lintA, lintB, makeCallOpMock, makeCallOpSpy, makeCtx, makeCycle, makeFinding, makeStrategy, typecheckC } from "./_cycle-fixtures";
 
 // ─── runFixCycle — partial give-up in a co-run group (#1369) ─────────────────
 
@@ -269,5 +269,146 @@ describe("runFixCycle — verdict-driven dispatch", () => {
     expect(r.exitReason).toBe("resolved");
     expect(cycle.iterations).toHaveLength(1);
     expect(dispatched.filter((n) => n === "acceptance-source-fix")).toHaveLength(1);
+  });
+});
+
+// ─── runFixCycle — fall through to a later claimant instead of exiting ────────
+//
+// #1654. When every strategy in the dispatched group answers UNRESOLVED, the
+// cycle used to return `agent-gave-up` immediately. That is right only when the
+// group was the last claimant: nothing touched the tree, so revalidating would
+// burn a full suite run to learn nothing. It is wrong when another, NOT-yet-
+// retired strategy still claims the findings — the correct response to "nothing
+// changed" is to dispatch the next claimant, not to end the cycle.
+//
+// This is what lets a story-scoped rectifier decline a failing test as
+// out-of-scope and hand it to a repo-scoped one, rather than deadlocking the
+// story and burning the escalation ladder on a test it was forbidden to touch.
+
+describe("runFixCycle — give-up falls through to a remaining claimant (#1654)", () => {
+  /** Exclusive strategy that always answers UNRESOLVED. */
+  const scoped = (name: string, dispatched: string[]) =>
+    makeStrategy({
+      name,
+      coRun: "exclusive",
+      maxAttempts: 3,
+      extractApplied: () => {
+        dispatched.push(name);
+        return { summary: "", unresolved: "outside this story's scope" };
+      },
+    });
+  /** Exclusive strategy that completes normally. */
+  const unscoped = (name: string, dispatched: string[], unresolved?: string) =>
+    makeStrategy({
+      name,
+      coRun: "exclusive",
+      maxAttempts: 1,
+      extractApplied: () => {
+        dispatched.push(name);
+        return { summary: "", ...(unresolved ? { unresolved } : {}) };
+      },
+    });
+
+  test("dispatches the next claimant rather than exiting agent-gave-up", async () => {
+    const dispatched: string[] = [];
+    const cycle = makeCycle(
+      [lintA],
+      [scoped("full-suite-rectify", dispatched), unscoped("regression-fix", dispatched)],
+      async () => [],
+    );
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
+    expect(dispatched).toEqual(["full-suite-rectify", "regression-fix"]);
+    expect(r.exitReason).toBe("resolved");
+  });
+
+  test("does not validate between the give-up and the fallthrough dispatch", async () => {
+    // The early return existed to avoid a pointless suite run. Falling through
+    // must not reintroduce one: nothing touched the tree, so there is still
+    // nothing to observe until the next claimant has actually run.
+    const validateCallsBeforeFallthrough: string[][] = [];
+    const dispatched: string[] = [];
+    const cycle = makeCycle(
+      [lintA],
+      [scoped("full-suite-rectify", dispatched), unscoped("regression-fix", dispatched)],
+      async () => {
+        validateCallsBeforeFallthrough.push([...dispatched]);
+        return [];
+      },
+    );
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
+    // Exactly one validate, and it happened only after BOTH strategies ran.
+    expect(validateCallsBeforeFallthrough).toEqual([["full-suite-rectify", "regression-fix"]]);
+  });
+
+  test("exits agent-gave-up when the fallthrough claimant also gives up", async () => {
+    const dispatched: string[] = [];
+    const cycle = makeCycle(
+      [lintA],
+      [scoped("full-suite-rectify", dispatched), unscoped("regression-fix", dispatched, "cannot fix this either")],
+      async () => [lintA],
+    );
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
+    expect(dispatched).toEqual(["full-suite-rectify", "regression-fix"]);
+    expect(r.exitReason).toBe("agent-gave-up");
+    expect(r.unresolvedDetail).toBe("cannot fix this either");
+  });
+
+  test("still exits agent-gave-up when the remaining claimant is exhausted", async () => {
+    // A strategy at its cap is not a viable fallthrough target — exiting is
+    // correct, and must not be turned into an infinite loop by the new check.
+    const dispatched: string[] = [];
+    const exhausted = makeStrategy({
+      name: "regression-fix",
+      coRun: "exclusive",
+      maxAttempts: 0,
+      extractApplied: () => {
+        dispatched.push("regression-fix");
+        return { summary: "" };
+      },
+    });
+    const cycle = makeCycle([lintA], [scoped("full-suite-rectify", dispatched), exhausted], async () => [lintA]);
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
+    expect(dispatched).toEqual(["full-suite-rectify"]);
+    expect(r.exitReason).toBe("agent-gave-up");
+  });
+
+  test("still exits agent-gave-up when the remaining claimant does not claim the findings", async () => {
+    const dispatched: string[] = [];
+    const otherSource = makeStrategy({
+      name: "regression-fix",
+      coRun: "exclusive",
+      maxAttempts: 1,
+      appliesTo: (f: Finding) => f.source === "typecheck",
+      extractApplied: () => {
+        dispatched.push("regression-fix");
+        return { summary: "" };
+      },
+    });
+    const cycle = makeCycle([lintA], [scoped("full-suite-rectify", dispatched), otherSource], async () => [lintA]);
+    const r = await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: makeCallOpSpy().fn });
+    expect(dispatched).toEqual(["full-suite-rectify"]);
+    expect(r.exitReason).toBe("agent-gave-up");
+  });
+});
+
+// ─── runFixCycle — per-strategy session isolation (#1654) ────────────────────
+
+describe("runFixCycle — strategy.sessionRole isolates the dispatch session", () => {
+  test("forwards sessionRole onto the call context as a sessionOverride", async () => {
+    const spy = makeCallOpSpy();
+    const cycle = makeCycle(
+      [lintA],
+      [makeStrategy({ name: "regression-fix", coRun: "exclusive", sessionRole: "regression-fix" })],
+      async () => [],
+    );
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: spy.fn });
+    expect(spy.calls[0]?.ctx.sessionOverride?.role).toBe("regression-fix");
+  });
+
+  test("leaves sessionOverride unset for a strategy that declares no sessionRole", async () => {
+    const spy = makeCallOpSpy();
+    const cycle = makeCycle([lintA], [makeStrategy({ name: "full-suite-rectify", coRun: "exclusive" })], async () => []);
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { callOp: spy.fn });
+    expect(spy.calls[0]?.ctx.sessionOverride).toBeUndefined();
   });
 });

--- a/test/unit/operations/full-suite-rectify-op.test.ts
+++ b/test/unit/operations/full-suite-rectify-op.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { fullSuiteRectifyOp } from "@/operations";
-import { RectifierPromptBuilder } from "@/prompts";
+import { RectifierPromptBuilder, repoScopedRectification } from "@/prompts";
 import type { Finding } from "@/findings/types";
 import { makeStory } from "@test/helpers";
 
@@ -107,5 +107,49 @@ UNRESOLVED: AC6 cannot be satisfied without changing the assertion.`;
     const result = fullSuiteRectifyOp.parse(output, input, ctx);
     expect(result.testEditDeclarations).toHaveLength(1);
     expect(result.unresolvedReason).toBe("AC6 cannot be satisfied without changing the assertion.");
+  });
+});
+
+// ─── Repo-scoped dispatch (#1654) ────────────────────────────────────────────
+//
+// The same op serves both the story-scoped rectifier and the repo-scoped
+// regression fixer; only the mandate differs. Sharing the op keeps one
+// UNRESOLVED protocol and one declaration parser across both dispatches.
+
+describe("fullSuiteRectifyOp.build — scope: 'repo'", () => {
+  test("uses the repo-scoped mandate, not the story-scoped one", () => {
+    const result = fullSuiteRectifyOp.build({ story, findings: [finding], scope: "repo" }, ctx);
+    expect(result.task.content).toBe(repoScopedRectification([finding], story));
+    expect(result.task.content).not.toBe(RectifierPromptBuilder.failingTestRectification([finding], story));
+  });
+
+  test("omitting scope keeps the story-scoped prompt byte-identical", () => {
+    const withoutScope = fullSuiteRectifyOp.build({ story, findings: [finding] }, ctx);
+    const withStoryScope = fullSuiteRectifyOp.build({ story, findings: [finding], scope: "story" }, ctx);
+    const expected = RectifierPromptBuilder.failingTestRectification([finding], story);
+    expect(withoutScope.task.content).toBe(expected);
+    expect(withStoryScope.task.content).toBe(expected);
+  });
+
+  test("still carries the test-edit declaration protocol", () => {
+    // Lifting the scope constraint must not lift the test-integrity rules — an
+    // agent free to touch any file is exactly the one that must not be free to
+    // delete the failing assertion.
+    const result = fullSuiteRectifyOp.build({ story, findings: [finding], scope: "repo" }, ctx);
+    expect(result.task.content).toContain("TEST_EDIT_REASON");
+  });
+});
+
+describe("fullSuiteRectifyOp.keepOpen — scope: 'repo'", () => {
+  test("repo scope does not keep the session open", () => {
+    // The repo-scoped dispatch runs under its own session role and gets one
+    // attempt; leaving it warm would strand a session nothing resumes.
+    // biome-ignore lint/suspicious/noExplicitAny: buildCtx stub for a resolver that ignores it
+    expect(fullSuiteRectifyOp.keepOpen?.({ story, findings: [finding], scope: "repo" }, {} as any)).toBe(false);
+  });
+
+  test("story scope keeps the warm session the op declares", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: buildCtx stub for a resolver that ignores it
+    expect(fullSuiteRectifyOp.keepOpen?.({ story, findings: [finding] }, {} as any)).toBe(true);
   });
 });

--- a/test/unit/operations/full-suite-rectify.test.ts
+++ b/test/unit/operations/full-suite-rectify.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   makeFullSuiteRectifyStrategy,
-  makeRegressionFixStrategy,
+  makeRepoScopedTestFixStrategy,
   fullSuiteRectifyOp,
   makeDeclarationSink,
 } from "@/operations";
@@ -285,21 +285,21 @@ describe("makeFullSuiteRectifyStrategy — mock_structure handoff short-circuit 
   });
 });
 
-// ─── makeRegressionFixStrategy (#1654) ───────────────────────────────────────
+// ─── makeRepoScopedTestFixStrategy (#1654) ───────────────────────────────────────
 //
 // The fallthrough claimant for failing tests the story-scoped rectifier
 // declined. Registered alongside `full-suite-rectify`, it shares that
 // strategy's op but runs it with the scope constraint lifted, under its own
 // session role so it does not inherit the refusal it is meant to overturn.
 
-describe("makeRegressionFixStrategy", () => {
-  const strategy = () => makeRegressionFixStrategy(makeTestStory(), makeDeclarationSink());
+describe("makeRepoScopedTestFixStrategy", () => {
+  const strategy = () => makeRepoScopedTestFixStrategy(makeTestStory(), makeDeclarationSink());
 
-  test("name is regression-fix so it retires independently of full-suite-rectify", () => {
+  test("name is repo-scoped-test-fix so it retires independently of full-suite-rectify", () => {
     // Retirement and attempt caps are both keyed on the strategy name. A shared
     // name would make the story-scoped give-up retire this strategy too, and the
     // fallthrough would never dispatch.
-    expect(strategy().name).toBe("regression-fix");
+    expect(strategy().name).toBe("repo-scoped-test-fix");
     expect(strategy().name).not.toBe(makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig()).name);
   });
 
@@ -313,7 +313,7 @@ describe("makeRegressionFixStrategy", () => {
   });
 
   test("runs under its own session role", () => {
-    expect(strategy().sessionRole).toBe("regression-fix");
+    expect(strategy().sessionRole).toBe("repo-scoped-test-fix");
   });
 
   test("reuses fullSuiteRectifyOp rather than declaring a second op", () => {

--- a/test/unit/operations/full-suite-rectify.test.ts
+++ b/test/unit/operations/full-suite-rectify.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   makeFullSuiteRectifyStrategy,
+  makeRegressionFixStrategy,
   fullSuiteRectifyOp,
   makeDeclarationSink,
 } from "@/operations";
@@ -281,5 +282,66 @@ describe("makeFullSuiteRectifyStrategy — mock_structure handoff short-circuit 
     pushHandoff(sink);
     // A lint finding never matched regardless of handoff state.
     expect(strategy.appliesTo(makeTestFinding({ source: "lint" }))).toBe(false);
+  });
+});
+
+// ─── makeRegressionFixStrategy (#1654) ───────────────────────────────────────
+//
+// The fallthrough claimant for failing tests the story-scoped rectifier
+// declined. Registered alongside `full-suite-rectify`, it shares that
+// strategy's op but runs it with the scope constraint lifted, under its own
+// session role so it does not inherit the refusal it is meant to overturn.
+
+describe("makeRegressionFixStrategy", () => {
+  const strategy = () => makeRegressionFixStrategy(makeTestStory(), makeDeclarationSink());
+
+  test("name is regression-fix so it retires independently of full-suite-rectify", () => {
+    // Retirement and attempt caps are both keyed on the strategy name. A shared
+    // name would make the story-scoped give-up retire this strategy too, and the
+    // fallthrough would never dispatch.
+    expect(strategy().name).toBe("regression-fix");
+    expect(strategy().name).not.toBe(makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig()).name);
+  });
+
+  test("claims the same failing-test findings full-suite-rectify claims", () => {
+    expect(strategy().appliesTo(makeTestFinding({ category: "failed-test" }))).toBe(true);
+    expect(strategy().appliesTo(makeTestFinding({ category: "execution-failed" }))).toBe(true);
+  });
+
+  test("does not claim findings from other sources", () => {
+    expect(strategy().appliesTo(makeTestFinding({ source: "lint", category: "lint-error" }))).toBe(false);
+  });
+
+  test("runs under its own session role", () => {
+    expect(strategy().sessionRole).toBe("regression-fix");
+  });
+
+  test("reuses fullSuiteRectifyOp rather than declaring a second op", () => {
+    expect(strategy().fixOp).toBe(fullSuiteRectifyOp);
+  });
+
+  test("buildInput requests repo scope", () => {
+    const input = strategy().buildInput([makeTestFinding()], [], {} as never) as FullSuiteRectifyInput;
+    expect(input.scope).toBe("repo");
+  });
+
+  test("gets one attempt — it is the last claimant, not another ladder rung", () => {
+    expect(strategy().maxAttempts).toBe(1);
+  });
+
+  test("is exclusive so it does not co-run with the strategy that declined", () => {
+    expect(strategy().coRun).toBe("exclusive");
+  });
+
+  test("propagates UNRESOLVED so the cycle still exits agent-gave-up", async () => {
+    const output = { applied: true, testEditDeclarations: [], unresolvedReason: "tests contradict" } as FullSuiteRectifyOutput;
+    const applied = await strategy().extractApplied?.(output, {} as never);
+    expect(applied?.unresolved).toBe("tests contradict");
+  });
+
+  test("reports no unresolved when the agent fixed the tests", async () => {
+    const output = { applied: true, testEditDeclarations: [] } as FullSuiteRectifyOutput;
+    const applied = await strategy().extractApplied?.(output, {} as never);
+    expect(applied?.unresolved).toBeUndefined();
   });
 });

--- a/test/unit/prompts/rectifier-builder.test.ts
+++ b/test/unit/prompts/rectifier-builder.test.ts
@@ -10,8 +10,9 @@
 
 import { describe, expect, test } from "bun:test";
 import { makeStory } from "@test/helpers";
-import { RectifierPromptBuilder } from "@/prompts";
+import { RectifierPromptBuilder, repoScopedRectification } from "@/prompts";
 import type { FailureRecord } from "@/prompts";
+import type { Finding } from "@/findings/types";
 import type { ReviewCheckResult } from "@/review/types";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -273,5 +274,81 @@ describe("RectifierPromptBuilder.continuation", () => {
     expect(result).toContain("Rethink your approach");
     expect(result).toContain("URGENT: This is your final attempt");
     expect(result).toMatchSnapshot();
+  });
+});
+
+// ─── repoScopedRectification (#1654) ─────────────────────────────────────────
+//
+// The mandate handed to the fallthrough claimant after the story-scoped
+// rectifier declined a failing test as out-of-scope. Its job is to remove the
+// contradiction that produced the refusal — "fix this test, but do not touch
+// what is broken" — without removing the test-integrity rules alongside it.
+
+describe("repoScopedRectification", () => {
+  const failing: Finding = {
+    source: "test-runner",
+    severity: "error",
+    category: "failed-test",
+    rule: "computes the median",
+    file: "test/unit/stats.test.ts",
+    message: "AssertionError: expected 3 to be 4",
+  };
+
+  test("names the failing test so the agent knows what it is fixing", () => {
+    const prompt = repoScopedRectification([failing], STORY);
+    expect(prompt).toContain("test/unit/stats.test.ts");
+    expect(prompt).toContain("computes the median");
+  });
+
+  test("drops the sibling-scope exception that tells the agent to punt", () => {
+    // Exception 3 instructs the agent to declare `sibling_scope` and continue,
+    // on the grounds that out-of-scope failures do not block the story. That is
+    // the exact instruction this dispatch exists to override; leaving it in
+    // would re-license the refusal we are responding to.
+    const prompt = repoScopedRectification([failing], STORY);
+    expect(prompt).not.toContain("sibling_scope");
+    expect(RectifierPromptBuilder.failingTestRectification([failing], STORY)).toContain("sibling_scope");
+  });
+
+  test("states that out-of-scope is not a reason to decline", () => {
+    const prompt = repoScopedRectification([failing], STORY);
+    expect(prompt.toLowerCase()).toContain("not a reason to decline");
+  });
+
+  test("keeps the UNRESOLVED protocol for genuinely unsatisfiable tests", () => {
+    expect(repoScopedRectification([failing], STORY)).toContain("UNRESOLVED:");
+  });
+
+  test("keeps the prohibition on weakening tests", () => {
+    // An agent authorised to edit any file is precisely the one that must not be
+    // authorised to make a red test green by deleting its assertion.
+    const prompt = repoScopedRectification([failing], STORY);
+    expect(prompt).toContain("TEST_EDIT_REASON");
+    expect(prompt.toLowerCase()).toContain("weaken");
+  });
+
+  test("routes a nondeterministic failure to UNRESOLVED rather than to a fix", () => {
+    // Flake triage normally quarantines these before rectification, but it has
+    // skip paths (probe cap exceeded, unresolvable baseline diff, framework not
+    // detected) that leave a flaky test looking deterministic. An agent
+    // authorised to edit any file and told to make the test pass is the worst
+    // possible reader of a test that fails at random — it will weaken it. Name
+    // the case and give it the terminal channel instead.
+    const prompt = repoScopedRectification([failing], STORY);
+    expect(prompt.toLowerCase()).toContain("flaky");
+  });
+
+  test("the stated exception count matches the exceptions actually present", () => {
+    // buildEscapeHatch interpolates the exception count into its prose and the
+    // headings are numbered literals, so dropping one without adjusting the set
+    // yields a prompt that numbers its exceptions 1, 2, 4 while telling the agent
+    // to check "Exceptions 1-3".
+    const prompt = repoScopedRectification([failing], STORY);
+    const headings = prompt.match(/^### Exception (\d+) —/gm) ?? [];
+    expect(headings.length).toBeGreaterThan(0);
+    expect(prompt).toContain(`Exceptions 1\u2013${headings.length}`);
+    expect(headings.map((h) => h.match(/\d+/)?.[0])).toEqual(
+      Array.from({ length: headings.length }, (_, i) => String(i + 1)),
+    );
   });
 });


### PR DESCRIPTION
Closes #1654.

## The problem

A test that is red for reasons outside the story deadlocks **every** story in the package.

The story-scoped rectifier is handed the failing test together with a mandate that forbids touching what is broken — and Exception 3 in the escape hatch explicitly tells it to declare `sibling_scope` and move on. `UNRESOLVED:` is the agent correctly reporting that contradiction. The cycle then exits `agent-gave-up`, the story burns its escalation ladder, and the next story hits the same wall.

## The approach

The issue proposes capturing a merge-base baseline to decide whether a failure is pre-existing. That was tried before (`src/tdd/baseline.ts`, reverted in c5d964e7c) and failed three ways: an extra suite run on every story, file-level granularity that laundered real regressions, and a fail-open path where count-only test output made the gate return `passed: true`.

This takes the other route: **remove the contradiction instead of classifying the failure.** Whoever broke the test, the remedy is to make it pass — so attribution is never needed. No baseline capture, no merge-base probe, no extra suite run.

## What changed

- **`repo-scoped-test-fix`** — a second strategy over the existing `fullSuiteRectifyOp`, selected by a new `scope: "repo"` input field. Retirement and attempt caps key on strategy *name*, so the two retire independently while sharing one op, one UNRESOLVED protocol, and one declaration parser. One attempt: it is the last claimant, not another ladder rung.
- **`repoScopedRectification`** — lifts the scope constraint and nothing else. Drops Exception 3 (the punt this dispatch overrides) and Exception 4 (whose handoff target does not own tests outside the story); keeps the declaration protocol, the prohibition on weakening tests, and routes a nondeterministic failure to `UNRESOLVED` rather than to a fix.
- **`FixStrategy.sessionRole`** → `CallContext.sessionOverride.role`. Session resume is keyed on the role, so the new role yields a fresh session: the agent is not asked to reverse a refusal sitting in its own context, and the story-scoped framing that is now wrong does not carry over. A `keepOpen` resolver closes it after its single attempt.
- **`runFixCycle`** no longer exits on `allGaveUp` while another non-retired, non-exhausted strategy still claims the findings. Skipping validation stays right — nothing touched the tree — but ending the cycle does not.

Gated by `execution.rectification.repoScopedFallback` (default `true`). Registered on the blocking cycle only; the non-blocking cycle does not deadlock a story.

## Two defects found reviewing the above (second commit)

1. **`withNoProgressBail` counted the give-up iteration toward its streak.** That iteration records `findingsAfter === findingsBefore`, so `madeNoProgress` is trivially true — but nothing was dispatched, so it is evidence of nothing. Before the fallthrough, an all-declined iteration always terminated the cycle and could never sit inside a trailing window. A story already stalled for two iterations would bail at the give-up and never reach the claimant, silently defeating the feature in exactly the case it exists for. Such iterations are now *excluded* from the window — not credited as progress, so the bail still fires once real attempts refill it.
2. **`repo-scoped-test-fix` was absent from `STRATEGY_TO_REVALIDATION_PHASES`,** so `phasesToRevalidate` took its unknown-strategy fallback and re-ran *all* phases — including `test-writer`, `greenfield-gate`, and `implementer`. A strategy that only fixed a failing test would have re-run the story's authoring sessions. Now declared, sharing one named set with `full-suite-rectify`: a wider file scope is not a wider phase scope.

## Not included

The uncapped survivor flake-probe discussed during design. Flake triage already re-runs these findings twice in isolation before they reach rectification, so the gap is only its skip paths (`maxProbesPerGate: 5` exceeded, unresolvable baseline diff, framework undetected). The clean signal exists — the triage seam reports `flakeTriageRan` — but it is currently consumed only by the NBF path for telemetry, so wiring it into the blocking cycle is real plumbing for a case with no frequency data behind it. The repo-scoped mandate instead names the flake case directly and routes it to `UNRESOLVED`. Worth measuring how often triage skips before building the real guard.

## Test plan

- [x] `bun run test` — 13,848 unit + 1,135 integration + 37 UI, 0 failures
- [x] `bun run typecheck`
- [x] `bun run check:all` — all 23 gates; test-typecheck and `as unknown as` ratchets both held at baseline
- [x] New cycle tests verified to fail against the unfixed code before implementing
- [ ] Exercise on a real repo with a known pre-existing red test and confirm the story completes instead of deadlocking

## Reviewer notes

- `src/findings/cycle-selection.ts` is an extraction from `cycle.ts` (strategy selection + attempt counting) made to keep that file under the 600-line limit; `hasRemainingClaimant` is the only new logic in it.
- One consequence to accept: the fix lands in the story's commit, so a story may carry a repair to something it did not break. Better than a deadlock, but there is no report line for it yet.