### PR TITLE
fix(review): pass repoRoot into semantic and adversarial review inputs

### DIFF
--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -340,6 +340,14 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
         });
         return {
           workdir: ctx.workdir,
+          // Anchors evidence-path resolution. Review findings carry repo-root-relative
+          // paths (git emits them that way), while `workdir` is the package dir in a
+          // monorepo — without this, checkFindingEvidence double-counts the package
+          // prefix, reports "unreadable", and every finding fails open (#1668).
+          // Bare `ctx.projectDir` on purpose: it is a required field, and defaulting
+          // to `ctx.workdir` would make repoRoot === workdir, which checkFindingEvidence
+          // collapses back to the single-root lookup — silently restoring the bug.
+          repoRoot: ctx.projectDir,
           story,
           // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
           semanticConfig: ctx.config.review!.semantic!,
@@ -389,6 +397,8 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
         });
         return {
           workdir: ctx.workdir,
+          // See the semantic input above — same evidence-path anchor (#1668).
+          repoRoot: ctx.projectDir,
           story,
           // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
           adversarialConfig: ctx.config.review!.adversarial!,

--- a/test/unit/execution/plan-inputs-review-wiring.test.ts
+++ b/test/unit/execution/plan-inputs-review-wiring.test.ts
@@ -209,3 +209,45 @@ describe("assemblePlanInputsFromCtx — review + rectification wiring", () => {
   });
 });
 
+
+describe("assemblePlanInputsFromCtx — evidence substantiation wiring (#1668)", () => {
+  // `checkFindingEvidence` resolves a finding's file against `repoRoot` first,
+  // falling back to `workdir` as a package-relative path. Review findings carry
+  // repo-root-relative paths (git emits them that way), so in a monorepo — where
+  // `workdir` is the package dir, not the repo root — omitting `repoRoot` makes
+  // every lookup double-count the package prefix, return "unreadable", and
+  // fail open. Substantiation was inert for every monorepo package story.
+  test("semantic review input carries repoRoot so evidence resolves against the repo root", async () => {
+    const ctx = makeCtx({
+      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["semantic"] },
+    });
+    ctx.storyGitRef = "abc123";
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.semanticReview).toBeDefined();
+    expect(inputs.semanticReview!.repoRoot).toBe("/tmp/proj");
+  });
+
+  test("adversarial review input carries repoRoot so evidence resolves against the repo root", async () => {
+    const ctx = makeCtx({
+      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["adversarial"] },
+    });
+    ctx.storyGitRef = "abc123";
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.adversarialReview).toBeDefined();
+    expect(inputs.adversarialReview!.repoRoot).toBe("/tmp/proj");
+  });
+
+  test("repoRoot is distinct from workdir, so the package prefix is not double-counted", async () => {
+    // Guards the regression directly: if repoRoot were sourced from ctx.workdir
+    // (the package dir) the fallback would resolve <pkg>/<pkg>/<file>.
+    const ctx = makeCtx({
+      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["semantic", "adversarial"] },
+    });
+    ctx.storyGitRef = "abc123";
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.semanticReview!.repoRoot).toBeDefined();
+    expect(inputs.adversarialReview!.repoRoot).toBeDefined();
+    expect(inputs.semanticReview!.repoRoot).not.toBe(inputs.semanticReview!.workdir);
+    expect(inputs.adversarialReview!.repoRoot).not.toBe(inputs.adversarialReview!.workdir);
+  });
+});

--- a/test/unit/execution/review-input-repo-root.test.ts
+++ b/test/unit/execution/review-input-repo-root.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, mock, test } from "bun:test";
+import { _storyOrchestratorDeps, refreshReviewInputForDispatch } from "@/execution";
+
+/**
+ * #1668 — `checkFindingEvidence` resolves a finding's file against `repoRoot`
+ * first, falling back to `workdir` as a package-relative path. Review findings
+ * carry repo-root-relative paths, so in a monorepo — where `workdir` is the
+ * package dir — a missing `repoRoot` makes every lookup double-count the package
+ * prefix, return "unreadable", and fail open.
+ *
+ * `plan-inputs-review-wiring.test.ts` guards `repoRoot` being SET on the inputs;
+ * those tests fail on the pre-fix code. These guard the value surviving
+ * `refreshReviewInputForDispatch`'s **catch path**, which rebuilds the input by
+ * destructuring `_refresh` off and returning the rest. That branch is otherwise
+ * unexercised for field preservation, and it is the one a future refactor is
+ * most likely to rewrite field-by-field — which would drop `repoRoot` and
+ * silently restore the fail-open on exactly the runs where the refresh already
+ * failed.
+ */
+describe("review input repoRoot — refresh failure path (#1668)", () => {
+  const STALE = {
+    workdir: "/tmp/repo/packages/api",
+    repoRoot: "/tmp/repo",
+    story: { id: "US-x" },
+    mode: "ref" as const,
+    stat: "",
+    storyGitRef: "stale-ref",
+    excludePatterns: [],
+    _refresh: { projectDir: "/tmp/repo", storyId: "US-x", storyGitRef: "stale-ref" },
+  };
+
+  test("semantic-review keeps repoRoot when the refresh throws", async () => {
+    const orig = _storyOrchestratorDeps.prepareSemanticReviewInput;
+    _storyOrchestratorDeps.prepareSemanticReviewInput = mock(async () => {
+      throw new Error("git unavailable");
+    }) as typeof _storyOrchestratorDeps.prepareSemanticReviewInput;
+
+    try {
+      const out = (await refreshReviewInputForDispatch("semantic-review", {
+        ...STALE,
+        semanticConfig: { diffMode: "ref" },
+      })) as Record<string, unknown>;
+      expect(out.repoRoot).toBe("/tmp/repo");
+      expect(out.repoRoot).not.toBe(out.workdir);
+      // _refresh must still be stripped on the fallback.
+      expect(out._refresh).toBeUndefined();
+    } finally {
+      _storyOrchestratorDeps.prepareSemanticReviewInput = orig;
+    }
+  });
+
+  test("adversarial-review keeps repoRoot when the refresh throws", async () => {
+    const orig = _storyOrchestratorDeps.prepareAdversarialReviewInput;
+    _storyOrchestratorDeps.prepareAdversarialReviewInput = mock(async () => {
+      throw new Error("git unavailable");
+    }) as typeof _storyOrchestratorDeps.prepareAdversarialReviewInput;
+
+    try {
+      const out = (await refreshReviewInputForDispatch("adversarial-review", {
+        ...STALE,
+        adversarialConfig: { diffMode: "ref" },
+      })) as Record<string, unknown>;
+      expect(out.repoRoot).toBe("/tmp/repo");
+      expect(out.repoRoot).not.toBe(out.workdir);
+      expect(out._refresh).toBeUndefined();
+    } finally {
+      _storyOrchestratorDeps.prepareAdversarialReviewInput = orig;
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1668.

## Problem

`checkFindingEvidence` resolves a review finding's file against `repoRoot` first,
then falls back to `workdir` as a package-relative path:

```ts
// repoRoot first (git paths are repo-root-relative), then workdir as a
// package-relative fallback. Dedupe when they are equal (single-package).
const roots = opts.repoRoot && opts.repoRoot !== opts.workdir
  ? [opts.repoRoot, opts.workdir] : [opts.workdir];
```

The review inputs built in `src/execution/plan-inputs.ts` never set `repoRoot`.
`SemanticReviewInput.repoRoot` is optional, so this type-checked. Findings carry
repo-root-relative paths (git emits them that way), so in a monorepo — where
`workdir` is the package dir — the join double-counted the package prefix:

```
workdir  = <repo>/packages/<pkg>
finding  = packages/<pkg>/src/<module>.py
resolved = <repo>/packages/<pkg>/packages/<pkg>/src/<module>.py   ← does not exist
```

`readSafeFile` returned null → status `unreadable` → and
`substantiateSemanticEvidence` downgrades only on `unmatched`, so the finding
passed through at full blocking severity.

**Evidence substantiation has been inert for every monorepo package story, in both
reviewers.** It only functioned when `workdir === repoRoot` — single-package repos,
where the double-join is a no-op.

## Impact observed

A semantic finding whose `verifiedBy.observed` was a prose description of the diff
(*"…is visible in the diff"* — exactly the shape the reviewer prompt forbids)
blocked a story for **12 review rounds across all four escalation tiers**. It was a
false positive: the code it called missing was in the same file, in lines the diff
did not touch. Zero `Downgraded unsubstantiated review finding` events were emitted
across the whole run.

Verified against that recorded finding:

```
BEFORE (no repoRoot passed): error        -> blocks: true
AFTER  (repoRoot passed)   : unverifiable -> blocks: false
```

## Change

Two lines: `repoRoot: ctx.projectDir` on the semantic and adversarial review
inputs.

`verifyScoped` and `mutationCheck` already pass `repoRoot: ctx.projectDir` a few
lines away in the same function — the former with a comment calling it
"monorepo-correct". The two review inputs were missed. This makes all four call
sites in the file consistent.

Note the helper side was already fixed and tested for this exact case —
`semantic-evidence.test.ts` has a `checkFindingEvidence — monorepo repoRoot
resolution` block, including a test commented *"Before the fix this was
'unreadable' (doubled path) and the finding survived."* Those tests pass `repoRoot`
explicitly; the production wiring was never done. This PR completes that fix.

## Deliberately not changed

- **The `unreadable` fail-open.** It is intentional — `adversarial-verifiedby.test.ts`
  asserts *"preserves blocking finding when source file is unreadable (fail-open)"*
  on the rationale that a tool failure is not fabrication. With `repoRoot` wired,
  the readable path is reached.
- **Bare `ctx.projectDir`, not `ctx.projectDir ?? ctx.workdir`.** `projectDir` is a
  required field, and the fallback would make `repoRoot === workdir` — which
  `checkFindingEvidence` collapses back to the single-root lookup, silently
  restoring this bug rather than surfacing the broken invariant.
- **Making `repoRoot` required** on both input types (suggested on the issue as a
  recurrence guard). It would touch 22+ test files, disproportionate to a two-line
  fix. Worth doing as its own change.

## Tests

- `plan-inputs-review-wiring.test.ts` — 3 tests asserting `repoRoot` is set on both
  inputs and is distinct from `workdir`. **These fail on the pre-fix code** (3 fail
  / 10, verified by checking out the base version of `plan-inputs.ts`).
- `review-input-repo-root.test.ts` — new file covering `refreshReviewInputForDispatch`'s
  **catch path**, which rebuilds the input by destructuring `_refresh` off. That
  branch is otherwise unexercised for field preservation and is what a future
  field-by-field refactor would break. Its doc comment states plainly that it
  guards a future regression, not the original one.

An earlier revision of that second file tested the happy path and did **not**
discriminate — it hand-supplied `repoRoot` and the object spread preserved it
regardless, so it passed on the pre-fix commit. Caught in review and rewritten.

## Verification

`bun run typecheck` clean · `bun run lint` clean ·
**13,908 unit + 1,135 integration + 37 UI, 0 failures.**
