### PR TITLE
feat(flake-triage): count every path where triage is skipped (#1657)

### DIFF
--- a/docs/specs/flaky-test-quarantine-design.md
+++ b/docs/specs/flaky-test-quarantine-design.md
@@ -99,6 +99,35 @@ Every quarantine decision emits a structured log line + a pipeline-bus event —
 landing in the existing review-warning aggregation, the TUI, and the run
 report/JSONL. No cross-run persistence.
 
+#### Skip telemetry (#1657)
+
+Every path where triage is *skipped* — so a flake and a deterministic failure
+are indistinguishable to the `repo-scoped-test-fix` fallthrough (#1656) —
+emits one `flake.triage.skipped` event via `logFlakeTriageSkip`
+(`src/verification/flake-triage-telemetry.ts`):
+
+| `reason` | Emitted from | `candidateBasis` |
+|:---|:---|:---|
+| `max-probes-per-gate` | `triageFlakyFindings` | `probe-eligible` (exact) |
+| `framework-undetected` | `productionTriageSeam` | `gate-findings` (upper bound) |
+| `no-test-command` | `productionTriageSeam` | `gate-findings` |
+| `baseline-diff-unresolved` | `productionTriageSeam` | `gate-findings` |
+| `context-error` | `productionTriageSeam` | `gate-findings` |
+
+`flakeDetection.enabled: false` emits nothing — an operator opt-out is not a
+gap in a feature believed to be on.
+
+Read the accrued counter off the run logs:
+
+```bash
+jq -c 'select(.data.event == "flake.triage.skipped") | .data' ~/.nax/*/features/*/runs/*.jsonl \
+  | jq -s 'group_by(.reason) | map({reason: .[0].reason, count: length, maxCandidates: (map(.candidateCount) | max)})'
+```
+
+Per #1657 the follow-up guard (requiring `flakeTriageRan` before the
+fallthrough dispatches) is gated on `max-probes-per-gate` in particular showing
+up at a meaningful rate — the plumbing is not paid for on speculation.
+
 ## Config
 
 One new block under `execution` (Zod schema, `src/config/schemas*.ts`):

--- a/docs/specs/flaky-test-quarantine-design.md
+++ b/docs/specs/flaky-test-quarantine-design.md
@@ -109,24 +109,60 @@ emits one `flake.triage.skipped` event via `logFlakeTriageSkip`
 | `reason` | Emitted from | `candidateBasis` |
 |:---|:---|:---|
 | `max-probes-per-gate` | `triageFlakyFindings` | `probe-eligible` (exact) |
-| `framework-undetected` | `productionTriageSeam` | `gate-findings` (upper bound) |
+| `framework-undetected` | `productionTriageSeam`, `runRegressionFlakeTriage` | `gate-findings` (upper bound) |
 | `no-test-command` | `productionTriageSeam` | `gate-findings` |
-| `baseline-diff-unresolved` | `productionTriageSeam` | `gate-findings` |
+| `baseline-diff-unresolved` | `productionTriageSeam`, `runRegressionFlakeTriage` | `gate-findings` |
 | `context-error` | `productionTriageSeam` | `gate-findings` |
+
+`gate-findings` is the raw finding set handed to the seam — unnarrowed by the
+baseline diff and unfiltered by category — so it is an upper bound, never a
+probe count. Only `probe-eligible` is exact.
 
 `flakeDetection.enabled: false` emits nothing — an operator opt-out is not a
 gap in a feature believed to be on.
 
+**`scope` is the field that decides #1657 §3.** Every row carries one of:
+
+| `scope` | Cycle | Can dispatch `repo-scoped-test-fix`? |
+|:---|:---|:---|
+| `blocking-gate` | `triageGateFindings`, once per rectification entry | **Yes** — the only one |
+| `nbf` | `triageNbfGate`, per phase per `runRectify` attempt | No — not registered on that cycle |
+| `regression` | `runRegressionFlakeTriage`, the run-scoped deferred gate | No |
+
+`makeRepoScopedTestFixStrategy` is registered on the blocking cycle only
+(`src/execution/build-plan-for-strategy.ts`). Counting `nbf` rows — which the
+per-attempt revalidation loop multiplies — toward the decision would argue for
+plumbing on traffic that carries none of the risk. The field is required rather
+than defaulted: a mislabeled row cannot be repaired once the data has accrued.
+
+A completed triage emits the matching denominator, `flake.triage.ran`, at
+`debug` (no console lines in a normal run; the JSONL records every level).
+Without it "only if path 1 shows up at a meaningful rate" has no rate.
+
 Read the accrued counter off the run logs:
 
 ```bash
-jq -c 'select(.data.event == "flake.triage.skipped") | .data' ~/.nax/*/features/*/runs/*.jsonl \
-  | jq -s 'group_by(.reason) | map({reason: .[0].reason, count: length, maxCandidates: (map(.candidateCount) | max)})'
+jq -c 'select(.data.event == "flake.triage.skipped" or .data.event == "flake.triage.ran") | .data' \
+  ~/.nax/*/features/*/runs/*.jsonl \
+  | jq -s 'group_by(.scope) | map({
+      scope: .[0].scope,
+      ran: (map(select(.event == "flake.triage.ran")) | length),
+      skipped: (group_by(.reason) | map(select(.[0].reason != null) | {(.[0].reason): length}) | add)
+    })'
 ```
 
-Per #1657 the follow-up guard (requiring `flakeTriageRan` before the
-fallthrough dispatches) is gated on `max-probes-per-gate` in particular showing
-up at a meaningful rate — the plumbing is not paid for on speculation.
+Per #1657 the follow-up guard is gated on `max-probes-per-gate` at
+`scope: "blocking-gate"` in particular showing up at a meaningful rate — the
+plumbing is not paid for on speculation.
+
+**If that guard is built, `flakeTriageRan` is the wrong signal for it.**
+`triageFlakyFindings` returns normally on the `max-probes-per-gate` skip, so
+`productionTriageSeam` reports `flakeTriageRan: true` for exactly the path
+#1657 names as mattering most — a guard written against that flag would be
+inert there. Step 3 needs a distinct signal (`probed`, or a `false` on the cap
+path), and changing `flakeTriageRan` itself is not free: `triageNbfGate` feeds
+it into `recordAttempt`, where `false` also changes which keys are marked
+attempted.
 
 ## Config
 

--- a/src/execution/lifecycle/run-regression-triage.ts
+++ b/src/execution/lifecycle/run-regression-triage.ts
@@ -13,7 +13,7 @@ import type { Finding } from "@/findings";
 import { getSafeLogger } from "@/logger";
 import { detectFramework } from "@/test-runners";
 import type { TestSummary } from "@/test-runners";
-import type { resolveFlakeBaselineDiff } from "@/verification";
+import { logFlakeTriageSkip, type resolveFlakeBaselineDiff } from "@/verification";
 import type { FlakeQuarantineReport, QuarantineMemo, triageFlakyFindings } from "@/verification/flake-triage";
 import type { DeferredRegressionResult } from "./run-regression";
 
@@ -63,17 +63,48 @@ export async function runRegressionFlakeTriage(params: {
     flakeDetection,
   } = params;
   const logger = getSafeLogger();
-  const baselineDiff = await resolveBaselineDiffFn(config, workdir);
-  if (baselineDiff === null) {
-    // Fail closed: skip triage entirely rather than substituting an empty
-    // diff, which would make every failing test look pre-existing (see
-    // resolveFlakeBaselineDiff's doc comment) — the opposite of fail-closed.
+
+  // #1657: this gate is the second `triageFlakyFindings` caller and it has the
+  // same skip paths as the per-story seam. Counted under `scope: "regression"`
+  // so the §3 decision — which is about the blocking cycle only — can exclude
+  // them, while the paths themselves stop reading as zero by construction.
+  const untriagedFailures = (): RegressionTriageOutcome => {
     const untriaged = regressionFindings.filter((f) => f.category === "failed-test");
     const testFilesInFailures = new Set<string>();
     for (const finding of untriaged) {
       if (finding.file) testFilesInFailures.add(finding.file);
     }
     return { shortCircuit: false, triagedFailedFindings: untriaged, testFilesInFailures, quarantineReport: undefined };
+  };
+  const failedTestCount = regressionFindings.filter((f) => f.category === "failed-test").length;
+
+  const framework = detectFramework(rawOutput);
+  if (framework === "unknown") {
+    // Previously fell through to triage, which probes nothing under an unknown
+    // framework (`runFlakeProbe` returns "unprobeable" for every candidate) and
+    // quarantines nothing. Bailing here makes that identical outcome visible
+    // instead of silent, and matches what `productionTriageSeam` already does.
+    logFlakeTriageSkip({
+      reason: "framework-undetected",
+      candidateCount: failedTestCount,
+      candidateBasis: "gate-findings",
+      scope: "regression",
+    });
+    return untriagedFailures();
+  }
+
+  const baselineDiff = await resolveBaselineDiffFn(config, workdir);
+  if (baselineDiff === null) {
+    // Fail closed: skip triage entirely rather than substituting an empty
+    // diff, which would make every failing test look pre-existing (see
+    // resolveFlakeBaselineDiff's doc comment) — the opposite of fail-closed.
+    logFlakeTriageSkip({
+      reason: "baseline-diff-unresolved",
+      candidateCount: failedTestCount,
+      candidateBasis: "gate-findings",
+      scope: "regression",
+    });
+    return untriagedFailures();
   }
   const triageResult = await triageFn({
     findings: regressionFindings,
@@ -81,8 +112,9 @@ export async function runRegressionFlakeTriage(params: {
     flakeDetection,
     baseCommand: testCommand,
     cwd: workdir,
-    framework: detectFramework(rawOutput),
+    framework,
     quarantineMemo,
+    scope: "regression",
   });
   const quarantineReport = triageResult.quarantineReport.keys.length > 0 ? triageResult.quarantineReport : undefined;
   const triagedFailedFindings = triageResult.findings.filter((f) => f.category === "failed-test");

--- a/src/execution/story-orchestrator/flake-triage-seam.ts
+++ b/src/execution/story-orchestrator/flake-triage-seam.ts
@@ -12,7 +12,7 @@ import { getSafeLogger } from "@/logger";
 import type { CallContext } from "@/operations";
 import { detectFramework } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
-import { type QuarantineMemo, resolveFlakeBaselineDiff, triageFlakyFindings } from "@/verification";
+import { type QuarantineMemo, logFlakeTriageSkip, resolveFlakeBaselineDiff, triageFlakyFindings } from "@/verification";
 
 /** Triage result tuple shape — produced by `_storyOrchestratorDeps.triage`. */
 export type TriageResult = readonly [Finding[], { quarantinedKeys: readonly string[]; flakeTriageRan?: boolean }];
@@ -70,24 +70,43 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
     return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
   }
 
+  // #1657: every bail-out below leaves the surviving findings looking
+  // deterministic to the repo-scoped-test-fix fallthrough. `candidateBasis` is
+  // "gate-findings" and not "probe-eligible" because the baseline diff that
+  // narrows candidates does not exist yet on these paths — the count is an
+  // upper bound. `flakeDetection.enabled: false` is not counted: an operator
+  // opt-out is not a gap in a feature believed to be on.
+  const candidateCount = gateFindings.length;
+  const storyId = ctx.storyId;
+
   const framework = detectFramework(rawOutput);
   if (framework === "unknown") {
+    logFlakeTriageSkip({ reason: "framework-undetected", candidateCount, candidateBasis: "gate-findings", storyId });
     return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
   }
 
-  const workdir = ctx.runtime.workdir;
-  const storyWorkdir = ctx.story?.workdir;
-
   try {
+    // Read inside the try so the catch covers every resolution this seam does,
+    // as its contract above promises — a malformed context must skip triage
+    // with a counter, not throw past the seam.
+    const workdir = ctx.runtime.workdir;
+    const storyWorkdir = ctx.story?.workdir;
     const { resolveQualityTestCommands } = await import("@/quality");
     const { testCommand } = await resolveQualityTestCommands(config, workdir, storyWorkdir);
     const baseCommand = testCommand ?? config.quality?.commands?.test;
     if (!baseCommand) {
+      logFlakeTriageSkip({ reason: "no-test-command", candidateCount, candidateBasis: "gate-findings", storyId });
       return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
     }
 
     const diff = await resolveFlakeBaselineDiff(config, workdir, storyWorkdir);
     if (diff === null) {
+      logFlakeTriageSkip({
+        reason: "baseline-diff-unresolved",
+        candidateCount,
+        candidateBasis: "gate-findings",
+        storyId,
+      });
       return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
     }
 
@@ -99,6 +118,7 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
       cwd: ctx.packageDir,
       framework,
       quarantineMemo: quarantineMemo ?? ctx.runtime.quarantineMemo,
+      storyId,
     });
     return [result.findings, { quarantinedKeys: result.quarantineReport.keys, flakeTriageRan: true }];
   } catch (err) {
@@ -106,10 +126,17 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
       "story-orchestrator",
       "Flake triage seam failed resolving context — keeping findings blocking (no quarantine)",
       {
-        storyId: ctx.storyId,
+        storyId,
         error: errorMessage(err),
       },
     );
+    logFlakeTriageSkip({
+      reason: "context-error",
+      candidateCount,
+      candidateBasis: "gate-findings",
+      storyId,
+      error: errorMessage(err),
+    });
     return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
   }
 };

--- a/src/execution/story-orchestrator/flake-triage-seam.ts
+++ b/src/execution/story-orchestrator/flake-triage-seam.ts
@@ -12,7 +12,13 @@ import { getSafeLogger } from "@/logger";
 import type { CallContext } from "@/operations";
 import { detectFramework } from "@/test-runners";
 import { errorMessage } from "@/utils/errors";
-import { type QuarantineMemo, logFlakeTriageSkip, resolveFlakeBaselineDiff, triageFlakyFindings } from "@/verification";
+import {
+  type FlakeTriageScope,
+  type QuarantineMemo,
+  logFlakeTriageSkip,
+  resolveFlakeBaselineDiff,
+  triageFlakyFindings,
+} from "@/verification";
 
 /** Triage result tuple shape — produced by `_storyOrchestratorDeps.triage`. */
 export type TriageResult = readonly [Finding[], { quarantinedKeys: readonly string[]; flakeTriageRan?: boolean }];
@@ -24,6 +30,12 @@ export interface TriageSeamContext {
   readonly rawOutput: string;
   /** Optional transaction-local memo used by ADR-024 NBF revalidation. */
   readonly quarantineMemo?: QuarantineMemo;
+  /**
+   * Which cycle this call belongs to (#1657 telemetry). Required so a `nbf`
+   * emit — multiplied by the per-attempt revalidation loop, and unable to
+   * dispatch `repo-scoped-test-fix` — is never mistaken for a blocking-gate one.
+   */
+  readonly scope: FlakeTriageScope;
 }
 
 /**
@@ -63,7 +75,7 @@ export const defaultTriageSeam: TriageSeam = async (gateFindings) => [
  * findings unchanged (no quarantine) rather than risking a false quarantine.
  * `triageFlakyFindings` itself already fails closed on probe errors.
  */
-export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawOutput, quarantineMemo }) => {
+export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawOutput, quarantineMemo, scope }) => {
   const config = ctx.packageView.config;
   const flakeDetection = config.execution?.flakeDetection;
   if (!flakeDetection?.enabled) {
@@ -72,16 +84,23 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
 
   // #1657: every bail-out below leaves the surviving findings looking
   // deterministic to the repo-scoped-test-fix fallthrough. `candidateBasis` is
-  // "gate-findings" and not "probe-eligible" because the baseline diff that
-  // narrows candidates does not exist yet on these paths — the count is an
-  // upper bound. `flakeDetection.enabled: false` is not counted: an operator
-  // opt-out is not a gap in a feature believed to be on.
+  // "gate-findings", never "probe-eligible": this count is the raw finding set
+  // handed to the seam, unnarrowed by the baseline diff and unfiltered by
+  // category, so it is an upper bound on the candidates.
+  // `flakeDetection.enabled: false` is not counted: an operator opt-out is not
+  // a gap in a feature believed to be on.
   const candidateCount = gateFindings.length;
   const storyId = ctx.storyId;
 
   const framework = detectFramework(rawOutput);
   if (framework === "unknown") {
-    logFlakeTriageSkip({ reason: "framework-undetected", candidateCount, candidateBasis: "gate-findings", storyId });
+    logFlakeTriageSkip({
+      reason: "framework-undetected",
+      candidateCount,
+      candidateBasis: "gate-findings",
+      scope,
+      storyId,
+    });
     return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
   }
 
@@ -95,7 +114,13 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
     const { testCommand } = await resolveQualityTestCommands(config, workdir, storyWorkdir);
     const baseCommand = testCommand ?? config.quality?.commands?.test;
     if (!baseCommand) {
-      logFlakeTriageSkip({ reason: "no-test-command", candidateCount, candidateBasis: "gate-findings", storyId });
+      logFlakeTriageSkip({
+        reason: "no-test-command",
+        candidateCount,
+        candidateBasis: "gate-findings",
+        scope,
+        storyId,
+      });
       return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
     }
 
@@ -105,6 +130,7 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
         reason: "baseline-diff-unresolved",
         candidateCount,
         candidateBasis: "gate-findings",
+        scope,
         storyId,
       });
       return [gateFindings, { quarantinedKeys: [], flakeTriageRan: false }];
@@ -118,8 +144,16 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
       cwd: ctx.packageDir,
       framework,
       quarantineMemo: quarantineMemo ?? ctx.runtime.quarantineMemo,
+      scope,
       storyId,
     });
+    // NOTE (#1657): `flakeTriageRan: true` here is also reported when
+    // `triageFlakyFindings` skipped the gate wholesale on `maxProbesPerGate` —
+    // it returns normally on that path. A step-3 guard written against this
+    // flag would therefore be inert for exactly the skip path #1657 names as
+    // mattering most; it needs a distinct signal. Not changed here: this flag
+    // feeds `triageNbfGate`'s `recordAttempt`, where a `false` also changes
+    // which keys are marked attempted.
     return [result.findings, { quarantinedKeys: result.quarantineReport.keys, flakeTriageRan: true }];
   } catch (err) {
     getSafeLogger()?.warn(
@@ -134,6 +168,7 @@ export const productionTriageSeam: TriageSeam = async (gateFindings, { ctx, rawO
       reason: "context-error",
       candidateCount,
       candidateBasis: "gate-findings",
+      scope,
       storyId,
       error: errorMessage(err),
     });

--- a/src/execution/story-orchestrator/nbf-flake-triage.ts
+++ b/src/execution/story-orchestrator/nbf-flake-triage.ts
@@ -80,6 +80,9 @@ export async function triageNbfGate(input: TriageNbfGateInput): Promise<void> {
       ctx: input.ctx,
       rawOutput,
       quarantineMemo: input.transaction.memo,
+      // Never "blocking-gate": this runs per phase per runRectify attempt, and
+      // the repo-scoped-test-fix strategy is not registered on this cycle.
+      scope: "nbf",
     });
     const ran = report.flakeTriageRan ?? true;
     if (ran) {

--- a/src/execution/story-orchestrator/rectification.ts
+++ b/src/execution/story-orchestrator/rectification.ts
@@ -128,7 +128,9 @@ export async function triageGateFindings(
   let triagedFindings: Finding[];
   let quarantinedKeys: readonly string[];
   try {
-    const [triaged, report] = await triage(findings, { ctx, rawOutput });
+    // scope: the blocking cycle is the only one that can dispatch
+    // repo-scoped-test-fix, so its skips are the ones #1657 §3 is deciding on.
+    const [triaged, report] = await triage(findings, { ctx, rawOutput, scope: "blocking-gate" });
     triagedFindings = triaged;
     quarantinedKeys = report.quarantinedKeys;
   } catch (err) {

--- a/src/verification/flake-triage-telemetry.ts
+++ b/src/verification/flake-triage-telemetry.ts
@@ -1,0 +1,69 @@
+/**
+ * Flake-Triage Skip Telemetry (#1657)
+ *
+ * Emits one structured counter every time flake triage is skipped for a gate,
+ * tagged with which skip path fired and how many findings were in play.
+ *
+ * Why: `repo-scoped-test-fix` (#1656) dispatches a repo-wide agent to make a
+ * failing test pass. That is safe only because `triageFlakyFindings` has
+ * already quarantined confirmed flakes — anything reaching the fallthrough has
+ * been judged deterministic. Every skip path below is a hole in that guarantee:
+ * a flake there is indistinguishable from a deterministic failure.
+ *
+ * Gating the fallthrough on `flakeTriageRan` means threading it through
+ * run-phase → rectification → the cycle context. This module measures the hole
+ * first so that plumbing is only paid for if the rate justifies it (#1657 §3).
+ *
+ * `flakeDetection.enabled: false` is deliberately NOT counted — that is an
+ * operator turning the feature off, not a gap in a feature believed to be on.
+ */
+
+import { getSafeLogger } from "../logger";
+
+/** Structured event name — the grep key for accruing this counter over runs. */
+export const FLAKE_TRIAGE_SKIP_EVENT = "flake.triage.skipped";
+
+/**
+ * Which skip path fired. `max-probes-per-gate` is the one #1657 cares about
+ * most: it skips the gate *wholesale*, and "many red tests at once" is exactly
+ * the shape that deadlocks a whole package.
+ */
+export type FlakeTriageSkipReason =
+  | "max-probes-per-gate"
+  | "baseline-diff-unresolved"
+  | "framework-undetected"
+  | "no-test-command"
+  | "context-error";
+
+/**
+ * How `candidateCount` was derived. The two emit sites can see different
+ * things, and conflating them would overstate the seam's numbers:
+ * - `probe-eligible` — post-baseline-filter, the exact set that would be probed.
+ * - `gate-findings` — the seam bails before the baseline diff exists, so this
+ *   is the gate's `failed-test` findings: an upper bound on the candidates.
+ */
+export type FlakeTriageCandidateBasis = "probe-eligible" | "gate-findings";
+
+export interface FlakeTriageSkipInput {
+  readonly reason: FlakeTriageSkipReason;
+  readonly candidateCount: number;
+  readonly candidateBasis: FlakeTriageCandidateBasis;
+  readonly storyId?: string;
+  /** The configured cap, when `reason` is `max-probes-per-gate`. */
+  readonly maxProbesPerGate?: number;
+  /** Error text, when `reason` is `context-error`. */
+  readonly error?: string;
+}
+
+/** Log one skip counter. Never throws — telemetry must not fail a gate. */
+export function logFlakeTriageSkip(input: FlakeTriageSkipInput): void {
+  getSafeLogger()?.info("flake-triage", `Flake triage skipped — ${input.reason}`, {
+    event: FLAKE_TRIAGE_SKIP_EVENT,
+    reason: input.reason,
+    candidateCount: input.candidateCount,
+    candidateBasis: input.candidateBasis,
+    ...(input.storyId !== undefined && { storyId: input.storyId }),
+    ...(input.maxProbesPerGate !== undefined && { maxProbesPerGate: input.maxProbesPerGate }),
+    ...(input.error !== undefined && { error: input.error }),
+  });
+}

--- a/src/verification/flake-triage-telemetry.ts
+++ b/src/verification/flake-triage-telemetry.ts
@@ -39,13 +39,26 @@ export type FlakeTriageSkipReason =
  * How `candidateCount` was derived. The two emit sites can see different
  * things, and conflating them would overstate the seam's numbers:
  * - `probe-eligible` — post-baseline-filter, the exact set that would be probed.
- * - `gate-findings` — the seam bails before the baseline diff exists, so this
- *   is the gate's `failed-test` findings: an upper bound on the candidates.
+ * - `gate-findings` — the whole finding set handed to the seam, unfiltered by
+ *   category (`extractPhaseFindings` keeps `execution-failed` and friends too):
+ *   an upper bound on the candidates, never an exact probe count.
  */
 export type FlakeTriageCandidateBasis = "probe-eligible" | "gate-findings";
 
+/**
+ * Which cycle the skipped gate belongs to. Load-bearing for #1657 §3: only
+ * `blocking-gate` can dispatch `repo-scoped-test-fix` — the strategy is
+ * "registered on the blocking cycle only" (see `build-plan-for-strategy.ts`).
+ * `nbf` emits are multiplied by the per-attempt revalidation loop and `regression`
+ * is the run-scoped deferred gate; counting either toward the decision would
+ * argue for plumbing on traffic that carries none of the risk. Required, not
+ * defaulted — a mislabeled row is unrecoverable once the data has accrued.
+ */
+export type FlakeTriageScope = "blocking-gate" | "nbf" | "regression";
+
 export interface FlakeTriageSkipInput {
   readonly reason: FlakeTriageSkipReason;
+  readonly scope: FlakeTriageScope;
   readonly candidateCount: number;
   readonly candidateBasis: FlakeTriageCandidateBasis;
   readonly storyId?: string;
@@ -57,13 +70,50 @@ export interface FlakeTriageSkipInput {
 
 /** Log one skip counter. Never throws — telemetry must not fail a gate. */
 export function logFlakeTriageSkip(input: FlakeTriageSkipInput): void {
-  getSafeLogger()?.info("flake-triage", `Flake triage skipped — ${input.reason}`, {
-    event: FLAKE_TRIAGE_SKIP_EVENT,
-    reason: input.reason,
-    candidateCount: input.candidateCount,
-    candidateBasis: input.candidateBasis,
-    ...(input.storyId !== undefined && { storyId: input.storyId }),
-    ...(input.maxProbesPerGate !== undefined && { maxProbesPerGate: input.maxProbesPerGate }),
-    ...(input.error !== undefined && { error: input.error }),
-  });
+  // Enforced, not merely asserted: this is called from gate paths whose whole
+  // point is to degrade rather than throw, including one inside a catch block.
+  try {
+    getSafeLogger()?.info("flake-triage", `Flake triage skipped — ${input.reason}`, {
+      event: FLAKE_TRIAGE_SKIP_EVENT,
+      reason: input.reason,
+      scope: input.scope,
+      candidateCount: input.candidateCount,
+      candidateBasis: input.candidateBasis,
+      ...(input.storyId !== undefined && { storyId: input.storyId }),
+      ...(input.maxProbesPerGate !== undefined && { maxProbesPerGate: input.maxProbesPerGate }),
+      ...(input.error !== undefined && { error: input.error }),
+    });
+  } catch {
+    // Telemetry must never fail a gate.
+  }
+}
+
+/**
+ * The denominator. Without it "#1657 §3: only if path 1 shows up at a
+ * meaningful rate" has no rate — skip counts alone are absolute. Emitted at
+ * `debug` so it costs no console lines in a normal run while still landing in
+ * the JSONL, which records every level.
+ */
+export const FLAKE_TRIAGE_RAN_EVENT = "flake.triage.ran";
+
+export interface FlakeTriageRanInput {
+  readonly scope: FlakeTriageScope;
+  readonly candidateCount: number;
+  readonly quarantinedCount: number;
+  readonly storyId?: string;
+}
+
+/** Log one completed-triage counter. Never throws. */
+export function logFlakeTriageRan(input: FlakeTriageRanInput): void {
+  try {
+    getSafeLogger()?.debug("flake-triage", "Flake triage ran", {
+      event: FLAKE_TRIAGE_RAN_EVENT,
+      scope: input.scope,
+      candidateCount: input.candidateCount,
+      quarantinedCount: input.quarantinedCount,
+      ...(input.storyId !== undefined && { storyId: input.storyId }),
+    });
+  } catch {
+    // Telemetry must never fail a gate.
+  }
 }

--- a/src/verification/flake-triage.ts
+++ b/src/verification/flake-triage.ts
@@ -25,6 +25,7 @@ import { getSafeLogger } from "../logger";
 import type { Framework } from "../test-runners/detector";
 import type { TestFailure } from "../test-runners/types";
 import { type FlakeProbeInput, runFlakeProbe } from "./flake-probe";
+import { logFlakeTriageSkip } from "./flake-triage-telemetry";
 
 /** Run-scoped quarantine memo — shared across gates within a single run. */
 export interface QuarantineMemo {
@@ -63,6 +64,11 @@ export interface FlakeTriageInput {
   framework: Framework;
   /** Run-scoped memo so re-probing is skipped for tests already quarantined. */
   quarantineMemo: QuarantineMemo;
+  /**
+   * Story this gate belongs to, for #1657 skip telemetry only. Absent for
+   * run-scoped callers (the deferred regression gate) that have no story.
+   */
+  storyId?: string;
 }
 
 /** Report of quarantined flakes for logging/events. */
@@ -125,7 +131,7 @@ export const _flakeTriageDeps = {
  * Returns a new findings array; the input is not mutated.
  */
 export async function triageFlakyFindings(input: FlakeTriageInput): Promise<FlakeTriageResult> {
-  const { findings, diff, flakeDetection, baseCommand, cwd, framework, quarantineMemo } = input;
+  const { findings, diff, flakeDetection, baseCommand, cwd, framework, quarantineMemo, storyId } = input;
   const logger = getSafeLogger();
 
   const result: Finding[] = [];
@@ -151,11 +157,16 @@ export async function triageFlakyFindings(input: FlakeTriageInput): Promise<Flak
   const candidates = findings.filter((f) => isProbeCandidate(f, changedTestSet, mappedTestSet));
 
   if (candidates.length > flakeDetection.maxProbesPerGate) {
-    logger?.info(
-      "flake-triage",
-      `Skipping flake triage — ${candidates.length} candidates exceed maxProbesPerGate=${flakeDetection.maxProbesPerGate}`,
-    );
     reasons.push(`skipped: ${candidates.length} candidates exceed maxProbesPerGate=${flakeDetection.maxProbesPerGate}`);
+    // #1657: the wholesale skip is the path that most often leaves a flake
+    // looking deterministic to the repo-scoped-test-fix fallthrough — count it.
+    logFlakeTriageSkip({
+      reason: "max-probes-per-gate",
+      candidateCount: candidates.length,
+      candidateBasis: "probe-eligible",
+      maxProbesPerGate: flakeDetection.maxProbesPerGate,
+      storyId,
+    });
     for (const f of findings) result.push({ ...f });
     return { findings: result, quarantineReport: { keys, reasons } };
   }

--- a/src/verification/flake-triage.ts
+++ b/src/verification/flake-triage.ts
@@ -25,7 +25,7 @@ import { getSafeLogger } from "../logger";
 import type { Framework } from "../test-runners/detector";
 import type { TestFailure } from "../test-runners/types";
 import { type FlakeProbeInput, runFlakeProbe } from "./flake-probe";
-import { logFlakeTriageSkip } from "./flake-triage-telemetry";
+import { type FlakeTriageScope, logFlakeTriageRan, logFlakeTriageSkip } from "./flake-triage-telemetry";
 
 /** Run-scoped quarantine memo — shared across gates within a single run. */
 export interface QuarantineMemo {
@@ -65,7 +65,13 @@ export interface FlakeTriageInput {
   /** Run-scoped memo so re-probing is skipped for tests already quarantined. */
   quarantineMemo: QuarantineMemo;
   /**
-   * Story this gate belongs to, for #1657 skip telemetry only. Absent for
+   * Which cycle this gate belongs to, for #1657 telemetry only. Required: only
+   * the blocking cycle can dispatch `repo-scoped-test-fix`, so an unlabeled row
+   * cannot be counted toward that decision.
+   */
+  scope: FlakeTriageScope;
+  /**
+   * Story this gate belongs to, for #1657 telemetry only. Absent for
    * run-scoped callers (the deferred regression gate) that have no story.
    */
   storyId?: string;
@@ -131,7 +137,7 @@ export const _flakeTriageDeps = {
  * Returns a new findings array; the input is not mutated.
  */
 export async function triageFlakyFindings(input: FlakeTriageInput): Promise<FlakeTriageResult> {
-  const { findings, diff, flakeDetection, baseCommand, cwd, framework, quarantineMemo, storyId } = input;
+  const { findings, diff, flakeDetection, baseCommand, cwd, framework, quarantineMemo, scope, storyId } = input;
   const logger = getSafeLogger();
 
   const result: Finding[] = [];
@@ -165,6 +171,7 @@ export async function triageFlakyFindings(input: FlakeTriageInput): Promise<Flak
       candidateCount: candidates.length,
       candidateBasis: "probe-eligible",
       maxProbesPerGate: flakeDetection.maxProbesPerGate,
+      scope,
       storyId,
     });
     for (const f of findings) result.push({ ...f });
@@ -247,6 +254,7 @@ export async function triageFlakyFindings(input: FlakeTriageInput): Promise<Flak
     result.push(copy);
   }
 
+  logFlakeTriageRan({ scope, candidateCount: candidates.length, quarantinedCount: keys.length, storyId });
   return { findings: result, quarantineReport: { keys, reasons } };
 }
 

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -11,6 +11,7 @@ export * from "./runners";
 export * from "./rectification";
 export * from "./flake-probe";
 export * from "./flake-triage";
+export * from "./flake-triage-telemetry";
 export * from "./flake-baseline-diff";
 export * from "./mutation";
 export * from "./shell-quote";

--- a/test/unit/execution/lifecycle/run-regression-flake-triage.test.ts
+++ b/test/unit/execution/lifecycle/run-regression-flake-triage.test.ts
@@ -11,7 +11,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { _regressionDeps, runDeferredRegression } from "@/execution";
 import type { DeferredRegressionOptions } from "@/execution";
 import type { Finding } from "@/findings/types";
+import { type LogEntry, addSink, initLogger, resetLogger } from "@/logger";
 import type { VerificationResult } from "@/verification";
+import { FLAKE_TRIAGE_SKIP_EVENT } from "@/verification";
+import type { FlakeTriageInput, FlakeTriageResult } from "@/verification/flake-triage";
 import type { QuarantineMemo } from "@/verification/flake-triage";
 import { makeMockRuntime, makeNaxConfig } from "@test/helpers";
 
@@ -298,9 +301,7 @@ describe("runDeferredRegression — shared quarantine memo (AC5)", () => {
       return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
     });
 
-    const result = await runDeferredRegression(
-      makeOptions({ storyIds: ["US-001"], quarantineMemo: memo }),
-    );
+    const result = await runDeferredRegression(makeOptions({ storyIds: ["US-001"], quarantineMemo: memo }));
 
     // No attribution, no fix cycle.
     expect(result.affectedStories).toEqual([]);
@@ -449,5 +450,85 @@ describe("runDeferredRegression — flakeDetection.enabled === false", () => {
     expect(result.quarantineReport).toBeUndefined();
     // Attribution + fix cycles proceeded normally.
     expect(rectifiedStories).toEqual(["US-001"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1657 — the deferred regression gate is the second `triageFlakyFindings`
+// caller, and it has the same skip paths as the per-story seam. Uncounted,
+// they read as zero by construction and the §3 decision is made on data
+// missing a whole caller.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("runDeferredRegression — skip telemetry (#1657)", () => {
+  let entries: LogEntry[];
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    resetLogger();
+    initLogger({ level: "silent" });
+    entries = [];
+    unsubscribe = addSink((entry) => entries.push(entry));
+    _regressionDeps.runFixCycle = mock(async () => ({
+      iterations: [],
+      finalFindings: [],
+      exitReason: "max-attempts-total" as const,
+      costUsd: 0,
+    }));
+    _regressionDeps.parseTestOutput = mock(() => ({
+      passed: 0,
+      failed: 1,
+      failures: [{ file: "a.test.ts", testName: "test a", error: "boom", stackTrace: [] }],
+    }));
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    resetLogger();
+  });
+
+  function skips(): LogEntry[] {
+    return entries.filter((e) => e.data?.event === FLAKE_TRIAGE_SKIP_EVENT);
+  }
+
+  test("an unresolvable baseline diff emits a regression-scoped counter", async () => {
+    _regressionDeps.runVerification = mock(async () => makeVerifyResult());
+    _regressionDeps.resolveFlakeBaselineDiff = mock(async () => null);
+    const triage = mock(
+      async (input: FlakeTriageInput): Promise<FlakeTriageResult> => ({
+        findings: input.findings.map((f) => ({ ...f })),
+        quarantineReport: { keys: [], reasons: [] },
+      }),
+    );
+    _regressionDeps.triageFlakyFindings = triage;
+
+    await runDeferredRegression(makeOptions({ storyIds: ["US-001"] }));
+
+    expect(triage).not.toHaveBeenCalled();
+    expect(skips().length).toBe(1);
+    expect(skips()[0]?.data?.reason).toBe("baseline-diff-unresolved");
+    // Never "blocking-gate" — this gate cannot dispatch repo-scoped-test-fix.
+    expect(skips()[0]?.data?.scope).toBe("regression");
+  });
+
+  test("an undetectable framework emits a counter instead of probing nothing in silence", async () => {
+    // Under an unknown framework `runFlakeProbe` returns "unprobeable" for every
+    // candidate, so triage quarantines nothing either way — the counter is the
+    // only difference between that outcome and a real triage pass.
+    _regressionDeps.runVerification = mock(async () => makeVerifyResult({ output: "totally unrecognized output" }));
+    const triage = mock(
+      async (input: FlakeTriageInput): Promise<FlakeTriageResult> => ({
+        findings: input.findings.map((f) => ({ ...f })),
+        quarantineReport: { keys: [], reasons: [] },
+      }),
+    );
+    _regressionDeps.triageFlakyFindings = triage;
+
+    await runDeferredRegression(makeOptions({ storyIds: ["US-001"] }));
+
+    expect(triage).not.toHaveBeenCalled();
+    expect(skips().length).toBe(1);
+    expect(skips()[0]?.data?.reason).toBe("framework-undetected");
+    expect(skips()[0]?.data?.scope).toBe("regression");
   });
 });

--- a/test/unit/execution/story-orchestrator/flake-triage-seam.test.ts
+++ b/test/unit/execution/story-orchestrator/flake-triage-seam.test.ts
@@ -7,12 +7,14 @@
  * seam previously was.
  */
 
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { _storyOrchestratorDeps } from "@/execution";
-import type { Finding } from "@/findings";
 import { productionTriageSeam } from "@/execution/story-orchestrator/flake-triage-seam";
+import type { Finding } from "@/findings";
+import { type LogEntry, addSink, initLogger, resetLogger } from "@/logger";
+import { FLAKE_TRIAGE_SKIP_EVENT } from "@/verification";
 import { _flakeTriageDeps } from "@/verification/flake-triage";
 import { cleanupTempDir, makeNaxConfig, makeTempDir, makeTestRuntime } from "@test/helpers";
 
@@ -147,5 +149,120 @@ describe("productionTriageSeam", () => {
 
   test("is wired as the production seam in _storyOrchestratorDeps.triage", () => {
     expect(_storyOrchestratorDeps.triage).toBe(productionTriageSeam);
+  });
+
+  // ── #1657 — skip telemetry ────────────────────────────────────────────────
+  //
+  // Each seam bail-out leaves the surviving findings indistinguishable from
+  // deterministic failures for the repo-scoped-test-fix fallthrough (#1656).
+  // Count them so the decision to thread `flakeTriageRan` through the blocking
+  // cycle can be made on data.
+  describe("skip telemetry (#1657)", () => {
+    let entries: LogEntry[];
+    let unsubscribe: () => void;
+
+    beforeEach(() => {
+      resetLogger();
+      initLogger({ level: "silent" });
+      entries = [];
+      unsubscribe = addSink((entry) => entries.push(entry));
+    });
+
+    afterEach(() => {
+      unsubscribe();
+      resetLogger();
+    });
+
+    function skips(): LogEntry[] {
+      return entries.filter((e) => e.data?.event === FLAKE_TRIAGE_SKIP_EVENT);
+    }
+
+    test("unknown framework emits a framework-undetected counter", async () => {
+      const config = makeNaxConfig({ execution: { flakeDetection: { enabled: true } } });
+      const { ctx } = makeCtx(config);
+      await productionTriageSeam([makeFailedTest(), makeFailedTest({ rule: "shouldBaz" })], {
+        ctx,
+        rawOutput: "totally unrecognized output",
+      });
+
+      expect(skips().length).toBe(1);
+      expect(skips()[0]?.data?.reason).toBe("framework-undetected");
+      expect(skips()[0]?.data?.candidateCount).toBe(2);
+      expect(skips()[0]?.data?.candidateBasis).toBe("gate-findings");
+      expect(skips()[0]?.data?.storyId).toBe("US-003");
+    });
+
+    test("an unresolvable baseline diff emits a baseline-diff-unresolved counter", async () => {
+      // `workdir` is an initialized repo with no commits — `getMergeBase()`
+      // exhausts every fallback, so `resolveFlakeBaselineDiff` returns null.
+      const config = makeNaxConfig({
+        execution: { flakeDetection: { enabled: true } },
+        quality: { commands: { test: "bun test" } },
+      });
+      const { ctx } = makeCtx(config);
+      const [result, report] = await productionTriageSeam([makeFailedTest()], { ctx, rawOutput: BUN_FAIL_OUTPUT });
+
+      expect(report.flakeTriageRan).toBe(false);
+      expect(result[0]?.category).toBe("failed-test");
+      expect(skips().length).toBe(1);
+      expect(skips()[0]?.data?.reason).toBe("baseline-diff-unresolved");
+      expect(skips()[0]?.data?.candidateCount).toBe(1);
+    });
+
+    test("a thrown context resolution emits a context-error counter carrying the message", async () => {
+      const config = makeNaxConfig({
+        execution: { flakeDetection: { enabled: true } },
+        quality: { commands: { test: "bun test" } },
+      });
+      const { ctx } = makeCtx(config);
+      // `packageView` is read before the try block; make the inner resolution throw
+      // by removing the runtime the quality resolver walks.
+      // The point of this test is a ctx the type system forbids: no factory can
+      // produce a runtime-less CallContext.
+      const brokenCtx = { ...ctx, runtime: undefined } as unknown as typeof ctx; // test-ratchet-allow: as-unknown-as
+
+      const [, report] = await productionTriageSeam([makeFailedTest()], { ctx: brokenCtx, rawOutput: BUN_FAIL_OUTPUT });
+
+      expect(report.flakeTriageRan).toBe(false);
+      expect(skips().length).toBe(1);
+      expect(skips()[0]?.data?.reason).toBe("context-error");
+      expect(typeof skips()[0]?.data?.error).toBe("string");
+    });
+
+    test("flakeDetection disabled emits nothing — an operator opt-out is not a gap", async () => {
+      const config = makeNaxConfig({ execution: { flakeDetection: { enabled: false } } });
+      const { ctx } = makeCtx(config);
+      await productionTriageSeam([makeFailedTest()], { ctx, rawOutput: BUN_FAIL_OUTPUT });
+
+      expect(skips().length).toBe(0);
+    });
+
+    test("a completed triage emits no skip counter", async () => {
+      await Bun.write(`${workdir}/pre-existing.test.ts`, "test('shouldBar', () => {});\n");
+      git(workdir, "add", ".");
+      git(workdir, "commit", "-q", "-m", "baseline");
+      git(workdir, "checkout", "-q", "-b", "feature");
+      await Bun.write(`${workdir}/unrelated.ts`, "export const x = 1;\n");
+      git(workdir, "add", ".");
+      git(workdir, "commit", "-q", "-m", "story touches something else entirely");
+      _flakeTriageDeps.runFlakeProbe = async () => ({
+        verdict: "consistent-failure",
+        probeRuns: 2,
+        attributableRuns: 2,
+      });
+
+      const config = makeNaxConfig({
+        execution: { flakeDetection: { enabled: true } },
+        quality: { commands: { test: "bun test" } },
+      });
+      const { ctx } = makeCtx(config);
+      const [, report] = await productionTriageSeam([makeFailedTest({ file: "pre-existing.test.ts" })], {
+        ctx,
+        rawOutput: BUN_FAIL_OUTPUT,
+      });
+
+      expect(report.flakeTriageRan).toBe(true);
+      expect(skips().length).toBe(0);
+    });
   });
 });

--- a/test/unit/execution/story-orchestrator/flake-triage-seam.test.ts
+++ b/test/unit/execution/story-orchestrator/flake-triage-seam.test.ts
@@ -76,7 +76,11 @@ describe("productionTriageSeam", () => {
     const config = makeNaxConfig({ execution: { flakeDetection: { enabled: false } } });
     const { ctx } = makeCtx(config);
     const findings = [makeFailedTest()];
-    const [result, report] = await productionTriageSeam(findings, { ctx, rawOutput: BUN_FAIL_OUTPUT });
+    const [result, report] = await productionTriageSeam(findings, {
+      ctx,
+      rawOutput: BUN_FAIL_OUTPUT,
+      scope: "blocking-gate",
+    });
     expect(result).toEqual(findings);
     expect(report.quarantinedKeys).toEqual([]);
   });
@@ -85,7 +89,11 @@ describe("productionTriageSeam", () => {
     const config = makeNaxConfig({ execution: { flakeDetection: { enabled: true } } });
     const { ctx } = makeCtx(config);
     const findings = [makeFailedTest()];
-    const [result, report] = await productionTriageSeam(findings, { ctx, rawOutput: "totally unrecognized output" });
+    const [result, report] = await productionTriageSeam(findings, {
+      ctx,
+      rawOutput: "totally unrecognized output",
+      scope: "blocking-gate",
+    });
     expect(result).toEqual(findings);
     expect(report.quarantinedKeys).toEqual([]);
   });
@@ -113,7 +121,7 @@ describe("productionTriageSeam", () => {
     });
     const { ctx } = makeCtx(config);
     const findings = [makeFailedTest({ file: "pre-existing.test.ts" })];
-    const [result] = await productionTriageSeam(findings, { ctx, rawOutput: BUN_FAIL_OUTPUT });
+    const [result] = await productionTriageSeam(findings, { ctx, rawOutput: BUN_FAIL_OUTPUT, scope: "blocking-gate" });
 
     expect(probeCalled).toBe(false);
     expect(result[0]?.category).toBe("failed-test");
@@ -140,7 +148,11 @@ describe("productionTriageSeam", () => {
     });
     const { ctx } = makeCtx(config);
     const findings = [makeFailedTest({ file: "pre-existing.test.ts" })];
-    const [result, report] = await productionTriageSeam(findings, { ctx, rawOutput: BUN_FAIL_OUTPUT });
+    const [result, report] = await productionTriageSeam(findings, {
+      ctx,
+      rawOutput: BUN_FAIL_OUTPUT,
+      scope: "blocking-gate",
+    });
 
     expect(probeCalled).toBe(true);
     expect(result[0]?.category).toBe("flaky-test");
@@ -183,10 +195,14 @@ describe("productionTriageSeam", () => {
       await productionTriageSeam([makeFailedTest(), makeFailedTest({ rule: "shouldBaz" })], {
         ctx,
         rawOutput: "totally unrecognized output",
+        scope: "nbf",
       });
 
       expect(skips().length).toBe(1);
       expect(skips()[0]?.data?.reason).toBe("framework-undetected");
+      // The caller's cycle must survive into the row: an nbf skip can never
+      // dispatch repo-scoped-test-fix, so #1657 §3 must be able to exclude it.
+      expect(skips()[0]?.data?.scope).toBe("nbf");
       expect(skips()[0]?.data?.candidateCount).toBe(2);
       expect(skips()[0]?.data?.candidateBasis).toBe("gate-findings");
       expect(skips()[0]?.data?.storyId).toBe("US-003");
@@ -200,7 +216,11 @@ describe("productionTriageSeam", () => {
         quality: { commands: { test: "bun test" } },
       });
       const { ctx } = makeCtx(config);
-      const [result, report] = await productionTriageSeam([makeFailedTest()], { ctx, rawOutput: BUN_FAIL_OUTPUT });
+      const [result, report] = await productionTriageSeam([makeFailedTest()], {
+        ctx,
+        rawOutput: BUN_FAIL_OUTPUT,
+        scope: "blocking-gate",
+      });
 
       expect(report.flakeTriageRan).toBe(false);
       expect(result[0]?.category).toBe("failed-test");
@@ -221,7 +241,11 @@ describe("productionTriageSeam", () => {
       // produce a runtime-less CallContext.
       const brokenCtx = { ...ctx, runtime: undefined } as unknown as typeof ctx; // test-ratchet-allow: as-unknown-as
 
-      const [, report] = await productionTriageSeam([makeFailedTest()], { ctx: brokenCtx, rawOutput: BUN_FAIL_OUTPUT });
+      const [, report] = await productionTriageSeam([makeFailedTest()], {
+        ctx: brokenCtx,
+        rawOutput: BUN_FAIL_OUTPUT,
+        scope: "blocking-gate",
+      });
 
       expect(report.flakeTriageRan).toBe(false);
       expect(skips().length).toBe(1);
@@ -229,10 +253,39 @@ describe("productionTriageSeam", () => {
       expect(typeof skips()[0]?.data?.error).toBe("string");
     });
 
+    // Without this case the `no-test-command` emit could be deleted and the
+    // suite would stay green — the only other reference to it is a direct call
+    // in the telemetry module's own test, which exercises the logger wrapper.
+    test("a package with no resolvable test command emits a no-test-command counter", async () => {
+      await Bun.write(`${workdir}/pre-existing.test.ts`, "test('shouldBar', () => {});\n");
+      git(workdir, "add", ".");
+      git(workdir, "commit", "-q", "-m", "baseline");
+
+      const config = makeNaxConfig({ execution: { flakeDetection: { enabled: true } } });
+      // makeNaxConfig seeds quality.commands.test; unset it so neither the
+      // resolver nor the config fallback yields a base command.
+      const withoutTestCommand = {
+        ...config,
+        quality: { ...config.quality, commands: { ...config.quality?.commands, test: undefined } },
+      };
+      const { ctx } = makeCtx(withoutTestCommand as typeof config);
+
+      const [, report] = await productionTriageSeam([makeFailedTest()], {
+        ctx,
+        rawOutput: BUN_FAIL_OUTPUT,
+        scope: "blocking-gate",
+      });
+
+      expect(report.flakeTriageRan).toBe(false);
+      expect(skips().length).toBe(1);
+      expect(skips()[0]?.data?.reason).toBe("no-test-command");
+      expect(skips()[0]?.data?.scope).toBe("blocking-gate");
+    });
+
     test("flakeDetection disabled emits nothing — an operator opt-out is not a gap", async () => {
       const config = makeNaxConfig({ execution: { flakeDetection: { enabled: false } } });
       const { ctx } = makeCtx(config);
-      await productionTriageSeam([makeFailedTest()], { ctx, rawOutput: BUN_FAIL_OUTPUT });
+      await productionTriageSeam([makeFailedTest()], { ctx, rawOutput: BUN_FAIL_OUTPUT, scope: "blocking-gate" });
 
       expect(skips().length).toBe(0);
     });
@@ -259,6 +312,7 @@ describe("productionTriageSeam", () => {
       const [, report] = await productionTriageSeam([makeFailedTest({ file: "pre-existing.test.ts" })], {
         ctx,
         rawOutput: BUN_FAIL_OUTPUT,
+        scope: "blocking-gate",
       });
 
       expect(report.flakeTriageRan).toBe(true);

--- a/test/unit/verification/flake-triage-telemetry.test.ts
+++ b/test/unit/verification/flake-triage-telemetry.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Flake-Triage Skip Telemetry (#1657)
+ *
+ * The counter that decides whether the `repo-scoped-test-fix` fallthrough
+ * (#1656) needs to be gated on `flakeTriageRan`. Every skip path must emit
+ * exactly one event carrying the reason tag and the candidate count.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type LogEntry, addSink, initLogger, resetLogger } from "@/logger";
+import { FLAKE_TRIAGE_SKIP_EVENT, logFlakeTriageSkip } from "@/verification";
+
+describe("logFlakeTriageSkip", () => {
+  let entries: LogEntry[];
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    resetLogger();
+    initLogger({ level: "silent" });
+    entries = [];
+    unsubscribe = addSink((entry) => entries.push(entry));
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    resetLogger();
+  });
+
+  test("emits one greppable event tagged with reason, count, and basis", () => {
+    logFlakeTriageSkip({
+      reason: "max-probes-per-gate",
+      candidateCount: 9,
+      candidateBasis: "probe-eligible",
+      storyId: "US-004",
+      maxProbesPerGate: 5,
+    });
+
+    expect(entries.length).toBe(1);
+    const entry = entries[0];
+    expect(entry?.stage).toBe("flake-triage");
+    expect(entry?.data?.event).toBe(FLAKE_TRIAGE_SKIP_EVENT);
+    expect(entry?.data?.reason).toBe("max-probes-per-gate");
+    expect(entry?.data?.candidateCount).toBe(9);
+    expect(entry?.data?.candidateBasis).toBe("probe-eligible");
+    expect(entry?.data?.maxProbesPerGate).toBe(5);
+    expect(entry?.data?.storyId).toBe("US-004");
+  });
+
+  test("omits optional fields that were not supplied", () => {
+    logFlakeTriageSkip({ reason: "framework-undetected", candidateCount: 2, candidateBasis: "gate-findings" });
+
+    const data = entries[0]?.data ?? {};
+    expect("maxProbesPerGate" in data).toBe(false);
+    expect("error" in data).toBe(false);
+    expect("storyId" in data).toBe(false);
+  });
+
+  test("carries the error text on the context-error path", () => {
+    logFlakeTriageSkip({
+      reason: "context-error",
+      candidateCount: 1,
+      candidateBasis: "gate-findings",
+      error: "resolveQualityTestCommands exploded",
+    });
+
+    expect(entries[0]?.data?.error).toBe("resolveQualityTestCommands exploded");
+  });
+
+  test("never throws when no logger is initialized", () => {
+    resetLogger();
+    expect(() =>
+      logFlakeTriageSkip({ reason: "no-test-command", candidateCount: 0, candidateBasis: "gate-findings" }),
+    ).not.toThrow();
+  });
+});

--- a/test/unit/verification/flake-triage-telemetry.test.ts
+++ b/test/unit/verification/flake-triage-telemetry.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { type LogEntry, addSink, initLogger, resetLogger } from "@/logger";
-import { FLAKE_TRIAGE_SKIP_EVENT, logFlakeTriageSkip } from "@/verification";
+import { FLAKE_TRIAGE_RAN_EVENT, FLAKE_TRIAGE_SKIP_EVENT, logFlakeTriageRan, logFlakeTriageSkip } from "@/verification";
 
 describe("logFlakeTriageSkip", () => {
   let entries: LogEntry[];
@@ -29,6 +29,7 @@ describe("logFlakeTriageSkip", () => {
   test("emits one greppable event tagged with reason, count, and basis", () => {
     logFlakeTriageSkip({
       reason: "max-probes-per-gate",
+      scope: "blocking-gate",
       candidateCount: 9,
       candidateBasis: "probe-eligible",
       storyId: "US-004",
@@ -40,6 +41,7 @@ describe("logFlakeTriageSkip", () => {
     expect(entry?.stage).toBe("flake-triage");
     expect(entry?.data?.event).toBe(FLAKE_TRIAGE_SKIP_EVENT);
     expect(entry?.data?.reason).toBe("max-probes-per-gate");
+    expect(entry?.data?.scope).toBe("blocking-gate");
     expect(entry?.data?.candidateCount).toBe(9);
     expect(entry?.data?.candidateBasis).toBe("probe-eligible");
     expect(entry?.data?.maxProbesPerGate).toBe(5);
@@ -47,7 +49,12 @@ describe("logFlakeTriageSkip", () => {
   });
 
   test("omits optional fields that were not supplied", () => {
-    logFlakeTriageSkip({ reason: "framework-undetected", candidateCount: 2, candidateBasis: "gate-findings" });
+    logFlakeTriageSkip({
+      reason: "framework-undetected",
+      scope: "nbf",
+      candidateCount: 2,
+      candidateBasis: "gate-findings",
+    });
 
     const data = entries[0]?.data ?? {};
     expect("maxProbesPerGate" in data).toBe(false);
@@ -58,6 +65,7 @@ describe("logFlakeTriageSkip", () => {
   test("carries the error text on the context-error path", () => {
     logFlakeTriageSkip({
       reason: "context-error",
+      scope: "regression",
       candidateCount: 1,
       candidateBasis: "gate-findings",
       error: "resolveQualityTestCommands exploded",
@@ -69,7 +77,47 @@ describe("logFlakeTriageSkip", () => {
   test("never throws when no logger is initialized", () => {
     resetLogger();
     expect(() =>
-      logFlakeTriageSkip({ reason: "no-test-command", candidateCount: 0, candidateBasis: "gate-findings" }),
+      logFlakeTriageSkip({
+        reason: "no-test-command",
+        scope: "blocking-gate",
+        candidateCount: 0,
+        candidateBasis: "gate-findings",
+      }),
     ).not.toThrow();
+  });
+});
+
+describe("logFlakeTriageRan", () => {
+  let entries: LogEntry[];
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    resetLogger();
+    initLogger({ level: "silent" });
+    entries = [];
+    unsubscribe = addSink((entry) => entries.push(entry));
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    resetLogger();
+  });
+
+  // Without a denominator, #1657 §3's "meaningful rate" has no rate at all.
+  test("emits the denominator counter at debug, so it costs no console lines", () => {
+    logFlakeTriageRan({ scope: "blocking-gate", candidateCount: 4, quarantinedCount: 1, storyId: "US-002" });
+
+    expect(entries.length).toBe(1);
+    expect(entries[0]?.level).toBe("debug");
+    expect(entries[0]?.data?.event).toBe(FLAKE_TRIAGE_RAN_EVENT);
+    expect(entries[0]?.data?.scope).toBe("blocking-gate");
+    expect(entries[0]?.data?.candidateCount).toBe(4);
+    expect(entries[0]?.data?.quarantinedCount).toBe(1);
+    expect(entries[0]?.data?.storyId).toBe("US-002");
+  });
+
+  test("never throws when no logger is initialized", () => {
+    resetLogger();
+    expect(() => logFlakeTriageRan({ scope: "regression", candidateCount: 0, quarantinedCount: 0 })).not.toThrow();
   });
 });

--- a/test/unit/verification/flake-triage.test.ts
+++ b/test/unit/verification/flake-triage.test.ts
@@ -13,7 +13,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { FlakeDetectionConfig } from "@/config/runtime-types";
 import type { Finding } from "@/findings/types";
-import { type FlakeTriageInput, _flakeTriageDeps, triageFlakyFindings } from "@/verification";
+import { type LogEntry, addSink, initLogger, resetLogger } from "@/logger";
+import { FLAKE_TRIAGE_SKIP_EVENT, type FlakeTriageInput, _flakeTriageDeps, triageFlakyFindings } from "@/verification";
 import type { FlakeProbeVerdict } from "@/verification/flake-probe";
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
@@ -320,6 +321,65 @@ describe("triageFlakyFindings — maxProbesPerGate cap (AC8)", () => {
       expect(f.category).toBe("failed-test");
     }
     expect(result.quarantineReport.reasons.some((r) => r.includes("maxProbesPerGate"))).toBe(true);
+  });
+
+  // #1657 — the skip must be measurable, not just reported in the quarantine
+  // report: this is the path that leaves a flake indistinguishable from a
+  // deterministic failure right before the repo-scoped-test-fix fallthrough.
+  test("#1657 — emits a skip counter tagged with the probe-eligible candidate count", async () => {
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
+
+    resetLogger();
+    initLogger({ level: "silent" });
+    const entries: LogEntry[] = [];
+    const unsubscribe = addSink((entry) => entries.push(entry));
+
+    try {
+      const findings: Finding[] = [];
+      for (let i = 0; i < 6; i++) {
+        findings.push(makeFinding({ file: `test/unit/foo${i}.test.ts`, rule: `should work ${i}` }));
+      }
+      // One story-touched test is not probe-eligible — the counter must report
+      // the eligible candidates (6), not the raw finding count (7).
+      findings.push(makeFinding({ file: "test/unit/touched.test.ts", rule: "should be excluded" }));
+
+      await triageFlakyFindings(
+        makeInput({
+          findings,
+          diff: { changedTestFiles: ["test/unit/touched.test.ts"], mappedTestFiles: [] },
+          flakeDetection: { ...defaultFlakeConfig, maxProbesPerGate: 2 },
+          storyId: "US-007",
+        }),
+      );
+
+      const skips = entries.filter((e) => e.data?.event === FLAKE_TRIAGE_SKIP_EVENT);
+      expect(skips.length).toBe(1);
+      expect(skips[0]?.data?.reason).toBe("max-probes-per-gate");
+      expect(skips[0]?.data?.candidateCount).toBe(6);
+      expect(skips[0]?.data?.candidateBasis).toBe("probe-eligible");
+      expect(skips[0]?.data?.maxProbesPerGate).toBe(2);
+      expect(skips[0]?.data?.storyId).toBe("US-007");
+    } finally {
+      unsubscribe();
+      resetLogger();
+    }
+  });
+
+  test("#1657 — emits no skip counter when triage actually runs", async () => {
+    _flakeTriageDeps.runFlakeProbe = async () => ({ verdict: "consistent-failure", probeRuns: 1, attributableRuns: 1 });
+
+    resetLogger();
+    initLogger({ level: "silent" });
+    const entries: LogEntry[] = [];
+    const unsubscribe = addSink((entry) => entries.push(entry));
+
+    try {
+      await triageFlakyFindings(makeInput({ findings: [makeFinding()] }));
+      expect(entries.filter((e) => e.data?.event === FLAKE_TRIAGE_SKIP_EVENT).length).toBe(0);
+    } finally {
+      unsubscribe();
+      resetLogger();
+    }
   });
 });
 

--- a/test/unit/verification/flake-triage.test.ts
+++ b/test/unit/verification/flake-triage.test.ts
@@ -14,7 +14,13 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { FlakeDetectionConfig } from "@/config/runtime-types";
 import type { Finding } from "@/findings/types";
 import { type LogEntry, addSink, initLogger, resetLogger } from "@/logger";
-import { FLAKE_TRIAGE_SKIP_EVENT, type FlakeTriageInput, _flakeTriageDeps, triageFlakyFindings } from "@/verification";
+import {
+  FLAKE_TRIAGE_RAN_EVENT,
+  FLAKE_TRIAGE_SKIP_EVENT,
+  type FlakeTriageInput,
+  _flakeTriageDeps,
+  triageFlakyFindings,
+} from "@/verification";
 import type { FlakeProbeVerdict } from "@/verification/flake-probe";
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
@@ -53,6 +59,7 @@ function makeInput(overrides: Partial<FlakeTriageInput> = {}): FlakeTriageInput 
     cwd: "/tmp/probe",
     framework: "bun",
     quarantineMemo: emptyMemo,
+    scope: "blocking-gate",
     ...overrides,
   };
 }
@@ -348,6 +355,7 @@ describe("triageFlakyFindings — maxProbesPerGate cap (AC8)", () => {
           findings,
           diff: { changedTestFiles: ["test/unit/touched.test.ts"], mappedTestFiles: [] },
           flakeDetection: { ...defaultFlakeConfig, maxProbesPerGate: 2 },
+          scope: "blocking-gate",
           storyId: "US-007",
         }),
       );
@@ -359,6 +367,7 @@ describe("triageFlakyFindings — maxProbesPerGate cap (AC8)", () => {
       expect(skips[0]?.data?.candidateBasis).toBe("probe-eligible");
       expect(skips[0]?.data?.maxProbesPerGate).toBe(2);
       expect(skips[0]?.data?.storyId).toBe("US-007");
+      expect(skips[0]?.data?.scope).toBe("blocking-gate");
     } finally {
       unsubscribe();
       resetLogger();
@@ -376,6 +385,10 @@ describe("triageFlakyFindings — maxProbesPerGate cap (AC8)", () => {
     try {
       await triageFlakyFindings(makeInput({ findings: [makeFinding()] }));
       expect(entries.filter((e) => e.data?.event === FLAKE_TRIAGE_SKIP_EVENT).length).toBe(0);
+      // ... and the denominator fires instead, so a rate is computable (#1657 §2).
+      const ran = entries.filter((e) => e.data?.event === FLAKE_TRIAGE_RAN_EVENT);
+      expect(ran.length).toBe(1);
+      expect(ran[0]?.data?.candidateCount).toBe(1);
     } finally {
       unsubscribe();
       resetLogger();


### PR DESCRIPTION
Closes #1657. Follow-up to #1654 / #1656.

## The problem

`repo-scoped-test-fix` dispatches an agent that may edit any file in the repo to make a failing test pass. If the test is actually *flaky*, that agent is the worst possible reader of it. The only reason that is safe today is that `triageFlakyFindings` has already quarantined confirmed flakes — anything reaching the fallthrough has been judged deterministic.

Triage has paths where it does not run at all. On those, a flake and a deterministic failure are indistinguishable. The issue's own conclusion is that the guard (gating the fallthrough on `flakeTriageRan`) is real plumbing and there is **no frequency data behind it** — so measure first.

This PR is step 1 only. Steps 2 and 3 stay deferred, deliberately.

## What changed

One `flake.triage.skipped` event per skip, via `logFlakeTriageSkip` (`src/verification/flake-triage-telemetry.ts`):

| `reason` | Emitted from | `candidateBasis` |
|:---|:---|:---|
| `max-probes-per-gate` | `triageFlakyFindings` | `probe-eligible` (exact) |
| `framework-undetected` | `productionTriageSeam`, `runRegressionFlakeTriage` | `gate-findings` (upper bound) |
| `no-test-command` | `productionTriageSeam` | `gate-findings` |
| `baseline-diff-unresolved` | `productionTriageSeam`, `runRegressionFlakeTriage` | `gate-findings` |
| `context-error` | `productionTriageSeam` | `gate-findings` |

The issue named three paths; the seam has two more with identical consequences, so they are counted too. `flakeDetection.enabled: false` is **not** counted — an operator opt-out is not a gap in a feature believed to be on.

## `scope` is the field that actually decides step 3

Every row carries `blocking-gate | nbf | regression`, and it is **required, not defaulted** — a mislabeled row cannot be repaired once the data has accrued.

`makeRepoScopedTestFixStrategy` is registered on the **blocking cycle only** (`build-plan-for-strategy.ts`). But `productionTriageSeam` is also called from `triageNbfGate` — inside the per-phase loop, per `runRectify` attempt. Without the label, a counter reading "40 events, meaningful rate" could be 36 NBF emits that can never dispatch the fallthrough, and #1657's plumbing gets paid for on traffic carrying none of the risk.

`flake.triage.ran` (at `debug`, so no console lines) is the matching denominator. "Only if path 1 shows up at a meaningful rate" has no rate without one.

## The second caller was the real gap

`runRegressionFlakeTriage` is the other `triageFlakyFindings` caller and its `baselineDiff === null` bail-out **is literally path 2 from the issue**. It emitted nothing. On a shallow CI clone or detached HEAD — where `getMergeBase()` exhausts its fallbacks — that entire class of run read as zero, and step 3's decision would have been made against data missing a whole caller.

Its unknown-framework case now bails early with a counter as well. This is not a behavior change in outcome: `runFlakeProbe` returns `unprobeable` for every candidate under an unknown framework, so triage quarantined nothing before and quarantines nothing now. The difference is that it is no longer silent.

## `flakeTriageRan` is the wrong signal for the guard

Worth recording before anyone builds step 3: `triageFlakyFindings` returns **normally** on the `max-probes-per-gate` skip, so the seam reports `flakeTriageRan: true` for exactly the path the issue names as mattering most. A guard written against that flag would be inert there. Documented in the design doc and noted at the site that produces the flag. Not changed here — `triageNbfGate` feeds it into `recordAttempt`, where a `false` also changes which keys are marked attempted.

## Two small behavior changes, flagged

1. The seam's `ctx.runtime` reads moved **inside** its `try`, so a malformed context skips with a counter instead of throwing past the seam — which the seam's fail-closed contract already claimed. Both callers (`triageGateFindings`, `triageNbfGate`) already caught and degraded identically, so no caller depended on the throw escaping.
2. The regression gate's unknown-framework early bail, above.

## Review

Reviewed before opening; the review found the missing second caller (HIGH), the missing `scope` discriminator, the missing denominator, and the `flakeTriageRan` fact — all fixed in the second commit. It also caught that `no-test-command` had no test that would fail if the emit were deleted; that test now exists.

## Test plan

- [x] `bun run test` — 13878 unit + 1135 integration + 37 ui, 0 fail
- [x] `bun run lint`, `bun run typecheck`, all pre-commit ratchets at baseline
- [x] Each of the 5 reasons has a test asserting the emit fires exactly once with the right reason and scope — deleting any emit site fails the suite
- [x] Documented `jq` query executed against a sample JSONL with the real event shape
- [ ] Accrue over real runs (step 2), then decide step 3
