### PR TITLE
fix: mock sendTelegramNotify in the undelivered-escalation test

### DIFF
--- a/test/unit/finish/phase.test.ts
+++ b/test/unit/finish/phase.test.ts
@@ -298,6 +298,13 @@ test("an undelivered escalation is surfaced on the finish status entry", async (
     escalationReason: "needs a human",
     deliveryError: "gh pr comment failed",
   });
+  // This test's config carries no `interaction.plugin: "telegram"`, so
+  // `telegramCreds()` (src/finish/notify.ts) falls through to ambient
+  // NAX_TELEGRAM_TOKEN / TELEGRAM_BOT_TOKEN / NAX_TELEGRAM_CHAT_ID env vars.
+  // test/preload.ts scrubs those and sentinels the underlying fetch as a
+  // global safety net, but this test must not depend on that for its own
+  // hermeticity — mock the seam directly, like every sibling test above does.
+  _finishPhaseDeps.sendTelegramNotify = async () => false;
   const ctx = {
     ...makeCtx(),
     statusWriter: {


### PR DESCRIPTION
## Summary
- `test/unit/finish/phase.test.ts`'s "an undelivered escalation is surfaced on the finish status entry" test built a `FinishResult` with `feature: "f"` and `escalationReason: "needs a human"` — exactly what `buildEscalationMessage()` turns into `"nax-finish escalated f: needs a human"`.
- Unlike every sibling test in the file, it never mocked `_finishPhaseDeps.sendTelegramNotify`, so `runFinishPhase()`'s `notify()` reached the real seam: `telegramCreds()` (`src/finish/notify.ts`) falls back to ambient `NAX_TELEGRAM_TOKEN` / `TELEGRAM_BOT_TOKEN` / `NAX_TELEGRAM_CHAT_ID` env vars outside any `_deps` injection point.
- `test/preload.ts` already scrubs those vars and sentinels the underlying fetch as a global safety net, but that made this test's isolation implicit and external rather than self-contained — a hermeticity violation independent of whether a message has actually escaped. This is the exact message text ("nax-finish escalated f: needs a human") reported as randomly arriving via Telegram.
- Fix: mock `_finishPhaseDeps.sendTelegramNotify` directly in this test, matching the pattern every other test in the file already uses. It's restored by the test's existing `finally { Object.assign(_finishPhaseDeps, restore); }`.

Confirmed no other test in `test/unit/finish/` or `test/unit/execution/runner-completion-postrun.test.ts` reaches the real `sendTelegramNotify`/fetch seam unmocked — this was the only gap.

## Test plan
- [x] `bun test test/unit/finish/phase.test.ts --timeout=5000` — 16 pass
- [x] `bun test test/unit/finish/ --timeout=5000` — 380 pass
- [x] `bun run typecheck` — clean
- [x] Independent code-review pass confirmed correctness, root-cause coverage, and no regression risk

https://claude.ai/code/session_0129m38XwbvPNmnLuooe1kAd