### PR TITLE
docs: add repo-scoped-test-fix to session role registry

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -45,7 +45,7 @@ The agent adapter exposes exactly 4 primitives: `openSession`, `sendTurn`, `clos
 
 | Role | Dispatch |
 |:---|:---|
-| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-revise`, `plan-critic`, `plan-refine`, `setup`, `debate-stateful`, `debate-hybrid`, `debate-plan`, `finish-review-spec`, `finish-review-quality`, `finish-fix`, `finish-narrative` | `callOp` run-kind |
+| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `repo-scoped-test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-revise`, `plan-critic`, `plan-refine`, `setup`, `debate-stateful`, `debate-hybrid`, `debate-plan`, `finish-review-spec`, `finish-review-quality`, `finish-fix`, `finish-narrative` | `callOp` run-kind |
 | `decompose`, `refine`, `fix-gen`, `auto`, `synthesis`, `judge` | `callOp` complete-kind |
 
 ## Rule 3: Adapter primitives stay inside the wiring layer

--- a/.nax/rules/adapter-wiring.md
+++ b/.nax/rules/adapter-wiring.md
@@ -54,7 +54,7 @@ The agent adapter exposes exactly 4 primitives: `openSession`, `sendTurn`, `clos
 
 | Role | Dispatch |
 |:---|:---|
-| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-revise`, `plan-critic`, `plan-refine`, `setup`, `debate-stateful`, `debate-hybrid`, `debate-plan`, `finish-review-spec`, `finish-review-quality`, `finish-fix`, `finish-narrative` | `callOp` run-kind |
+| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `repo-scoped-test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-revise`, `plan-critic`, `plan-refine`, `setup`, `debate-stateful`, `debate-hybrid`, `debate-plan`, `finish-review-spec`, `finish-review-quality`, `finish-fix`, `finish-narrative` | `callOp` run-kind |
 | `decompose`, `refine`, `fix-gen`, `auto`, `synthesis`, `judge` | `callOp` complete-kind |
 
 ## Rule 3: Adapter primitives stay inside the wiring layer

--- a/docs/20260821-review-v0.81.0-to-main.md
+++ b/docs/20260821-review-v0.81.0-to-main.md
@@ -1,0 +1,74 @@
+# Deep Code Review: nax (v0.81.0 → main)
+
+**Date:** 2026-08-21
+**Reviewer:** Claude (AI)
+**Range:** `v0.81.0..main` (10 commits, HEAD `93169a7f3`)
+**Files changed:** 887 total — 133 in `src/`, 722 in `test/`, 32 elsewhere
+**Scope note:** ~85% of the changed-file count (722 test files + most of the 133 `src/` files) is a **mechanical barrel-import path migration** — rewriting relative imports to `@/`-alias form and splitting a handful of files into `dir/index.ts` (commits `6437c7d8b`, `e94195c03`, `22de72bc6`, `49c987ac2`). These carry no behavior change and were excluded from line-level review after spot-checking several for accidental logic drift (none found).
+
+The reviewed logic surface is five feature/fix commits:
+
+| Commit | Summary |
+|:---|:---|
+| `5a7f9880d` (#1654) | Dispatch a repo-scoped test fix when the story-scoped rectifier gives up |
+| `e560b92f6` (#1658) | Record and announce repo-scoped repairs on the story |
+| `93169a7f3` (#1658 follow-up) | Persist repo-scoped fix records on the PRD story |
+| `eeb09eb39` (#1657) | Count every path where flake triage is skipped |
+| `4a90b2c90` (#1653) | Suppress `story.start` for attempts refused by the tier pre-check |
+
+---
+
+## Overall Grade: A- (88/100)
+
+This is unusually well-documented, deliberate code — nearly every non-obvious decision (why a mutation is safe under the worktree-clone model, why a field is *not* named what it looks like it should be named, why an exit ordering matters) is explained inline with the issue number that motivated it, and the explanations check out against the actual call graph. I traced the two most failure-prone paths in the range end-to-end:
+
+- **`#1654` fallthrough dispatch** (`src/findings/cycle.ts` + `cycle-selection.ts`): confirmed that a story-scoped strategy's give-up correctly retires *only* that strategy via `DeclineLedger`, that `selectable`/`active`/`uncappedActive` re-derive from the ledger on the `continue`-driven re-entry, and that the repo-scoped strategy is consequently selectable on the very next loop pass without an infinite-loop risk. No bug found.
+- **`#1658` persistence** (`repo-scoped-fix-record.ts` → `pipeline/stages/execution.ts` → `unified-executor.ts`): confirmed the mutate-by-reference claim in the doc comment — `buildWorktreePipelineContext` `structuredClone`s `prd` but passes `story` through by reference (`src/execution/parallel-worker.ts:26-29`), so `story.repoScopedFixes` written by `recordRepoScopedFixes` survives to the `savePRD` call that follows. This is the same class of bug flagged in memory as latent elsewhere (`outputFiles`/`diffSummary` lost on reload) — here it does **not** reproduce, because the write targets the live reference rather than a value that gets reloaded out from under it.
+
+The one finding below is a documentation-drift item, not a functional defect. Scoring loses points only for that gap and for the generally very large blast radius of a migration this size landing in one branch (887 files is hard to review with full confidence even when 85% is mechanical).
+
+---
+
+## Findings
+
+### 🟢 LOW
+
+#### DOC-1: Session-role registry doc not updated for the new `repo-scoped-test-fix` role
+**Severity:** LOW | **Category:** Documentation drift
+
+`src/runtime/session-role.ts` gained a new canonical session role in this range:
+
+```diff
+ export type CanonicalSessionRole =
++  | "repo-scoped-test-fix"
+   | "verifier"
+   ...
+ export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
++  "repo-scoped-test-fix",
+   "verifier",
+```
+
+`src/operations/full-suite-rectify.ts` (new in this range) uses it: `sessionRole: "repo-scoped-test-fix"` (in `makeRepoScopedTestFixStrategy`).
+
+`.claude/rules/adapter-wiring.md`'s "Session role registry" table (§ Rule 2) enumerates every `callOp` run-kind role by hand and was **not** updated — `repo-scoped-test-fix` is absent from it. Confirmed via `git log v0.81.0..main -- .claude/rules/adapter-wiring.md`, which shows zero commits touching that file in this range.
+
+**Risk:** Low — the code path is unaffected (the type union and `KNOWN_SESSION_ROLES` array are the actual enforcement points, and both were updated correctly). The risk is purely to future readers/agents who consult the rules doc as the source of truth for valid session roles and won't find this one listed.
+
+**Fix:** Add `repo-scoped-test-fix` to the table row list in `.claude/rules/adapter-wiring.md` § "Session role registry".
+
+---
+
+## Notable Positives
+
+- **`no-progress-bail.ts`** (`everyFixDeclined` / `withNoProgressBail`): the guard against counting a no-op (all-declined) iteration as "no progress" is precise — it correctly leaves carry-forward iterations (`fixesApplied: []`) un-exempted, and the doc comment's claim that `withIncreasingFailuresBail` needs no equivalent guard checks out against that bail's actual predicate (`findingsAfter.length > findingsBefore.length`, unsatisfiable by a no-op iteration).
+- **`flake-triage-telemetry.ts` / `#1657`**: all five declared `FlakeTriageSkipReason` values (`max-probes-per-gate`, `baseline-diff-unresolved`, `framework-undetected`, `no-test-command`, `context-error`) are wired to real call sites across `flake-triage.ts`, `flake-triage-seam.ts`, and `run-regression-triage.ts` — no dead enum members. The `scope` field is `required` (not defaulted), which is a good call given the doc's own warning that "a mislabeled row is unrecoverable once the data has accrued."
+- **`repo-scoped-fix-record.ts`**: the `findingsCleared` field is deliberately *not* named `resolved`, with a clear explanation of why (verifier-SSOT carve-out ambiguity) and `filesChanged` is correctly identified as the actual discriminating signal. This is exactly the kind of naming precision that prevents a future consumer from misreading the field.
+- **`rectifier-builder-helpers.ts`**: the repo-scoped prompt correctly drops Exception 3 (sibling-scope decline) and Exception 4 (mock handoff) with an explanation of why each would be self-defeating in the repo-scoped context — this is the kind of prompt-logic error that's easy to introduce silently and easy to miss in review; it was not present here.
+
+---
+
+## Priority Fix Order
+
+| Priority | ID | Effort | Description |
+|:---|:---|:---|:---|
+| P3 | DOC-1 | S | Add `repo-scoped-test-fix` to the session-role table in `.claude/rules/adapter-wiring.md` |


### PR DESCRIPTION
## Summary
- Adds the `repo-scoped-test-fix` session role (introduced by `full-suite-rectify.ts` for #1654) to the "Session role registry" table in both `.nax/rules/adapter-wiring.md` and `.claude/rules/adapter-wiring.md` — the code registry (`session-role.ts`) already had it, only the docs were stale.
- Adds `docs/20260821-review-v0.81.0-to-main.md`: a verified code review of the diff from `v0.81.0` to `main` (10 commits). This doc-drift gap was the only finding (LOW severity); the two riskiest new code paths (#1654 fallthrough dispatch, #1658 fix-record persistence) were traced end-to-end and confirmed correct.

## Test plan
- [x] Pre-commit hooks (typecheck, lint, all static checks) passed on commit.
- [x] Docs-only change — no runtime behavior affected.